### PR TITLE
Remove mobile breadcrumb page title

### DIFF
--- a/frontend/components/product-list/ProductListBreadcrumb.tsx
+++ b/frontend/components/product-list/ProductListBreadcrumb.tsx
@@ -31,7 +31,17 @@ export function ProductListBreadcrumb({
    return (
       <Breadcrumb
          spacing={1}
-         separator={<Icon as={HiChevronRight} color="gray.300" mt="1" />}
+         separator={
+            <Icon
+               as={HiChevronRight}
+               display={{
+                  base: 'none',
+                  md: 'initial',
+               }}
+               color="gray.300"
+               mt="1"
+            />
+         }
          fontSize="sm"
          display="flex"
          flexWrap="nowrap"
@@ -100,7 +110,13 @@ export function ProductListBreadcrumb({
                </Menu>
             </BreadcrumbItem>
          )}
-         <BreadcrumbItem isCurrentPage>
+         <BreadcrumbItem
+            isCurrentPage
+            display={{
+               base: 'none',
+               md: 'flex',
+            }}
+         >
             <Text
                color="black"
                fontWeight="bold"


### PR DESCRIPTION
fixes #201  

## QA

1. Visit the Vercel PR preview (replace `vercel.app` with `cominor.com`)
2. Visit all parts product list 
3. Verify that breadcrumb product list title is not visible for mobile screens