### PR TITLE
Collections: Add OEM partnership flare

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -189,7 +189,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                               px="2.5"
                               py="1"
                            >
-                              Lifetime warranty
+                              Lifetime Warranty
                            </Badge>
                         )}
                      </Flex>

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -13,6 +13,7 @@ import {
    Text,
    VStack,
 } from '@chakra-ui/react';
+import { ThemeTypings } from '@chakra-ui/styled-system';
 import { Rating } from '@components/ui';
 import { useAppContext } from '@ifixit/ui';
 import { ProductSearchHit } from '@models/product-list';
@@ -163,51 +164,26 @@ export function ProductListItem({ product }: ProductListItemProps) {
                            },
                         }}
                      >
-                        {showProBadge && (
-                           <Badge
-                              colorScheme="orange"
-                              textTransform="none"
-                              borderRadius="lg"
-                              px="2.5"
-                              py="1"
-                           >
-                              PRO
-                           </Badge>
-                        )}
-
-                        {showDiscountBadge && (
-                           <Badge
-                              colorScheme="red"
-                              textTransform="none"
-                              borderRadius="lg"
-                              px="2.5"
-                              py="1"
-                           >
-                              {percentage}% Off
-                           </Badge>
-                        )}
-                        {showOemPartnershipBadge && (
-                           <Badge
-                              colorScheme="green"
-                              textTransform="none"
-                              borderRadius="lg"
-                              px="2.5"
-                              py="1"
-                           >
-                              {product.oem_partnership}
-                           </Badge>
-                        )}
-                        {showLifetimeWarrantyBadge && (
-                           <Badge
-                              colorScheme="blue"
-                              textTransform="none"
-                              borderRadius="lg"
-                              px="2.5"
-                              py="1"
-                           >
-                              Lifetime Warranty
-                           </Badge>
-                        )}
+                        {showProBadge &&
+                           ProductListItemBadge({
+                              content: 'PRO',
+                              colorScheme: 'orange',
+                           })}
+                        {showDiscountBadge &&
+                           ProductListItemBadge({
+                              content: `${percentage}% Off`,
+                              colorScheme: 'red',
+                           })}
+                        {showOemPartnershipBadge &&
+                           ProductListItemBadge({
+                              content: product.oem_partnership!,
+                              colorScheme: 'green',
+                           })}
+                        {showLifetimeWarrantyBadge &&
+                           ProductListItemBadge({
+                              content: 'Lifetime Warranty',
+                              colorScheme: 'blue',
+                           })}
                      </Flex>
                   )}
                </Box>
@@ -295,5 +271,27 @@ export function ProductListItem({ product }: ProductListItemProps) {
             </Stack>
          </Flex>
       </LinkBox>
+   );
+}
+
+interface ProductListItemBadgeProps {
+   content: string;
+   colorScheme: ThemeTypings['colorSchemes'];
+}
+
+function ProductListItemBadge({
+   content,
+   colorScheme,
+}: ProductListItemBadgeProps) {
+   return (
+      <Badge
+         colorScheme={colorScheme}
+         textTransform="none"
+         borderRadius="lg"
+         px="2.5"
+         py="1"
+      >
+         {content}
+      </Badge>
    );
 }

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -54,8 +54,13 @@ export function ProductListItem({ product }: ProductListItemProps) {
    const showDiscountBadge = quantityAvailable > 0 && isDiscounted;
    const showLifetimeWarrantyBadge =
       quantityAvailable > 0 && product.lifetime_warranty;
+   const showOemPartnershipBadge =
+      quantityAvailable > 0 && product.oem_partnership;
    const showBadges =
-      showProBadge || showDiscountBadge || showLifetimeWarrantyBadge;
+      showProBadge ||
+      showDiscountBadge ||
+      showLifetimeWarrantyBadge ||
+      showOemPartnershipBadge;
 
    return (
       <LinkBox as="article" aria-labelledby={productHeadingId}>
@@ -179,6 +184,17 @@ export function ProductListItem({ product }: ProductListItemProps) {
                               py="1"
                            >
                               {percentage}% Off
+                           </Badge>
+                        )}
+                        {showOemPartnershipBadge && (
+                           <Badge
+                              colorScheme="green"
+                              textTransform="none"
+                              borderRadius="lg"
+                              px="2.5"
+                              py="1"
+                           >
+                              {product.oem_partnership}
                            </Badge>
                         )}
                         {showLifetimeWarrantyBadge && (

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -166,7 +166,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                      >
                         {showProBadge &&
                            ProductListItemBadge({
-                              content: 'PRO',
+                              content: 'iFixit Pro',
                               colorScheme: 'orange',
                            })}
                         {showDiscountBadge &&

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -11,6 +11,7 @@ export interface ProductSearchHit {
    short_description?: string;
    quantity_available: number;
    lifetime_warranty: boolean;
+   oem_partnership: string | null;
    rating: number;
    rating_count: number;
    url: string;


### PR DESCRIPTION
Adds a green OEM Partnership flare tag to product list items if the field exists in Algolia. Also updates the flare text for some badges.

## QA
Find products in product_en in [Algolia](https://www.algolia.com/apps/XQEP3AD9ZT/) that have the oem_partnership field. Also test when it is null.

Visit the vercel preview and view those products. Make sure the tag is present, and meets the conditions specified in the issue. The flare should come before 'Lifetime Warranty'.

(You can type 'teenage' into the search bar, and results come up with this flare)

Also make sure that these flares have the right text:
- 'Lifetime warranty' is now 'Lifetime Warranty'
- 'PRO' is now 'iFixit Pro'

CC @sterlinghirsh 

Closes #316
Closes #317 