### PR TITLE
Images: add IfixitImage component

### DIFF
--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -50,7 +50,7 @@ import {
 import { GlobalSettings } from '@models/global-settings';
 import { MenuItemType } from '@models/menu';
 import { Store, StoreListItem } from '@models/store';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 import * as React from 'react';
 import { RiCheckFill } from 'react-icons/ri';
 
@@ -161,7 +161,7 @@ export function LayoutFooter({
                               p="0"
                            >
                               {partner.image?.url ? (
-                                 <Image
+                                 <IfixitImage
                                     layout="fill"
                                     objectFit="contain"
                                     src={partner.image.url}
@@ -171,7 +171,7 @@ export function LayoutFooter({
                                     }
                                  />
                               ) : (
-                                 <Image
+                                 <IfixitImage
                                     layout="fill"
                                     objectFit="contain"
                                     src={noImageFixie}

--- a/frontend/components/common/ProductCard.tsx
+++ b/frontend/components/common/ProductCard.tsx
@@ -12,7 +12,7 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { Rating } from '@components/ui';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 import React from 'react';
 
 export const ProductCard = (props: StackProps) => {
@@ -38,7 +38,7 @@ export const ProductCardImage = ({ src, alt }: ProductCardImageProps) => {
    if (src == null) {
       return (
          <AspectRatio ratio={1} flexGrow={0} flexShrink={0} position="relative">
-            <Image
+            <IfixitImage
                sizes="30vw"
                layout="fill"
                src={placeholderImageUrl}
@@ -49,7 +49,7 @@ export const ProductCardImage = ({ src, alt }: ProductCardImageProps) => {
    }
    return (
       <AspectRatio ratio={1} flexGrow={0} flexShrink={0} position="relative">
-         <Image
+         <IfixitImage
             sizes="30vw"
             layout="fill"
             objectFit="contain"

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -1,17 +1,19 @@
 import Image, { ImageProps, ImageLoader } from 'next/image';
 
 export function IfixitImage(props: ImageProps) {
+   let unoptimized = props.unoptimized;
+
    if (typeof props.src === 'string') {
       if (isGuideImage(props.src)) {
-         props.loader = passThroughLoader;
+         unoptimized = true;
       } else if (isCartImage(props.src)) {
-         props.loader = passThroughLoader;
+         unoptimized = true;
       } else if (isStrapiImage(props.src)) {
-         props.loader = passThroughLoader;
+         unoptimized = true;
       }
    }
 
-   return <Image {...props} />;
+   return <Image {...props} unoptimized={unoptimized} />;
 }
 
 function isGuideImage(src: string) {
@@ -30,8 +32,4 @@ function isStrapiImage(src: string) {
    return src.match(
       /^https:\/\/ifixit-(dev-)?strapi-uploads.s3.amazonaws.com\//
    );
-}
-
-function passThroughLoader({ src }: { src: string }) {
-   return src;
 }

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -22,7 +22,7 @@ function isGuideImage(src: string) {
 
 function isCartImage(src: string) {
    return src.match(
-      /^https:\/\/(cart-products\.cdn\.ifixit\.com\/|([^/]+\.(ubreakit|cominor)\.com\/cart-products))\//
+      /^https:\/\/(cart-products\.cdn\.ifixit\.com\/|([^/]+\.(ubreakit|cominor)\.com\/cart-products))/
    );
 }
 

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -1,0 +1,5 @@
+import Image, { ImageProps } from 'next/image';
+
+export function IfixitImage(props: ImageProps) {
+   return <Image {...props} />;
+}

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -1,5 +1,37 @@
-import Image, { ImageProps } from 'next/image';
+import Image, { ImageProps, ImageLoader } from 'next/image';
 
 export function IfixitImage(props: ImageProps) {
+   if (typeof props.src === 'string') {
+      if (isGuideImage(props.src)) {
+         props.loader = passThroughLoader;
+      } else if (isCartImage(props.src)) {
+         props.loader = passThroughLoader;
+      } else if (isStrapiImage(props.src)) {
+         props.loader = passThroughLoader;
+      }
+   }
+
    return <Image {...props} />;
+}
+
+function isGuideImage(src: string) {
+   return src.match(
+      /^https:\/\/(guide-images\.cdn\.ifixit\.com\/|([^/]+\.(ubreakit|cominor)\.com\/igi))\//
+   );
+}
+
+function isCartImage(src: string) {
+   return src.match(
+      /^https:\/\/(cart-products\.cdn\.ifixit\.com\/|([^/]+\.(ubreakit|cominor)\.com\/cart-products))\//
+   );
+}
+
+function isStrapiImage(src: string) {
+   return src.match(
+      /^https:\/\/ifixit-(dev-)?strapi-uploads.s3.amazonaws.com\//
+   );
+}
+
+function passThroughLoader({ src }: { src: string }) {
+   return src;
 }

--- a/frontend/components/ifixit-image/index.ts
+++ b/frontend/components/ifixit-image/index.ts
@@ -1,0 +1,1 @@
+export { IfixitImage } from './ifixit-image';

--- a/frontend/components/product-list/sections/BannerSection/index.tsx
+++ b/frontend/components/product-list/sections/BannerSection/index.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Flex, Icon, Text } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import * as React from 'react';
 import backgroundImage from './lifetime-guarantee-background.jpg';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 
 export interface BannerSectionProps {
    title: string;
@@ -28,7 +28,12 @@ export function BannerSection({
          overflow="hidden"
          position="relative"
       >
-         <Image src={backgroundImage} alt="" layout="fill" objectFit="cover" />
+         <IfixitImage
+            src={backgroundImage}
+            alt=""
+            layout="fill"
+            objectFit="cover"
+         />
          <Flex
             p={{
                base: 10,

--- a/frontend/components/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/components/product-list/sections/FeaturedProductListSection.tsx
@@ -27,7 +27,7 @@ import { useAppContext } from '@ifixit/app';
 import { FeaturedProductList, ProductSearchHit } from '@models/product-list';
 import type { SearchClient } from 'algoliasearch/lite';
 import algoliasearch from 'algoliasearch/lite';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 import NextLink from 'next/link';
 import * as React from 'react';
 import {
@@ -79,7 +79,7 @@ export function FeaturedProductListSection({
                alignItems="center"
             >
                {productList.image && (
-                  <Image
+                  <IfixitImage
                      src={productList.image.url}
                      alt={productList.image.alternativeText ?? ''}
                      objectFit="contain"

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -17,7 +17,7 @@ import { ThemeTypings } from '@chakra-ui/styled-system';
 import { Rating } from '@components/ui';
 import { useAppContext } from '@ifixit/app';
 import { ProductSearchHit } from '@models/product-list';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 import * as React from 'react';
 import { useProductSearchHitPricing } from './useProductSearchHitPricing';
 
@@ -84,7 +84,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                }}
             >
                {product.image_url ? (
-                  <Image
+                  <IfixitImage
                      src={product.image_url}
                      alt={product.group_title}
                      objectFit="contain"
@@ -92,7 +92,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                      height="180px"
                   />
                ) : (
-                  <Image
+                  <IfixitImage
                      src={placeholderImageUrl}
                      alt={product.group_title}
                      sizes="180px"

--- a/frontend/components/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/components/product-list/sections/ProductListChildrenSection.tsx
@@ -12,7 +12,7 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { useIsMounted } from '@ifixit/ui';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 import NextLink from 'next/link';
 import * as React from 'react';
 
@@ -180,7 +180,7 @@ const ChildLink = ({ child }: ChildLinkProps) => {
                         flexShrink={0}
                         position="relative"
                      >
-                        <Image
+                        <IfixitImage
                            src={child.image.url}
                            alt={child.image.alt}
                            objectFit="cover"

--- a/frontend/components/product-list/sections/ProductListSetSection.tsx
+++ b/frontend/components/product-list/sections/ProductListSetSection.tsx
@@ -8,7 +8,7 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { ProductListPreview } from '@models/product-list';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 import NextLink from 'next/link';
 import * as React from 'react';
 
@@ -73,7 +73,7 @@ const ProductListLink = ({ productList }: ProductListLinkProps) => {
                   flexGrow={0}
                   flexShrink={0}
                >
-                  <Image
+                  <IfixitImage
                      src={productList.image.url}
                      alt={productList.image.alternativeText ?? ''}
                      width="80px"

--- a/frontend/components/product-list/sections/RelatedPostsSection/PostCard.tsx
+++ b/frontend/components/product-list/sections/RelatedPostsSection/PostCard.tsx
@@ -10,7 +10,7 @@ import { Card } from '@components/ui';
 import dayjs from 'dayjs';
 import NextLink from 'next/link';
 import * as React from 'react';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 
 export interface PostCardProps {
    title: string;
@@ -42,7 +42,7 @@ export function PostCard({
          <Flex direction="column">
             {imageSrc && (
                <Box position="relative" h="140px">
-                  <Image
+                  <IfixitImage
                      src={imageSrc}
                      alt={imageAlt}
                      layout="fill"

--- a/packages/ui/cart/drawer/CartLineItem.tsx
+++ b/packages/ui/cart/drawer/CartLineItem.tsx
@@ -20,7 +20,7 @@ import {
    useUpdateLineItemQuantity,
 } from '@ifixit/cart-sdk';
 import { motion } from 'framer-motion';
-import Image from 'next/image';
+import { IfixitImage } from '@components/ifixit-image';
 import * as React from 'react';
 import {
    HiOutlineMinusCircle,
@@ -94,7 +94,7 @@ export function CartLineItem({ lineItem }: CartLineItemProps) {
                   borderRadius="lg"
                   overflow="hidden"
                >
-                  <Image
+                  <IfixitImage
                      src={lineItem.imageSrc}
                      alt=""
                      priority


### PR DESCRIPTION
We want fine grained control over when and how we use next/image and its image resizing pipeline. Given that each of our images are rendered in many sizes, we want to be able to choose the sizes to use and when.

This is a minimal starting point. This gives us one place where we can tune when to use which sizes and when to use next's image pipeline. For the time being, all images are served directly from their sources instead of being re-compressed on the fly.

CC @sterlinghirsh @andyg0808 

