### PR TITLE
fix: Use `npm` target instead of `postinstall` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can run the backend both using SQLite and using Postgres with docker compose
 This command will install both backend and frontend dependencies:
 
 ```sh
-npm install
+npm run npm
 ```
 
 ### Dev server

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start:frontend": "cd frontend && npm run start",
     "start": "cross-env FORCE_COLOR=1 npm-run-all -l -p start:*",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "npm run install:backend && npm run install:frontend",
+    "npm": "npm install && npm run install:backend && npm run install:frontend",
     "install:backend": "cd backend && npm install",
     "install:frontend": "cd frontend && npm install",
     "transform-svg": "cd frontend && npm run transform-svg"


### PR DESCRIPTION
This allows us to install the top-level package without having to convince Rush not to run postinstall scripts. For our iFixit monorepo, the subprojects will be installed by Rush, rather than with `npm` as here.

This will require `npm`-based users of this repo to switch to `npm run npm` as the install command.

# QA
Please confirm that `npm run npm` sets everything up correctly.

@dhmacs, feel free to push back if you don't like this idea. I realize it's a bit invasive, and I'm game to try something different if you'd rather.