### PR TITLE
Add legacy description field

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ This command will start Strapi dev server and Next.js dev server:
 npm run dev
 ```
 
+### Working with Strapi
+
+After running the dev server, you can access the Strapi admin panel at `http://localhost:1337/admin`. To login use email `strapi@ifixit.com` and password `Password1`.
+
+The local Strapi dev server will allow you to make changes to the schema of content types. When you're satisfied with the changes, you can push into a new branch to get a preview url from [govinor](https://govinor.com/).
+
 ### Test
 
 This command will start Cypress:

--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -152,6 +152,14 @@
       },
       "type": "integer",
       "default": 0
+    },
+    "legacyDescription": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "richtext"
     }
   }
 }


### PR DESCRIPTION
fixes #243 

This PR also adds instructions for how to work with Strapi and make changes to the content types.

## QA

1. Visit https://add-legacy-description-field.govinor.com/admin/
2. Use credentials found in the readme to login
3. Verify that product lists have the new legacy description 
