### PR TITLE
Algolia: Use `product_group_en`

### DIFF
--- a/frontend/config/constants.ts
+++ b/frontend/config/constants.ts
@@ -1,4 +1,4 @@
 export const PRODUCT_LIST_PAGE_PARAM = 'p';
 export const PRODUCT_LIST_QUERY_PARAM = 'q';
 export const DEFAULT_ANIMATION_DURATION_MS = 300;
-export const ALGOLIA_DEFAULT_INDEX_NAME = 'product_en';
+export const ALGOLIA_DEFAULT_INDEX_NAME = 'product_group_en';


### PR DESCRIPTION
Instead of `product_en`.

We can't get accurate counts on facet values because of the way algolia faceting works with combining product variant records into product group records with the algolia's distinct feature. This results in extraneous facet options showing up.

This change should avoid having to use distinct and fix facet value counts.

## QA

Run through all parts of the preview, and make sure nothing appears broken compared to main's preview.

CC @sterlinghirsh 

Closes #305