### PR TITLE
Improve collection scroll behavior

### DIFF
--- a/features/collection/components/FilterableProductSection.tsx
+++ b/features/collection/components/FilterableProductSection.tsx
@@ -173,12 +173,10 @@ function useCollectionState(): CollectionState {
 function useScrollIntoViewEffect(deps: React.DependencyList) {
    const ref = React.useRef<HTMLDivElement>(null);
    React.useEffect(() => {
-      if (ref.current) {
-         if (ref.current.getBoundingClientRect().top < 0) {
-            ref.current.scrollIntoView({
-               behavior: 'smooth',
-            });
-         }
+      if (ref.current && ref.current.getBoundingClientRect().top < 0) {
+         ref.current.scrollIntoView({
+            behavior: 'smooth',
+         });
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
    }, deps);

--- a/features/collection/components/FilterableProductSection.tsx
+++ b/features/collection/components/FilterableProductSection.tsx
@@ -43,12 +43,19 @@ export const FilterableProductSection = React.memo(() => {
    const [isFilterModalOpen, setIsFilterModalOpen] = React.useState(false);
    const collectionState = useCollectionState();
 
+   const productsContainerScrollRef = useScrollIntoViewEffect([hits]);
+
    if (collectionState === CollectionState.Empty) {
       return <CollectionEmptyState />;
    }
 
    return (
-      <VStack align="stretch" mb="4" spacing="4">
+      <VStack
+         align="stretch"
+         mb="4"
+         spacing="4"
+         ref={productsContainerScrollRef}
+      >
          <Toolbar
             leftContent={<NumberOfHits />}
             rightContent={
@@ -161,6 +168,21 @@ function useCollectionState(): CollectionState {
       return CollectionState.Filtered;
    }
    return CollectionState.Idle;
+}
+
+function useScrollIntoViewEffect(deps: React.DependencyList) {
+   const ref = React.useRef<HTMLDivElement>(null);
+   React.useEffect(() => {
+      if (ref.current) {
+         if (ref.current.getBoundingClientRect().top < 0) {
+            ref.current.scrollIntoView({
+               behavior: 'smooth',
+            });
+         }
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+   }, deps);
+   return ref;
 }
 
 const FilterCard = ({

--- a/lib/algolia/reducers/filtersCleared.ts
+++ b/lib/algolia/reducers/filtersCleared.ts
@@ -14,6 +14,7 @@ function clearFilters(draft: Draft<SearchState>, filtersIds?: string[]) {
       draft.params.filters.rootIds = [];
       draft.params.filters.byId = {};
    } else {
+      draft.params.page = 1;
       filtersIds.forEach((filterId) => {
          const filter = draft.params.filters.byId[filterId];
          if (filter != null) {

--- a/lib/algolia/reducers/listFilterAllItemsCleared.ts
+++ b/lib/algolia/reducers/listFilterAllItemsCleared.ts
@@ -3,15 +3,16 @@ import { ListFilterAllItemsClearedAction, SearchState } from '../types';
 import { isListFilter } from '../utils';
 
 export function listFilterAllItemsCleared(
-   draftState: Draft<SearchState>,
+   draft: Draft<SearchState>,
    action: ListFilterAllItemsClearedAction
 ) {
-   const filter = draftState.params.filters.byId[action.filterId];
+   const filter = draft.params.filters.byId[action.filterId];
 
    if (isListFilter(filter)) {
+      draft.params.page = 1;
       filter.filterIds.forEach((itemId) => {
-         delete draftState.params.filters.byId[itemId];
-         draftState.params.filters.allIds = draftState.params.filters.allIds.filter(
+         delete draft.params.filters.byId[itemId];
+         draft.params.filters.allIds = draft.params.filters.allIds.filter(
             (id) => id != itemId
          );
       });

--- a/lib/algolia/reducers/listFilterItemAdded.ts
+++ b/lib/algolia/reducers/listFilterItemAdded.ts
@@ -3,24 +3,25 @@ import { ListFilterItemAddedAction, SearchState } from '../types';
 import { createBasicFilter, getListFilterItemIds, mergeUnique } from '../utils';
 
 export function listFilterItemAdded(
-   draftState: Draft<SearchState>,
+   draft: Draft<SearchState>,
    action: ListFilterItemAddedAction
 ) {
-   if (!draftState.params.filters.rootIds.includes(action.filterId)) {
-      draftState.params.filters.rootIds.push(action.filterId);
-      draftState.params.filters.allIds.push(action.filterId);
+   draft.params.page = 1;
+   if (!draft.params.filters.rootIds.includes(action.filterId)) {
+      draft.params.filters.rootIds.push(action.filterId);
+      draft.params.filters.allIds.push(action.filterId);
    }
    const newItemFilter = createBasicFilter(
       action.filterId,
       action.valueId,
       action.filterId
    );
-   const filterItemIds = getListFilterItemIds(draftState, action.filterId);
-   draftState.params.filters.byId[action.filterId] = {
+   const filterItemIds = getListFilterItemIds(draft, action.filterId);
+   draft.params.filters.byId[action.filterId] = {
       id: action.filterId,
       filterIds: mergeUnique(filterItemIds, [newItemFilter.id]),
       type: action.filterType,
    };
-   draftState.params.filters.byId[newItemFilter.id] = newItemFilter;
-   draftState.params.filters.allIds.push(newItemFilter.id);
+   draft.params.filters.byId[newItemFilter.id] = newItemFilter;
+   draft.params.filters.allIds.push(newItemFilter.id);
 }

--- a/lib/algolia/reducers/listFilterItemCleared.ts
+++ b/lib/algolia/reducers/listFilterItemCleared.ts
@@ -3,27 +3,28 @@ import { ListFilterItemClearedAction, SearchState } from '../types';
 import { createBasicFilter, isListFilter } from '../utils';
 
 export function listFilterItemCleared(
-   draftState: Draft<SearchState>,
+   draft: Draft<SearchState>,
    action: ListFilterItemClearedAction
 ) {
-   const filter = draftState.params.filters.byId[action.filterId];
+   const filter = draft.params.filters.byId[action.filterId];
    if (isListFilter(filter)) {
+      draft.params.page = 1;
       const itemFilter = createBasicFilter(
          action.filterId,
          action.valueId,
          action.filterId
       );
-      delete draftState.params.filters.byId[itemFilter.id];
-      draftState.params.filters.allIds = draftState.params.filters.allIds.filter(
+      delete draft.params.filters.byId[itemFilter.id];
+      draft.params.filters.allIds = draft.params.filters.allIds.filter(
          (id) => id != itemFilter.id
       );
       filter.filterIds = filter.filterIds.filter((id) => id !== itemFilter.id);
       if (filter.filterIds.length === 0) {
-         delete draftState.params.filters.byId[filter.id];
-         draftState.params.filters.allIds = draftState.params.filters.allIds.filter(
+         delete draft.params.filters.byId[filter.id];
+         draft.params.filters.allIds = draft.params.filters.allIds.filter(
             (id) => id !== filter.id
          );
-         draftState.params.filters.rootIds = draftState.params.filters.rootIds.filter(
+         draft.params.filters.rootIds = draft.params.filters.rootIds.filter(
             (id) => id !== filter.id
          );
       }

--- a/lib/algolia/reducers/listFilterItemSet.ts
+++ b/lib/algolia/reducers/listFilterItemSet.ts
@@ -6,6 +6,7 @@ export function listFilterItemSet(
    draft: Draft<SearchState>,
    action: ListFilterItemSetAction
 ) {
+   draft.params.page = 1;
    if (!draft.params.filters.rootIds.includes(action.filterId)) {
       draft.params.filters.rootIds.push(action.filterId);
    }

--- a/lib/algolia/reducers/listFilterItemToggled.ts
+++ b/lib/algolia/reducers/listFilterItemToggled.ts
@@ -9,23 +9,24 @@ import { listFilterItemAdded } from './listFilterItemAdded';
 import { listFilterItemCleared } from './listFilterItemCleared';
 
 export function listFilterItemToggled(
-   draftState: Draft<SearchState>,
+   draft: Draft<SearchState>,
    action: ListFilterItemToggledAction
 ) {
+   draft.params.page = 1;
    const newItemFilter = createBasicFilter(
       action.filterId,
       action.valueId,
       action.filterId
    );
-   const filterItemIds = getListFilterItemIds(draftState, action.filterId);
+   const filterItemIds = getListFilterItemIds(draft, action.filterId);
    if (filterItemIds.includes(newItemFilter.id)) {
-      return listFilterItemCleared(draftState, {
+      return listFilterItemCleared(draft, {
          type: SearchActionType.ListFilterItemCleared,
          filterId: action.filterId,
          valueId: action.valueId,
       });
    }
-   return listFilterItemAdded(draftState, {
+   return listFilterItemAdded(draft, {
       type: SearchActionType.ListFilterItemAdded,
       filterId: action.filterId,
       filterType: action.filterType,

--- a/lib/algolia/reducers/queryChanged.ts
+++ b/lib/algolia/reducers/queryChanged.ts
@@ -2,8 +2,9 @@ import { Draft } from 'immer';
 import { QueryChangedAction, SearchState } from '../types';
 
 export function queryChanged(
-   draftState: Draft<SearchState>,
+   draft: Draft<SearchState>,
    action: QueryChangedAction
 ) {
-   draftState.params.query = action.query;
+   draft.params.query = action.query;
+   draft.params.page = 1;
 }

--- a/lib/algolia/reducers/rangeFilterSet.ts
+++ b/lib/algolia/reducers/rangeFilterSet.ts
@@ -16,10 +16,11 @@ import {
 } from '../utils';
 
 export function rangeFilterSet(
-   draftState: Draft<SearchState>,
+   draft: Draft<SearchState>,
    action: RangeFilterSetAction
 ) {
-   const filter = draftState.params.filters.byId[action.filterId];
+   draft.params.page = 1;
+   const filter = draft.params.filters.byId[action.filterId];
    const draftRange = getRangeFromFilter(filter);
    if (isInvalidRange(action.range) || isSameRange(action.range, draftRange)) {
       return;
@@ -40,19 +41,19 @@ export function rangeFilterSet(
          NumericComparisonOperator.GreaterThanOrEqual
       );
    } else {
-      draftState.params.filters.allIds = draftState.params.filters.allIds.filter(
+      draft.params.filters.allIds = draft.params.filters.allIds.filter(
          (id) => id !== action.filterId
       );
-      draftState.params.filters.rootIds = draftState.params.filters.rootIds.filter(
+      draft.params.filters.rootIds = draft.params.filters.rootIds.filter(
          (id) => id !== action.filterId
       );
-      delete draftState.params.filters.byId[action.filterId];
+      delete draft.params.filters.byId[action.filterId];
    }
    if (newFilter != null) {
-      draftState.params.filters.byId[action.filterId] = newFilter;
+      draft.params.filters.byId[action.filterId] = newFilter;
       if (filter == null) {
-         draftState.params.filters.allIds.push(action.filterId);
-         draftState.params.filters.rootIds.push(action.filterId);
+         draft.params.filters.allIds.push(action.filterId);
+         draft.params.filters.rootIds.push(action.filterId);
       }
    }
 }


### PR DESCRIPTION
This PR closes #53, #54 and fixes #63 

## QA

1. Visit the Vercel PR preview
2. Visit any collection that contains products
3. Verify that when you change the page of the product list, the top item is scrolled into view
4. Verify that when you change filters or search query, the top item is scrolled into view