### PR TITLE
Clear yarn cache during docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,7 +9,7 @@ COPY ./package.json ./
 COPY ./yarn.lock ./
 ENV PATH /opt/node_modules/.bin:$PATH
 RUN yarn config set network-timeout 600000 -g
-RUN yarn install
+RUN yarn install && yarn cache clean --all
 WORKDIR /opt/app
 COPY ./ .
 RUN NODE_ENV=production yarn build


### PR DESCRIPTION
The strapi docker image is kind of big-ish at 1.2GB. We can cut that almost _in half_ by cleaning out the yarn package cache.

Clearing the cache brings the image down to ~650MB, which isnt the smallest image, but is a relatively normal size.

qa_req 0

CC @danielbeardsley 

Closes: https://github.com/iFixit/react-commerce/issues/296