### PR TITLE
Search facets  hide irrelevant ones

### DIFF
--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -59,7 +59,7 @@ export function ProductListView({
                   {productList.children.length > 0 && (
                      <ProductListChildrenSection productList={productList} />
                   )}
-                  <FilterableProductsSection />
+                  <FilterableProductsSection productList={productList} />
                   {productList.sections.map((section, index) => {
                      switch (section.type) {
                         case ProductListSectionType.Banner: {

--- a/frontend/components/product-list/sections/FilterableProductsSection/FiltersModal.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FiltersModal.tsx
@@ -8,6 +8,7 @@ import {
    ModalOverlay,
 } from '@chakra-ui/react';
 import { useIsMounted } from '@ifixit/ui';
+import { ProductList } from '@models/product-list';
 import * as React from 'react';
 import { AppliedFilters } from './AppliedFilters';
 import { ProductListFilters } from './ProductListFilters';
@@ -15,9 +16,14 @@ import { ProductListFilters } from './ProductListFilters';
 type FiltersModalProps = {
    isOpen: boolean;
    onClose: () => void;
+   productList: ProductList;
 };
 
-export function FiltersModal({ isOpen, onClose }: FiltersModalProps) {
+export function FiltersModal({
+   isOpen,
+   onClose,
+   productList,
+}: FiltersModalProps) {
    const [canRenderList, setCanRenderList] = React.useState(false);
    const handleAnimationComplete = React.useCallback(() => {
       setCanRenderList(isOpen);
@@ -36,7 +42,9 @@ export function FiltersModal({ isOpen, onClose }: FiltersModalProps) {
             <ModalBody pt="2.5">
                <AppliedFilters pb="2" />
                <Box h="320px" mx="-6" overflow="hidden">
-                  {canRenderList && <ProductListFilters />}
+                  {canRenderList && (
+                     <ProductListFilters productList={productList} />
+                  )}
                </Box>
             </ModalBody>
             <ModalFooter flexDirection="column" alignItems="stretch">

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductListFilters/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductListFilters/index.tsx
@@ -189,27 +189,23 @@ function useFilteredFacets(wikiInfo: WikiInfoEntry[]) {
    const user = useAuthenticatedUser();
    const isProUser = user.data?.discountTier != null;
    const facets = useFacets();
-   const infoNames = React.useMemo(
-      () => new Set(wikiInfo.map((info) => `facet_tags.${info.name}`)),
-      [wikiInfo]
-   );
-   const sortedFacets = React.useMemo(() => {
-      return facets.slice().sort((a, b) => a.name.localeCompare(b.name));
-   }, [facets]);
-   const usefulFacets = React.useMemo(() => {
-      const facets = sortedFacets
+   const infoNames = React.useMemo(() => {
+      return new Set(wikiInfo.map((info) => `facet_tags.${info.name}`));
+   }, [wikiInfo]);
+   const [userFacets, refinedFacets] = React.useMemo(() => {
+      const usefulFacets = facets
+         .slice()
+         .sort((a, b) => a.name.localeCompare(b.name))
          .filter(isUsefulFacet)
          .filter((facet) => !infoNames.has(facet.algoliaName));
-      return isProUser ? facets.filter(isAvailableToProUsers) : facets;
-   }, [sortedFacets, isProUser, wikiInfo]);
-   const refinedFacets = React.useMemo(() => {
-      return usefulFacets.filter(hasMatchingOptions);
-   }, [usefulFacets]);
-   const displayedFacets = React.useMemo(() => {
-      return refinedFacets.length > 0 ? refinedFacets : usefulFacets;
-   }, [usefulFacets, refinedFacets]);
+      const userFacets = isProUser
+         ? usefulFacets.filter(isAvailableToProUsers)
+         : usefulFacets;
+      const refinedFacets = userFacets.filter(hasMatchingOptions);
+      return [userFacets, refinedFacets];
+   }, [facets, isProUser, infoNames]);
    return {
-      facets: displayedFacets,
+      facets: refinedFacets.length > 0 ? refinedFacets : userFacets,
       areRefined: refinedFacets.length > 0,
    };
 }

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -23,7 +23,10 @@ import {
    useSearchParams,
    useSearchState,
 } from '@lib/algolia';
-import { ProductSearchHit } from '@models/product-list';
+import {
+   ProductList as ProductListType,
+   ProductSearchHit,
+} from '@models/product-list';
 import * as React from 'react';
 import { AppliedFilters } from './AppliedFilters';
 import { FiltersModal } from './FiltersModal';
@@ -48,7 +51,12 @@ export enum ProductViewType {
 
 const PRODUCT_VIEW_TYPE_STORAGE_KEY = 'productViewType';
 
-export const FilterableProductsSection = React.memo(() => {
+type SectionProps = {
+   productList: ProductListType;
+};
+
+export const FilterableProductsSection = React.memo((props: SectionProps) => {
+   const { productList } = props;
    const [productViewType, setProductViewType] = useLocalPreference(
       PRODUCT_VIEW_TYPE_STORAGE_KEY,
       ProductViewType.List
@@ -112,6 +120,7 @@ export const FilterableProductsSection = React.memo(() => {
                   <FiltersModal
                      isOpen={isFilterModalOpen}
                      onClose={() => setIsFilterModalOpen(false)}
+                     productList={productList}
                   />
                   <VStack w="full" align="stretch" spacing={{ base: 2, md: 0 }}>
                      <HStack>
@@ -177,7 +186,7 @@ export const FilterableProductsSection = React.memo(() => {
                      <Skeleton height="30px" />
                   </VStack>
                ) : (
-                  <ProductListFilters />
+                  <ProductListFilters productList={productList} />
                )}
             </FilterCard>
             <VStack align="stretch" flex={1} spacing="0">

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -54,15 +54,9 @@ export async function findProductList(
       return null;
    }
    const productListImageAttributes = productList.image?.data?.attributes;
-   const shouldFetchDeviceWiki =
-      productList.image?.data?.attributes == null ||
-      productList.children?.data?.some(
-         (child) => child.attributes?.image?.data?.attributes == null
-      );
-   const deviceWiki =
-      shouldFetchDeviceWiki && productList.deviceTitle != null
-         ? await fetchDeviceWiki(productList.deviceTitle)
-         : null;
+   const deviceWiki = productList.deviceTitle
+      ? await fetchDeviceWiki(productList.deviceTitle)
+      : null;
 
    const algoliaApiKey = createProductListAlgoliaKey({
       appId: ALGOLIA_APP_ID,
@@ -100,6 +94,7 @@ export async function findProductList(
       algolia: {
          apiKey: algoliaApiKey,
       },
+      wikiInfo: deviceWiki?.info || [],
    };
 }
 

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -17,6 +17,12 @@ export interface ProductSearchHit {
    is_pro: number;
 }
 
+export type WikiInfoEntry = {
+   name: string;
+   value: string;
+   inheritedFrom: string | null;
+};
+
 export interface ProductList {
    title: string;
    handle: string;
@@ -34,6 +40,7 @@ export interface ProductList {
    algolia: {
       apiKey: string;
    };
+   wikiInfo: WikiInfoEntry[];
 }
 
 export interface ProductListAncestor {


### PR DESCRIPTION
Hide Facets that are already specified by the Device Parts page we are on.

Context: Assume we are on the `iPhone 7` parts list page
The "Device Brand" facet and its "iPhone" option is useless and
confusing cause *all* products here are already compatible with iPhones.

Here we hide any facets that come from the wiki info of the current
device and its ancestors.

Closes #299 