### PR TITLE
Update meta title to display product list name before brand name

### DIFF
--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -13,10 +13,11 @@ export function MetaTags({ productList }: MetaTagsProps) {
    const searchParams = useSearchParams();
    const isFiltered =
       searchParams.query.length > 0 || searchParams.filters.allIds.length > 0;
-   let title = `${productList.title} | iFixit`;
+   let title = productList.title;
    if (!isFiltered && searchParams.page > 1) {
       title += ` - Page ${searchParams.page}`;
    }
+   title += ' | iFixit';
    const canonicalUrl = `${IFIXIT_ORIGIN}${productList.path}${
       searchParams.page > 1
          ? `?${PRODUCT_LIST_PAGE_PARAM}=${searchParams.page}`

--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -13,7 +13,7 @@ export function MetaTags({ productList }: MetaTagsProps) {
    const searchParams = useSearchParams();
    const isFiltered =
       searchParams.query.length > 0 || searchParams.filters.allIds.length > 0;
-   let title = `iFixit | ${productList.title}`;
+   let title = `${productList.title} | iFixit`;
    if (!isFiltered && searchParams.page > 1) {
       title += ` - Page ${searchParams.page}`;
    }


### PR DESCRIPTION
closes #282 

## QA
1. visit vercel preview (replace _vercel.app_ with _cominor.com_)
2. navigate to `/Store/Parts`
3. confirm that the page title displays in the tab as "All Parts | iFixit"