### PR TITLE
Use new collection type names

### DIFF
--- a/lib/api/collection/index.ts
+++ b/lib/api/collection/index.ts
@@ -30,7 +30,7 @@ export async function fetchCollectionPageData(
          code: options.storeCode,
       },
    });
-   const collection = result.collections?.[0];
+   const collection = result.productLists?.[0];
    if (collection == null) {
       return null;
    }
@@ -48,6 +48,9 @@ export async function fetchCollectionPageData(
    }
    return {
       ...getLayoutProps(result),
+      global: {
+         newsletterForm: result.global?.newsletterForm,
+      },
       collection: {
          handle: collection.handle,
          title: collection.title,
@@ -65,12 +68,11 @@ export async function fetchCollectionPageData(
          }),
          sections: filterNullableItems(collection.sections).map((section) => {
             if (
-               section.__typename ===
-               'ComponentCollectionFeaturedSubcollections'
+               section.__typename === 'ComponentProductListLinkedProductListSet'
             ) {
                return {
                   ...section,
-                  collections: filterNullableItems(section.collections).map(
+                  productLists: filterNullableItems(section.productLists).map(
                      (collection) => {
                         return {
                            ...collection,
@@ -94,12 +96,16 @@ export type CollectionData = NonNullable<
    Awaited<ReturnType<typeof fetchCollectionPageData>>
 >['collection'];
 
+export type ProductListGlobal = NonNullable<
+   Awaited<ReturnType<typeof fetchCollectionPageData>>
+>['global'];
+
 type StrapiCollectionPageData = NonNullable<
    NonNullable<Awaited<ReturnType<typeof strapi['getCollectionPageData']>>>
 >;
 
 type StrapiCollection = NonNullable<
-   NonNullable<StrapiCollectionPageData['collections']>[0]
+   NonNullable<StrapiCollectionPageData['productLists']>[0]
 >;
 
 interface Ancestor {

--- a/lib/api/layout/index.ts
+++ b/lib/api/layout/index.ts
@@ -56,8 +56,8 @@ function getMenu(rawMenu: Menu) {
             case 'ComponentMenuCollectionLink': {
                return {
                   name: item.name,
-                  url: item.linkedCollection
-                     ? `/collections/${item.linkedCollection.handle}`
+                  url: item.productList
+                     ? `/collections/${item.productList.handle}`
                      : '#',
                };
             }

--- a/lib/api/strapi/generated/sdk.ts
+++ b/lib/api/strapi/generated/sdk.ts
@@ -9,8 +9,6 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** Input type for dynamic zone sections of Collection */
-  CollectionSectionsDynamicZoneInput: any;
   /** A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
   Date: any;
   /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
@@ -21,6 +19,8 @@ export type Scalars = {
   Long: any;
   /** Input type for dynamic zone items of Menu */
   MenuItemsDynamicZoneInput: any;
+  /** Input type for dynamic zone sections of ProductList */
+  ProductListSectionsDynamicZoneInput: any;
   /** A time string with format: HH:mm:ss.SSS */
   Time: any;
   /** The `Upload` scalar type represents a file upload. */
@@ -35,390 +35,32 @@ export type AdminUser = {
   username?: Maybe<Scalars['String']>;
 };
 
-export type BottomContext = {
-  __typename?: 'BottomContext';
-  created_at: Scalars['DateTime'];
-  device_summary?: Maybe<Scalars['String']>;
+export type ComponentGlobalNewsletterForm = {
+  __typename?: 'ComponentGlobalNewsletterForm';
+  callToActionButtonTitle: Scalars['String'];
   id: Scalars['ID'];
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<BottomContext>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  subheading?: Maybe<Scalars['String']>;
-  updated_at: Scalars['DateTime'];
-};
-
-
-export type BottomContextLocalizationsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-export type BottomContextAggregator = {
-  __typename?: 'BottomContextAggregator';
-  count?: Maybe<Scalars['Int']>;
-  totalCount?: Maybe<Scalars['Int']>;
-};
-
-export type BottomContextConnection = {
-  __typename?: 'BottomContextConnection';
-  aggregate?: Maybe<BottomContextAggregator>;
-  groupBy?: Maybe<BottomContextGroupBy>;
-  values?: Maybe<Array<Maybe<BottomContext>>>;
-};
-
-export type BottomContextConnectionCreated_At = {
-  __typename?: 'BottomContextConnectionCreated_at';
-  connection?: Maybe<BottomContextConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type BottomContextConnectionDevice_Summary = {
-  __typename?: 'BottomContextConnectionDevice_summary';
-  connection?: Maybe<BottomContextConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type BottomContextConnectionId = {
-  __typename?: 'BottomContextConnectionId';
-  connection?: Maybe<BottomContextConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type BottomContextConnectionLocale = {
-  __typename?: 'BottomContextConnectionLocale';
-  connection?: Maybe<BottomContextConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type BottomContextConnectionPublished_At = {
-  __typename?: 'BottomContextConnectionPublished_at';
-  connection?: Maybe<BottomContextConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type BottomContextConnectionSubheading = {
-  __typename?: 'BottomContextConnectionSubheading';
-  connection?: Maybe<BottomContextConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type BottomContextConnectionUpdated_At = {
-  __typename?: 'BottomContextConnectionUpdated_at';
-  connection?: Maybe<BottomContextConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type BottomContextGroupBy = {
-  __typename?: 'BottomContextGroupBy';
-  created_at?: Maybe<Array<Maybe<BottomContextConnectionCreated_At>>>;
-  device_summary?: Maybe<Array<Maybe<BottomContextConnectionDevice_Summary>>>;
-  id?: Maybe<Array<Maybe<BottomContextConnectionId>>>;
-  locale?: Maybe<Array<Maybe<BottomContextConnectionLocale>>>;
-  published_at?: Maybe<Array<Maybe<BottomContextConnectionPublished_At>>>;
-  subheading?: Maybe<Array<Maybe<BottomContextConnectionSubheading>>>;
-  updated_at?: Maybe<Array<Maybe<BottomContextConnectionUpdated_At>>>;
-};
-
-export type BottomContextInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  device_summary?: Maybe<Scalars['String']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  subheading?: Maybe<Scalars['String']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type Collection = {
-  __typename?: 'Collection';
-  children?: Maybe<Array<Maybe<Collection>>>;
-  created_at: Scalars['DateTime'];
-  description: Scalars['String'];
-  device_title?: Maybe<Scalars['String']>;
-  filters?: Maybe<Scalars['String']>;
-  handle: Scalars['String'];
-  id: Scalars['ID'];
-  image?: Maybe<UploadFile>;
-  legacy_plp_pageid?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Collection>>>;
-  metaDescription?: Maybe<Scalars['String']>;
-  parent?: Maybe<Collection>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  sections: Array<Maybe<CollectionSectionsDynamicZone>>;
-  tagline?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
-  updated_at: Scalars['DateTime'];
-};
-
-
-export type CollectionChildrenArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type CollectionLocalizationsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-export type CollectionAggregator = {
-  __typename?: 'CollectionAggregator';
-  avg?: Maybe<CollectionAggregatorAvg>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<CollectionAggregatorMax>;
-  min?: Maybe<CollectionAggregatorMin>;
-  sum?: Maybe<CollectionAggregatorSum>;
-  totalCount?: Maybe<Scalars['Int']>;
-};
-
-export type CollectionAggregatorAvg = {
-  __typename?: 'CollectionAggregatorAvg';
-  legacy_plp_pageid?: Maybe<Scalars['Float']>;
-};
-
-export type CollectionAggregatorMax = {
-  __typename?: 'CollectionAggregatorMax';
-  legacy_plp_pageid?: Maybe<Scalars['Float']>;
-};
-
-export type CollectionAggregatorMin = {
-  __typename?: 'CollectionAggregatorMin';
-  legacy_plp_pageid?: Maybe<Scalars['Float']>;
-};
-
-export type CollectionAggregatorSum = {
-  __typename?: 'CollectionAggregatorSum';
-  legacy_plp_pageid?: Maybe<Scalars['Float']>;
-};
-
-export type CollectionConnection = {
-  __typename?: 'CollectionConnection';
-  aggregate?: Maybe<CollectionAggregator>;
-  groupBy?: Maybe<CollectionGroupBy>;
-  values?: Maybe<Array<Maybe<Collection>>>;
-};
-
-export type CollectionConnectionCreated_At = {
-  __typename?: 'CollectionConnectionCreated_at';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type CollectionConnectionDescription = {
-  __typename?: 'CollectionConnectionDescription';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type CollectionConnectionDevice_Title = {
-  __typename?: 'CollectionConnectionDevice_title';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type CollectionConnectionFilters = {
-  __typename?: 'CollectionConnectionFilters';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type CollectionConnectionHandle = {
-  __typename?: 'CollectionConnectionHandle';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type CollectionConnectionId = {
-  __typename?: 'CollectionConnectionId';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type CollectionConnectionImage = {
-  __typename?: 'CollectionConnectionImage';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type CollectionConnectionLegacy_Plp_Pageid = {
-  __typename?: 'CollectionConnectionLegacy_plp_pageid';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['Int']>;
-};
-
-export type CollectionConnectionLocale = {
-  __typename?: 'CollectionConnectionLocale';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type CollectionConnectionMetaDescription = {
-  __typename?: 'CollectionConnectionMetaDescription';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type CollectionConnectionParent = {
-  __typename?: 'CollectionConnectionParent';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type CollectionConnectionPublished_At = {
-  __typename?: 'CollectionConnectionPublished_at';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type CollectionConnectionTagline = {
-  __typename?: 'CollectionConnectionTagline';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type CollectionConnectionTitle = {
-  __typename?: 'CollectionConnectionTitle';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type CollectionConnectionUpdated_At = {
-  __typename?: 'CollectionConnectionUpdated_at';
-  connection?: Maybe<CollectionConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type CollectionGroupBy = {
-  __typename?: 'CollectionGroupBy';
-  created_at?: Maybe<Array<Maybe<CollectionConnectionCreated_At>>>;
-  description?: Maybe<Array<Maybe<CollectionConnectionDescription>>>;
-  device_title?: Maybe<Array<Maybe<CollectionConnectionDevice_Title>>>;
-  filters?: Maybe<Array<Maybe<CollectionConnectionFilters>>>;
-  handle?: Maybe<Array<Maybe<CollectionConnectionHandle>>>;
-  id?: Maybe<Array<Maybe<CollectionConnectionId>>>;
-  image?: Maybe<Array<Maybe<CollectionConnectionImage>>>;
-  legacy_plp_pageid?: Maybe<Array<Maybe<CollectionConnectionLegacy_Plp_Pageid>>>;
-  locale?: Maybe<Array<Maybe<CollectionConnectionLocale>>>;
-  metaDescription?: Maybe<Array<Maybe<CollectionConnectionMetaDescription>>>;
-  parent?: Maybe<Array<Maybe<CollectionConnectionParent>>>;
-  published_at?: Maybe<Array<Maybe<CollectionConnectionPublished_At>>>;
-  tagline?: Maybe<Array<Maybe<CollectionConnectionTagline>>>;
-  title?: Maybe<Array<Maybe<CollectionConnectionTitle>>>;
-  updated_at?: Maybe<Array<Maybe<CollectionConnectionUpdated_At>>>;
-};
-
-export type CollectionInput = {
-  children?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  created_by?: Maybe<Scalars['ID']>;
-  description: Scalars['String'];
-  device_title?: Maybe<Scalars['String']>;
-  filters?: Maybe<Scalars['String']>;
-  handle: Scalars['String'];
-  image?: Maybe<Scalars['ID']>;
-  legacy_plp_pageid?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  metaDescription?: Maybe<Scalars['String']>;
-  parent?: Maybe<Scalars['ID']>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  sections: Array<Scalars['CollectionSectionsDynamicZoneInput']>;
-  tagline?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type CollectionSectionsDynamicZone = ComponentCollectionBanner | ComponentCollectionFeaturedCollection | ComponentCollectionFeaturedSubcollections | ComponentCollectionNewsletterForm | ComponentCollectionRelatedPosts;
-
-export type ComponentCollectionBanner = {
-  __typename?: 'ComponentCollectionBanner';
-  callToActionLabel: Scalars['String'];
-  description: Scalars['String'];
-  id: Scalars['ID'];
-  title: Scalars['String'];
-  url: Scalars['String'];
-};
-
-export type ComponentCollectionBannerInput = {
-  callToActionLabel: Scalars['String'];
-  description: Scalars['String'];
-  title: Scalars['String'];
-  url?: Maybe<Scalars['String']>;
-};
-
-export type ComponentCollectionFeaturedCollection = {
-  __typename?: 'ComponentCollectionFeaturedCollection';
-  featuredCollection?: Maybe<Collection>;
-  id: Scalars['ID'];
-};
-
-export type ComponentCollectionFeaturedCollectionInput = {
-  featuredCollection?: Maybe<Scalars['ID']>;
-};
-
-export type ComponentCollectionFeaturedSubcollectionInput = {
-  collections?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  inputPlaceholder: Scalars['String'];
+  subtitle: Scalars['String'];
   title: Scalars['String'];
 };
 
-export type ComponentCollectionFeaturedSubcollections = {
-  __typename?: 'ComponentCollectionFeaturedSubcollections';
-  collections?: Maybe<Array<Maybe<Collection>>>;
-  id: Scalars['ID'];
-  title: Scalars['String'];
-};
-
-
-export type ComponentCollectionFeaturedSubcollectionsCollectionsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-export type ComponentCollectionNewsletterForm = {
-  __typename?: 'ComponentCollectionNewsletterForm';
-  callToActionLabel: Scalars['String'];
-  description: Scalars['String'];
-  id: Scalars['ID'];
+export type ComponentGlobalNewsletterFormInput = {
+  callToActionButtonTitle?: Maybe<Scalars['String']>;
   inputPlaceholder?: Maybe<Scalars['String']>;
+  subtitle: Scalars['String'];
   title: Scalars['String'];
-};
-
-export type ComponentCollectionNewsletterFormInput = {
-  callToActionLabel?: Maybe<Scalars['String']>;
-  description: Scalars['String'];
-  inputPlaceholder?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
-};
-
-export type ComponentCollectionRelatedPostInput = {
-  tags?: Maybe<Scalars['String']>;
-};
-
-export type ComponentCollectionRelatedPosts = {
-  __typename?: 'ComponentCollectionRelatedPosts';
-  id: Scalars['ID'];
-  tags?: Maybe<Scalars['String']>;
 };
 
 export type ComponentMenuCollectionLink = {
   __typename?: 'ComponentMenuCollectionLink';
   id: Scalars['ID'];
-  linkedCollection?: Maybe<Collection>;
   name: Scalars['String'];
+  productList?: Maybe<ProductList>;
 };
 
 export type ComponentMenuCollectionLinkInput = {
-  linkedCollection?: Maybe<Scalars['ID']>;
   name: Scalars['String'];
+  productList?: Maybe<Scalars['ID']>;
 };
 
 export type ComponentMenuLink = {
@@ -436,19 +78,83 @@ export type ComponentMenuLinkInput = {
 export type ComponentMenuLinkWithImage = {
   __typename?: 'ComponentMenuLinkWithImage';
   id: Scalars['ID'];
-  image?: Maybe<UploadFile>;
+  image?: Maybe<Array<Maybe<UploadFile>>>;
   name: Scalars['String'];
   url: Scalars['String'];
+};
+
+
+export type ComponentMenuLinkWithImageImageArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  sort?: Maybe<Scalars['String']>;
+  start?: Maybe<Scalars['Int']>;
+  where?: Maybe<Scalars['JSON']>;
 };
 
 export type ComponentMenuLinkWithImageInput = {
-  image?: Maybe<Scalars['ID']>;
+  image?: Maybe<Array<Maybe<Scalars['ID']>>>;
   name: Scalars['String'];
   url: Scalars['String'];
 };
 
-export type ComponentSettingsFooter = {
-  __typename?: 'ComponentSettingsFooter';
+export type ComponentProductListBanner = {
+  __typename?: 'ComponentProductListBanner';
+  callToActionLabel: Scalars['String'];
+  description: Scalars['String'];
+  id: Scalars['ID'];
+  title: Scalars['String'];
+  url: Scalars['String'];
+};
+
+export type ComponentProductListBannerInput = {
+  callToActionLabel: Scalars['String'];
+  description: Scalars['String'];
+  title: Scalars['String'];
+  url: Scalars['String'];
+};
+
+export type ComponentProductListFeaturedProductList = {
+  __typename?: 'ComponentProductListFeaturedProductList';
+  id: Scalars['ID'];
+  productList?: Maybe<ProductList>;
+};
+
+export type ComponentProductListFeaturedProductListInput = {
+  productList?: Maybe<Scalars['ID']>;
+};
+
+export type ComponentProductListLinkedProductListSet = {
+  __typename?: 'ComponentProductListLinkedProductListSet';
+  id: Scalars['ID'];
+  productLists?: Maybe<Array<Maybe<ProductList>>>;
+  title: Scalars['String'];
+};
+
+
+export type ComponentProductListLinkedProductListSetProductListsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  sort?: Maybe<Scalars['String']>;
+  start?: Maybe<Scalars['Int']>;
+  where?: Maybe<Scalars['JSON']>;
+};
+
+export type ComponentProductListLinkedProductListSetInput = {
+  productLists?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  title: Scalars['String'];
+};
+
+export type ComponentProductListRelatedPostInput = {
+  tags?: Maybe<Scalars['String']>;
+};
+
+export type ComponentProductListRelatedPosts = {
+  __typename?: 'ComponentProductListRelatedPosts';
+  id: Scalars['ID'];
+  tags?: Maybe<Scalars['String']>;
+};
+
+export type ComponentStoreFooter = {
+  __typename?: 'ComponentStoreFooter';
   bottomMenu?: Maybe<Menu>;
   id: Scalars['ID'];
   menu1?: Maybe<Menu>;
@@ -456,43 +162,11 @@ export type ComponentSettingsFooter = {
   partners?: Maybe<Menu>;
 };
 
-export type ComponentSettingsFooterInput = {
+export type ComponentStoreFooterInput = {
   bottomMenu?: Maybe<Scalars['ID']>;
   menu1?: Maybe<Scalars['ID']>;
   menu2?: Maybe<Scalars['ID']>;
   partners?: Maybe<Scalars['ID']>;
-};
-
-export type ComponentSettingsPartner = {
-  __typename?: 'ComponentSettingsPartner';
-  id: Scalars['ID'];
-  logo?: Maybe<UploadFile>;
-  name: Scalars['String'];
-  url: Scalars['String'];
-};
-
-export type ComponentSettingsPartnerInput = {
-  logo?: Maybe<Scalars['ID']>;
-  name: Scalars['String'];
-  url: Scalars['String'];
-};
-
-export type ComponentSettingsSocial = {
-  __typename?: 'ComponentSettingsSocial';
-  facebook?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  instagram?: Maybe<Scalars['String']>;
-  repairOrg?: Maybe<Scalars['String']>;
-  twitter?: Maybe<Scalars['String']>;
-  youtube?: Maybe<Scalars['String']>;
-};
-
-export type ComponentSettingsSocialInput = {
-  facebook?: Maybe<Scalars['String']>;
-  instagram?: Maybe<Scalars['String']>;
-  repairOrg?: Maybe<Scalars['String']>;
-  twitter?: Maybe<Scalars['String']>;
-  youtube?: Maybe<Scalars['String']>;
 };
 
 export type ComponentStoreShopifySettingInput = {
@@ -507,443 +181,31 @@ export type ComponentStoreShopifySettings = {
   storefrontDomain: Scalars['String'];
 };
 
-export type Device = {
-  __typename?: 'Device';
-  canonical_override?: Maybe<Scalars['String']>;
-  created_at: Scalars['DateTime'];
-  device: Scalars['String'];
-  device_summary?: Maybe<BottomContext>;
-  faq_section?: Maybe<FaqSection>;
+export type ComponentStoreSocialMediaAccountInput = {
+  facebook?: Maybe<Scalars['String']>;
+  instagram?: Maybe<Scalars['String']>;
+  repairOrg?: Maybe<Scalars['String']>;
+  twitter?: Maybe<Scalars['String']>;
+  youtube?: Maybe<Scalars['String']>;
+};
+
+export type ComponentStoreSocialMediaAccounts = {
+  __typename?: 'ComponentStoreSocialMediaAccounts';
+  facebook?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
-  image?: Maybe<Array<Maybe<UploadFile>>>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Device>>>;
-  meta_description?: Maybe<Scalars['String']>;
-  part_type?: Maybe<Scalars['String']>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  subheading?: Maybe<Scalars['String']>;
-  summary?: Maybe<Scalars['String']>;
-  updated_at: Scalars['DateTime'];
+  instagram?: Maybe<Scalars['String']>;
+  repairOrg?: Maybe<Scalars['String']>;
+  twitter?: Maybe<Scalars['String']>;
+  youtube?: Maybe<Scalars['String']>;
 };
 
-
-export type DeviceImageArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type DeviceLocalizationsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-export type DeviceAggregator = {
-  __typename?: 'DeviceAggregator';
-  count?: Maybe<Scalars['Int']>;
-  totalCount?: Maybe<Scalars['Int']>;
-};
-
-export type DeviceConnection = {
-  __typename?: 'DeviceConnection';
-  aggregate?: Maybe<DeviceAggregator>;
-  groupBy?: Maybe<DeviceGroupBy>;
-  values?: Maybe<Array<Maybe<Device>>>;
-};
-
-export type DeviceConnectionCanonical_Override = {
-  __typename?: 'DeviceConnectionCanonical_override';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type DeviceConnectionCreated_At = {
-  __typename?: 'DeviceConnectionCreated_at';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type DeviceConnectionDevice = {
-  __typename?: 'DeviceConnectionDevice';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type DeviceConnectionDevice_Summary = {
-  __typename?: 'DeviceConnectionDevice_summary';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type DeviceConnectionFaq_Section = {
-  __typename?: 'DeviceConnectionFaq_section';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type DeviceConnectionId = {
-  __typename?: 'DeviceConnectionId';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type DeviceConnectionLocale = {
-  __typename?: 'DeviceConnectionLocale';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type DeviceConnectionMeta_Description = {
-  __typename?: 'DeviceConnectionMeta_description';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type DeviceConnectionPart_Type = {
-  __typename?: 'DeviceConnectionPart_type';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type DeviceConnectionPublished_At = {
-  __typename?: 'DeviceConnectionPublished_at';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type DeviceConnectionSubheading = {
-  __typename?: 'DeviceConnectionSubheading';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type DeviceConnectionSummary = {
-  __typename?: 'DeviceConnectionSummary';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type DeviceConnectionUpdated_At = {
-  __typename?: 'DeviceConnectionUpdated_at';
-  connection?: Maybe<DeviceConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type DeviceGroupBy = {
-  __typename?: 'DeviceGroupBy';
-  canonical_override?: Maybe<Array<Maybe<DeviceConnectionCanonical_Override>>>;
-  created_at?: Maybe<Array<Maybe<DeviceConnectionCreated_At>>>;
-  device?: Maybe<Array<Maybe<DeviceConnectionDevice>>>;
-  device_summary?: Maybe<Array<Maybe<DeviceConnectionDevice_Summary>>>;
-  faq_section?: Maybe<Array<Maybe<DeviceConnectionFaq_Section>>>;
-  id?: Maybe<Array<Maybe<DeviceConnectionId>>>;
-  locale?: Maybe<Array<Maybe<DeviceConnectionLocale>>>;
-  meta_description?: Maybe<Array<Maybe<DeviceConnectionMeta_Description>>>;
-  part_type?: Maybe<Array<Maybe<DeviceConnectionPart_Type>>>;
-  published_at?: Maybe<Array<Maybe<DeviceConnectionPublished_At>>>;
-  subheading?: Maybe<Array<Maybe<DeviceConnectionSubheading>>>;
-  summary?: Maybe<Array<Maybe<DeviceConnectionSummary>>>;
-  updated_at?: Maybe<Array<Maybe<DeviceConnectionUpdated_At>>>;
-};
-
-export type DeviceHandle = {
-  __typename?: 'DeviceHandle';
-  created_at: Scalars['DateTime'];
-  handle: Scalars['String'];
-  id: Scalars['ID'];
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_at: Scalars['DateTime'];
-};
-
-export type DeviceHandleAggregator = {
-  __typename?: 'DeviceHandleAggregator';
-  count?: Maybe<Scalars['Int']>;
-  totalCount?: Maybe<Scalars['Int']>;
-};
-
-export type DeviceHandleConnection = {
-  __typename?: 'DeviceHandleConnection';
-  aggregate?: Maybe<DeviceHandleAggregator>;
-  groupBy?: Maybe<DeviceHandleGroupBy>;
-  values?: Maybe<Array<Maybe<DeviceHandle>>>;
-};
-
-export type DeviceHandleConnectionCreated_At = {
-  __typename?: 'DeviceHandleConnectionCreated_at';
-  connection?: Maybe<DeviceHandleConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type DeviceHandleConnectionHandle = {
-  __typename?: 'DeviceHandleConnectionHandle';
-  connection?: Maybe<DeviceHandleConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type DeviceHandleConnectionId = {
-  __typename?: 'DeviceHandleConnectionId';
-  connection?: Maybe<DeviceHandleConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type DeviceHandleConnectionPublished_At = {
-  __typename?: 'DeviceHandleConnectionPublished_at';
-  connection?: Maybe<DeviceHandleConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type DeviceHandleConnectionUpdated_At = {
-  __typename?: 'DeviceHandleConnectionUpdated_at';
-  connection?: Maybe<DeviceHandleConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type DeviceHandleGroupBy = {
-  __typename?: 'DeviceHandleGroupBy';
-  created_at?: Maybe<Array<Maybe<DeviceHandleConnectionCreated_At>>>;
-  handle?: Maybe<Array<Maybe<DeviceHandleConnectionHandle>>>;
-  id?: Maybe<Array<Maybe<DeviceHandleConnectionId>>>;
-  published_at?: Maybe<Array<Maybe<DeviceHandleConnectionPublished_At>>>;
-  updated_at?: Maybe<Array<Maybe<DeviceHandleConnectionUpdated_At>>>;
-};
-
-export type DeviceHandleInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  handle: Scalars['String'];
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type DeviceInput = {
-  canonical_override?: Maybe<Scalars['String']>;
-  created_by?: Maybe<Scalars['ID']>;
-  device: Scalars['String'];
-  device_summary?: Maybe<Scalars['ID']>;
-  faq_section?: Maybe<Scalars['ID']>;
-  image?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  meta_description?: Maybe<Scalars['String']>;
-  part_type?: Maybe<Scalars['String']>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  subheading?: Maybe<Scalars['String']>;
-  summary?: Maybe<Scalars['String']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type Faq = {
-  __typename?: 'Faq';
-  Answer?: Maybe<Scalars['String']>;
-  Question?: Maybe<Scalars['String']>;
-  created_at: Scalars['DateTime'];
-  id: Scalars['ID'];
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Faq>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_at: Scalars['DateTime'];
-};
-
-
-export type FaqLocalizationsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-export type FaqAggregator = {
-  __typename?: 'FaqAggregator';
-  count?: Maybe<Scalars['Int']>;
-  totalCount?: Maybe<Scalars['Int']>;
-};
-
-export type FaqConnection = {
-  __typename?: 'FaqConnection';
-  aggregate?: Maybe<FaqAggregator>;
-  groupBy?: Maybe<FaqGroupBy>;
-  values?: Maybe<Array<Maybe<Faq>>>;
-};
-
-export type FaqConnectionAnswer = {
-  __typename?: 'FaqConnectionAnswer';
-  connection?: Maybe<FaqConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type FaqConnectionCreated_At = {
-  __typename?: 'FaqConnectionCreated_at';
-  connection?: Maybe<FaqConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type FaqConnectionId = {
-  __typename?: 'FaqConnectionId';
-  connection?: Maybe<FaqConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type FaqConnectionLocale = {
-  __typename?: 'FaqConnectionLocale';
-  connection?: Maybe<FaqConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type FaqConnectionPublished_At = {
-  __typename?: 'FaqConnectionPublished_at';
-  connection?: Maybe<FaqConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type FaqConnectionQuestion = {
-  __typename?: 'FaqConnectionQuestion';
-  connection?: Maybe<FaqConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type FaqConnectionUpdated_At = {
-  __typename?: 'FaqConnectionUpdated_at';
-  connection?: Maybe<FaqConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type FaqGroupBy = {
-  __typename?: 'FaqGroupBy';
-  Answer?: Maybe<Array<Maybe<FaqConnectionAnswer>>>;
-  Question?: Maybe<Array<Maybe<FaqConnectionQuestion>>>;
-  created_at?: Maybe<Array<Maybe<FaqConnectionCreated_At>>>;
-  id?: Maybe<Array<Maybe<FaqConnectionId>>>;
-  locale?: Maybe<Array<Maybe<FaqConnectionLocale>>>;
-  published_at?: Maybe<Array<Maybe<FaqConnectionPublished_At>>>;
-  updated_at?: Maybe<Array<Maybe<FaqConnectionUpdated_At>>>;
-};
-
-export type FaqInput = {
-  Answer?: Maybe<Scalars['String']>;
-  Question?: Maybe<Scalars['String']>;
-  created_by?: Maybe<Scalars['ID']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type FaqSection = {
-  __typename?: 'FaqSection';
-  created_at: Scalars['DateTime'];
-  faq1?: Maybe<Faq>;
-  faq2?: Maybe<Faq>;
-  faq3?: Maybe<Faq>;
-  heading?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<FaqSection>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_at: Scalars['DateTime'];
-};
-
-
-export type FaqSectionLocalizationsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-export type FaqSectionAggregator = {
-  __typename?: 'FaqSectionAggregator';
-  count?: Maybe<Scalars['Int']>;
-  totalCount?: Maybe<Scalars['Int']>;
-};
-
-export type FaqSectionConnection = {
-  __typename?: 'FaqSectionConnection';
-  aggregate?: Maybe<FaqSectionAggregator>;
-  groupBy?: Maybe<FaqSectionGroupBy>;
-  values?: Maybe<Array<Maybe<FaqSection>>>;
-};
-
-export type FaqSectionConnectionCreated_At = {
-  __typename?: 'FaqSectionConnectionCreated_at';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type FaqSectionConnectionFaq1 = {
-  __typename?: 'FaqSectionConnectionFaq1';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type FaqSectionConnectionFaq2 = {
-  __typename?: 'FaqSectionConnectionFaq2';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type FaqSectionConnectionFaq3 = {
-  __typename?: 'FaqSectionConnectionFaq3';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type FaqSectionConnectionHeading = {
-  __typename?: 'FaqSectionConnectionHeading';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type FaqSectionConnectionId = {
-  __typename?: 'FaqSectionConnectionId';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type FaqSectionConnectionLocale = {
-  __typename?: 'FaqSectionConnectionLocale';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type FaqSectionConnectionPublished_At = {
-  __typename?: 'FaqSectionConnectionPublished_at';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type FaqSectionConnectionUpdated_At = {
-  __typename?: 'FaqSectionConnectionUpdated_at';
-  connection?: Maybe<FaqSectionConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type FaqSectionGroupBy = {
-  __typename?: 'FaqSectionGroupBy';
-  created_at?: Maybe<Array<Maybe<FaqSectionConnectionCreated_At>>>;
-  faq1?: Maybe<Array<Maybe<FaqSectionConnectionFaq1>>>;
-  faq2?: Maybe<Array<Maybe<FaqSectionConnectionFaq2>>>;
-  faq3?: Maybe<Array<Maybe<FaqSectionConnectionFaq3>>>;
-  heading?: Maybe<Array<Maybe<FaqSectionConnectionHeading>>>;
-  id?: Maybe<Array<Maybe<FaqSectionConnectionId>>>;
-  locale?: Maybe<Array<Maybe<FaqSectionConnectionLocale>>>;
-  published_at?: Maybe<Array<Maybe<FaqSectionConnectionPublished_At>>>;
-  updated_at?: Maybe<Array<Maybe<FaqSectionConnectionUpdated_At>>>;
-};
-
-export type FaqSectionInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  faq1?: Maybe<Scalars['ID']>;
-  faq2?: Maybe<Scalars['ID']>;
-  faq3?: Maybe<Scalars['ID']>;
-  heading?: Maybe<Scalars['String']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
+export enum Enum_Store_Currency {
+  Aud = 'AUD',
+  Cad = 'CAD',
+  Eur = 'EUR',
+  Gbp = 'GBP',
+  Usd = 'USD'
+}
 
 export type FileInfoInput = {
   alternativeText?: Maybe<Scalars['String']>;
@@ -971,72 +233,32 @@ export type FileInput = {
   width?: Maybe<Scalars['Int']>;
 };
 
-export type FunFactInput = {
-  content?: Maybe<Scalars['String']>;
-  created_by?: Maybe<Scalars['ID']>;
-  title: Scalars['String'];
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type FunFacts = {
-  __typename?: 'FunFacts';
-  content?: Maybe<Scalars['String']>;
+export type Global = {
+  __typename?: 'Global';
   created_at: Scalars['DateTime'];
   id: Scalars['ID'];
-  title: Scalars['String'];
+  locale?: Maybe<Scalars['String']>;
+  localizations?: Maybe<Array<Maybe<Global>>>;
+  newsletterForm?: Maybe<ComponentGlobalNewsletterForm>;
+  published_at?: Maybe<Scalars['DateTime']>;
   updated_at: Scalars['DateTime'];
 };
 
-export type FunFactsAggregator = {
-  __typename?: 'FunFactsAggregator';
-  count?: Maybe<Scalars['Int']>;
-  totalCount?: Maybe<Scalars['Int']>;
+
+export type GlobalLocalizationsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  sort?: Maybe<Scalars['String']>;
+  start?: Maybe<Scalars['Int']>;
+  where?: Maybe<Scalars['JSON']>;
 };
 
-export type FunFactsConnection = {
-  __typename?: 'FunFactsConnection';
-  aggregate?: Maybe<FunFactsAggregator>;
-  groupBy?: Maybe<FunFactsGroupBy>;
-  values?: Maybe<Array<Maybe<FunFacts>>>;
-};
-
-export type FunFactsConnectionContent = {
-  __typename?: 'FunFactsConnectionContent';
-  connection?: Maybe<FunFactsConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type FunFactsConnectionCreated_At = {
-  __typename?: 'FunFactsConnectionCreated_at';
-  connection?: Maybe<FunFactsConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type FunFactsConnectionId = {
-  __typename?: 'FunFactsConnectionId';
-  connection?: Maybe<FunFactsConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type FunFactsConnectionTitle = {
-  __typename?: 'FunFactsConnectionTitle';
-  connection?: Maybe<FunFactsConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type FunFactsConnectionUpdated_At = {
-  __typename?: 'FunFactsConnectionUpdated_at';
-  connection?: Maybe<FunFactsConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type FunFactsGroupBy = {
-  __typename?: 'FunFactsGroupBy';
-  content?: Maybe<Array<Maybe<FunFactsConnectionContent>>>;
-  created_at?: Maybe<Array<Maybe<FunFactsConnectionCreated_At>>>;
-  id?: Maybe<Array<Maybe<FunFactsConnectionId>>>;
-  title?: Maybe<Array<Maybe<FunFactsConnectionTitle>>>;
-  updated_at?: Maybe<Array<Maybe<FunFactsConnectionUpdated_At>>>;
+export type GlobalInput = {
+  created_by?: Maybe<Scalars['ID']>;
+  locale?: Maybe<Scalars['String']>;
+  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  newsletterForm: ComponentGlobalNewsletterFormInput;
+  published_at?: Maybe<Scalars['DateTime']>;
+  updated_by?: Maybe<Scalars['ID']>;
 };
 
 export type I18NLocale = {
@@ -1150,47 +372,28 @@ export type MenuInput = {
 
 export type MenuItemsDynamicZone = ComponentMenuCollectionLink | ComponentMenuLink | ComponentMenuLinkWithImage;
 
-export type Morph = BottomContext | BottomContextAggregator | BottomContextConnection | BottomContextConnectionCreated_At | BottomContextConnectionDevice_Summary | BottomContextConnectionId | BottomContextConnectionLocale | BottomContextConnectionPublished_At | BottomContextConnectionSubheading | BottomContextConnectionUpdated_At | BottomContextGroupBy | Collection | CollectionAggregator | CollectionAggregatorAvg | CollectionAggregatorMax | CollectionAggregatorMin | CollectionAggregatorSum | CollectionConnection | CollectionConnectionCreated_At | CollectionConnectionDescription | CollectionConnectionDevice_Title | CollectionConnectionFilters | CollectionConnectionHandle | CollectionConnectionId | CollectionConnectionImage | CollectionConnectionLegacy_Plp_Pageid | CollectionConnectionLocale | CollectionConnectionMetaDescription | CollectionConnectionParent | CollectionConnectionPublished_At | CollectionConnectionTagline | CollectionConnectionTitle | CollectionConnectionUpdated_At | CollectionGroupBy | ComponentCollectionBanner | ComponentCollectionFeaturedCollection | ComponentCollectionFeaturedSubcollections | ComponentCollectionNewsletterForm | ComponentCollectionRelatedPosts | ComponentMenuCollectionLink | ComponentMenuLink | ComponentMenuLinkWithImage | ComponentSettingsFooter | ComponentSettingsPartner | ComponentSettingsSocial | ComponentStoreShopifySettings | Device | DeviceAggregator | DeviceConnection | DeviceConnectionCanonical_Override | DeviceConnectionCreated_At | DeviceConnectionDevice | DeviceConnectionDevice_Summary | DeviceConnectionFaq_Section | DeviceConnectionId | DeviceConnectionLocale | DeviceConnectionMeta_Description | DeviceConnectionPart_Type | DeviceConnectionPublished_At | DeviceConnectionSubheading | DeviceConnectionSummary | DeviceConnectionUpdated_At | DeviceGroupBy | DeviceHandle | DeviceHandleAggregator | DeviceHandleConnection | DeviceHandleConnectionCreated_At | DeviceHandleConnectionHandle | DeviceHandleConnectionId | DeviceHandleConnectionPublished_At | DeviceHandleConnectionUpdated_At | DeviceHandleGroupBy | Faq | FaqAggregator | FaqConnection | FaqConnectionAnswer | FaqConnectionCreated_At | FaqConnectionId | FaqConnectionLocale | FaqConnectionPublished_At | FaqConnectionQuestion | FaqConnectionUpdated_At | FaqGroupBy | FaqSection | FaqSectionAggregator | FaqSectionConnection | FaqSectionConnectionCreated_At | FaqSectionConnectionFaq1 | FaqSectionConnectionFaq2 | FaqSectionConnectionFaq3 | FaqSectionConnectionHeading | FaqSectionConnectionId | FaqSectionConnectionLocale | FaqSectionConnectionPublished_At | FaqSectionConnectionUpdated_At | FaqSectionGroupBy | FunFacts | FunFactsAggregator | FunFactsConnection | FunFactsConnectionContent | FunFactsConnectionCreated_At | FunFactsConnectionId | FunFactsConnectionTitle | FunFactsConnectionUpdated_At | FunFactsGroupBy | I18NLocale | Menu | MenuAggregator | MenuConnection | MenuConnectionCreated_At | MenuConnectionId | MenuConnectionLocale | MenuConnectionPublished_At | MenuConnectionTitle | MenuConnectionUpdated_At | MenuGroupBy | PartCollections | PartCollectionsAggregator | PartCollectionsConnection | PartCollectionsConnectionCreated_At | PartCollectionsConnectionDetails | PartCollectionsConnectionDevice_Handle | PartCollectionsConnectionId | PartCollectionsConnectionMeta_Description | PartCollectionsConnectionPublished_At | PartCollectionsConnectionSummary | PartCollectionsConnectionTitle | PartCollectionsConnectionUpdated_At | PartCollectionsGroupBy | Store | StoreAggregator | StoreConnection | StoreConnectionCode | StoreConnectionCreated_At | StoreConnectionCurrency | StoreConnectionFooter | StoreConnectionId | StoreConnectionName | StoreConnectionPublished_At | StoreConnectionShopifySettings | StoreConnectionSocialMediaAccounts | StoreConnectionStore_Settings | StoreConnectionUpdated_At | StoreConnectionUrl | StoreGroupBy | StoreSettings | StoreSettingsAggregator | StoreSettingsConnection | StoreSettingsConnectionCreated_At | StoreSettingsConnectionFooter | StoreSettingsConnectionId | StoreSettingsConnectionLocale | StoreSettingsConnectionPublished_At | StoreSettingsConnectionSocialMediaAccounts | StoreSettingsConnectionStore | StoreSettingsConnectionUpdated_At | StoreSettingsGroupBy | UploadFile | UploadFileAggregator | UploadFileAggregatorAvg | UploadFileAggregatorMax | UploadFileAggregatorMin | UploadFileAggregatorSum | UploadFileConnection | UploadFileConnectionAlternativeText | UploadFileConnectionCaption | UploadFileConnectionCreated_At | UploadFileConnectionExt | UploadFileConnectionFormats | UploadFileConnectionHash | UploadFileConnectionHeight | UploadFileConnectionId | UploadFileConnectionMime | UploadFileConnectionName | UploadFileConnectionPreviewUrl | UploadFileConnectionProvider | UploadFileConnectionProvider_Metadata | UploadFileConnectionSize | UploadFileConnectionUpdated_At | UploadFileConnectionUrl | UploadFileConnectionWidth | UploadFileGroupBy | UserPermissionsPasswordPayload | UsersPermissionsLoginPayload | UsersPermissionsMe | UsersPermissionsMeRole | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsRoleAggregator | UsersPermissionsRoleConnection | UsersPermissionsRoleConnectionDescription | UsersPermissionsRoleConnectionId | UsersPermissionsRoleConnectionName | UsersPermissionsRoleConnectionType | UsersPermissionsRoleGroupBy | UsersPermissionsUser | UsersPermissionsUserAggregator | UsersPermissionsUserConnection | UsersPermissionsUserConnectionBlocked | UsersPermissionsUserConnectionConfirmed | UsersPermissionsUserConnectionCreated_At | UsersPermissionsUserConnectionEmail | UsersPermissionsUserConnectionId | UsersPermissionsUserConnectionProvider | UsersPermissionsUserConnectionRole | UsersPermissionsUserConnectionUpdated_At | UsersPermissionsUserConnectionUsername | UsersPermissionsUserGroupBy | CreateBottomContextPayload | CreateCollectionPayload | CreateDeviceHandlePayload | CreateDevicePayload | CreateFaqPayload | CreateFaqSectionPayload | CreateFunFactPayload | CreateMenuPayload | CreatePartCollectionPayload | CreateRolePayload | CreateStorePayload | CreateStoreSettingPayload | CreateUserPayload | DeleteBottomContextPayload | DeleteCollectionPayload | DeleteDeviceHandlePayload | DeleteDevicePayload | DeleteFaqPayload | DeleteFaqSectionPayload | DeleteFilePayload | DeleteFunFactPayload | DeleteMenuPayload | DeletePartCollectionPayload | DeleteRolePayload | DeleteStorePayload | DeleteStoreSettingPayload | DeleteUserPayload | UpdateBottomContextPayload | UpdateCollectionPayload | UpdateDeviceHandlePayload | UpdateDevicePayload | UpdateFaqPayload | UpdateFaqSectionPayload | UpdateFunFactPayload | UpdateMenuPayload | UpdatePartCollectionPayload | UpdateRolePayload | UpdateStorePayload | UpdateStoreSettingPayload | UpdateUserPayload;
+export type Morph = ComponentGlobalNewsletterForm | ComponentMenuCollectionLink | ComponentMenuLink | ComponentMenuLinkWithImage | ComponentProductListBanner | ComponentProductListFeaturedProductList | ComponentProductListLinkedProductListSet | ComponentProductListRelatedPosts | ComponentStoreFooter | ComponentStoreShopifySettings | ComponentStoreSocialMediaAccounts | Global | I18NLocale | Menu | MenuAggregator | MenuConnection | MenuConnectionCreated_At | MenuConnectionId | MenuConnectionLocale | MenuConnectionPublished_At | MenuConnectionTitle | MenuConnectionUpdated_At | MenuGroupBy | ProductList | ProductListAggregator | ProductListAggregatorAvg | ProductListAggregatorMax | ProductListAggregatorMin | ProductListAggregatorSum | ProductListConnection | ProductListConnectionCreated_At | ProductListConnectionDescription | ProductListConnectionDeviceTitle | ProductListConnectionExcludeFromHierarchyDisplay | ProductListConnectionFilters | ProductListConnectionHandle | ProductListConnectionId | ProductListConnectionImage | ProductListConnectionLegacyPageId | ProductListConnectionLocale | ProductListConnectionMetaDescription | ProductListConnectionParent | ProductListConnectionPublished_At | ProductListConnectionTagline | ProductListConnectionTitle | ProductListConnectionUpdated_At | ProductListGroupBy | Store | StoreAggregator | StoreConnection | StoreConnectionCode | StoreConnectionCreated_At | StoreConnectionCurrency | StoreConnectionFooter | StoreConnectionId | StoreConnectionName | StoreConnectionPublished_At | StoreConnectionShopifySettings | StoreConnectionSocialMediaAccounts | StoreConnectionUpdated_At | StoreConnectionUrl | StoreGroupBy | UploadFile | UploadFileAggregator | UploadFileAggregatorAvg | UploadFileAggregatorMax | UploadFileAggregatorMin | UploadFileAggregatorSum | UploadFileConnection | UploadFileConnectionAlternativeText | UploadFileConnectionCaption | UploadFileConnectionCreated_At | UploadFileConnectionExt | UploadFileConnectionFormats | UploadFileConnectionHash | UploadFileConnectionHeight | UploadFileConnectionId | UploadFileConnectionMime | UploadFileConnectionName | UploadFileConnectionPreviewUrl | UploadFileConnectionProvider | UploadFileConnectionProvider_Metadata | UploadFileConnectionSize | UploadFileConnectionUpdated_At | UploadFileConnectionUrl | UploadFileConnectionWidth | UploadFileGroupBy | UserPermissionsPasswordPayload | UsersPermissionsLoginPayload | UsersPermissionsMe | UsersPermissionsMeRole | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsRoleAggregator | UsersPermissionsRoleConnection | UsersPermissionsRoleConnectionDescription | UsersPermissionsRoleConnectionId | UsersPermissionsRoleConnectionName | UsersPermissionsRoleConnectionType | UsersPermissionsRoleGroupBy | UsersPermissionsUser | UsersPermissionsUserAggregator | UsersPermissionsUserConnection | UsersPermissionsUserConnectionBlocked | UsersPermissionsUserConnectionConfirmed | UsersPermissionsUserConnectionCreated_At | UsersPermissionsUserConnectionEmail | UsersPermissionsUserConnectionId | UsersPermissionsUserConnectionProvider | UsersPermissionsUserConnectionRole | UsersPermissionsUserConnectionUpdated_At | UsersPermissionsUserConnectionUsername | UsersPermissionsUserGroupBy | CreateMenuPayload | CreateProductListPayload | CreateRolePayload | CreateStorePayload | CreateUserPayload | DeleteFilePayload | DeleteGlobalPayload | DeleteMenuPayload | DeleteProductListPayload | DeleteRolePayload | DeleteStorePayload | DeleteUserPayload | UpdateGlobalPayload | UpdateMenuPayload | UpdateProductListPayload | UpdateRolePayload | UpdateStorePayload | UpdateUserPayload;
 
 export type Mutation = {
   __typename?: 'Mutation';
-  createBottomContext?: Maybe<CreateBottomContextPayload>;
-  createBottomContextLocalization: BottomContext;
-  createCollection?: Maybe<CreateCollectionPayload>;
-  createCollectionLocalization: Collection;
-  createDevice?: Maybe<CreateDevicePayload>;
-  createDeviceHandle?: Maybe<CreateDeviceHandlePayload>;
-  createDeviceLocalization: Device;
-  createFaq?: Maybe<CreateFaqPayload>;
-  createFaqLocalization: Faq;
-  createFaqSection?: Maybe<CreateFaqSectionPayload>;
-  createFaqSectionLocalization: FaqSection;
-  createFunFact?: Maybe<CreateFunFactPayload>;
+  createGlobalLocalization: Global;
   createMenu?: Maybe<CreateMenuPayload>;
   createMenuLocalization: Menu;
-  createPartCollection?: Maybe<CreatePartCollectionPayload>;
+  createProductList?: Maybe<CreateProductListPayload>;
+  createProductListLocalization: ProductList;
   /** Create a new role */
   createRole?: Maybe<CreateRolePayload>;
   createStore?: Maybe<CreateStorePayload>;
-  createStoreSetting?: Maybe<CreateStoreSettingPayload>;
-  createStoreSettingLocalization: StoreSettings;
   /** Create a new user */
   createUser?: Maybe<CreateUserPayload>;
-  deleteBottomContext?: Maybe<DeleteBottomContextPayload>;
-  deleteCollection?: Maybe<DeleteCollectionPayload>;
-  deleteDevice?: Maybe<DeleteDevicePayload>;
-  deleteDeviceHandle?: Maybe<DeleteDeviceHandlePayload>;
-  deleteFaq?: Maybe<DeleteFaqPayload>;
-  deleteFaqSection?: Maybe<DeleteFaqSectionPayload>;
   /** Delete one file */
   deleteFile?: Maybe<DeleteFilePayload>;
-  deleteFunFact?: Maybe<DeleteFunFactPayload>;
+  deleteGlobal?: Maybe<DeleteGlobalPayload>;
   deleteMenu?: Maybe<DeleteMenuPayload>;
-  deletePartCollection?: Maybe<DeletePartCollectionPayload>;
+  deleteProductList?: Maybe<DeleteProductListPayload>;
   /** Delete an existing role */
   deleteRole?: Maybe<DeleteRolePayload>;
   deleteStore?: Maybe<DeleteStorePayload>;
-  deleteStoreSetting?: Maybe<DeleteStoreSettingPayload>;
   /** Delete an existing user */
   deleteUser?: Maybe<DeleteUserPayload>;
   emailConfirmation?: Maybe<UsersPermissionsLoginPayload>;
@@ -1199,83 +402,21 @@ export type Mutation = {
   multipleUpload: Array<Maybe<UploadFile>>;
   register: UsersPermissionsLoginPayload;
   resetPassword?: Maybe<UsersPermissionsLoginPayload>;
-  updateBottomContext?: Maybe<UpdateBottomContextPayload>;
-  updateCollection?: Maybe<UpdateCollectionPayload>;
-  updateDevice?: Maybe<UpdateDevicePayload>;
-  updateDeviceHandle?: Maybe<UpdateDeviceHandlePayload>;
-  updateFaq?: Maybe<UpdateFaqPayload>;
-  updateFaqSection?: Maybe<UpdateFaqSectionPayload>;
   updateFileInfo: UploadFile;
-  updateFunFact?: Maybe<UpdateFunFactPayload>;
+  updateGlobal?: Maybe<UpdateGlobalPayload>;
   updateMenu?: Maybe<UpdateMenuPayload>;
-  updatePartCollection?: Maybe<UpdatePartCollectionPayload>;
+  updateProductList?: Maybe<UpdateProductListPayload>;
   /** Update an existing role */
   updateRole?: Maybe<UpdateRolePayload>;
   updateStore?: Maybe<UpdateStorePayload>;
-  updateStoreSetting?: Maybe<UpdateStoreSettingPayload>;
   /** Update an existing user */
   updateUser?: Maybe<UpdateUserPayload>;
   upload: UploadFile;
 };
 
 
-export type MutationCreateBottomContextArgs = {
-  input?: Maybe<CreateBottomContextInput>;
-};
-
-
-export type MutationCreateBottomContextLocalizationArgs = {
-  input: UpdateBottomContextInput;
-};
-
-
-export type MutationCreateCollectionArgs = {
-  input?: Maybe<CreateCollectionInput>;
-};
-
-
-export type MutationCreateCollectionLocalizationArgs = {
-  input: UpdateCollectionInput;
-};
-
-
-export type MutationCreateDeviceArgs = {
-  input?: Maybe<CreateDeviceInput>;
-};
-
-
-export type MutationCreateDeviceHandleArgs = {
-  input?: Maybe<CreateDeviceHandleInput>;
-};
-
-
-export type MutationCreateDeviceLocalizationArgs = {
-  input: UpdateDeviceInput;
-};
-
-
-export type MutationCreateFaqArgs = {
-  input?: Maybe<CreateFaqInput>;
-};
-
-
-export type MutationCreateFaqLocalizationArgs = {
-  input: UpdateFaqInput;
-};
-
-
-export type MutationCreateFaqSectionArgs = {
-  input?: Maybe<CreateFaqSectionInput>;
-};
-
-
-export type MutationCreateFaqSectionLocalizationArgs = {
-  input: UpdateFaqSectionInput;
-};
-
-
-export type MutationCreateFunFactArgs = {
-  input?: Maybe<CreateFunFactInput>;
+export type MutationCreateGlobalLocalizationArgs = {
+  input: UpdateGlobalInput;
 };
 
 
@@ -1289,8 +430,13 @@ export type MutationCreateMenuLocalizationArgs = {
 };
 
 
-export type MutationCreatePartCollectionArgs = {
-  input?: Maybe<CreatePartCollectionInput>;
+export type MutationCreateProductListArgs = {
+  input?: Maybe<CreateProductListInput>;
+};
+
+
+export type MutationCreateProductListLocalizationArgs = {
+  input: UpdateProductListInput;
 };
 
 
@@ -1304,48 +450,8 @@ export type MutationCreateStoreArgs = {
 };
 
 
-export type MutationCreateStoreSettingArgs = {
-  input?: Maybe<CreateStoreSettingInput>;
-};
-
-
-export type MutationCreateStoreSettingLocalizationArgs = {
-  input: UpdateStoreSettingInput;
-};
-
-
 export type MutationCreateUserArgs = {
   input?: Maybe<CreateUserInput>;
-};
-
-
-export type MutationDeleteBottomContextArgs = {
-  input?: Maybe<DeleteBottomContextInput>;
-};
-
-
-export type MutationDeleteCollectionArgs = {
-  input?: Maybe<DeleteCollectionInput>;
-};
-
-
-export type MutationDeleteDeviceArgs = {
-  input?: Maybe<DeleteDeviceInput>;
-};
-
-
-export type MutationDeleteDeviceHandleArgs = {
-  input?: Maybe<DeleteDeviceHandleInput>;
-};
-
-
-export type MutationDeleteFaqArgs = {
-  input?: Maybe<DeleteFaqInput>;
-};
-
-
-export type MutationDeleteFaqSectionArgs = {
-  input?: Maybe<DeleteFaqSectionInput>;
 };
 
 
@@ -1354,8 +460,8 @@ export type MutationDeleteFileArgs = {
 };
 
 
-export type MutationDeleteFunFactArgs = {
-  input?: Maybe<DeleteFunFactInput>;
+export type MutationDeleteGlobalArgs = {
+  locale?: Maybe<Scalars['String']>;
 };
 
 
@@ -1364,8 +470,8 @@ export type MutationDeleteMenuArgs = {
 };
 
 
-export type MutationDeletePartCollectionArgs = {
-  input?: Maybe<DeletePartCollectionInput>;
+export type MutationDeleteProductListArgs = {
+  input?: Maybe<DeleteProductListInput>;
 };
 
 
@@ -1376,11 +482,6 @@ export type MutationDeleteRoleArgs = {
 
 export type MutationDeleteStoreArgs = {
   input?: Maybe<DeleteStoreInput>;
-};
-
-
-export type MutationDeleteStoreSettingArgs = {
-  input?: Maybe<DeleteStoreSettingInput>;
 };
 
 
@@ -1425,44 +526,15 @@ export type MutationResetPasswordArgs = {
 };
 
 
-export type MutationUpdateBottomContextArgs = {
-  input?: Maybe<UpdateBottomContextInput>;
-};
-
-
-export type MutationUpdateCollectionArgs = {
-  input?: Maybe<UpdateCollectionInput>;
-};
-
-
-export type MutationUpdateDeviceArgs = {
-  input?: Maybe<UpdateDeviceInput>;
-};
-
-
-export type MutationUpdateDeviceHandleArgs = {
-  input?: Maybe<UpdateDeviceHandleInput>;
-};
-
-
-export type MutationUpdateFaqArgs = {
-  input?: Maybe<UpdateFaqInput>;
-};
-
-
-export type MutationUpdateFaqSectionArgs = {
-  input?: Maybe<UpdateFaqSectionInput>;
-};
-
-
 export type MutationUpdateFileInfoArgs = {
   id: Scalars['ID'];
   info: FileInfoInput;
 };
 
 
-export type MutationUpdateFunFactArgs = {
-  input?: Maybe<UpdateFunFactInput>;
+export type MutationUpdateGlobalArgs = {
+  input?: Maybe<UpdateGlobalInput>;
+  locale?: Maybe<Scalars['String']>;
 };
 
 
@@ -1471,8 +543,8 @@ export type MutationUpdateMenuArgs = {
 };
 
 
-export type MutationUpdatePartCollectionArgs = {
-  input?: Maybe<UpdatePartCollectionInput>;
+export type MutationUpdateProductListArgs = {
+  input?: Maybe<UpdateProductListInput>;
 };
 
 
@@ -1483,11 +555,6 @@ export type MutationUpdateRoleArgs = {
 
 export type MutationUpdateStoreArgs = {
   input?: Maybe<UpdateStoreInput>;
-};
-
-
-export type MutationUpdateStoreSettingArgs = {
-  input?: Maybe<UpdateStoreSettingInput>;
 };
 
 
@@ -1505,109 +572,220 @@ export type MutationUploadArgs = {
   source?: Maybe<Scalars['String']>;
 };
 
-export type PartCollectionInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  details?: Maybe<Scalars['String']>;
-  device_handle: Scalars['String'];
-  meta_description?: Maybe<Scalars['String']>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  summary?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type PartCollections = {
-  __typename?: 'PartCollections';
+export type ProductList = {
+  __typename?: 'ProductList';
+  children?: Maybe<Array<Maybe<ProductList>>>;
   created_at: Scalars['DateTime'];
-  details?: Maybe<Scalars['String']>;
-  device_handle: Scalars['String'];
+  description: Scalars['String'];
+  deviceTitle?: Maybe<Scalars['String']>;
+  excludeFromHierarchyDisplay: Scalars['Boolean'];
+  filters?: Maybe<Scalars['String']>;
+  handle: Scalars['String'];
   id: Scalars['ID'];
-  meta_description?: Maybe<Scalars['String']>;
+  image?: Maybe<UploadFile>;
+  legacyPageId?: Maybe<Scalars['Int']>;
+  locale?: Maybe<Scalars['String']>;
+  localizations?: Maybe<Array<Maybe<ProductList>>>;
+  metaDescription?: Maybe<Scalars['String']>;
+  parent?: Maybe<ProductList>;
   published_at?: Maybe<Scalars['DateTime']>;
-  summary?: Maybe<Scalars['String']>;
+  sections: Array<Maybe<ProductListSectionsDynamicZone>>;
+  tagline?: Maybe<Scalars['String']>;
   title: Scalars['String'];
   updated_at: Scalars['DateTime'];
 };
 
-export type PartCollectionsAggregator = {
-  __typename?: 'PartCollectionsAggregator';
+
+export type ProductListChildrenArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  sort?: Maybe<Scalars['String']>;
+  start?: Maybe<Scalars['Int']>;
+  where?: Maybe<Scalars['JSON']>;
+};
+
+
+export type ProductListLocalizationsArgs = {
+  limit?: Maybe<Scalars['Int']>;
+  sort?: Maybe<Scalars['String']>;
+  start?: Maybe<Scalars['Int']>;
+  where?: Maybe<Scalars['JSON']>;
+};
+
+export type ProductListAggregator = {
+  __typename?: 'ProductListAggregator';
+  avg?: Maybe<ProductListAggregatorAvg>;
   count?: Maybe<Scalars['Int']>;
+  max?: Maybe<ProductListAggregatorMax>;
+  min?: Maybe<ProductListAggregatorMin>;
+  sum?: Maybe<ProductListAggregatorSum>;
   totalCount?: Maybe<Scalars['Int']>;
 };
 
-export type PartCollectionsConnection = {
-  __typename?: 'PartCollectionsConnection';
-  aggregate?: Maybe<PartCollectionsAggregator>;
-  groupBy?: Maybe<PartCollectionsGroupBy>;
-  values?: Maybe<Array<Maybe<PartCollections>>>;
+export type ProductListAggregatorAvg = {
+  __typename?: 'ProductListAggregatorAvg';
+  legacyPageId?: Maybe<Scalars['Float']>;
 };
 
-export type PartCollectionsConnectionCreated_At = {
-  __typename?: 'PartCollectionsConnectionCreated_at';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListAggregatorMax = {
+  __typename?: 'ProductListAggregatorMax';
+  legacyPageId?: Maybe<Scalars['Float']>;
+};
+
+export type ProductListAggregatorMin = {
+  __typename?: 'ProductListAggregatorMin';
+  legacyPageId?: Maybe<Scalars['Float']>;
+};
+
+export type ProductListAggregatorSum = {
+  __typename?: 'ProductListAggregatorSum';
+  legacyPageId?: Maybe<Scalars['Float']>;
+};
+
+export type ProductListConnection = {
+  __typename?: 'ProductListConnection';
+  aggregate?: Maybe<ProductListAggregator>;
+  groupBy?: Maybe<ProductListGroupBy>;
+  values?: Maybe<Array<Maybe<ProductList>>>;
+};
+
+export type ProductListConnectionCreated_At = {
+  __typename?: 'ProductListConnectionCreated_at';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['DateTime']>;
 };
 
-export type PartCollectionsConnectionDetails = {
-  __typename?: 'PartCollectionsConnectionDetails';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListConnectionDescription = {
+  __typename?: 'ProductListConnectionDescription';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['String']>;
 };
 
-export type PartCollectionsConnectionDevice_Handle = {
-  __typename?: 'PartCollectionsConnectionDevice_handle';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListConnectionDeviceTitle = {
+  __typename?: 'ProductListConnectionDeviceTitle';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['String']>;
 };
 
-export type PartCollectionsConnectionId = {
-  __typename?: 'PartCollectionsConnectionId';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListConnectionExcludeFromHierarchyDisplay = {
+  __typename?: 'ProductListConnectionExcludeFromHierarchyDisplay';
+  connection?: Maybe<ProductListConnection>;
+  key?: Maybe<Scalars['Boolean']>;
+};
+
+export type ProductListConnectionFilters = {
+  __typename?: 'ProductListConnectionFilters';
+  connection?: Maybe<ProductListConnection>;
+  key?: Maybe<Scalars['String']>;
+};
+
+export type ProductListConnectionHandle = {
+  __typename?: 'ProductListConnectionHandle';
+  connection?: Maybe<ProductListConnection>;
+  key?: Maybe<Scalars['String']>;
+};
+
+export type ProductListConnectionId = {
+  __typename?: 'ProductListConnectionId';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['ID']>;
 };
 
-export type PartCollectionsConnectionMeta_Description = {
-  __typename?: 'PartCollectionsConnectionMeta_description';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListConnectionImage = {
+  __typename?: 'ProductListConnectionImage';
+  connection?: Maybe<ProductListConnection>;
+  key?: Maybe<Scalars['ID']>;
+};
+
+export type ProductListConnectionLegacyPageId = {
+  __typename?: 'ProductListConnectionLegacyPageId';
+  connection?: Maybe<ProductListConnection>;
+  key?: Maybe<Scalars['Int']>;
+};
+
+export type ProductListConnectionLocale = {
+  __typename?: 'ProductListConnectionLocale';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['String']>;
 };
 
-export type PartCollectionsConnectionPublished_At = {
-  __typename?: 'PartCollectionsConnectionPublished_at';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListConnectionMetaDescription = {
+  __typename?: 'ProductListConnectionMetaDescription';
+  connection?: Maybe<ProductListConnection>;
+  key?: Maybe<Scalars['String']>;
+};
+
+export type ProductListConnectionParent = {
+  __typename?: 'ProductListConnectionParent';
+  connection?: Maybe<ProductListConnection>;
+  key?: Maybe<Scalars['ID']>;
+};
+
+export type ProductListConnectionPublished_At = {
+  __typename?: 'ProductListConnectionPublished_at';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['DateTime']>;
 };
 
-export type PartCollectionsConnectionSummary = {
-  __typename?: 'PartCollectionsConnectionSummary';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListConnectionTagline = {
+  __typename?: 'ProductListConnectionTagline';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['String']>;
 };
 
-export type PartCollectionsConnectionTitle = {
-  __typename?: 'PartCollectionsConnectionTitle';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListConnectionTitle = {
+  __typename?: 'ProductListConnectionTitle';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['String']>;
 };
 
-export type PartCollectionsConnectionUpdated_At = {
-  __typename?: 'PartCollectionsConnectionUpdated_at';
-  connection?: Maybe<PartCollectionsConnection>;
+export type ProductListConnectionUpdated_At = {
+  __typename?: 'ProductListConnectionUpdated_at';
+  connection?: Maybe<ProductListConnection>;
   key?: Maybe<Scalars['DateTime']>;
 };
 
-export type PartCollectionsGroupBy = {
-  __typename?: 'PartCollectionsGroupBy';
-  created_at?: Maybe<Array<Maybe<PartCollectionsConnectionCreated_At>>>;
-  details?: Maybe<Array<Maybe<PartCollectionsConnectionDetails>>>;
-  device_handle?: Maybe<Array<Maybe<PartCollectionsConnectionDevice_Handle>>>;
-  id?: Maybe<Array<Maybe<PartCollectionsConnectionId>>>;
-  meta_description?: Maybe<Array<Maybe<PartCollectionsConnectionMeta_Description>>>;
-  published_at?: Maybe<Array<Maybe<PartCollectionsConnectionPublished_At>>>;
-  summary?: Maybe<Array<Maybe<PartCollectionsConnectionSummary>>>;
-  title?: Maybe<Array<Maybe<PartCollectionsConnectionTitle>>>;
-  updated_at?: Maybe<Array<Maybe<PartCollectionsConnectionUpdated_At>>>;
+export type ProductListGroupBy = {
+  __typename?: 'ProductListGroupBy';
+  created_at?: Maybe<Array<Maybe<ProductListConnectionCreated_At>>>;
+  description?: Maybe<Array<Maybe<ProductListConnectionDescription>>>;
+  deviceTitle?: Maybe<Array<Maybe<ProductListConnectionDeviceTitle>>>;
+  excludeFromHierarchyDisplay?: Maybe<Array<Maybe<ProductListConnectionExcludeFromHierarchyDisplay>>>;
+  filters?: Maybe<Array<Maybe<ProductListConnectionFilters>>>;
+  handle?: Maybe<Array<Maybe<ProductListConnectionHandle>>>;
+  id?: Maybe<Array<Maybe<ProductListConnectionId>>>;
+  image?: Maybe<Array<Maybe<ProductListConnectionImage>>>;
+  legacyPageId?: Maybe<Array<Maybe<ProductListConnectionLegacyPageId>>>;
+  locale?: Maybe<Array<Maybe<ProductListConnectionLocale>>>;
+  metaDescription?: Maybe<Array<Maybe<ProductListConnectionMetaDescription>>>;
+  parent?: Maybe<Array<Maybe<ProductListConnectionParent>>>;
+  published_at?: Maybe<Array<Maybe<ProductListConnectionPublished_At>>>;
+  tagline?: Maybe<Array<Maybe<ProductListConnectionTagline>>>;
+  title?: Maybe<Array<Maybe<ProductListConnectionTitle>>>;
+  updated_at?: Maybe<Array<Maybe<ProductListConnectionUpdated_At>>>;
 };
+
+export type ProductListInput = {
+  children?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  created_by?: Maybe<Scalars['ID']>;
+  description: Scalars['String'];
+  deviceTitle?: Maybe<Scalars['String']>;
+  excludeFromHierarchyDisplay?: Maybe<Scalars['Boolean']>;
+  filters?: Maybe<Scalars['String']>;
+  handle: Scalars['String'];
+  image?: Maybe<Scalars['ID']>;
+  legacyPageId?: Maybe<Scalars['Int']>;
+  locale?: Maybe<Scalars['String']>;
+  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  metaDescription?: Maybe<Scalars['String']>;
+  parent?: Maybe<Scalars['ID']>;
+  published_at?: Maybe<Scalars['DateTime']>;
+  sections: Array<Scalars['ProductListSectionsDynamicZoneInput']>;
+  tagline?: Maybe<Scalars['String']>;
+  title: Scalars['String'];
+  updated_by?: Maybe<Scalars['ID']>;
+};
+
+export type ProductListSectionsDynamicZone = ComponentProductListBanner | ComponentProductListFeaturedProductList | ComponentProductListLinkedProductListSet | ComponentProductListRelatedPosts;
 
 export enum PublicationState {
   Live = 'LIVE',
@@ -1616,197 +794,26 @@ export enum PublicationState {
 
 export type Query = {
   __typename?: 'Query';
-  bottomContext?: Maybe<BottomContext>;
-  bottomContexts?: Maybe<Array<Maybe<BottomContext>>>;
-  bottomContextsConnection?: Maybe<BottomContextConnection>;
-  collection?: Maybe<Collection>;
-  collections?: Maybe<Array<Maybe<Collection>>>;
-  collectionsConnection?: Maybe<CollectionConnection>;
-  device?: Maybe<Device>;
-  deviceHandle?: Maybe<DeviceHandle>;
-  deviceHandles?: Maybe<Array<Maybe<DeviceHandle>>>;
-  deviceHandlesConnection?: Maybe<DeviceHandleConnection>;
-  devices?: Maybe<Array<Maybe<Device>>>;
-  devicesConnection?: Maybe<DeviceConnection>;
-  faq?: Maybe<Faq>;
-  faqSection?: Maybe<FaqSection>;
-  faqSections?: Maybe<Array<Maybe<FaqSection>>>;
-  faqSectionsConnection?: Maybe<FaqSectionConnection>;
-  faqs?: Maybe<Array<Maybe<Faq>>>;
-  faqsConnection?: Maybe<FaqConnection>;
   files?: Maybe<Array<Maybe<UploadFile>>>;
   filesConnection?: Maybe<UploadFileConnection>;
-  funFact?: Maybe<FunFacts>;
-  funFacts?: Maybe<Array<Maybe<FunFacts>>>;
-  funFactsConnection?: Maybe<FunFactsConnection>;
+  global?: Maybe<Global>;
   me?: Maybe<UsersPermissionsMe>;
   menu?: Maybe<Menu>;
   menus?: Maybe<Array<Maybe<Menu>>>;
   menusConnection?: Maybe<MenuConnection>;
-  partCollection?: Maybe<PartCollections>;
-  partCollections?: Maybe<Array<Maybe<PartCollections>>>;
-  partCollectionsConnection?: Maybe<PartCollectionsConnection>;
+  productList?: Maybe<ProductList>;
+  productLists?: Maybe<Array<Maybe<ProductList>>>;
+  productListsConnection?: Maybe<ProductListConnection>;
   role?: Maybe<UsersPermissionsRole>;
   /** Retrieve all the existing roles. You can't apply filters on this query. */
   roles?: Maybe<Array<Maybe<UsersPermissionsRole>>>;
   rolesConnection?: Maybe<UsersPermissionsRoleConnection>;
   store?: Maybe<Store>;
-  storeSetting?: Maybe<StoreSettings>;
-  storeSettings?: Maybe<Array<Maybe<StoreSettings>>>;
-  storeSettingsConnection?: Maybe<StoreSettingsConnection>;
   stores?: Maybe<Array<Maybe<Store>>>;
   storesConnection?: Maybe<StoreConnection>;
   user?: Maybe<UsersPermissionsUser>;
   users?: Maybe<Array<Maybe<UsersPermissionsUser>>>;
   usersConnection?: Maybe<UsersPermissionsUserConnection>;
-};
-
-
-export type QueryBottomContextArgs = {
-  id: Scalars['ID'];
-  publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryBottomContextsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  publicationState?: Maybe<PublicationState>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryBottomContextsConnectionArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryCollectionArgs = {
-  id: Scalars['ID'];
-  publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryCollectionsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  publicationState?: Maybe<PublicationState>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryCollectionsConnectionArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryDeviceArgs = {
-  id: Scalars['ID'];
-  publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryDeviceHandleArgs = {
-  id: Scalars['ID'];
-  publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryDeviceHandlesArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  publicationState?: Maybe<PublicationState>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryDeviceHandlesConnectionArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryDevicesArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  publicationState?: Maybe<PublicationState>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryDevicesConnectionArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryFaqArgs = {
-  id: Scalars['ID'];
-  publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryFaqSectionArgs = {
-  id: Scalars['ID'];
-  publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryFaqSectionsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  publicationState?: Maybe<PublicationState>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryFaqSectionsConnectionArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryFaqsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  publicationState?: Maybe<PublicationState>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryFaqsConnectionArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
 };
 
 
@@ -1827,26 +834,9 @@ export type QueryFilesConnectionArgs = {
 };
 
 
-export type QueryFunFactArgs = {
-  id: Scalars['ID'];
+export type QueryGlobalArgs = {
+  locale?: Maybe<Scalars['String']>;
   publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryFunFactsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  publicationState?: Maybe<PublicationState>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryFunFactsConnectionArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
 };
 
 
@@ -1875,14 +865,15 @@ export type QueryMenusConnectionArgs = {
 };
 
 
-export type QueryPartCollectionArgs = {
+export type QueryProductListArgs = {
   id: Scalars['ID'];
   publicationState?: Maybe<PublicationState>;
 };
 
 
-export type QueryPartCollectionsArgs = {
+export type QueryProductListsArgs = {
   limit?: Maybe<Scalars['Int']>;
+  locale?: Maybe<Scalars['String']>;
   publicationState?: Maybe<PublicationState>;
   sort?: Maybe<Scalars['String']>;
   start?: Maybe<Scalars['Int']>;
@@ -1890,8 +881,9 @@ export type QueryPartCollectionsArgs = {
 };
 
 
-export type QueryPartCollectionsConnectionArgs = {
+export type QueryProductListsConnectionArgs = {
   limit?: Maybe<Scalars['Int']>;
+  locale?: Maybe<Scalars['String']>;
   sort?: Maybe<Scalars['String']>;
   start?: Maybe<Scalars['Int']>;
   where?: Maybe<Scalars['JSON']>;
@@ -1924,31 +916,6 @@ export type QueryRolesConnectionArgs = {
 export type QueryStoreArgs = {
   id: Scalars['ID'];
   publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryStoreSettingArgs = {
-  id: Scalars['ID'];
-  publicationState?: Maybe<PublicationState>;
-};
-
-
-export type QueryStoreSettingsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  publicationState?: Maybe<PublicationState>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-
-export type QueryStoreSettingsConnectionArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
 };
 
 
@@ -2005,14 +972,13 @@ export type Store = {
   __typename?: 'Store';
   code: Scalars['String'];
   created_at: Scalars['DateTime'];
-  currency: Scalars['String'];
-  footer?: Maybe<ComponentSettingsFooter>;
+  currency: Enum_Store_Currency;
+  footer?: Maybe<ComponentStoreFooter>;
   id: Scalars['ID'];
   name: Scalars['String'];
   published_at?: Maybe<Scalars['DateTime']>;
   shopifySettings?: Maybe<ComponentStoreShopifySettings>;
-  socialMediaAccounts?: Maybe<ComponentSettingsSocial>;
-  store_settings?: Maybe<StoreSettings>;
+  socialMediaAccounts?: Maybe<ComponentStoreSocialMediaAccounts>;
   updated_at: Scalars['DateTime'];
   url: Scalars['String'];
 };
@@ -2084,12 +1050,6 @@ export type StoreConnectionSocialMediaAccounts = {
   key?: Maybe<Scalars['ID']>;
 };
 
-export type StoreConnectionStore_Settings = {
-  __typename?: 'StoreConnectionStore_settings';
-  connection?: Maybe<StoreConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
 export type StoreConnectionUpdated_At = {
   __typename?: 'StoreConnectionUpdated_at';
   connection?: Maybe<StoreConnection>;
@@ -2113,7 +1073,6 @@ export type StoreGroupBy = {
   published_at?: Maybe<Array<Maybe<StoreConnectionPublished_At>>>;
   shopifySettings?: Maybe<Array<Maybe<StoreConnectionShopifySettings>>>;
   socialMediaAccounts?: Maybe<Array<Maybe<StoreConnectionSocialMediaAccounts>>>;
-  store_settings?: Maybe<Array<Maybe<StoreConnectionStore_Settings>>>;
   updated_at?: Maybe<Array<Maybe<StoreConnectionUpdated_At>>>;
   url?: Maybe<Array<Maybe<StoreConnectionUrl>>>;
 };
@@ -2121,120 +1080,14 @@ export type StoreGroupBy = {
 export type StoreInput = {
   code: Scalars['String'];
   created_by?: Maybe<Scalars['ID']>;
-  currency: Scalars['String'];
-  footer: ComponentSettingsFooterInput;
+  currency: Enum_Store_Currency;
+  footer: ComponentStoreFooterInput;
   name: Scalars['String'];
   published_at?: Maybe<Scalars['DateTime']>;
   shopifySettings: ComponentStoreShopifySettingInput;
-  socialMediaAccounts: ComponentSettingsSocialInput;
-  store_settings?: Maybe<Scalars['ID']>;
+  socialMediaAccounts: ComponentStoreSocialMediaAccountInput;
   updated_by?: Maybe<Scalars['ID']>;
   url: Scalars['String'];
-};
-
-export type StoreSettingInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  footer: ComponentSettingsFooterInput;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  socialMediaAccounts: ComponentSettingsSocialInput;
-  store?: Maybe<Scalars['ID']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type StoreSettings = {
-  __typename?: 'StoreSettings';
-  created_at: Scalars['DateTime'];
-  footer?: Maybe<ComponentSettingsFooter>;
-  id: Scalars['ID'];
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<StoreSettings>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  socialMediaAccounts?: Maybe<ComponentSettingsSocial>;
-  store?: Maybe<Store>;
-  updated_at: Scalars['DateTime'];
-};
-
-
-export type StoreSettingsLocalizationsArgs = {
-  limit?: Maybe<Scalars['Int']>;
-  sort?: Maybe<Scalars['String']>;
-  start?: Maybe<Scalars['Int']>;
-  where?: Maybe<Scalars['JSON']>;
-};
-
-export type StoreSettingsAggregator = {
-  __typename?: 'StoreSettingsAggregator';
-  count?: Maybe<Scalars['Int']>;
-  totalCount?: Maybe<Scalars['Int']>;
-};
-
-export type StoreSettingsConnection = {
-  __typename?: 'StoreSettingsConnection';
-  aggregate?: Maybe<StoreSettingsAggregator>;
-  groupBy?: Maybe<StoreSettingsGroupBy>;
-  values?: Maybe<Array<Maybe<StoreSettings>>>;
-};
-
-export type StoreSettingsConnectionCreated_At = {
-  __typename?: 'StoreSettingsConnectionCreated_at';
-  connection?: Maybe<StoreSettingsConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type StoreSettingsConnectionFooter = {
-  __typename?: 'StoreSettingsConnectionFooter';
-  connection?: Maybe<StoreSettingsConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type StoreSettingsConnectionId = {
-  __typename?: 'StoreSettingsConnectionId';
-  connection?: Maybe<StoreSettingsConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type StoreSettingsConnectionLocale = {
-  __typename?: 'StoreSettingsConnectionLocale';
-  connection?: Maybe<StoreSettingsConnection>;
-  key?: Maybe<Scalars['String']>;
-};
-
-export type StoreSettingsConnectionPublished_At = {
-  __typename?: 'StoreSettingsConnectionPublished_at';
-  connection?: Maybe<StoreSettingsConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type StoreSettingsConnectionSocialMediaAccounts = {
-  __typename?: 'StoreSettingsConnectionSocialMediaAccounts';
-  connection?: Maybe<StoreSettingsConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type StoreSettingsConnectionStore = {
-  __typename?: 'StoreSettingsConnectionStore';
-  connection?: Maybe<StoreSettingsConnection>;
-  key?: Maybe<Scalars['ID']>;
-};
-
-export type StoreSettingsConnectionUpdated_At = {
-  __typename?: 'StoreSettingsConnectionUpdated_at';
-  connection?: Maybe<StoreSettingsConnection>;
-  key?: Maybe<Scalars['DateTime']>;
-};
-
-export type StoreSettingsGroupBy = {
-  __typename?: 'StoreSettingsGroupBy';
-  created_at?: Maybe<Array<Maybe<StoreSettingsConnectionCreated_At>>>;
-  footer?: Maybe<Array<Maybe<StoreSettingsConnectionFooter>>>;
-  id?: Maybe<Array<Maybe<StoreSettingsConnectionId>>>;
-  locale?: Maybe<Array<Maybe<StoreSettingsConnectionLocale>>>;
-  published_at?: Maybe<Array<Maybe<StoreSettingsConnectionPublished_At>>>;
-  socialMediaAccounts?: Maybe<Array<Maybe<StoreSettingsConnectionSocialMediaAccounts>>>;
-  store?: Maybe<Array<Maybe<StoreSettingsConnectionStore>>>;
-  updated_at?: Maybe<Array<Maybe<StoreSettingsConnectionUpdated_At>>>;
 };
 
 export type UploadFile = {
@@ -2665,69 +1518,6 @@ export type UsersPermissionsUserGroupBy = {
   username?: Maybe<Array<Maybe<UsersPermissionsUserConnectionUsername>>>;
 };
 
-export type CreateBottomContextInput = {
-  data?: Maybe<BottomContextInput>;
-};
-
-export type CreateBottomContextPayload = {
-  __typename?: 'createBottomContextPayload';
-  bottomContext?: Maybe<BottomContext>;
-};
-
-export type CreateCollectionInput = {
-  data?: Maybe<CollectionInput>;
-};
-
-export type CreateCollectionPayload = {
-  __typename?: 'createCollectionPayload';
-  collection?: Maybe<Collection>;
-};
-
-export type CreateDeviceHandleInput = {
-  data?: Maybe<DeviceHandleInput>;
-};
-
-export type CreateDeviceHandlePayload = {
-  __typename?: 'createDeviceHandlePayload';
-  deviceHandle?: Maybe<DeviceHandle>;
-};
-
-export type CreateDeviceInput = {
-  data?: Maybe<DeviceInput>;
-};
-
-export type CreateDevicePayload = {
-  __typename?: 'createDevicePayload';
-  device?: Maybe<Device>;
-};
-
-export type CreateFaqInput = {
-  data?: Maybe<FaqInput>;
-};
-
-export type CreateFaqPayload = {
-  __typename?: 'createFaqPayload';
-  faq?: Maybe<Faq>;
-};
-
-export type CreateFaqSectionInput = {
-  data?: Maybe<FaqSectionInput>;
-};
-
-export type CreateFaqSectionPayload = {
-  __typename?: 'createFaqSectionPayload';
-  faqSection?: Maybe<FaqSection>;
-};
-
-export type CreateFunFactInput = {
-  data?: Maybe<FunFactInput>;
-};
-
-export type CreateFunFactPayload = {
-  __typename?: 'createFunFactPayload';
-  funFact?: Maybe<FunFacts>;
-};
-
 export type CreateMenuInput = {
   data?: Maybe<MenuInput>;
 };
@@ -2737,13 +1527,13 @@ export type CreateMenuPayload = {
   menu?: Maybe<Menu>;
 };
 
-export type CreatePartCollectionInput = {
-  data?: Maybe<PartCollectionInput>;
+export type CreateProductListInput = {
+  data?: Maybe<ProductListInput>;
 };
 
-export type CreatePartCollectionPayload = {
-  __typename?: 'createPartCollectionPayload';
-  partCollection?: Maybe<PartCollections>;
+export type CreateProductListPayload = {
+  __typename?: 'createProductListPayload';
+  productList?: Maybe<ProductList>;
 };
 
 export type CreateRoleInput = {
@@ -2764,15 +1554,6 @@ export type CreateStorePayload = {
   store?: Maybe<Store>;
 };
 
-export type CreateStoreSettingInput = {
-  data?: Maybe<StoreSettingInput>;
-};
-
-export type CreateStoreSettingPayload = {
-  __typename?: 'createStoreSettingPayload';
-  storeSetting?: Maybe<StoreSettings>;
-};
-
 export type CreateUserInput = {
   data?: Maybe<UserInput>;
 };
@@ -2780,60 +1561,6 @@ export type CreateUserInput = {
 export type CreateUserPayload = {
   __typename?: 'createUserPayload';
   user?: Maybe<UsersPermissionsUser>;
-};
-
-export type DeleteBottomContextInput = {
-  where?: Maybe<InputId>;
-};
-
-export type DeleteBottomContextPayload = {
-  __typename?: 'deleteBottomContextPayload';
-  bottomContext?: Maybe<BottomContext>;
-};
-
-export type DeleteCollectionInput = {
-  where?: Maybe<InputId>;
-};
-
-export type DeleteCollectionPayload = {
-  __typename?: 'deleteCollectionPayload';
-  collection?: Maybe<Collection>;
-};
-
-export type DeleteDeviceHandleInput = {
-  where?: Maybe<InputId>;
-};
-
-export type DeleteDeviceHandlePayload = {
-  __typename?: 'deleteDeviceHandlePayload';
-  deviceHandle?: Maybe<DeviceHandle>;
-};
-
-export type DeleteDeviceInput = {
-  where?: Maybe<InputId>;
-};
-
-export type DeleteDevicePayload = {
-  __typename?: 'deleteDevicePayload';
-  device?: Maybe<Device>;
-};
-
-export type DeleteFaqInput = {
-  where?: Maybe<InputId>;
-};
-
-export type DeleteFaqPayload = {
-  __typename?: 'deleteFaqPayload';
-  faq?: Maybe<Faq>;
-};
-
-export type DeleteFaqSectionInput = {
-  where?: Maybe<InputId>;
-};
-
-export type DeleteFaqSectionPayload = {
-  __typename?: 'deleteFaqSectionPayload';
-  faqSection?: Maybe<FaqSection>;
 };
 
 export type DeleteFileInput = {
@@ -2845,13 +1572,9 @@ export type DeleteFilePayload = {
   file?: Maybe<UploadFile>;
 };
 
-export type DeleteFunFactInput = {
-  where?: Maybe<InputId>;
-};
-
-export type DeleteFunFactPayload = {
-  __typename?: 'deleteFunFactPayload';
-  funFact?: Maybe<FunFacts>;
+export type DeleteGlobalPayload = {
+  __typename?: 'deleteGlobalPayload';
+  global?: Maybe<Global>;
 };
 
 export type DeleteMenuInput = {
@@ -2863,13 +1586,13 @@ export type DeleteMenuPayload = {
   menu?: Maybe<Menu>;
 };
 
-export type DeletePartCollectionInput = {
+export type DeleteProductListInput = {
   where?: Maybe<InputId>;
 };
 
-export type DeletePartCollectionPayload = {
-  __typename?: 'deletePartCollectionPayload';
-  partCollection?: Maybe<PartCollections>;
+export type DeleteProductListPayload = {
+  __typename?: 'deleteProductListPayload';
+  productList?: Maybe<ProductList>;
 };
 
 export type DeleteRoleInput = {
@@ -2890,15 +1613,6 @@ export type DeleteStorePayload = {
   store?: Maybe<Store>;
 };
 
-export type DeleteStoreSettingInput = {
-  where?: Maybe<InputId>;
-};
-
-export type DeleteStoreSettingPayload = {
-  __typename?: 'deleteStoreSettingPayload';
-  storeSetting?: Maybe<StoreSettings>;
-};
-
 export type DeleteUserInput = {
   where?: Maybe<InputId>;
 };
@@ -2908,72 +1622,18 @@ export type DeleteUserPayload = {
   user?: Maybe<UsersPermissionsUser>;
 };
 
-export type EditBottomContextInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  device_summary?: Maybe<Scalars['String']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  subheading?: Maybe<Scalars['String']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type EditCollectionInput = {
-  children?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  created_by?: Maybe<Scalars['ID']>;
-  description?: Maybe<Scalars['String']>;
-  device_title?: Maybe<Scalars['String']>;
-  filters?: Maybe<Scalars['String']>;
-  handle?: Maybe<Scalars['String']>;
-  image?: Maybe<Scalars['ID']>;
-  legacy_plp_pageid?: Maybe<Scalars['Int']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  metaDescription?: Maybe<Scalars['String']>;
-  parent?: Maybe<Scalars['ID']>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  sections: Array<Scalars['CollectionSectionsDynamicZoneInput']>;
-  tagline?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type EditComponentCollectionBannerInput = {
-  callToActionLabel?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  title?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
-};
-
-export type EditComponentCollectionFeaturedCollectionInput = {
-  featuredCollection?: Maybe<Scalars['ID']>;
-  id?: Maybe<Scalars['ID']>;
-};
-
-export type EditComponentCollectionFeaturedSubcollectionInput = {
-  collections?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  id?: Maybe<Scalars['ID']>;
-  title?: Maybe<Scalars['String']>;
-};
-
-export type EditComponentCollectionNewsletterFormInput = {
-  callToActionLabel?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
+export type EditComponentGlobalNewsletterFormInput = {
+  callToActionButtonTitle?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['ID']>;
   inputPlaceholder?: Maybe<Scalars['String']>;
+  subtitle?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
-};
-
-export type EditComponentCollectionRelatedPostInput = {
-  id?: Maybe<Scalars['ID']>;
-  tags?: Maybe<Scalars['String']>;
 };
 
 export type EditComponentMenuCollectionLinkInput = {
   id?: Maybe<Scalars['ID']>;
-  linkedCollection?: Maybe<Scalars['ID']>;
   name?: Maybe<Scalars['String']>;
+  productList?: Maybe<Scalars['ID']>;
 };
 
 export type EditComponentMenuLinkInput = {
@@ -2984,33 +1644,41 @@ export type EditComponentMenuLinkInput = {
 
 export type EditComponentMenuLinkWithImageInput = {
   id?: Maybe<Scalars['ID']>;
-  image?: Maybe<Scalars['ID']>;
+  image?: Maybe<Array<Maybe<Scalars['ID']>>>;
   name?: Maybe<Scalars['String']>;
   url?: Maybe<Scalars['String']>;
 };
 
-export type EditComponentSettingsFooterInput = {
+export type EditComponentProductListBannerInput = {
+  callToActionLabel?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']>;
+  title?: Maybe<Scalars['String']>;
+  url?: Maybe<Scalars['String']>;
+};
+
+export type EditComponentProductListFeaturedProductListInput = {
+  id?: Maybe<Scalars['ID']>;
+  productList?: Maybe<Scalars['ID']>;
+};
+
+export type EditComponentProductListLinkedProductListSetInput = {
+  id?: Maybe<Scalars['ID']>;
+  productLists?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  title?: Maybe<Scalars['String']>;
+};
+
+export type EditComponentProductListRelatedPostInput = {
+  id?: Maybe<Scalars['ID']>;
+  tags?: Maybe<Scalars['String']>;
+};
+
+export type EditComponentStoreFooterInput = {
   bottomMenu?: Maybe<Scalars['ID']>;
   id?: Maybe<Scalars['ID']>;
   menu1?: Maybe<Scalars['ID']>;
   menu2?: Maybe<Scalars['ID']>;
   partners?: Maybe<Scalars['ID']>;
-};
-
-export type EditComponentSettingsPartnerInput = {
-  id?: Maybe<Scalars['ID']>;
-  logo?: Maybe<Scalars['ID']>;
-  name?: Maybe<Scalars['String']>;
-  url?: Maybe<Scalars['String']>;
-};
-
-export type EditComponentSettingsSocialInput = {
-  facebook?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  instagram?: Maybe<Scalars['String']>;
-  repairOrg?: Maybe<Scalars['String']>;
-  twitter?: Maybe<Scalars['String']>;
-  youtube?: Maybe<Scalars['String']>;
 };
 
 export type EditComponentStoreShopifySettingInput = {
@@ -3019,50 +1687,13 @@ export type EditComponentStoreShopifySettingInput = {
   storefrontDomain?: Maybe<Scalars['String']>;
 };
 
-export type EditDeviceHandleInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  handle?: Maybe<Scalars['String']>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type EditDeviceInput = {
-  canonical_override?: Maybe<Scalars['String']>;
-  created_by?: Maybe<Scalars['ID']>;
-  device?: Maybe<Scalars['String']>;
-  device_summary?: Maybe<Scalars['ID']>;
-  faq_section?: Maybe<Scalars['ID']>;
-  image?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  meta_description?: Maybe<Scalars['String']>;
-  part_type?: Maybe<Scalars['String']>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  subheading?: Maybe<Scalars['String']>;
-  summary?: Maybe<Scalars['String']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type EditFaqInput = {
-  Answer?: Maybe<Scalars['String']>;
-  Question?: Maybe<Scalars['String']>;
-  created_by?: Maybe<Scalars['ID']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_by?: Maybe<Scalars['ID']>;
-};
-
-export type EditFaqSectionInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  faq1?: Maybe<Scalars['ID']>;
-  faq2?: Maybe<Scalars['ID']>;
-  faq3?: Maybe<Scalars['ID']>;
-  heading?: Maybe<Scalars['String']>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  updated_by?: Maybe<Scalars['ID']>;
+export type EditComponentStoreSocialMediaAccountInput = {
+  facebook?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['ID']>;
+  instagram?: Maybe<Scalars['String']>;
+  repairOrg?: Maybe<Scalars['String']>;
+  twitter?: Maybe<Scalars['String']>;
+  youtube?: Maybe<Scalars['String']>;
 };
 
 export type EditFileInput = {
@@ -3085,10 +1716,12 @@ export type EditFileInput = {
   width?: Maybe<Scalars['Int']>;
 };
 
-export type EditFunFactInput = {
-  content?: Maybe<Scalars['String']>;
+export type EditGlobalInput = {
   created_by?: Maybe<Scalars['ID']>;
-  title?: Maybe<Scalars['String']>;
+  locale?: Maybe<Scalars['String']>;
+  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  newsletterForm?: Maybe<EditComponentGlobalNewsletterFormInput>;
+  published_at?: Maybe<Scalars['DateTime']>;
   updated_by?: Maybe<Scalars['ID']>;
 };
 
@@ -3109,13 +1742,23 @@ export type EditMenuInput = {
   updated_by?: Maybe<Scalars['ID']>;
 };
 
-export type EditPartCollectionInput = {
+export type EditProductListInput = {
+  children?: Maybe<Array<Maybe<Scalars['ID']>>>;
   created_by?: Maybe<Scalars['ID']>;
-  details?: Maybe<Scalars['String']>;
-  device_handle?: Maybe<Scalars['String']>;
-  meta_description?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  deviceTitle?: Maybe<Scalars['String']>;
+  excludeFromHierarchyDisplay?: Maybe<Scalars['Boolean']>;
+  filters?: Maybe<Scalars['String']>;
+  handle?: Maybe<Scalars['String']>;
+  image?: Maybe<Scalars['ID']>;
+  legacyPageId?: Maybe<Scalars['Int']>;
+  locale?: Maybe<Scalars['String']>;
+  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  metaDescription?: Maybe<Scalars['String']>;
+  parent?: Maybe<Scalars['ID']>;
   published_at?: Maybe<Scalars['DateTime']>;
-  summary?: Maybe<Scalars['String']>;
+  sections: Array<Scalars['ProductListSectionsDynamicZoneInput']>;
+  tagline?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
   updated_by?: Maybe<Scalars['ID']>;
 };
@@ -3133,26 +1776,14 @@ export type EditRoleInput = {
 export type EditStoreInput = {
   code?: Maybe<Scalars['String']>;
   created_by?: Maybe<Scalars['ID']>;
-  currency?: Maybe<Scalars['String']>;
-  footer?: Maybe<EditComponentSettingsFooterInput>;
+  currency?: Maybe<Enum_Store_Currency>;
+  footer?: Maybe<EditComponentStoreFooterInput>;
   name?: Maybe<Scalars['String']>;
   published_at?: Maybe<Scalars['DateTime']>;
   shopifySettings?: Maybe<EditComponentStoreShopifySettingInput>;
-  socialMediaAccounts?: Maybe<EditComponentSettingsSocialInput>;
-  store_settings?: Maybe<Scalars['ID']>;
+  socialMediaAccounts?: Maybe<EditComponentStoreSocialMediaAccountInput>;
   updated_by?: Maybe<Scalars['ID']>;
   url?: Maybe<Scalars['String']>;
-};
-
-export type EditStoreSettingInput = {
-  created_by?: Maybe<Scalars['ID']>;
-  footer?: Maybe<EditComponentSettingsFooterInput>;
-  locale?: Maybe<Scalars['String']>;
-  localizations?: Maybe<Array<Maybe<Scalars['ID']>>>;
-  published_at?: Maybe<Scalars['DateTime']>;
-  socialMediaAccounts?: Maybe<EditComponentSettingsSocialInput>;
-  store?: Maybe<Scalars['ID']>;
-  updated_by?: Maybe<Scalars['ID']>;
 };
 
 export type EditUserInput = {
@@ -3169,74 +1800,13 @@ export type EditUserInput = {
   username?: Maybe<Scalars['String']>;
 };
 
-export type UpdateBottomContextInput = {
-  data?: Maybe<EditBottomContextInput>;
-  where?: Maybe<InputId>;
+export type UpdateGlobalInput = {
+  data?: Maybe<EditGlobalInput>;
 };
 
-export type UpdateBottomContextPayload = {
-  __typename?: 'updateBottomContextPayload';
-  bottomContext?: Maybe<BottomContext>;
-};
-
-export type UpdateCollectionInput = {
-  data?: Maybe<EditCollectionInput>;
-  where?: Maybe<InputId>;
-};
-
-export type UpdateCollectionPayload = {
-  __typename?: 'updateCollectionPayload';
-  collection?: Maybe<Collection>;
-};
-
-export type UpdateDeviceHandleInput = {
-  data?: Maybe<EditDeviceHandleInput>;
-  where?: Maybe<InputId>;
-};
-
-export type UpdateDeviceHandlePayload = {
-  __typename?: 'updateDeviceHandlePayload';
-  deviceHandle?: Maybe<DeviceHandle>;
-};
-
-export type UpdateDeviceInput = {
-  data?: Maybe<EditDeviceInput>;
-  where?: Maybe<InputId>;
-};
-
-export type UpdateDevicePayload = {
-  __typename?: 'updateDevicePayload';
-  device?: Maybe<Device>;
-};
-
-export type UpdateFaqInput = {
-  data?: Maybe<EditFaqInput>;
-  where?: Maybe<InputId>;
-};
-
-export type UpdateFaqPayload = {
-  __typename?: 'updateFaqPayload';
-  faq?: Maybe<Faq>;
-};
-
-export type UpdateFaqSectionInput = {
-  data?: Maybe<EditFaqSectionInput>;
-  where?: Maybe<InputId>;
-};
-
-export type UpdateFaqSectionPayload = {
-  __typename?: 'updateFaqSectionPayload';
-  faqSection?: Maybe<FaqSection>;
-};
-
-export type UpdateFunFactInput = {
-  data?: Maybe<EditFunFactInput>;
-  where?: Maybe<InputId>;
-};
-
-export type UpdateFunFactPayload = {
-  __typename?: 'updateFunFactPayload';
-  funFact?: Maybe<FunFacts>;
+export type UpdateGlobalPayload = {
+  __typename?: 'updateGlobalPayload';
+  global?: Maybe<Global>;
 };
 
 export type UpdateMenuInput = {
@@ -3249,14 +1819,14 @@ export type UpdateMenuPayload = {
   menu?: Maybe<Menu>;
 };
 
-export type UpdatePartCollectionInput = {
-  data?: Maybe<EditPartCollectionInput>;
+export type UpdateProductListInput = {
+  data?: Maybe<EditProductListInput>;
   where?: Maybe<InputId>;
 };
 
-export type UpdatePartCollectionPayload = {
-  __typename?: 'updatePartCollectionPayload';
-  partCollection?: Maybe<PartCollections>;
+export type UpdateProductListPayload = {
+  __typename?: 'updateProductListPayload';
+  productList?: Maybe<ProductList>;
 };
 
 export type UpdateRoleInput = {
@@ -3279,16 +1849,6 @@ export type UpdateStorePayload = {
   store?: Maybe<Store>;
 };
 
-export type UpdateStoreSettingInput = {
-  data?: Maybe<EditStoreSettingInput>;
-  where?: Maybe<InputId>;
-};
-
-export type UpdateStoreSettingPayload = {
-  __typename?: 'updateStoreSettingPayload';
-  storeSetting?: Maybe<StoreSettings>;
-};
-
 export type UpdateUserInput = {
   data?: Maybe<EditUserInput>;
   where?: Maybe<InputId>;
@@ -3305,11 +1865,11 @@ export type GetCollectionPageDataQueryVariables = Exact<{
 }>;
 
 
-export type GetCollectionPageDataQuery = { __typename?: 'Query', collections?: Maybe<Array<Maybe<{ __typename?: 'Collection', id: string, handle: string, title: string, tagline?: Maybe<string>, description: string, filters?: Maybe<string>, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>, parent?: Maybe<{ __typename?: 'Collection', title: string, handle: string, parent?: Maybe<{ __typename?: 'Collection', title: string, handle: string, parent?: Maybe<{ __typename?: 'Collection', title: string, handle: string, parent?: Maybe<{ __typename?: 'Collection', title: string, handle: string }> }> }> }>, children?: Maybe<Array<Maybe<{ __typename?: 'Collection', handle: string, title: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>>>, sections: Array<Maybe<{ __typename: 'ComponentCollectionBanner', id: string, title: string, description: string, callToActionLabel: string, url: string } | { __typename: 'ComponentCollectionFeaturedCollection', id: string, featuredCollection?: Maybe<{ __typename?: 'Collection', handle: string, title: string, description: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }> } | { __typename: 'ComponentCollectionFeaturedSubcollections', id: string, title: string, collections?: Maybe<Array<Maybe<{ __typename?: 'Collection', handle: string, title: string, description: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>>> } | { __typename: 'ComponentCollectionNewsletterForm', id: string, title: string, description: string, inputPlaceholder?: Maybe<string>, callToActionLabel: string } | { __typename: 'ComponentCollectionRelatedPosts', id: string, tags?: Maybe<string> }>> }>>>, stores?: Maybe<Array<Maybe<{ __typename?: 'Store', code: string, name: string, url: string, currency: string }>>>, currentStore?: Maybe<Array<Maybe<{ __typename?: 'Store', shopifySettings?: Maybe<{ __typename?: 'ComponentStoreShopifySettings', storefrontDomain: string, storefrontAccessToken: string }>, footer?: Maybe<{ __typename?: 'ComponentSettingsFooter', menu1?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> }>, menu2?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> }>, partners?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> }>, bottomMenu?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> }> }>, socialMediaAccounts?: Maybe<{ __typename?: 'ComponentSettingsSocial', twitter?: Maybe<string>, facebook?: Maybe<string>, instagram?: Maybe<string>, youtube?: Maybe<string>, repairOrg?: Maybe<string> }> }>>> };
+export type GetCollectionPageDataQuery = { __typename?: 'Query', global?: Maybe<{ __typename?: 'Global', newsletterForm?: Maybe<{ __typename?: 'ComponentGlobalNewsletterForm', title: string, subtitle: string, inputPlaceholder: string, callToActionButtonTitle: string }> }>, productLists?: Maybe<Array<Maybe<{ __typename?: 'ProductList', id: string, handle: string, title: string, tagline?: Maybe<string>, description: string, filters?: Maybe<string>, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>, parent?: Maybe<{ __typename?: 'ProductList', title: string, handle: string, parent?: Maybe<{ __typename?: 'ProductList', title: string, handle: string, parent?: Maybe<{ __typename?: 'ProductList', title: string, handle: string, parent?: Maybe<{ __typename?: 'ProductList', title: string, handle: string, parent?: Maybe<{ __typename?: 'ProductList', title: string, handle: string, parent?: Maybe<{ __typename?: 'ProductList', title: string, handle: string }> }> }> }> }> }>, children?: Maybe<Array<Maybe<{ __typename?: 'ProductList', handle: string, title: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>>>, sections: Array<Maybe<{ __typename: 'ComponentProductListBanner', id: string, title: string, description: string, callToActionLabel: string, url: string } | { __typename: 'ComponentProductListFeaturedProductList', id: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string, title: string, description: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }> } | { __typename: 'ComponentProductListLinkedProductListSet', id: string, title: string, productLists?: Maybe<Array<Maybe<{ __typename?: 'ProductList', handle: string, title: string, description: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>>> } | { __typename: 'ComponentProductListRelatedPosts', id: string, tags?: Maybe<string> }>> }>>>, stores?: Maybe<Array<Maybe<{ __typename?: 'Store', code: string, name: string, url: string, currency: Enum_Store_Currency }>>>, currentStore?: Maybe<Array<Maybe<{ __typename?: 'Store', shopifySettings?: Maybe<{ __typename?: 'ComponentStoreShopifySettings', storefrontDomain: string, storefrontAccessToken: string }>, footer?: Maybe<{ __typename?: 'ComponentStoreFooter', menu1?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> }>, menu2?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> }>, partners?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> }>, bottomMenu?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> }> }>, socialMediaAccounts?: Maybe<{ __typename?: 'ComponentStoreSocialMediaAccounts', twitter?: Maybe<string>, facebook?: Maybe<string>, instagram?: Maybe<string>, youtube?: Maybe<string>, repairOrg?: Maybe<string> }> }>>> };
 
-export type LayoutPropsFragment = { __typename?: 'Query', stores?: Maybe<Array<Maybe<{ __typename?: 'Store', code: string, name: string, url: string, currency: string }>>>, currentStore?: Maybe<Array<Maybe<{ __typename?: 'Store', shopifySettings?: Maybe<{ __typename?: 'ComponentStoreShopifySettings', storefrontDomain: string, storefrontAccessToken: string }>, footer?: Maybe<{ __typename?: 'ComponentSettingsFooter', menu1?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> }>, menu2?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> }>, partners?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> }>, bottomMenu?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> }> }>, socialMediaAccounts?: Maybe<{ __typename?: 'ComponentSettingsSocial', twitter?: Maybe<string>, facebook?: Maybe<string>, instagram?: Maybe<string>, youtube?: Maybe<string>, repairOrg?: Maybe<string> }> }>>> };
+export type LayoutPropsFragment = { __typename?: 'Query', stores?: Maybe<Array<Maybe<{ __typename?: 'Store', code: string, name: string, url: string, currency: Enum_Store_Currency }>>>, currentStore?: Maybe<Array<Maybe<{ __typename?: 'Store', shopifySettings?: Maybe<{ __typename?: 'ComponentStoreShopifySettings', storefrontDomain: string, storefrontAccessToken: string }>, footer?: Maybe<{ __typename?: 'ComponentStoreFooter', menu1?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> }>, menu2?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> }>, partners?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> }>, bottomMenu?: Maybe<{ __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> }> }>, socialMediaAccounts?: Maybe<{ __typename?: 'ComponentStoreSocialMediaAccounts', twitter?: Maybe<string>, facebook?: Maybe<string>, instagram?: Maybe<string>, youtube?: Maybe<string>, repairOrg?: Maybe<string> }> }>>> };
 
-export type MenuPropsFragment = { __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, linkedCollection?: Maybe<{ __typename?: 'Collection', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }> }>> };
+export type MenuPropsFragment = { __typename?: 'Menu', items: Array<Maybe<{ __typename: 'ComponentMenuCollectionLink', name: string, productList?: Maybe<{ __typename?: 'ProductList', handle: string }> } | { __typename: 'ComponentMenuLink', name: string, url: string } | { __typename: 'ComponentMenuLinkWithImage', name: string, url: string, image?: Maybe<Array<Maybe<{ __typename?: 'UploadFile', alternativeText?: Maybe<string>, url: string, formats?: Maybe<any> }>>> }>> };
 
 export const MenuPropsFragmentDoc = `
     fragment MenuProps on Menu {
@@ -3321,7 +1881,7 @@ export const MenuPropsFragmentDoc = `
     }
     ... on ComponentMenuCollectionLink {
       name
-      linkedCollection {
+      productList {
         handle
       }
     }
@@ -3377,7 +1937,15 @@ export const LayoutPropsFragmentDoc = `
 export const GetCollectionPageDataDocument = `
     query getCollectionPageData($whereCollection: JSON, $whereStoreSettings: JSON) {
   ...LayoutProps
-  collections(limit: 1, where: $whereCollection) {
+  global {
+    newsletterForm {
+      title
+      subtitle
+      inputPlaceholder
+      callToActionButtonTitle
+    }
+  }
+  productLists(limit: 1, where: $whereCollection) {
     id
     handle
     title
@@ -3401,6 +1969,14 @@ export const GetCollectionPageDataDocument = `
           parent {
             title
             handle
+            parent {
+              title
+              handle
+              parent {
+                title
+                handle
+              }
+            }
           }
         }
       }
@@ -3416,27 +1992,20 @@ export const GetCollectionPageDataDocument = `
     }
     sections {
       __typename
-      ... on ComponentCollectionBanner {
+      ... on ComponentProductListBanner {
         id
         title
         description
         callToActionLabel
         url
       }
-      ... on ComponentCollectionRelatedPosts {
+      ... on ComponentProductListRelatedPosts {
         id
         tags
       }
-      ... on ComponentCollectionNewsletterForm {
+      ... on ComponentProductListFeaturedProductList {
         id
-        title
-        description
-        inputPlaceholder
-        callToActionLabel
-      }
-      ... on ComponentCollectionFeaturedCollection {
-        id
-        featuredCollection {
+        productList {
           handle
           title
           description
@@ -3447,10 +2016,10 @@ export const GetCollectionPageDataDocument = `
           }
         }
       }
-      ... on ComponentCollectionFeaturedSubcollections {
+      ... on ComponentProductListLinkedProductListSet {
         id
         title
-        collections(limit: 3) {
+        productLists(limit: 3) {
           handle
           title
           description

--- a/lib/api/strapi/operations/getCollection.graphql
+++ b/lib/api/strapi/operations/getCollection.graphql
@@ -1,6 +1,14 @@
 query getCollectionPageData($whereCollection: JSON, $whereStoreSettings: JSON) {
    ...LayoutProps
-   collections(limit: 1, where: $whereCollection) {
+   global {
+      newsletterForm {
+         title
+         subtitle
+         inputPlaceholder
+         callToActionButtonTitle
+      }
+   }
+   productLists(limit: 1, where: $whereCollection) {
       id
       handle
       title
@@ -24,6 +32,14 @@ query getCollectionPageData($whereCollection: JSON, $whereStoreSettings: JSON) {
                parent {
                   title
                   handle
+                  parent {
+                     title
+                     handle
+                     parent {
+                        title
+                        handle
+                     }
+                  }
                }
             }
          }
@@ -39,27 +55,20 @@ query getCollectionPageData($whereCollection: JSON, $whereStoreSettings: JSON) {
       }
       sections {
          __typename
-         ... on ComponentCollectionBanner {
+         ... on ComponentProductListBanner {
             id
             title
             description
             callToActionLabel
             url
          }
-         ... on ComponentCollectionRelatedPosts {
+         ... on ComponentProductListRelatedPosts {
             id
             tags
          }
-         ... on ComponentCollectionNewsletterForm {
+         ... on ComponentProductListFeaturedProductList {
             id
-            title
-            description
-            inputPlaceholder
-            callToActionLabel
-         }
-         ... on ComponentCollectionFeaturedCollection {
-            id
-            featuredCollection {
+            productList {
                handle
                title
                description
@@ -70,10 +79,10 @@ query getCollectionPageData($whereCollection: JSON, $whereStoreSettings: JSON) {
                }
             }
          }
-         ... on ComponentCollectionFeaturedSubcollections {
+         ... on ComponentProductListLinkedProductListSet {
             id
             title
-            collections(limit: 3) {
+            productLists(limit: 3) {
                handle
                title
                description

--- a/lib/api/strapi/operations/layout.graphql
+++ b/lib/api/strapi/operations/layout.graphql
@@ -43,7 +43,7 @@ fragment MenuProps on Menu {
       }
       ... on ComponentMenuCollectionLink {
          name
-         linkedCollection {
+         productList {
             handle
          }
       }

--- a/test/cypress/integration/collection/newsletter_subscribe.spec.ts
+++ b/test/cypress/integration/collection/newsletter_subscribe.spec.ts
@@ -1,7 +1,7 @@
 describe('subscribe to newsletter', () => {
    const user = cy;
    beforeEach(() => {
-      user.visit('/collections/phone');
+      user.visit('/collections/parts');
    });
 
    it('requires an email', () => {


### PR DESCRIPTION
This PR closes #116 

I'm still keeping the name "collections" in many parts of the codebase mostly to avoid conflicts with other branches that are ready to be reviewed after this PR. When those branches will be merged too then I'll refactor all references to "collection"

## QA

1. Visit the Vercel PR preview
2. Visit the parts collection page
3. Verify that product list page works with the new Strapi instance