### PR TITLE
Hide out of stock alerts from product cards

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -7,7 +7,6 @@ import {
    ProductCardImage,
    ProductCardPricing,
    ProductCardRating,
-   ProductCardSoldOutBadge,
    ProductCardTitle,
 } from '@components/common';
 import { IFIXIT_ORIGIN } from '@config/env';
@@ -51,19 +50,13 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
         )
       : 0;
 
-   const isSoldOut = product.quantity_available <= 0;
-
    return (
       <LinkBox as="article" display="block" w="full">
          <ProductCard h="full">
             <ProductCardImage src={product.image_url} alt={product.title} />
             <ProductCardBadgeList>
-               {isSoldOut ? (
-                  <ProductCardSoldOutBadge />
-               ) : (
-                  isDiscounted && (
-                     <ProductCardDiscountBadge percentage={percentage} />
-                  )
+               {isDiscounted && (
+                  <ProductCardDiscountBadge percentage={percentage} />
                )}
             </ProductCardBadgeList>
             <ProductCardBody>

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -145,7 +145,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                         },
                      }}
                   >
-                     {product.quantity_available > 0 ? (
+                     {product.quantity_available > 0 && (
                         <>
                            {percentage > 0 && (
                               <Badge
@@ -179,16 +179,6 @@ export function ProductListItem({ product }: ProductListItemProps) {
                               Ship today if ordered by 5pm
                            </Badge>
                         </>
-                     ) : (
-                        <Badge
-                           colorScheme="gray"
-                           textTransform="none"
-                           borderRadius="lg"
-                           px="2.5"
-                           py="1"
-                        >
-                           Sold out
-                        </Badge>
                      )}
                   </Flex>
                </Box>
@@ -267,11 +257,9 @@ export function ProductListItem({ product }: ProductListItemProps) {
                         View
                      </Button>
                   </LinkOverlay>
-                  {quantityAvailable < 10 && (
+                  {quantityAvailable < 10 && quantityAvailable > 0 && (
                      <Text color="gray.500" fontSize="14px">
-                        {quantityAvailable > 0
-                           ? `Only ${quantityAvailable} left in stock`
-                           : 'Out of stock'}
+                        Only {quantityAvailable} left in stock
                      </Text>
                   )}
                </Stack>


### PR DESCRIPTION
fixes #218   

## QA

1. Visit the Vercel PR preview (replace `vercel.app` with `cominor.com`)
2. Visit all parts product list 
3. Verify that out of stock alerts are not visible anymore