### PR TITLE
Add open graph tags

### DIFF
--- a/frontend/features/productList/components/MetaTags.tsx
+++ b/frontend/features/productList/components/MetaTags.tsx
@@ -12,34 +12,40 @@ export function MetaTags({ collection }: MetaTagsProps) {
    const searchParams = useSearchParams();
    const isFiltered =
       searchParams.query.length > 0 || searchParams.filters.allIds.length > 0;
+   let title = `iFixit | ${collection.title}`;
+   if (!isFiltered && searchParams.page > 1) {
+      title += ` - Page ${searchParams.page}`;
+   }
+   const canonicalUrl = `https://www.ifixit.com/collections/${
+      collection.handle
+   }${
+      searchParams.page > 1
+         ? `?${COLLECTION_PAGE_PARAM}=${searchParams.page}`
+         : ''
+   }`;
+   const imageUrl = collection.image?.url;
    return (
       <Head>
          {isFiltered ? (
             <meta name="robots" content="noindex,nofollow" />
          ) : (
             <>
-               <link
-                  rel="canonical"
-                  href={`https://www.ifixit.com/collections/${
-                     collection.handle
-                  }${
-                     searchParams.page > 1
-                        ? `?${COLLECTION_PAGE_PARAM}=${searchParams.page}`
-                        : ''
-                  }`}
-               />
+               <link rel="canonical" href={canonicalUrl} />
                <meta
                   name="description"
                   content={collection.metaDescription || collection.description}
                />
             </>
          )}
-         <title>
-            iFixit | {collection.title}
-            {!isFiltered && searchParams.page > 1
-               ? ` - Page ${searchParams.page}`
-               : ''}
-         </title>
+         <title>{title}</title>
+         <meta property="og:title" content={title} />
+         <meta
+            name="og:description"
+            content={collection.metaDescription || collection.description}
+         />
+         <meta property="og:type" content="website" />
+         <meta property="og:url" content={canonicalUrl} />
+         {imageUrl && <meta property="og:image" content={imageUrl} />}
       </Head>
    );
 }


### PR DESCRIPTION
This PR closes #103  

## Changelog

- Adds open graph tags

## QA

1. Visit the Vercel PR preview
2. Visit parts product list page and copy the url
3. Use Facebook sharing debug tool (https://developers.facebook.com/tools/debug) to verify that the generated preview link is correct. The description should come from product list `metaDescription`, or if not set it should come from product list `description`
    <img width="746" alt="Screenshot 2021-11-23 at 11 02 03" src="https://user-images.githubusercontent.com/4640135/143004605-c7acd126-8606-457e-9842-5c7075d4ae0d.png">

4. [Optional] You can try to paste the link on Slack, or twitter and see if a card is created