### PR TITLE
Show only public products

### DIFF
--- a/frontend/components/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/components/product-list/sections/FeaturedProductListSection.tsx
@@ -30,21 +30,11 @@ import NextLink from 'next/link';
 import * as React from 'react';
 
 export interface FeaturedProductListSectionProps {
-   // handle: string;
-   // title: string;
-   // description: string;
-   // imageSrc?: string;
-   // imageAlt?: string;
    productList: ProductListPreview;
    algoliaIndexName: string;
 }
 
 export function FeaturedProductListSection({
-   // handle,
-   // title,
-   // description,
-   // imageAlt,
-   // imageSrc,
    productList,
    algoliaIndexName,
 }: FeaturedProductListSectionProps) {
@@ -140,7 +130,8 @@ export function FeaturedProductListSection({
                   apiKey={ALGOLIA_API_KEY}
                   initialIndexName={algoliaIndexName}
                   filtersPreset={
-                     productList.filters ?? `device:${productList.deviceTitle}`
+                     productList.filters ??
+                     `device:${productList.deviceTitle} AND public=1`
                   }
                   productsPerPage={3}
                >

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -200,7 +200,7 @@ export const FilterableProductsSection = React.memo(() => {
                            {hits.map((hit) => {
                               return (
                                  <ProductListItem
-                                    key={hit.handle}
+                                    key={hit.objectID}
                                     product={hit}
                                  />
                               );

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -134,8 +134,8 @@ export async function createProductListSearchContext({
 }: CreateProductListSearchContextOptions): Promise<SearchContext<ProductSearchHit> | null> {
    const filtersPreset =
       filters && filters.length > 0
-         ? filters
-         : `device:${JSON.stringify(deviceTitle)}`;
+         ? `${filters} AND public=1`
+         : `device:${JSON.stringify(deviceTitle)} AND public=1`;
    const client = createAlgoliaClient(ALGOLIA_APP_ID, ALGOLIA_API_KEY);
 
    const pageParam = urlQuery[PRODUCT_LIST_PAGE_PARAM];

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -1,4 +1,5 @@
 export interface ProductSearchHit {
+   objectID: string;
    title: string;
    handle: string;
    price_float: number;


### PR DESCRIPTION
fixes #233 

## Changelog

- Use `public=1` when searching with Algolia

## QA

1. Visit the Vercel PR preview (replace `vercel.app` with `cominor.com`)
2. Visit all parts product list 
3. Verify that products marked with `public=0` in Algolia are not visible in product list search results