### PR TITLE
Store product list view user preference in local storage

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -15,6 +15,8 @@ import {
 } from '@chakra-ui/react';
 import { Card } from '@components/ui';
 import { useUpdateUrlQuery } from '@helpers/algolia-helpers';
+import { cypressWindowLog } from '@helpers/test-helpers';
+import { useLocalPreference } from '@ifixit/ui';
 import {
    useClearSearchParams,
    useHits,
@@ -24,10 +26,10 @@ import {
 import { ProductSearchHit } from '@models/product-list';
 import * as React from 'react';
 import { AppliedFilters } from './AppliedFilters';
-import { ProductListFilters } from './ProductListFilters';
 import { FiltersModal } from './FiltersModal';
 import { ProductGrid, ProductGridItem } from './ProductGrid';
 import { ProductList, ProductListItem } from './ProductList';
+import { ProductListFilters } from './ProductListFilters';
 import { ProductListPagination } from './ProductListPagination';
 import { SearchInput } from './SearchInput';
 import {
@@ -38,15 +40,17 @@ import {
    ProductViewSwitch,
    Toolbar,
 } from './Toolbar';
-import { cypressWindowLog } from '@helpers/test-helpers';
 
 export enum ProductViewType {
    Grid = 'grid',
    List = 'list',
 }
 
+const PRODUCT_VIEW_TYPE_STORAGE_KEY = 'productViewType';
+
 export const FilterableProductsSection = React.memo(() => {
-   const [productViewType, setProductViewType] = React.useState(
+   const [productViewType, setProductViewType] = useLocalPreference(
+      PRODUCT_VIEW_TYPE_STORAGE_KEY,
       ProductViewType.List
    );
    const [isFilterModalOpen, setIsFilterModalOpen] = React.useState(false);

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/ui/hooks/index.ts
+++ b/packages/ui/hooks/index.ts
@@ -127,3 +127,34 @@ export function useSSRBreakpointValue<Value>(
    const breakpointValue = useBreakpointValue(values, defaultBreakpoint);
    return isMounted ? breakpointValue : defaultBreakpoint;
 }
+
+/**
+ * A simple hook to store user preferences in local storage.
+ * @param key localStorage key
+ * @param defaultData
+ * @returns [value, setValue] tuple where `value` is the current value and `setValue` is a function to update it.
+ */
+export function useLocalPreference<Data = any>(
+   key: string,
+   defaultData: Data
+): [Data, (data: Data) => void] {
+   const [data, setData] = React.useState(defaultData);
+
+   React.useEffect(() => {
+      const serializedData = localStorage.getItem(key);
+      if (serializedData != null) {
+         try {
+            const data = JSON.parse(serializedData);
+            setData(data as Data);
+         } catch (error) {}
+      }
+   }, []);
+
+   const setAndSave = (data: Data) => {
+      setData(data);
+      const serializedData = JSON.stringify(data);
+      localStorage.setItem(key, serializedData);
+   };
+
+   return [data, setAndSave];
+}


### PR DESCRIPTION
fixes #95 

## Changelog

- Preserve user preference on product list view type

## QA

1. Visit the Vercel PR preview (replace vercel.app with cominor.com) 
2. Select product list `grid` type and verify that product list grid is shown
3. Reload the page a verify that the product list grid is still shown

cr_req  1