### PR TITLE
Use jwt secret from env

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,2 @@
-JWT_SECRET=
-API_TOKEN_SALT=
+JWT_SECRET=staging-secret
 SEED_DB=true

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
       DATABASE_PORT: 5432
       DATABASE_USERNAME: strapi
       DATABASE_PASSWORD: strapi
+      JWT_SECRET: "${JWT_SECRET}"
     ports:
       - "${HOST_PORT:-1337}:1337"
     depends_on:

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -1,11 +1,6 @@
 import { Flex, VStack } from '@chakra-ui/react';
-import {
-   PageContentWrapper,
-   SecondaryNavbar,
-   SecondaryNavbarItem,
-   SecondaryNavbarLink,
-} from '@components/common';
-import { ALGOLIA_API_KEY, ALGOLIA_APP_ID, IFIXIT_ORIGIN } from '@config/env';
+import { PageContentWrapper, SecondaryNavbar } from '@components/common';
+import { ALGOLIA_API_KEY, ALGOLIA_APP_ID } from '@config/env';
 import { AlgoliaProvider, SearchContext } from '@lib/algolia';
 import { GlobalSettings } from '@models/global-settings';
 import {
@@ -13,8 +8,6 @@ import {
    ProductListSectionType,
    ProductSearchHit,
 } from '@models/product-list';
-import snakeCase from 'lodash/snakeCase';
-import NextLink from 'next/link';
 import { MetaTags } from './MetaTags';
 import { ProductListBreadcrumb } from './ProductListBreadcrumb';
 import { ProductListDeviceNavigation } from './ProductListDeviceNavigation';


### PR DESCRIPTION
This PR enables Govinor to fill Strapi jwt secret token using `.env.example` file. 

## Changelog

- Add jwt secret to docker compose config env variable
- Remove unused code

# QA

- Visit https://fix-backend-jwt-secret.govinor.com/
- Verify that you can access Strapi Admin with email `strapi@ifixit.com` and password `Password1`