### PR TITLE
Images for imageless devices

### DIFF
--- a/frontend/helpers/strapi-helpers.ts
+++ b/frontend/helpers/strapi-helpers.ts
@@ -25,7 +25,5 @@ export function getImageFromStrapiImage(
 export interface Image {
    url: string;
    alternativeText: string | null;
-   formats: {
-      url: string;
-   };
+   formats: Record<string, { url: string }>;
 }

--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -22,3 +22,32 @@ export async function fetchDeviceWiki(
       return null;
    }
 }
+
+export type MultipleDeviceApiResponse = {
+   images: Record<string, string>;
+};
+
+export type GuideImageSize =
+   | 'mini'
+   | 'thumbnail'
+   | '140x105'
+   | '200x150'
+   | 'standard'
+   | '440x330'
+   | 'medium'
+   | 'large'
+   | 'huge';
+
+export function fetchMultipleDeviceImages(
+   deviceTitles: string[],
+   size: GuideImageSize
+): Promise<MultipleDeviceApiResponse> {
+   const apiUrl = new URL(`${IFIXIT_ORIGIN}/api/2.0/wikis/topic_images`);
+   apiUrl.searchParams.set('size', size);
+   deviceTitles.forEach((deviceTitle) => {
+      apiUrl.searchParams.append('t[]', deviceTitle);
+   });
+   return fetch(apiUrl.toString())
+      .then((response) => response.json())
+      .catch(() => ({ images: {} }));
+}

--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -1,0 +1,24 @@
+import { IFIXIT_ORIGIN } from '@config/env';
+import { getDeviceHandle } from '@models/product-list';
+
+export type DeviceWiki = Record<string, any>;
+
+export async function fetchDeviceWiki(
+   deviceTitle: string
+): Promise<DeviceWiki | null> {
+   const deviceHandle = getDeviceHandle(deviceTitle);
+   try {
+      const response = await fetch(
+         `${IFIXIT_ORIGIN}/api/2.0/wikis/CATEGORY/${deviceHandle}`,
+         {
+            headers: {
+               'Content-Type': 'application/json',
+            },
+         }
+      );
+      const payload = await response.json();
+      return payload;
+   } catch (error: any) {
+      return null;
+   }
+}

--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -1,5 +1,4 @@
 import { IFIXIT_ORIGIN } from '@config/env';
-import { getDeviceHandle } from '@models/product-list';
 
 export type DeviceWiki = Record<string, any>;
 
@@ -50,4 +49,11 @@ export function fetchMultipleDeviceImages(
    return fetch(apiUrl.toString())
       .then((response) => response.json())
       .catch(() => ({ images: {} }));
+}
+
+/**
+ * Convert product list device title to a URL friendly slug
+ */
+export function getDeviceHandle(deviceTitle: string): string {
+   return deviceTitle.replace(/\s+/g, '_');
 }

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -143,7 +143,7 @@ async function fillMissingImagesFromApi(
       if (imageFromDevice != null) {
          child.image = {
             url: imageFromDevice,
-            alternativeText: null,
+            alternativeText: child.deviceTitle,
          };
       }
    });

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -30,6 +30,7 @@ import {
 } from './types';
 import { getImageFromStrapiImage } from '@helpers/strapi-helpers';
 import algoliasearch from 'algoliasearch';
+import { DeviceWiki, fetchDeviceWiki } from '@lib/ifixit-api/devices';
 
 export { ProductListSectionType } from './types';
 export type {
@@ -103,27 +104,6 @@ export async function findProductList(
    };
 }
 
-type DeviceWiki = Record<string, any>;
-
-async function fetchDeviceWiki(
-   deviceTitle: string
-): Promise<DeviceWiki | null> {
-   const deviceHandle = getDeviceHandle(deviceTitle);
-   try {
-      const response = await fetch(
-         `${IFIXIT_ORIGIN}/api/2.0/wikis/CATEGORY/${deviceHandle}`,
-         {
-            headers: {
-               'Content-Type': 'application/json',
-            },
-         }
-      );
-      const payload = await response.json();
-      return payload;
-   } catch (error: any) {
-      return null;
-   }
-}
 
 function getDeviceImage(deviceWiki: DeviceWiki): ProductListImage | null {
    return deviceWiki.image?.original == null

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -136,7 +136,7 @@ async function fillMissingImagesFromApi(
                   // typescript just doesn't understand
    const imagesResponse = await fetchMultipleDeviceImages(
       deviceTitlesWithoutImages,
-      'standard'
+      'thumbnail'
    );
    childrenWithoutImages.forEach((child) => {
       const imageFromDevice = imagesResponse.images[child.deviceTitle as string];

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -34,6 +34,7 @@ import {
    DeviceWiki,
    fetchDeviceWiki,
    fetchMultipleDeviceImages,
+   getDeviceHandle,
 } from '@lib/ifixit-api/devices';
 
 export { ProductListSectionType } from './types';
@@ -164,13 +165,6 @@ function getChildDeviceImage(
       };
    }
    return null;
-}
-
-/**
- * Convert product list device title to a URL friendly slug
- */
-export function getDeviceHandle(deviceTitle: string): string {
-   return deviceTitle.replace(/\s+/g, '_');
 }
 
 /**

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -30,7 +30,11 @@ import {
 } from './types';
 import { getImageFromStrapiImage } from '@helpers/strapi-helpers';
 import algoliasearch from 'algoliasearch';
-import { DeviceWiki, fetchDeviceWiki, fetchMultipleDeviceImages } from '@lib/ifixit-api/devices';
+import {
+   DeviceWiki,
+   fetchDeviceWiki,
+   fetchMultipleDeviceImages,
+} from '@lib/ifixit-api/devices';
 
 export { ProductListSectionType } from './types';
 export type {
@@ -128,13 +132,14 @@ async function fillMissingImagesFromApi(
    }
    const deviceTitlesWithoutImages = childrenWithoutImages.map(
       (child) => child.deviceTitle
-   );
+   ) as string[]; // cast is safe cause we filter nulls above,
+                  // typescript just doesn't understand
    const imagesResponse = await fetchMultipleDeviceImages(
       deviceTitlesWithoutImages,
       'standard'
    );
    childrenWithoutImages.forEach((child) => {
-      const imageFromDevice = imagesResponse.images[child.deviceTitle];
+      const imageFromDevice = imagesResponse.images[child.deviceTitle as string];
       if (imageFromDevice != null) {
          child.image = {
             url: imageFromDevice,
@@ -300,7 +305,7 @@ function createProductListChild(deviceWiki: DeviceWiki | null) {
       const imageAttributes = attributes.image?.data?.attributes;
       return {
          title: attributes.title,
-         deviceTitle: attributes.deviceTitle,
+         deviceTitle: attributes.deviceTitle || null,
          handle: attributes.handle,
          path: getProductListPath(attributes),
          image:

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -44,6 +44,7 @@ export interface ProductListAncestor {
 
 export interface ProductListChild {
    title: string;
+   deviceTitle: string | null;
    handle: string;
    path: string;
    image: ProductListImage | null;


### PR DESCRIPTION
Fill in images for some devices on Parts ProductList pages that were missing images.

### More specifically:
The list of child-nodes we show on a given product list page (parent device) sometimes don't match up with the list of device children in our ifixit.com hierarchy. When we query ifixit.com for the parent device, we only get pictures for the immediate children. For those nodes in strapi which aren't immediate children of the parent-device in our device hierarchy, the ifixit.com device api thus won't give us pictures. For these nodes without pictures, query their information (in bulk) via the new `topic_images` API so we can get images for them.

Closes #304