### PR TITLE
Make product list view selector responsive

### DIFF
--- a/frontend/features/productList/components/sections/FilterableProductsSection/Toolbar.tsx
+++ b/frontend/features/productList/components/sections/FilterableProductsSection/Toolbar.tsx
@@ -1,6 +1,7 @@
 import {
    Button,
    ButtonGroup,
+   ButtonGroupProps,
    ButtonProps,
    Icon,
    IconButton,
@@ -69,19 +70,8 @@ export const SortBySelect = (props: SelectProps) => {
    );
 };
 
-type ProductViewSwitchProps = React.PropsWithChildren<unknown>;
-
-export const ProductViewSwitch = ({ children }: ProductViewSwitchProps) => {
-   return (
-      <ButtonGroup
-         size="sm"
-         isAttached
-         bg="white"
-         display={{ base: 'none', md: 'flex' }}
-      >
-         {children}
-      </ButtonGroup>
-   );
+export const ProductViewSwitch = (props: ButtonGroupProps) => {
+   return <ButtonGroup size="sm" isAttached bg="white" {...props} />;
 };
 
 export const ProductViewListButton = (props: IconButtonProps) => {

--- a/frontend/features/productList/components/sections/FilterableProductsSection/index.tsx
+++ b/frontend/features/productList/components/sections/FilterableProductsSection/index.tsx
@@ -36,7 +36,6 @@ import {
    ProductViewGridButton,
    ProductViewListButton,
    ProductViewSwitch,
-   SortBySelect,
    Toolbar,
 } from './Toolbar';
 
@@ -108,17 +107,40 @@ export const FilterableProductsSection = React.memo(() => {
                         >
                            Filters
                         </OpenFiltersButton>
-                        <SortBySelect
-                           defaultValue="manual"
-                           placeholder="Select collection sort by"
+                        <ProductViewSwitch
+                           display={{
+                              base: 'flex',
+                              md: 'none',
+                           }}
                         >
-                           <option value="manual">Featured</option>
-                           <option value="best-selling">Most popular</option>
-                        </SortBySelect>
+                           <ProductViewListButton
+                              aria-label="Select list view"
+                              isActive={
+                                 productViewType === ProductViewType.List
+                              }
+                              onClick={() =>
+                                 setProductViewType(ProductViewType.List)
+                              }
+                           />
+                           <ProductViewGridButton
+                              aria-label="Select grid view"
+                              isActive={
+                                 productViewType === ProductViewType.Grid
+                              }
+                              onClick={() =>
+                                 setProductViewType(ProductViewType.Grid)
+                              }
+                           />
+                        </ProductViewSwitch>
                      </HStack>
                      <SearchInput maxW={{ md: 300 }} />
                   </VStack>
-                  <ProductViewSwitch>
+                  <ProductViewSwitch
+                     display={{
+                        base: 'none',
+                        md: 'flex',
+                     }}
+                  >
                      <ProductViewListButton
                         aria-label="Select list view"
                         isActive={productViewType === ProductViewType.List}

--- a/frontend/features/productList/components/sections/HeroSection.tsx
+++ b/frontend/features/productList/components/sections/HeroSection.tsx
@@ -70,7 +70,12 @@ export function HeroSection({ collection }: HeroSectionProps) {
                   <VStack>
                      <HeroTitle color="white">{collection.title}</HeroTitle>
                      {collection.tagline && collection.tagline.length > 0 && (
-                        <Text fontWeight="bold" fontSize="xl" color="gray.50">
+                        <Text
+                           fontWeight="bold"
+                           fontSize="xl"
+                           color="gray.50"
+                           px={{ base: 6, sm: 0 }}
+                        >
                            {collection.tagline}
                         </Text>
                      )}
@@ -87,7 +92,11 @@ export function HeroSection({ collection }: HeroSectionProps) {
                   {collection.tagline &&
                      collection.tagline.length > 0 &&
                      searchParams.page === 1 && (
-                        <Text fontWeight="bold" fontSize="xl">
+                        <Text
+                           fontWeight="bold"
+                           fontSize="xl"
+                           px={{ base: 6, sm: 0 }}
+                        >
                            {collection.tagline}
                         </Text>
                      )}


### PR DESCRIPTION
This PR closes #70 

## Changelog

- Makes product list view selector responsive
  ![image](https://user-images.githubusercontent.com/4640135/142997029-89b30300-cdce-4c93-b9b3-e3f7b6d1f246.png)


## QA

1. Visit the Vercel PR preview
2. Visit a parts product list and verify that the product list view selector is responsive (renders also on mobile sizes)