### PR TITLE
Pin Node.js docker image to Alpine 3.14

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:16-alpine
+FROM node:16-alpine3.14
 # Installing libvips for sharp compatibility
 RUN apk --update-cache add vips-dev \
- && rm -rf /var/cache/apk/*
+  && rm -rf /var/cache/apk/*
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 WORKDIR /opt/


### PR DESCRIPTION
Apparently the last update to the Docker image of Node.js Alpine broke our dockerfile. I'd need to spend more time to understand exactly what's causing the issue with Alpine `3.16`, but my best guess is that it is related to the removal of `python2` (see [release notes](https://www.alpinelinux.org/posts/Alpine-3.16.0-released.html)).

This PR pin the node image to Alpine `3.14` which we were using before.

## QA

Verify that you can access the Govinor deploy [preview](https://debug-broken-docker-image.govinor.com/admin) for this branch.

## Notes

This PR should unblock #328 