### PR TITLE
Fix facet accordion items borders

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -24,10 +24,19 @@ export function FacetsAccordion() {
    const countRefinements = useCountRefinements();
 
    return (
-      <Accordion allowMultiple data-testid="facets-accordion">
-         {facets.map((facet, index) => {
-            const isFirst = index === 0;
-            const isLast = index === facets.length - 1;
+      <Accordion
+         allowMultiple
+         data-testid="facets-accordion"
+         sx={{
+            '>:first-child': {
+               borderTop: 'none',
+            },
+            '>:last-child': {
+               borderBottom: 'none',
+            },
+         }}
+      >
+         {facets.map((facet) => {
             const facetAttributes = [facet];
             if (facet === 'price_range') {
                facetAttributes.push('facet_tags.Price');
@@ -38,8 +47,6 @@ export function FacetsAccordion() {
                   key={facet}
                   attribute={facet}
                   refinedCount={refinedCount}
-                  borderTop={isFirst ? 'none' : undefined}
-                  borderBottom={isLast ? 'none' : undefined}
                />
             );
          })}


### PR DESCRIPTION
~~🚨 Blocked by #332 deploy_block~~

This PR removes the top border for the first facet accordion item, and the bottom one from the last facet accordion item.

![Screenshot 2022-06-14 at 17 00 57](https://user-images.githubusercontent.com/4640135/173610337-46e7e8ea-0820-497e-b609-e8fc01cb5e45.png)


## QA

1. Visit the Vercel PR preview (replace vercel.app with cominor.com)
2. Verify that the first and last borders are not shown