### PR TITLE
Configure more specific name for backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "@ifixit/commerce-backend",
   "private": true,
   "version": "0.1.0",
   "description": "A Strapi application",


### PR DESCRIPTION
## Description
This restores the package name for the backend package from before the refactor.

qa_req 0