### PR TITLE
Add logs to graphql queries

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "@ifixit/commerce-backend",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/frontend/lib/strapi-sdk/index.ts
+++ b/frontend/lib/strapi-sdk/index.ts
@@ -16,12 +16,24 @@ const requester: Requester = async <R, V>(
          variables,
       }),
    });
+   let result: any;
+   try {
+      result = await response.json();
+   } catch (error) {
+      throw new Error(`Response is not a json: ${response.statusText}`);
+   }
    if (response.ok) {
-      const result = await response.json();
       if (result?.data) {
          return result.data;
       }
       throw new Error('Data not available in GraphQL response');
+   }
+   if (Array.isArray(result.errors)) {
+      console.log('GraphQL query failed with errors:');
+      result.errors.map((error: any) => {
+         const code = error.extensions?.code || 'UNKNOWN';
+         console.log(`\t[${code}]`, error.message);
+      });
    }
    throw new Error(`GraphQL query failed to execute: ${response.statusText}`);
 };

--- a/frontend/lib/strapi-sdk/index.ts
+++ b/frontend/lib/strapi-sdk/index.ts
@@ -29,7 +29,7 @@ const requester: Requester = async <R, V>(
       throw new Error('Data not available in GraphQL response');
    }
    if (Array.isArray(result.errors)) {
-      console.log('GraphQL query failed with errors:');
+      console.error('GraphQL query failed with errors:');
       result.errors.map((error: any) => {
          const code = error.extensions?.code || 'UNKNOWN';
          console.log(`\t[${code}]`, error.message);

--- a/frontend/lib/strapi-sdk/index.ts
+++ b/frontend/lib/strapi-sdk/index.ts
@@ -32,7 +32,7 @@ const requester: Requester = async <R, V>(
       console.error('GraphQL query failed with errors:');
       result.errors.map((error: any) => {
          const code = error.extensions?.code || 'UNKNOWN';
-         console.log(`\t[${code}]`, error.message);
+         console.error(`\t[${code}]`, error.message);
       });
    }
    throw new Error(`GraphQL query failed to execute: ${response.statusText}`);


### PR DESCRIPTION
closes #141 

cc @lithobraking @sterlinghirsh @andyg0808 

## Changelog

- Add better logging to graphql requests

## QA

There's not an easy way to promt Strapi to return errors in order to verify error logging. The way I did it while developing is by sending wrong queries on purpose.
If you want to reproduce an error yourself you need to clone the repo and replace this: https://github.com/iFixit/react-commerce/blob/094f877d2b90d464b970dda603e4692e8f6e7ec2/frontend/lib/strapi-sdk/index.ts#L16 with this:
```ts
         variables: {
            filters: {
               foo: 'bar',
            },
         },
```
Start the dev server (`npm run dev`) then navigate a product list page and you'll see an error like this on your terminal:

<img width="680" alt="Screenshot 2022-02-16 at 16 08 38" src="https://user-images.githubusercontent.com/4640135/154293766-128a6ba2-e2e8-4602-9631-1c29fe43d9e2.png">

