### PR TITLE
Replace `title` with `group_title`

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -53,7 +53,10 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
    return (
       <LinkBox as="article" display="block" w="full">
          <ProductCard h="full">
-            <ProductCardImage src={product.image_url} alt={product.title} />
+            <ProductCardImage
+               src={product.image_url}
+               alt={product.group_title}
+            />
             <ProductCardBadgeList>
                {isDiscounted && (
                   <ProductCardDiscountBadge percentage={percentage} />
@@ -61,7 +64,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
             </ProductCardBadgeList>
             <ProductCardBody>
                <LinkOverlay href={`${IFIXIT_ORIGIN}${product.url}`}>
-                  <ProductCardTitle>{product.title}</ProductCardTitle>
+                  <ProductCardTitle>{product.group_title}</ProductCardTitle>
                </LinkOverlay>
                {(product.rating >= 4 || product.rating_count > 10) && (
                   <ProductCardRating

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -94,7 +94,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                   {product.image_url ? (
                      <Image
                         src={product.image_url}
-                        alt={product.title}
+                        alt={product.group_title}
                         objectFit="contain"
                         width="180px"
                         height="180px"
@@ -102,7 +102,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                   ) : (
                      <Image
                         src={placeholderImageUrl}
-                        alt={product.title}
+                        alt={product.group_title}
                         sizes="180px"
                      />
                   )}
@@ -123,7 +123,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                         lg: 'lg',
                      }}
                   >
-                     {product.title}
+                     {product.group_title}
                   </Heading>
                   <Text
                      noOfLines={3}

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -1,6 +1,7 @@
 export interface ProductSearchHit {
    objectID: string;
    title: string;
+   group_title: string;
    handle: string;
    price_float: number;
    compare_at_price?: number;


### PR DESCRIPTION
fixes #212 

## Changelog

- Switch `title` with `group_title` in product list and grid views

## QA

1. Visit the Vercel PR preview (replace `vercel.app` with `cominor.com`)
2. Visit the parts product list
3. Verify that the changes close #212 