### PR TITLE
Decouple main product list from featured product list state

### DIFF
--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -1,12 +1,15 @@
 import { Flex, VStack } from '@chakra-ui/react';
 import { PageContentWrapper, SecondaryNavbar } from '@components/common';
 import { ALGOLIA_APP_ID } from '@config/env';
+import { computeProductListAlgoliaFilterPreset } from '@helpers/product-list-helpers';
 import { ProductList, ProductListSectionType } from '@models/product-list';
 import type { SearchClient } from 'algoliasearch/lite';
 import algoliasearch from 'algoliasearch/lite';
 import { history } from 'instantsearch.js/es/lib/routers';
 import * as React from 'react';
 import {
+   Configure,
+   Index,
    InstantSearch,
    InstantSearchServerState,
    InstantSearchSSRProvider,
@@ -41,6 +44,8 @@ export function ProductListView({
    algoliaClientRef.current =
       algoliaClientRef.current ??
       algoliasearch(ALGOLIA_APP_ID, productList.algolia.apiKey);
+
+   const filters = computeProductListAlgoliaFilterPreset(productList);
 
    return (
       <>
@@ -106,14 +111,19 @@ export function ProductListView({
                         }),
                      }}
                   >
-                     <MetaTags productList={productList} />
-                     <HeroSection productList={productList} />
-                     {productList.children.length > 0 && (
-                        <ProductListChildrenSection productList={productList} />
-                     )}
-                     <FilterableProductsSection
-                        wikiInfo={productList.wikiInfo}
-                     />
+                     <Index indexName={indexName}>
+                        <Configure filters={filters} />
+                        <MetaTags productList={productList} />
+                        <HeroSection productList={productList} />
+                        {productList.children.length > 0 && (
+                           <ProductListChildrenSection
+                              productList={productList}
+                           />
+                        )}
+                        <FilterableProductsSection
+                           wikiInfo={productList.wikiInfo}
+                        />
+                     </Index>
                      {productList.sections.map((section, index) => {
                         switch (section.type) {
                            case ProductListSectionType.Banner: {
@@ -146,6 +156,7 @@ export function ProductListView({
                                     <FeaturedProductListSection
                                        key={index}
                                        productList={productList}
+                                       index={index}
                                     />
                                  );
                               }

--- a/frontend/components/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/components/product-list/sections/FeaturedProductListSection.tsx
@@ -21,33 +21,24 @@ import {
    ProductCardTitle,
 } from '@components/common';
 import { Card } from '@components/ui';
-import { ALGOLIA_APP_ID } from '@config/env';
 import { computeDiscountPercentage } from '@helpers/commerce-helpers';
+import { computeProductListAlgoliaFilterPreset } from '@helpers/product-list-helpers';
 import { useAppContext } from '@ifixit/app';
 import { FeaturedProductList, ProductSearchHit } from '@models/product-list';
-import type { SearchClient } from 'algoliasearch/lite';
-import algoliasearch from 'algoliasearch/lite';
 import Image from 'next/image';
 import NextLink from 'next/link';
-import * as React from 'react';
-import {
-   Configure,
-   InstantSearch,
-   useHits,
-} from 'react-instantsearch-hooks-web';
+import { Configure, Index, useHits } from 'react-instantsearch-hooks-web';
 
 export interface FeaturedProductListSectionProps {
    productList: FeaturedProductList;
+   index: number;
 }
 
 export function FeaturedProductListSection({
    productList,
+   index,
 }: FeaturedProductListSectionProps) {
-   const algoliaClientRef = React.useRef<SearchClient>();
-   algoliaClientRef.current =
-      algoliaClientRef.current ??
-      algoliasearch(ALGOLIA_APP_ID, productList.algolia.apiKey);
-
+   const filters = computeProductListAlgoliaFilterPreset(productList);
    return (
       <Card
          overflow="hidden"
@@ -134,13 +125,13 @@ export function FeaturedProductListSection({
                </Box>
             </Box>
             <Box flexGrow={1}>
-               <InstantSearch
-                  searchClient={algoliaClientRef.current}
+               <Index
                   indexName={productList.algolia.indexName}
+                  indexId={`feature-product-list-${index}`}
                >
-                  <Configure hitsPerPage={3} />
+                  <Configure hitsPerPage={3} filters={filters} />
                   <ProductGrid />
-               </InstantSearch>
+               </Index>
             </Box>
          </Flex>
       </Card>

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -1,0 +1,17 @@
+type ProductListAttributes = {
+   filters?: string | null;
+   deviceTitle?: string | null;
+};
+
+export function computeProductListAlgoliaFilterPreset<
+   T extends ProductListAttributes
+>(productList: T): string | undefined {
+   const { filters, deviceTitle } = productList;
+   if (filters && filters.length > 0) {
+      return filters;
+   }
+   if (deviceTitle && deviceTitle.length > 0) {
+      return `device:${JSON.stringify(deviceTitle)}`;
+   }
+   return undefined;
+}

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -52,12 +52,10 @@ export async function findProductList(
       ? await fetchDeviceWiki(productList.deviceTitle)
       : null;
 
-   const algoliaApiKey = createProductListAlgoliaKey({
-      appId: ALGOLIA_APP_ID,
-      apiKey: ALGOLIA_API_KEY,
-      productListFilters: productList.filters,
-      deviceTitle: productList.deviceTitle,
-   });
+   const algoliaApiKey = createPublicAlgoliaKey(
+      ALGOLIA_APP_ID,
+      ALGOLIA_API_KEY
+   );
 
    return {
       title: productList.title,
@@ -286,12 +284,10 @@ function createProductListSection(
          }
          const image = productList.image?.data?.attributes;
 
-         const algoliaApiKey = createProductListAlgoliaKey({
-            appId: ALGOLIA_APP_ID,
-            apiKey: ALGOLIA_API_KEY,
-            productListFilters: productList.filters,
-            deviceTitle: productList.deviceTitle,
-         });
+         const algoliaApiKey = createPublicAlgoliaKey(
+            ALGOLIA_APP_ID,
+            ALGOLIA_API_KEY
+         );
 
          return {
             type: ProductListSectionType.FeaturedProductList,
@@ -351,20 +347,10 @@ function createProductListSection(
    }
 }
 
-function createProductListAlgoliaKey(options: {
-   appId: string;
-   apiKey: string;
-   productListFilters?: string | null;
-   deviceTitle?: string | null;
-}): string {
-   const client = algoliasearch(options.appId, options.apiKey);
-   const publicKey = client.generateSecuredApiKey(options.apiKey, {
-      filters:
-         options.productListFilters && options.productListFilters.length > 0
-            ? `${options.productListFilters} AND public=1`
-            : options.deviceTitle
-            ? `device:${JSON.stringify(options.deviceTitle)} AND public=1`
-            : 'public=1',
+function createPublicAlgoliaKey(appId: string, apiKey: string): string {
+   const client = algoliasearch(appId, apiKey);
+   const publicKey = client.generateSecuredApiKey(apiKey, {
+      filters: 'public=1',
    });
    return publicKey;
 }


### PR DESCRIPTION
fixes #342 

## Changelog

- Use instantsearch `Index` component to separate different Algolia use cases

## QA

1. Visit the Vercel PR preview (replace vercel.app with cominor.com)
2. Visit the `/Parts` product list
3. Verify that the product list displays generic parts, while the featured list below displays only Nintendo parts
