### PR TITLE
Search Facets: Hide irrelevant ones (algolia hooks version)

### DIFF
--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -106,7 +106,9 @@ export function ProductListView({
                      {productList.children.length > 0 && (
                         <ProductListChildrenSection productList={productList} />
                      )}
-                     <FilterableProductsSection />
+                     <FilterableProductsSection
+                        wikiInfo={productList.wikiInfo}
+                     />
                      {productList.sections.map((section, index) => {
                         switch (section.type) {
                            case ProductListSectionType.Banner: {

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -12,15 +12,21 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { formatFacetName } from '@helpers/algolia-helpers';
+import { WikiInfoEntry } from '@models/product-list/types';
 import * as React from 'react';
 import { useHits, useRefinementList } from 'react-instantsearch-hooks-web';
 import { RangeInput } from './RangeInput';
 import { RefinementList } from './RefinementList';
 import { useCountRefinements } from './useCountRefinements';
-import { useFacets } from './useFacets';
+import { useFilteredFacets } from './useFacets';
 
-export function FacetsAccordion() {
-   const facets = useFacets();
+type FacetsAccordianProps = {
+   wikiInfo: WikiInfoEntry[];
+};
+
+export function FacetsAccordion(props: FacetsAccordianProps) {
+   const { wikiInfo } = props;
+   const facets = useFilteredFacets(wikiInfo);
    const countRefinements = useCountRefinements();
 
    return (

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
@@ -14,6 +14,7 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { formatFacetName } from '@helpers/algolia-helpers';
+import { WikiInfoEntry } from '@models/product-list/types';
 import * as React from 'react';
 import { HiArrowLeft, HiChevronRight } from 'react-icons/hi';
 import {
@@ -23,15 +24,16 @@ import {
 import { RangeInput } from './RangeInput';
 import { RefinementList } from './RefinementList';
 import { useCountRefinements } from './useCountRefinements';
-import { useFacets } from './useFacets';
+import { useFilteredFacets } from './useFacets';
 
 type FacetsDrawerProps = {
    isOpen: boolean;
    onClose: () => void;
+   wikiInfo: WikiInfoEntry[];
 };
 
-export function FacetsDrawer({ isOpen, onClose }: FacetsDrawerProps) {
-   const facets = useFacets();
+export function FacetsDrawer({ isOpen, onClose, wikiInfo }: FacetsDrawerProps) {
+   const facets = useFilteredFacets(wikiInfo);
    const [currentFacet, setCurrentFacet] = React.useState<string | null>(null);
    const countRefinements = useCountRefinements();
 

--- a/frontend/components/product-list/sections/FilterableProductsSection/Toolbar.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/Toolbar.tsx
@@ -13,6 +13,7 @@ import {
    Text,
    useDisclosure,
 } from '@chakra-ui/react';
+import { WikiInfoEntry } from '@models/product-list/types';
 import * as React from 'react';
 import { HiOutlineMenu, HiOutlineViewGrid } from 'react-icons/hi';
 import { useHits } from 'react-instantsearch-hooks-web';
@@ -27,15 +28,21 @@ export enum ProductViewType {
 export type ToolbarProps = {
    viewType: ProductViewType;
    onViewTypeChange: (viewType: ProductViewType) => void;
+   wikiInfo: WikiInfoEntry[];
 };
 
-export function Toolbar({ viewType, onViewTypeChange }: ToolbarProps) {
+export function Toolbar(props: ToolbarProps) {
+   const { viewType, onViewTypeChange, wikiInfo } = props;
    const drawer = useDisclosure({
       defaultIsOpen: false,
    });
    return (
       <>
-         <FacetsDrawer isOpen={drawer.isOpen} onClose={drawer.onClose} />
+         <FacetsDrawer
+            isOpen={drawer.isOpen}
+            onClose={drawer.onClose}
+            wikiInfo={wikiInfo}
+         />
          <Stack
             justify={{ md: 'space-between' }}
             align={{ base: 'stretch', md: 'center' }}

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -16,6 +16,7 @@ import { Card } from '@components/ui';
 import { cypressWindowLog } from '@helpers/test-helpers';
 import { useLocalPreference } from '@ifixit/ui';
 import { ProductSearchHit } from '@models/product-list';
+import { WikiInfoEntry } from '@models/product-list/types';
 import * as React from 'react';
 import {
    useClearRefinements,
@@ -32,7 +33,12 @@ import { ProductViewType, Toolbar } from './Toolbar';
 
 const PRODUCT_VIEW_TYPE_STORAGE_KEY = 'productViewType';
 
-export function FilterableProductsSection() {
+type SectionProps = {
+   wikiInfo: WikiInfoEntry[];
+};
+
+export function FilterableProductsSection(props: SectionProps) {
+   const { wikiInfo } = props;
    const { hits } = useHits<ProductSearchHit>();
    const [viewType, setViewType] = useLocalPreference(
       PRODUCT_VIEW_TYPE_STORAGE_KEY,
@@ -58,11 +64,15 @@ export function FilterableProductsSection() {
          <Heading as="h2" id="filterable-products-section-heading" srOnly>
             Products
          </Heading>
-         <Toolbar viewType={viewType} onViewTypeChange={setViewType} />
+         <Toolbar
+            viewType={viewType}
+            onViewTypeChange={setViewType}
+            wikiInfo={wikiInfo}
+         />
          <CurrentRefinements />
          <HStack mt="4" align="flex-start" spacing={{ base: 0, md: 4 }}>
             <FacetCard>
-               <FacetsAccordion />
+               <FacetsAccordion wikiInfo={wikiInfo} />
             </FacetCard>
             <Card flex={1}>
                {isEmpty ? (

--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -1,4 +1,6 @@
+import * as React from 'react';
 import { useDynamicWidgets } from 'react-instantsearch-hooks-web';
+import { WikiInfoEntry } from '@models/product-list/types';
 
 export function useFacets() {
    const { attributesToRender } = useDynamicWidgets({
@@ -18,4 +20,21 @@ export function useFacets() {
       'worksin',
    ];
    // return attributesToRender;
+}
+
+export function useFilteredFacets(wikiInfo: WikiInfoEntry[]) {
+   const facets = useFacets();
+
+   const infoNames = React.useMemo(() => {
+      return new Set(wikiInfo.map((info) => `facet_tags.${info.name}`));
+   }, [wikiInfo]);
+
+   const usefulFacets = React.useMemo(() => {
+      const usefulFacets = facets
+         .slice()
+         .filter((facet) => !infoNames.has(facet));
+      return usefulFacets;
+   }, [facets, infoNames]);
+
+   return usefulFacets;
 }

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -47,15 +47,10 @@ export async function findProductList(
       return null;
    }
    const productListImageAttributes = productList.image?.data?.attributes;
-   const shouldFetchDeviceWiki =
-      productList.image?.data?.attributes == null ||
-      productList.children?.data?.some(
-         (child) => child.attributes?.image?.data?.attributes == null
-      );
-   const deviceWiki =
-      shouldFetchDeviceWiki && productList.deviceTitle != null
-         ? await fetchDeviceWiki(productList.deviceTitle)
-         : null;
+
+   const deviceWiki = productList.deviceTitle
+      ? await fetchDeviceWiki(productList.deviceTitle)
+      : null;
 
    const algoliaApiKey = createProductListAlgoliaKey({
       appId: ALGOLIA_APP_ID,
@@ -97,6 +92,7 @@ export async function findProductList(
       algolia: {
          apiKey: algoliaApiKey,
       },
+      wikiInfo: deviceWiki?.info || [],
    };
 }
 

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -18,6 +18,12 @@ export interface ProductSearchHit {
    [attribute: string]: unknown;
 }
 
+export type WikiInfoEntry = {
+   name: string;
+   value: string;
+   inheritedFrom: string | null;
+};
+
 export interface ProductList {
    title: string;
    handle: string;
@@ -35,6 +41,7 @@ export interface ProductList {
    algolia: {
       apiKey: string;
    };
+   wikiInfo: WikiInfoEntry[];
 }
 
 export interface ProductListAncestor {


### PR DESCRIPTION
Hide Facets that are already specified by the Device Parts page we are on.

Context: Assume we are on the iPhone 7 parts list page
The "Device Brand" facet and its "iPhone" option is useless and
confusing cause all products here are already compatible with iPhones.

Here we hide any facets that come from the wiki info of the current
device and its ancestors.

## QA
When you visit a refined page of parts or tools (like /Parts/Dell_Laptop) make sure that any facets that exist in the device's wiki info are excluded from the page, both on mobile and on desktop views.

Closes #299 