### PR TITLE
Filters: Sort capacity filter options

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductListFilters/FilterRow.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductListFilters/FilterRow.tsx
@@ -210,6 +210,16 @@ const Row = React.memo(
                                     onResize={onResize}
                                  />
                               );
+                           case facet.handle === 'capacity':
+                              return (
+                                 <ListFilter
+                                    key={facet.handle}
+                                    facet={facet}
+                                    multiple
+                                    showAllValues={showAllFacetValues}
+                                    sortItems={compareCapacity}
+                                 />
+                              );
                            default:
                               return (
                                  <ListFilter
@@ -308,4 +318,26 @@ function avg(x: string): number | null {
       return null;
    }
    return nums.reduce((x, y) => x + parseFloat(y), 0) / nums.length;
+}
+
+function compareCapacity(a: FacetOption, b: FacetOption): number {
+   return capacityStringToBytes(b.value) - capacityStringToBytes(a.value);
+}
+
+const unitToBytes = {
+   'B': 1,
+   'KB': 1024,
+   'MB': 1024 * 1024,
+   'GB': 1024 * 1024 * 1024,
+   'TB': 1024 * 1024 * 1024 * 1024,
+   'PB': 1024 * 1024 * 1024 * 1024 * 1024,
+};
+
+function capacityStringToBytes(x: string): number {
+   const size = parseFloat(x);
+   if (isNaN(size)) {
+      return 0;
+   }
+   const unit = x.replace(/[0-9.]+/, '').trim() as keyof typeof unitToBytes;
+   return size * (unitToBytes[unit] ?? 1);
 }

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductListFilters/FilterRow.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductListFilters/FilterRow.tsx
@@ -327,10 +327,10 @@ function compareCapacity(a: FacetOption, b: FacetOption): number {
 const unitToBytes = {
    'B': 1,
    'KB': 1024,
-   'MB': 1024 * 1024,
-   'GB': 1024 * 1024 * 1024,
-   'TB': 1024 * 1024 * 1024 * 1024,
-   'PB': 1024 * 1024 * 1024 * 1024 * 1024,
+   'MB': 1024 ** 2,
+   'GB': 1024 ** 3,
+   'TB': 1024 ** 4,
+   'PB': 1024 ** 5,
 };
 
 function capacityStringToBytes(x: string): number {

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductListFilters/FilterRow.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductListFilters/FilterRow.tsx
@@ -338,6 +338,6 @@ function capacityStringToBytes(x: string): number {
    if (isNaN(size)) {
       return 0;
    }
-   const unit = x.replace(/[0-9.]+/, '').trim() as keyof typeof unitToBytes;
+   const unit = (x.match(/[KMGTP]?B/)?.[0] ?? 'B') as keyof typeof unitToBytes;
    return size * (unitToBytes[unit] ?? 1);
 }


### PR DESCRIPTION
This sorts hard drive capacities from largest to smallest in the filter
options dropdown list. Before, they were being sorted alphabetically.

Triplet programmed with @danielbeardsley and @sterlinghirsh 

## QA
Visit the preview link.
Click the capacity dropdown and confirm that capacity sizes are sorted from largest to smallest.

Closes https://github.com/iFixit/ifixit/issues/42631