### PR TITLE
Fix Govinor deployment seed

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,8 @@
-AWS_REGION="us-west-1"
-S3_BUCKET="some-bucket-name"
+# This file is used by govinor to generate preview deployment for the branch
+# Every env variable in this file will be passed to the govinor preview deployment.
+# Env variable that are only meant for production (e.g. S3_BUCKET) should be commented out.
 JWT_SECRET=staging-secret
 SEED_DB=true
 API_TOKEN_SALT='Not_A-s3Cr3t-/Qr5iGP0g=='
+# AWS_REGION="us-west-1"
+# S3_BUCKET="some-bucket-name"


### PR DESCRIPTION
This PR fixes a Govinor deployment issue introduced by #309 that breaks the seed of new govinor preview instances.

The bug is due to Govinor usage of `.env.example` to populate env variables, but since Govinor deploys are not required to use S3, we're commenting out env variables related to that so they're not used by Govinor.
This is just a quick fix as probably a better way to solve it would be to build env variable management into Govinor.

# QA

1. Open the Govinor Strapi preview deployment for this branch
2. Verify that product lists have been seeded