### PR TITLE
fix(product list): Make product images fit container

### DIFF
--- a/frontend/components/common/ProductCard.tsx
+++ b/frontend/components/common/ProductCard.tsx
@@ -49,7 +49,13 @@ export const ProductCardImage = ({ src, alt }: ProductCardImageProps) => {
    }
    return (
       <AspectRatio ratio={1} flexGrow={0} flexShrink={0} position="relative">
-         <Image sizes="30vw" layout="fill" src={src} alt={alt} />
+         <Image
+            sizes="30vw"
+            layout="fill"
+            objectFit="contain"
+            src={src}
+            alt={alt}
+         />
       </AspectRatio>
    );
 };

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -83,6 +83,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                   <Image
                      src={product.image_url}
                      alt={product.title}
+                     objectFit="contain"
                      width="180px"
                      height="180px"
                   />


### PR DESCRIPTION
fixes #142 

| Before  | After |
| ------------- | ------------- |
| <img width="854" alt="Screenshot 2022-03-16 at 16 29 54" src="https://user-images.githubusercontent.com/4640135/158627151-3abf2d32-3e4a-46db-ab69-d3efcb89c197.png">  | <img width="865" alt="Screenshot 2022-03-16 at 16 30 14" src="https://user-images.githubusercontent.com/4640135/158627235-11a3494a-00c0-447e-bf4c-9ed9663a4e2f.png">  |

## QA

1. Visit the Vercel PR preview
2. Visit parts product list page
3. Verify that images are correctly displayed
4. Search for `xbox 360 S Hard Drive`
5. Verify that images are correctly displayed








