### PR TITLE
Webpack: Enable optimization on server-side bundles

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -82,18 +82,21 @@ const moduleExports = {
    }),
 };
 
-// Make sure adding Sentry options is the last code to run before exporting, to
-// ensure that your source maps include changes from all other Webpack plugins
-const plugins = withSentryConfig(
-   withBundleAnalyzer(withTM(moduleExports)),
-   SENTRY_AUTH_TOKEN ? sentryWebpackPluginOptions : undefined
-);
-
-module.exports = {
-   ...plugins,
-   webpack(config, info) {
-      config = plugins.webpack(config, info);
-      config.optimization.minimize = true;
-      return config;
+function withUniversalOptimization(plugins) {
+   const configureWebpack = plugins.webpack || ((config, info) => config);
+   return {
+      ...plugins,
+      webpack(config, info) {
+         config = configureWebpack(config, info)
+         config.optimization.minimize = true;
+         return config;
+      }
    }
 }
+
+// Make sure adding Sentry options is the last code to run before exporting, to
+// ensure that your source maps include changes from all other Webpack plugins
+module.exports = withSentryConfig(
+   withUniversalOptimization(withBundleAnalyzer(withTM(moduleExports))),
+   SENTRY_AUTH_TOKEN ? sentryWebpackPluginOptions : undefined
+)

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -84,9 +84,16 @@ const moduleExports = {
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = withBundleAnalyzer(
-   withSentryConfig(
-      withTM(moduleExports),
-      SENTRY_AUTH_TOKEN ? sentryWebpackPluginOptions : undefined
-   )
+const plugins = withSentryConfig(
+   withBundleAnalyzer(withTM(moduleExports)),
+   SENTRY_AUTH_TOKEN ? sentryWebpackPluginOptions : undefined
 );
+
+module.exports = {
+   ...plugins,
+   webpack(config, info) {
+      config = plugins.webpack(config, info);
+      config.optimization.minimize = true;
+      return config;
+   }
+}


### PR DESCRIPTION
NextJS doesn't tree-shake server-side bundles by default:
https://github.com/vercel/next.js/issues/8956#issuecomment-557867732

We suspect that the large amount of code being loaded by our Lambdas is resulting in slow startup times.

This enables tree-shaking and other optimizations on the server-side code, in order to reduce bundle size. We're hoping this helps with startup times.

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/1283490/174678952-a2fdbced-009c-4975-bc50-f99b443f78c4.png)


</details>
<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/1283490/174679021-139687fb-77e9-4fe2-a68e-ece3783127ef.png)

</details>