### PR TITLE
Cache: Bump it up

### DIFF
--- a/frontend/pages/Parts/[handle].tsx
+++ b/frontend/pages/Parts/[handle].tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    // The data is considered fresh for 10 seconds, and can be served even if stale for up to 10 minutes
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=10, stale-while-revalidate=600'
+      'public, s-maxage=600, stale-while-revalidate=1200'
    );
 
    const csrfToken = generateCSRFToken();

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    // The data is considered fresh for 10 seconds, and can be served even if stale for up to 10 minutes
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=10, stale-while-revalidate=600'
+      'public, s-maxage=600, stale-while-revalidate=1200'
    );
 
    const csrfToken = generateCSRFToken();

--- a/frontend/pages/Store/[handle].tsx
+++ b/frontend/pages/Store/[handle].tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    // The data is considered fresh for 10 seconds, and can be served even if stale for up to 10 minutes
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=10, stale-while-revalidate=600'
+      'public, s-maxage=600, stale-while-revalidate=1200'
    );
 
    const csrfToken = generateCSRFToken();

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    // The data is considered fresh for 10 seconds, and can be served even if stale for up to 10 minutes
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=10, stale-while-revalidate=600'
+      'public, s-maxage=600, stale-while-revalidate=1200'
    );
 
    const csrfToken = generateCSRFToken();

--- a/frontend/pages/Tools/index.tsx
+++ b/frontend/pages/Tools/index.tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    // The data is considered fresh for 10 seconds, and can be served even if stale for up to 10 minutes
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=10, stale-while-revalidate=600'
+      'public, s-maxage=600, stale-while-revalidate=1200'
    );
 
    const csrfToken = generateCSRFToken();


### PR DESCRIPTION
Cloudfront doesn't respect stale-while-revalidate, so at 10s, nearly all
of our page requests will be misses which are quite expensive.

Let's bump this because product data in algolia changes relatively
infrequently.