### PR TITLE
Fix filtered price range label bug

### DIFF
--- a/features/collection/components/sections/FilterableProductsSection/FilterList/FilterRow.tsx
+++ b/features/collection/components/sections/FilterableProductsSection/FilterList/FilterRow.tsx
@@ -175,12 +175,12 @@ const Row = React.memo(
                                  facetName={facet.name}
                                  multiple
                                  sortItems={sortByPriceRange}
-                                 renderItem={(item, index, list) => {
+                                 renderItem={(item) => {
                                     const [min, max] = parseRange(item.value);
-                                    if (index === 0) {
+                                    if (item.isRangeStart) {
                                        return `Under $${max}`;
                                     }
-                                    if (index === list.length - 1) {
+                                    if (item.isRangeEnd) {
                                        return `$${min} +`;
                                     }
                                     return `$${min} - $${max}`;

--- a/features/collection/components/sections/FilterableProductsSection/FilterList/RangeFilter/RangeFilterList.tsx
+++ b/features/collection/components/sections/FilterableProductsSection/FilterList/RangeFilter/RangeFilterList.tsx
@@ -14,12 +14,13 @@ export type RangeFilterListProps = {
    type?: ListFilter['type'];
    multiple?: boolean;
    sortItems?(a: FacetValueState, b: FacetValueState): number;
-   renderItem?(
-      item: FacetValueState,
-      index: number,
-      list: FacetValueState[]
-   ): React.ReactNode;
+   renderItem?(item: RangeItem): React.ReactNode;
 };
+
+interface RangeItem extends FacetValueState {
+   isRangeStart: boolean;
+   isRangeEnd: boolean;
+}
 
 export function RangeFilterList({
    facetName,
@@ -35,9 +36,14 @@ export function RangeFilterList({
    });
    useRegisterFacet(facetName);
 
-   const items = React.useMemo(() => {
+   const items = React.useMemo<RangeItem[]>(() => {
       return values
          .slice()
+         .map<RangeItem>((value, index) => ({
+            ...value,
+            isRangeStart: index === 0,
+            isRangeEnd: index === values.length - 1,
+         }))
          .filter((value) => value.filteredHitCount > 0)
          .sort(sortItems);
    }, [sortItems, values]);
@@ -67,7 +73,7 @@ export function RangeFilterList({
                      isChecked={selectedValueIds.includes(item.id)}
                      onChange={handleChange}
                   >
-                     {renderItem ? renderItem(item, index, values) : item.value}
+                     {renderItem ? renderItem(item) : item.value}
                   </FilterCheckbox>
                );
             }
@@ -85,7 +91,7 @@ export function RangeFilterList({
                   }}
                >
                   <Text fontSize="sm">
-                     {renderItem ? renderItem(item, index, values) : item.value}
+                     {renderItem ? renderItem(item) : item.value}
                   </Text>
                </Radio>
             );

--- a/features/collection/components/sections/FilterableProductsSection/FilterList/index.tsx
+++ b/features/collection/components/sections/FilterableProductsSection/FilterList/index.tsx
@@ -143,7 +143,6 @@ export const FilterList = chakra(({ className }: CollectionFiltersProps) => {
                   >
                      <VariableSizeList
                         ref={listRef}
-                        // overscanCount={2}
                         height={height}
                         itemCount={state.context.items.length}
                         itemKey={itemKey}

--- a/lib/api/strapi/generated/sdk.ts
+++ b/lib/api/strapi/generated/sdk.ts
@@ -424,6 +424,18 @@ export type ComponentSettingsSocialInput = {
   repairOrg?: Maybe<Scalars['String']>;
 };
 
+export type ComponentStoreShopifySettingInput = {
+  storefrontDomain: Scalars['String'];
+  storefrontAccessToken: Scalars['String'];
+};
+
+export type ComponentStoreShopifySettings = {
+  __typename?: 'ComponentStoreShopifySettings';
+  id: Scalars['ID'];
+  storefrontDomain: Scalars['String'];
+  storefrontAccessToken: Scalars['String'];
+};
+
 export type Device = {
   __typename?: 'Device';
   id: Scalars['ID'];
@@ -931,7 +943,7 @@ export type MenuInput = {
 
 export type MenuItemsDynamicZone = ComponentMenuLink | ComponentMenuCollectionLink | ComponentMenuLinkWithImage;
 
-export type Morph = UsersPermissionsMe | UsersPermissionsMeRole | UsersPermissionsLoginPayload | UserPermissionsPasswordPayload | BottomContext | BottomContextConnection | BottomContextAggregator | BottomContextGroupBy | BottomContextConnectionId | BottomContextConnectionCreated_At | BottomContextConnectionUpdated_At | BottomContextConnectionSubheading | BottomContextConnectionDevice_Summary | BottomContextConnectionLocale | BottomContextConnectionPublished_At | CreateBottomContextPayload | UpdateBottomContextPayload | DeleteBottomContextPayload | Collection | CollectionConnection | CollectionAggregator | CollectionGroupBy | CollectionConnectionId | CollectionConnectionCreated_At | CollectionConnectionUpdated_At | CollectionConnectionHandle | CollectionConnectionTitle | CollectionConnectionDescription | CollectionConnectionImage | CollectionConnectionFilters | CollectionConnectionParent | CollectionConnectionWiki_Title_Api_Validated | CollectionConnectionLocale | CollectionConnectionPublished_At | CreateCollectionPayload | UpdateCollectionPayload | DeleteCollectionPayload | Device | DeviceConnection | DeviceAggregator | DeviceGroupBy | DeviceConnectionId | DeviceConnectionCreated_At | DeviceConnectionUpdated_At | DeviceConnectionDevice | DeviceConnectionPart_Type | DeviceConnectionMeta_Description | DeviceConnectionSubheading | DeviceConnectionSummary | DeviceConnectionCanonical_Override | DeviceConnectionFaq_Section | DeviceConnectionDevice_Summary | DeviceConnectionLocale | DeviceConnectionPublished_At | CreateDevicePayload | UpdateDevicePayload | DeleteDevicePayload | FaqSection | FaqSectionConnection | FaqSectionAggregator | FaqSectionGroupBy | FaqSectionConnectionId | FaqSectionConnectionCreated_At | FaqSectionConnectionUpdated_At | FaqSectionConnectionHeading | FaqSectionConnectionFaq1 | FaqSectionConnectionFaq2 | FaqSectionConnectionFaq3 | FaqSectionConnectionLocale | FaqSectionConnectionPublished_At | CreateFaqSectionPayload | UpdateFaqSectionPayload | DeleteFaqSectionPayload | Faq | FaqConnection | FaqAggregator | FaqGroupBy | FaqConnectionId | FaqConnectionCreated_At | FaqConnectionUpdated_At | FaqConnectionQuestion | FaqConnectionAnswer | FaqConnectionLocale | FaqConnectionPublished_At | CreateFaqPayload | UpdateFaqPayload | DeleteFaqPayload | Menu | MenuConnection | MenuAggregator | MenuGroupBy | MenuConnectionId | MenuConnectionCreated_At | MenuConnectionUpdated_At | MenuConnectionTitle | MenuConnectionLocale | MenuConnectionPublished_At | CreateMenuPayload | UpdateMenuPayload | DeleteMenuPayload | StoreSettings | StoreSettingsConnection | StoreSettingsAggregator | StoreSettingsGroupBy | StoreSettingsConnectionId | StoreSettingsConnectionCreated_At | StoreSettingsConnectionUpdated_At | StoreSettingsConnectionFooter | StoreSettingsConnectionSocialMediaAccounts | StoreSettingsConnectionStore | StoreSettingsConnectionLocale | StoreSettingsConnectionPublished_At | CreateStoreSettingPayload | UpdateStoreSettingPayload | DeleteStoreSettingPayload | Store | StoreConnection | StoreAggregator | StoreGroupBy | StoreConnectionId | StoreConnectionCreated_At | StoreConnectionUpdated_At | StoreConnectionCode | StoreConnectionName | StoreConnectionUrl | StoreConnectionCurrency | StoreConnectionStore_Settings | StoreConnectionPublished_At | CreateStorePayload | UpdateStorePayload | DeleteStorePayload | I18NLocale | UploadFile | UploadFileConnection | UploadFileAggregator | UploadFileAggregatorSum | UploadFileAggregatorAvg | UploadFileAggregatorMin | UploadFileAggregatorMax | UploadFileGroupBy | UploadFileConnectionId | UploadFileConnectionCreated_At | UploadFileConnectionUpdated_At | UploadFileConnectionName | UploadFileConnectionAlternativeText | UploadFileConnectionCaption | UploadFileConnectionWidth | UploadFileConnectionHeight | UploadFileConnectionFormats | UploadFileConnectionHash | UploadFileConnectionExt | UploadFileConnectionMime | UploadFileConnectionSize | UploadFileConnectionUrl | UploadFileConnectionPreviewUrl | UploadFileConnectionProvider | UploadFileConnectionProvider_Metadata | DeleteFilePayload | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsRoleConnection | UsersPermissionsRoleAggregator | UsersPermissionsRoleGroupBy | UsersPermissionsRoleConnectionId | UsersPermissionsRoleConnectionName | UsersPermissionsRoleConnectionDescription | UsersPermissionsRoleConnectionType | CreateRolePayload | UpdateRolePayload | DeleteRolePayload | UsersPermissionsUser | UsersPermissionsUserConnection | UsersPermissionsUserAggregator | UsersPermissionsUserGroupBy | UsersPermissionsUserConnectionId | UsersPermissionsUserConnectionCreated_At | UsersPermissionsUserConnectionUpdated_At | UsersPermissionsUserConnectionUsername | UsersPermissionsUserConnectionEmail | UsersPermissionsUserConnectionProvider | UsersPermissionsUserConnectionConfirmed | UsersPermissionsUserConnectionBlocked | UsersPermissionsUserConnectionRole | CreateUserPayload | UpdateUserPayload | DeleteUserPayload | ComponentCollectionBanner | ComponentCollectionFeaturedCollection | ComponentCollectionNewsletterForm | ComponentCollectionRelatedPosts | ComponentMenuCollectionLink | ComponentMenuLinkWithImage | ComponentMenuLink | ComponentSettingsFooter | ComponentSettingsPartner | ComponentSettingsSocial;
+export type Morph = UsersPermissionsMe | UsersPermissionsMeRole | UsersPermissionsLoginPayload | UserPermissionsPasswordPayload | BottomContext | BottomContextConnection | BottomContextAggregator | BottomContextGroupBy | BottomContextConnectionId | BottomContextConnectionCreated_At | BottomContextConnectionUpdated_At | BottomContextConnectionSubheading | BottomContextConnectionDevice_Summary | BottomContextConnectionLocale | BottomContextConnectionPublished_At | CreateBottomContextPayload | UpdateBottomContextPayload | DeleteBottomContextPayload | Collection | CollectionConnection | CollectionAggregator | CollectionGroupBy | CollectionConnectionId | CollectionConnectionCreated_At | CollectionConnectionUpdated_At | CollectionConnectionHandle | CollectionConnectionTitle | CollectionConnectionDescription | CollectionConnectionImage | CollectionConnectionFilters | CollectionConnectionParent | CollectionConnectionWiki_Title_Api_Validated | CollectionConnectionLocale | CollectionConnectionPublished_At | CreateCollectionPayload | UpdateCollectionPayload | DeleteCollectionPayload | Device | DeviceConnection | DeviceAggregator | DeviceGroupBy | DeviceConnectionId | DeviceConnectionCreated_At | DeviceConnectionUpdated_At | DeviceConnectionDevice | DeviceConnectionPart_Type | DeviceConnectionMeta_Description | DeviceConnectionSubheading | DeviceConnectionSummary | DeviceConnectionCanonical_Override | DeviceConnectionFaq_Section | DeviceConnectionDevice_Summary | DeviceConnectionLocale | DeviceConnectionPublished_At | CreateDevicePayload | UpdateDevicePayload | DeleteDevicePayload | FaqSection | FaqSectionConnection | FaqSectionAggregator | FaqSectionGroupBy | FaqSectionConnectionId | FaqSectionConnectionCreated_At | FaqSectionConnectionUpdated_At | FaqSectionConnectionHeading | FaqSectionConnectionFaq1 | FaqSectionConnectionFaq2 | FaqSectionConnectionFaq3 | FaqSectionConnectionLocale | FaqSectionConnectionPublished_At | CreateFaqSectionPayload | UpdateFaqSectionPayload | DeleteFaqSectionPayload | Faq | FaqConnection | FaqAggregator | FaqGroupBy | FaqConnectionId | FaqConnectionCreated_At | FaqConnectionUpdated_At | FaqConnectionQuestion | FaqConnectionAnswer | FaqConnectionLocale | FaqConnectionPublished_At | CreateFaqPayload | UpdateFaqPayload | DeleteFaqPayload | Menu | MenuConnection | MenuAggregator | MenuGroupBy | MenuConnectionId | MenuConnectionCreated_At | MenuConnectionUpdated_At | MenuConnectionTitle | MenuConnectionLocale | MenuConnectionPublished_At | CreateMenuPayload | UpdateMenuPayload | DeleteMenuPayload | PartCollections | PartCollectionsConnection | PartCollectionsAggregator | PartCollectionsGroupBy | PartCollectionsConnectionId | PartCollectionsConnectionCreated_At | PartCollectionsConnectionUpdated_At | PartCollectionsConnectionDevice_Url | PartCollectionsConnectionTitle | PartCollectionsConnectionMeta_Description | PartCollectionsConnectionDetails | PartCollectionsConnectionSummary | PartCollectionsConnectionPublished_At | CreatePartCollectionPayload | UpdatePartCollectionPayload | DeletePartCollectionPayload | StoreSettings | StoreSettingsConnection | StoreSettingsAggregator | StoreSettingsGroupBy | StoreSettingsConnectionId | StoreSettingsConnectionCreated_At | StoreSettingsConnectionUpdated_At | StoreSettingsConnectionFooter | StoreSettingsConnectionSocialMediaAccounts | StoreSettingsConnectionStore | StoreSettingsConnectionLocale | StoreSettingsConnectionPublished_At | CreateStoreSettingPayload | UpdateStoreSettingPayload | DeleteStoreSettingPayload | Store | StoreConnection | StoreAggregator | StoreGroupBy | StoreConnectionId | StoreConnectionCreated_At | StoreConnectionUpdated_At | StoreConnectionCode | StoreConnectionName | StoreConnectionUrl | StoreConnectionCurrency | StoreConnectionStore_Settings | StoreConnectionShopifySettings | StoreConnectionFooter | StoreConnectionSocialMediaAccounts | StoreConnectionPublished_At | CreateStorePayload | UpdateStorePayload | DeleteStorePayload | I18NLocale | UploadFile | UploadFileConnection | UploadFileAggregator | UploadFileAggregatorSum | UploadFileAggregatorAvg | UploadFileAggregatorMin | UploadFileAggregatorMax | UploadFileGroupBy | UploadFileConnectionId | UploadFileConnectionCreated_At | UploadFileConnectionUpdated_At | UploadFileConnectionName | UploadFileConnectionAlternativeText | UploadFileConnectionCaption | UploadFileConnectionWidth | UploadFileConnectionHeight | UploadFileConnectionFormats | UploadFileConnectionHash | UploadFileConnectionExt | UploadFileConnectionMime | UploadFileConnectionSize | UploadFileConnectionUrl | UploadFileConnectionPreviewUrl | UploadFileConnectionProvider | UploadFileConnectionProvider_Metadata | DeleteFilePayload | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsRoleConnection | UsersPermissionsRoleAggregator | UsersPermissionsRoleGroupBy | UsersPermissionsRoleConnectionId | UsersPermissionsRoleConnectionName | UsersPermissionsRoleConnectionDescription | UsersPermissionsRoleConnectionType | CreateRolePayload | UpdateRolePayload | DeleteRolePayload | UsersPermissionsUser | UsersPermissionsUserConnection | UsersPermissionsUserAggregator | UsersPermissionsUserGroupBy | UsersPermissionsUserConnectionId | UsersPermissionsUserConnectionCreated_At | UsersPermissionsUserConnectionUpdated_At | UsersPermissionsUserConnectionUsername | UsersPermissionsUserConnectionEmail | UsersPermissionsUserConnectionProvider | UsersPermissionsUserConnectionConfirmed | UsersPermissionsUserConnectionBlocked | UsersPermissionsUserConnectionRole | CreateUserPayload | UpdateUserPayload | DeleteUserPayload | ComponentCollectionBanner | ComponentCollectionFeaturedCollection | ComponentCollectionNewsletterForm | ComponentCollectionRelatedPosts | ComponentMenuCollectionLink | ComponentMenuLinkWithImage | ComponentMenuLink | ComponentSettingsFooter | ComponentSettingsPartner | ComponentSettingsSocial | ComponentStoreShopifySettings;
 
 export type Mutation = {
   __typename?: 'Mutation';
@@ -953,6 +965,9 @@ export type Mutation = {
   createMenu?: Maybe<CreateMenuPayload>;
   updateMenu?: Maybe<UpdateMenuPayload>;
   deleteMenu?: Maybe<DeleteMenuPayload>;
+  createPartCollection?: Maybe<CreatePartCollectionPayload>;
+  updatePartCollection?: Maybe<UpdatePartCollectionPayload>;
+  deletePartCollection?: Maybe<DeletePartCollectionPayload>;
   createStoreSetting?: Maybe<CreateStoreSettingPayload>;
   updateStoreSetting?: Maybe<UpdateStoreSettingPayload>;
   deleteStoreSetting?: Maybe<DeleteStoreSettingPayload>;
@@ -1078,6 +1093,21 @@ export type MutationUpdateMenuArgs = {
 
 export type MutationDeleteMenuArgs = {
   input?: Maybe<DeleteMenuInput>;
+};
+
+
+export type MutationCreatePartCollectionArgs = {
+  input?: Maybe<CreatePartCollectionInput>;
+};
+
+
+export type MutationUpdatePartCollectionArgs = {
+  input?: Maybe<UpdatePartCollectionInput>;
+};
+
+
+export type MutationDeletePartCollectionArgs = {
+  input?: Maybe<DeletePartCollectionInput>;
 };
 
 
@@ -1232,6 +1262,110 @@ export type MutationEmailConfirmationArgs = {
   confirmation: Scalars['String'];
 };
 
+export type PartCollectionInput = {
+  device_url?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  meta_description?: Maybe<Scalars['String']>;
+  Details?: Maybe<Scalars['String']>;
+  summary?: Maybe<Scalars['String']>;
+  published_at?: Maybe<Scalars['DateTime']>;
+  created_by?: Maybe<Scalars['ID']>;
+  updated_by?: Maybe<Scalars['ID']>;
+};
+
+export type PartCollections = {
+  __typename?: 'PartCollections';
+  id: Scalars['ID'];
+  created_at: Scalars['DateTime'];
+  updated_at: Scalars['DateTime'];
+  device_url: Scalars['String'];
+  title?: Maybe<Scalars['String']>;
+  meta_description?: Maybe<Scalars['String']>;
+  Details?: Maybe<Scalars['String']>;
+  summary?: Maybe<Scalars['String']>;
+  published_at?: Maybe<Scalars['DateTime']>;
+};
+
+export type PartCollectionsAggregator = {
+  __typename?: 'PartCollectionsAggregator';
+  count?: Maybe<Scalars['Int']>;
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type PartCollectionsConnection = {
+  __typename?: 'PartCollectionsConnection';
+  values?: Maybe<Array<Maybe<PartCollections>>>;
+  groupBy?: Maybe<PartCollectionsGroupBy>;
+  aggregate?: Maybe<PartCollectionsAggregator>;
+};
+
+export type PartCollectionsConnectionCreated_At = {
+  __typename?: 'PartCollectionsConnectionCreated_at';
+  key?: Maybe<Scalars['DateTime']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsConnectionDetails = {
+  __typename?: 'PartCollectionsConnectionDetails';
+  key?: Maybe<Scalars['String']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsConnectionDevice_Url = {
+  __typename?: 'PartCollectionsConnectionDevice_url';
+  key?: Maybe<Scalars['String']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsConnectionId = {
+  __typename?: 'PartCollectionsConnectionId';
+  key?: Maybe<Scalars['ID']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsConnectionMeta_Description = {
+  __typename?: 'PartCollectionsConnectionMeta_description';
+  key?: Maybe<Scalars['String']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsConnectionPublished_At = {
+  __typename?: 'PartCollectionsConnectionPublished_at';
+  key?: Maybe<Scalars['DateTime']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsConnectionSummary = {
+  __typename?: 'PartCollectionsConnectionSummary';
+  key?: Maybe<Scalars['String']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsConnectionTitle = {
+  __typename?: 'PartCollectionsConnectionTitle';
+  key?: Maybe<Scalars['String']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsConnectionUpdated_At = {
+  __typename?: 'PartCollectionsConnectionUpdated_at';
+  key?: Maybe<Scalars['DateTime']>;
+  connection?: Maybe<PartCollectionsConnection>;
+};
+
+export type PartCollectionsGroupBy = {
+  __typename?: 'PartCollectionsGroupBy';
+  id?: Maybe<Array<Maybe<PartCollectionsConnectionId>>>;
+  created_at?: Maybe<Array<Maybe<PartCollectionsConnectionCreated_At>>>;
+  updated_at?: Maybe<Array<Maybe<PartCollectionsConnectionUpdated_At>>>;
+  device_url?: Maybe<Array<Maybe<PartCollectionsConnectionDevice_Url>>>;
+  title?: Maybe<Array<Maybe<PartCollectionsConnectionTitle>>>;
+  meta_description?: Maybe<Array<Maybe<PartCollectionsConnectionMeta_Description>>>;
+  Details?: Maybe<Array<Maybe<PartCollectionsConnectionDetails>>>;
+  summary?: Maybe<Array<Maybe<PartCollectionsConnectionSummary>>>;
+  published_at?: Maybe<Array<Maybe<PartCollectionsConnectionPublished_At>>>;
+};
+
 export enum PublicationState {
   Live = 'LIVE',
   Preview = 'PREVIEW'
@@ -1257,6 +1391,9 @@ export type Query = {
   menu?: Maybe<Menu>;
   menus?: Maybe<Array<Maybe<Menu>>>;
   menusConnection?: Maybe<MenuConnection>;
+  partCollection?: Maybe<PartCollections>;
+  partCollections?: Maybe<Array<Maybe<PartCollections>>>;
+  partCollectionsConnection?: Maybe<PartCollectionsConnection>;
   storeSetting?: Maybe<StoreSettings>;
   storeSettings?: Maybe<Array<Maybe<StoreSettings>>>;
   storeSettingsConnection?: Maybe<StoreSettingsConnection>;
@@ -1426,6 +1563,29 @@ export type QueryMenusConnectionArgs = {
 };
 
 
+export type QueryPartCollectionArgs = {
+  id: Scalars['ID'];
+  publicationState?: Maybe<PublicationState>;
+};
+
+
+export type QueryPartCollectionsArgs = {
+  sort?: Maybe<Scalars['String']>;
+  limit?: Maybe<Scalars['Int']>;
+  start?: Maybe<Scalars['Int']>;
+  where?: Maybe<Scalars['JSON']>;
+  publicationState?: Maybe<PublicationState>;
+};
+
+
+export type QueryPartCollectionsConnectionArgs = {
+  sort?: Maybe<Scalars['String']>;
+  limit?: Maybe<Scalars['Int']>;
+  start?: Maybe<Scalars['Int']>;
+  where?: Maybe<Scalars['JSON']>;
+};
+
+
 export type QueryStoreSettingArgs = {
   id: Scalars['ID'];
   publicationState?: Maybe<PublicationState>;
@@ -1556,6 +1716,9 @@ export type Store = {
   url: Scalars['String'];
   currency: Scalars['String'];
   store_settings?: Maybe<StoreSettings>;
+  shopifySettings?: Maybe<ComponentStoreShopifySettings>;
+  footer?: Maybe<ComponentSettingsFooter>;
+  socialMediaAccounts?: Maybe<ComponentSettingsSocial>;
   published_at?: Maybe<Scalars['DateTime']>;
 };
 
@@ -1590,6 +1753,12 @@ export type StoreConnectionCurrency = {
   connection?: Maybe<StoreConnection>;
 };
 
+export type StoreConnectionFooter = {
+  __typename?: 'StoreConnectionFooter';
+  key?: Maybe<Scalars['ID']>;
+  connection?: Maybe<StoreConnection>;
+};
+
 export type StoreConnectionId = {
   __typename?: 'StoreConnectionId';
   key?: Maybe<Scalars['ID']>;
@@ -1605,6 +1774,18 @@ export type StoreConnectionName = {
 export type StoreConnectionPublished_At = {
   __typename?: 'StoreConnectionPublished_at';
   key?: Maybe<Scalars['DateTime']>;
+  connection?: Maybe<StoreConnection>;
+};
+
+export type StoreConnectionShopifySettings = {
+  __typename?: 'StoreConnectionShopifySettings';
+  key?: Maybe<Scalars['ID']>;
+  connection?: Maybe<StoreConnection>;
+};
+
+export type StoreConnectionSocialMediaAccounts = {
+  __typename?: 'StoreConnectionSocialMediaAccounts';
+  key?: Maybe<Scalars['ID']>;
   connection?: Maybe<StoreConnection>;
 };
 
@@ -1636,6 +1817,9 @@ export type StoreGroupBy = {
   url?: Maybe<Array<Maybe<StoreConnectionUrl>>>;
   currency?: Maybe<Array<Maybe<StoreConnectionCurrency>>>;
   store_settings?: Maybe<Array<Maybe<StoreConnectionStore_Settings>>>;
+  shopifySettings?: Maybe<Array<Maybe<StoreConnectionShopifySettings>>>;
+  footer?: Maybe<Array<Maybe<StoreConnectionFooter>>>;
+  socialMediaAccounts?: Maybe<Array<Maybe<StoreConnectionSocialMediaAccounts>>>;
   published_at?: Maybe<Array<Maybe<StoreConnectionPublished_At>>>;
 };
 
@@ -1645,6 +1829,9 @@ export type StoreInput = {
   url: Scalars['String'];
   currency: Scalars['String'];
   store_settings?: Maybe<Scalars['ID']>;
+  shopifySettings: ComponentStoreShopifySettingInput;
+  footer: ComponentSettingsFooterInput;
+  socialMediaAccounts: ComponentSettingsSocialInput;
   published_at?: Maybe<Scalars['DateTime']>;
   created_by?: Maybe<Scalars['ID']>;
   updated_by?: Maybe<Scalars['ID']>;
@@ -2237,6 +2424,15 @@ export type CreateMenuPayload = {
   menu?: Maybe<Menu>;
 };
 
+export type CreatePartCollectionInput = {
+  data?: Maybe<PartCollectionInput>;
+};
+
+export type CreatePartCollectionPayload = {
+  __typename?: 'createPartCollectionPayload';
+  partCollection?: Maybe<PartCollections>;
+};
+
 export type CreateRoleInput = {
   data?: Maybe<RoleInput>;
 };
@@ -2334,6 +2530,15 @@ export type DeleteMenuInput = {
 export type DeleteMenuPayload = {
   __typename?: 'deleteMenuPayload';
   menu?: Maybe<Menu>;
+};
+
+export type DeletePartCollectionInput = {
+  where?: Maybe<InputId>;
+};
+
+export type DeletePartCollectionPayload = {
+  __typename?: 'deletePartCollectionPayload';
+  partCollection?: Maybe<PartCollections>;
 };
 
 export type DeleteRoleInput = {
@@ -2468,6 +2673,12 @@ export type EditComponentSettingsSocialInput = {
   repairOrg?: Maybe<Scalars['String']>;
 };
 
+export type EditComponentStoreShopifySettingInput = {
+  id?: Maybe<Scalars['ID']>;
+  storefrontDomain?: Maybe<Scalars['String']>;
+  storefrontAccessToken?: Maybe<Scalars['String']>;
+};
+
 export type EditDeviceInput = {
   device?: Maybe<Scalars['String']>;
   part_type?: Maybe<Scalars['String']>;
@@ -2544,6 +2755,17 @@ export type EditMenuInput = {
   updated_by?: Maybe<Scalars['ID']>;
 };
 
+export type EditPartCollectionInput = {
+  device_url?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+  meta_description?: Maybe<Scalars['String']>;
+  Details?: Maybe<Scalars['String']>;
+  summary?: Maybe<Scalars['String']>;
+  published_at?: Maybe<Scalars['DateTime']>;
+  created_by?: Maybe<Scalars['ID']>;
+  updated_by?: Maybe<Scalars['ID']>;
+};
+
 export type EditRoleInput = {
   name?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
@@ -2560,6 +2782,9 @@ export type EditStoreInput = {
   url?: Maybe<Scalars['String']>;
   currency?: Maybe<Scalars['String']>;
   store_settings?: Maybe<Scalars['ID']>;
+  shopifySettings?: Maybe<EditComponentStoreShopifySettingInput>;
+  footer?: Maybe<EditComponentSettingsFooterInput>;
+  socialMediaAccounts?: Maybe<EditComponentSettingsSocialInput>;
   published_at?: Maybe<Scalars['DateTime']>;
   created_by?: Maybe<Scalars['ID']>;
   updated_by?: Maybe<Scalars['ID']>;
@@ -2648,6 +2873,16 @@ export type UpdateMenuInput = {
 export type UpdateMenuPayload = {
   __typename?: 'updateMenuPayload';
   menu?: Maybe<Menu>;
+};
+
+export type UpdatePartCollectionInput = {
+  where?: Maybe<InputId>;
+  data?: Maybe<EditPartCollectionInput>;
+};
+
+export type UpdatePartCollectionPayload = {
+  __typename?: 'updatePartCollectionPayload';
+  partCollection?: Maybe<PartCollections>;
 };
 
 export type UpdateRoleInput = {


### PR DESCRIPTION
This PR fixes #45 

## QA

1. Visit the Vercel PR preview
2. Visit the parts collection page
3. Open price range filter and select `$10 - $25` option
4. Verify that the filter `$10 - $25` option text **does not** change to `Under $25`