### PR TITLE
Add docker persistent volume for file upload

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -15,6 +15,8 @@ services:
       JWT_SECRET: "${JWT_SECRET}"
     ports:
       - "${HOST_PORT:-1337}:1337"
+    volumes:
+      - uploads:/srv/app/public/uploads
     depends_on:
       - postgres
     command: "strapi start"
@@ -30,3 +32,4 @@ services:
 
 volumes:
   db_data:
+  uploads:


### PR DESCRIPTION
Currently Strapi images are being deleted when new changes are pushed to a branch since they're not backed by a persistent volume. This PR fixes the issue.

## Changelog

- Add docker volume to Strapi `/public/uploads` folder

## QA

The only file affected by this change is the docker compose config, so not sure what to QA beside that Strapi govinor deploy should still be up and running.