### PR TITLE
.gitignore: Ignore Rush tempfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Rush
+**/.rush/temp


### PR DESCRIPTION
As we pull this repo into our monorepo, I find that the top-level gitignore doesn't take effect within this submodule. This adds an ignore line to ignore some temp files Rush creates.

qa_req 0
This shouldn't be breaking anything serious.