### PR TITLE
Add temporary fix to avoid page crash

### DIFF
--- a/frontend/components/common/AppProviders.tsx
+++ b/frontend/components/common/AppProviders.tsx
@@ -5,6 +5,7 @@ import { theme } from '@ifixit/ui';
 import Head from 'next/head';
 import * as React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { AlgoliaProps, InstantSearchProvider } from './InstantSearchProvider';
 
 const customTheme = extendTheme({
    ...theme,
@@ -31,12 +32,19 @@ const customTheme = extendTheme({
 
 const queryClient = new QueryClient();
 
-export type AppProvidersProps = React.PropsWithChildren<{
-   csrfToken: string;
-}>;
+export type WithProvidersProps<T> = T & { appProps: AppProvidersProps };
 
-export function AppProviders({ children, csrfToken }: AppProvidersProps) {
-   return (
+export type AppProvidersProps = {
+   csrfToken: string;
+   algolia?: AlgoliaProps;
+};
+
+export function AppProviders({
+   children,
+   csrfToken,
+   algolia,
+}: React.PropsWithChildren<AppProvidersProps>) {
+   const markup = (
       <AppProvider ifixitOrigin={IFIXIT_ORIGIN} csrfToken={csrfToken}>
          <QueryClientProvider client={queryClient}>
             <Head>
@@ -65,4 +73,11 @@ export function AppProviders({ children, csrfToken }: AppProvidersProps) {
          </QueryClientProvider>
       </AppProvider>
    );
+
+   if (algolia) {
+      return (
+         <InstantSearchProvider {...algolia}>{markup}</InstantSearchProvider>
+      );
+   }
+   return markup;
 }

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -1,0 +1,115 @@
+import { ALGOLIA_APP_ID } from '@config/env';
+import algoliasearch, { SearchClient } from 'algoliasearch/lite';
+import { history } from 'instantsearch.js/es/lib/routers';
+import * as React from 'react';
+import {
+   InstantSearch,
+   InstantSearchServerState,
+   InstantSearchSSRProvider,
+} from 'react-instantsearch-hooks-web';
+
+type InstantSearchProviderProps = React.PropsWithChildren<AlgoliaProps>;
+
+export type AlgoliaProps = {
+   url: string;
+   indexName: string;
+   routing?: boolean;
+   serverState?: Partial<InstantSearchServerState>;
+   apiKey: string;
+};
+
+type RouteState = Partial<{
+   q: string;
+   p: number;
+   filter: Record<string, any>;
+   range: Record<string, string>;
+}>;
+
+export function InstantSearchProvider({
+   children,
+   url,
+   indexName,
+   serverState,
+   apiKey,
+   routing,
+}: InstantSearchProviderProps) {
+   const algoliaClientRef = React.useRef<SearchClient>();
+   algoliaClientRef.current =
+      algoliaClientRef.current ?? algoliasearch(ALGOLIA_APP_ID, apiKey);
+
+   // We're using this to make `InstantSearch` unmount at every re-render, since as of version 6.28.0 it breaks when
+   // it re-renders. Re-rendering though should be relatively infrequent in this component, so this should be fine.
+   const count = useCountRenders();
+
+   const provider = (
+      <InstantSearchSSRProvider {...serverState}>
+         <InstantSearch
+            key={count}
+            searchClient={algoliaClientRef.current}
+            indexName={indexName}
+            routing={{
+               stateMapping: {
+                  stateToRoute(uiState): any {
+                     const indexUiState = uiState[indexName];
+                     const routeState: RouteState = {};
+                     if (indexUiState.query) {
+                        routeState.q = indexUiState.query;
+                     }
+                     if (indexUiState.page) {
+                        routeState.p = indexUiState.page;
+                     }
+                     if (indexUiState.refinementList) {
+                        routeState.filter = indexUiState.refinementList;
+                     }
+                     if (indexUiState.range != null) {
+                        routeState.range = indexUiState.range;
+                     }
+                     return routeState;
+                  },
+                  routeToState(routeState: RouteState) {
+                     const stateObject: Record<string, any> = {};
+                     if (routeState.q != null) {
+                        stateObject.query = routeState.q;
+                     }
+                     if (routeState.p != null) {
+                        stateObject.page = routeState.p;
+                     }
+                     if (routeState.filter != null) {
+                        stateObject.refinementList = routeState.filter;
+                     }
+                     if (routeState.range != null) {
+                        stateObject.range = routeState.range;
+                     }
+                     return {
+                        [indexName]: stateObject,
+                     };
+                  },
+               },
+               router: history({
+                  getLocation() {
+                     if (typeof window === 'undefined') {
+                        return new URL(url) as unknown as Location;
+                     }
+
+                     return window.location;
+                  },
+               }),
+            }}
+         >
+            {children}
+         </InstantSearch>
+      </InstantSearchSSRProvider>
+   );
+   if (routing) {
+      <InstantSearchSSRProvider {...serverState}>
+         {provider}
+      </InstantSearchSSRProvider>;
+   }
+   return provider;
+}
+
+function useCountRenders() {
+   const countRef = React.useRef(0);
+   countRef.current++;
+   return countRef.current;
+}

--- a/frontend/components/common/Layout/index.tsx
+++ b/frontend/components/common/Layout/index.tsx
@@ -67,7 +67,7 @@ export interface LayoutProps {
    globalSettings: GlobalSettings;
 }
 
-export type WithLayoutProps<T> = T & LayoutProps;
+export type WithLayoutProps<T> = T & { layoutProps: LayoutProps };
 
 export function Layout({
    title,

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -1,19 +1,8 @@
 import { Flex, VStack } from '@chakra-ui/react';
 import { PageContentWrapper, SecondaryNavbar } from '@components/common';
-import { ALGOLIA_APP_ID } from '@config/env';
 import { computeProductListAlgoliaFilterPreset } from '@helpers/product-list-helpers';
 import { ProductList, ProductListSectionType } from '@models/product-list';
-import type { SearchClient } from 'algoliasearch/lite';
-import algoliasearch from 'algoliasearch/lite';
-import { history } from 'instantsearch.js/es/lib/routers';
-import * as React from 'react';
-import {
-   Configure,
-   Index,
-   InstantSearch,
-   InstantSearchServerState,
-   InstantSearchSSRProvider,
-} from 'react-instantsearch-hooks-web';
+import { Configure, Index } from 'react-instantsearch-hooks-web';
 import { MetaTags } from './MetaTags';
 import { ProductListBreadcrumb } from './ProductListBreadcrumb';
 import { ProductListDeviceNavigation } from './ProductListDeviceNavigation';
@@ -29,22 +18,13 @@ import {
 
 export interface ProductListViewProps {
    productList: ProductList;
-   url: string;
-   serverState?: Partial<InstantSearchServerState>;
    indexName: string;
 }
 
 export function ProductListView({
    productList,
-   url,
-   serverState,
    indexName,
 }: ProductListViewProps) {
-   const algoliaClientRef = React.useRef<SearchClient>();
-   algoliaClientRef.current =
-      algoliaClientRef.current ??
-      algoliasearch(ALGOLIA_APP_ID, productList.algolia.apiKey);
-
    const filters = computeProductListAlgoliaFilterPreset(productList);
 
    return (
@@ -65,128 +45,71 @@ export function ProductListView({
          </SecondaryNavbar>
          <PageContentWrapper py="10">
             <VStack align="stretch" spacing="12">
-               <InstantSearchSSRProvider
-                  {...serverState}
-                  key={productList.handle}
-               >
-                  <InstantSearch
-                     searchClient={algoliaClientRef.current}
-                     indexName={indexName}
-                     routing={{
-                        stateMapping: {
-                           stateToRoute(uiState) {
-                              const indexUiState = uiState[indexName];
-                              const routeObject: any = {
-                                 q: indexUiState.query,
-                                 p: indexUiState.page,
-                              };
-                              routeObject.filter = indexUiState.refinementList;
-                              if (indexUiState.range != null) {
-                                 routeObject.range = indexUiState.range;
-                              }
-                              return routeObject;
-                           },
-                           routeToState(routeState: any) {
-                              const stateObject: any = {
-                                 query: routeState.q,
-                                 page: routeState.p,
-                                 refinementList: routeState.filter,
-                              };
-                              if (routeState.range != null) {
-                                 stateObject.range = routeState.range;
-                              }
-                              return {
-                                 [indexName]: stateObject,
-                              };
-                           },
-                        },
-                        router: history({
-                           getLocation() {
-                              if (typeof window === 'undefined') {
-                                 return new URL(url) as unknown as Location;
-                              }
-
-                              return window.location;
-                           },
-                        }),
-                     }}
-                  >
-                     <Index indexName={indexName}>
-                        <Configure filters={filters} />
-                        <MetaTags productList={productList} />
-                        <HeroSection productList={productList} />
-                        {productList.children.length > 0 && (
-                           <ProductListChildrenSection
-                              productList={productList}
+               <Index indexName={indexName}>
+                  <Configure filters={filters} />
+                  <MetaTags productList={productList} />
+                  <HeroSection productList={productList} />
+                  {productList.children.length > 0 && (
+                     <ProductListChildrenSection productList={productList} />
+                  )}
+                  <FilterableProductsSection wikiInfo={productList.wikiInfo} />
+               </Index>
+               {productList.sections.map((section, index) => {
+                  switch (section.type) {
+                     case ProductListSectionType.Banner: {
+                        return (
+                           <BannerSection
+                              key={index}
+                              title={section.title}
+                              description={section.description}
+                              callToActionLabel={section.callToActionLabel}
+                              url={section.url}
                            />
-                        )}
-                        <FilterableProductsSection
-                           wikiInfo={productList.wikiInfo}
-                        />
-                     </Index>
-                     {productList.sections.map((section, index) => {
-                        switch (section.type) {
-                           case ProductListSectionType.Banner: {
-                              return (
-                                 <BannerSection
-                                    key={index}
-                                    title={section.title}
-                                    description={section.description}
-                                    callToActionLabel={
-                                       section.callToActionLabel
-                                    }
-                                    url={section.url}
-                                 />
-                              );
-                           }
-                           case ProductListSectionType.RelatedPosts: {
-                              const tags = [productList.title].concat(
-                                 section.tags
-                                    ?.split(',')
-                                    .map((tag) => tag.trim()) || []
-                              );
-                              return (
-                                 <RelatedPostsSection key={index} tags={tags} />
-                              );
-                           }
-                           case ProductListSectionType.FeaturedProductList: {
-                              const { productList } = section;
-                              if (productList) {
-                                 return (
-                                    <FeaturedProductListSection
-                                       key={index}
-                                       productList={productList}
-                                       index={index}
-                                    />
-                                 );
-                              }
-                              return null;
-                           }
-                           case ProductListSectionType.ProductListSet: {
-                              const { title, productLists } = section;
-                              if (productLists.length > 0) {
-                                 return (
-                                    <ProductListSetSection
-                                       key={index}
-                                       title={title}
-                                       productLists={productLists}
-                                    />
-                                 );
-                              }
-                              return null;
-                           }
-                           default: {
-                              console.warn(
-                                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                                 // @ts-ignore
-                                 `Section ${section.__typename} not implemented`
-                              );
-                              return null;
-                           }
+                        );
+                     }
+                     case ProductListSectionType.RelatedPosts: {
+                        const tags = [productList.title].concat(
+                           section.tags?.split(',').map((tag) => tag.trim()) ||
+                              []
+                        );
+                        return <RelatedPostsSection key={index} tags={tags} />;
+                     }
+                     case ProductListSectionType.FeaturedProductList: {
+                        const { productList } = section;
+                        if (productList) {
+                           return (
+                              <FeaturedProductListSection
+                                 key={index}
+                                 productList={productList}
+                                 index={index}
+                              />
+                           );
                         }
-                     })}
-                  </InstantSearch>
-               </InstantSearchSSRProvider>
+                        return null;
+                     }
+                     case ProductListSectionType.ProductListSet: {
+                        const { title, productLists } = section;
+                        if (productLists.length > 0) {
+                           return (
+                              <ProductListSetSection
+                                 key={index}
+                                 title={title}
+                                 productLists={productLists}
+                              />
+                           );
+                        }
+                        return null;
+                     }
+                     default: {
+                        console.warn(
+                           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                           // @ts-ignore
+                           `Section ${section.__typename} not implemented`
+                        );
+                        return null;
+                     }
+                  }
+               })}
             </VStack>
          </PageContentWrapper>
       </>

--- a/frontend/components/product-list/sections/FilterableProductsSection/Pagination.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/Pagination.tsx
@@ -5,7 +5,6 @@ import {
    PaginationLink,
    useIsMounted,
 } from '@ifixit/ui';
-import * as React from 'react';
 import {
    HiChevronDoubleLeft,
    HiChevronDoubleRight,

--- a/frontend/pages/Parts/[handle].tsx
+++ b/frontend/pages/Parts/[handle].tsx
@@ -1,15 +1,17 @@
-import { AppProviders, Layout, WithLayoutProps } from '@components/common';
+import {
+   AppProviders,
+   AppProvidersProps,
+   Layout,
+   WithLayoutProps,
+   WithProvidersProps,
+} from '@components/common';
 import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
 import { IFIXIT_ORIGIN } from '@config/env';
-import {
-   generateCSRFToken,
-   setCSRFCookie,
-   WithCSRFProps,
-} from '@ifixit/auth-sdk';
+import { generateCSRFToken, setCSRFCookie } from '@ifixit/auth-sdk';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList, getDeviceTitle } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -17,7 +19,7 @@ import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
 
 type PageProps = WithLayoutProps<ProductListViewProps>;
-type AppPageProps = WithCSRFProps<PageProps>;
+type AppPageProps = WithProvidersProps<PageProps>;
 
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
@@ -66,53 +68,54 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.req.url}`;
    const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+
+   const appProps: AppProvidersProps = {
+      csrfToken,
+      algolia: {
+         indexName,
+         url,
+         routing: true,
+         apiKey: productList.algolia.apiKey,
+      },
+   };
+
    const serverState = await getServerState(
-      <AppProviders csrfToken={csrfToken}>
-         <ProductListPage
-            productList={productList}
-            url={url}
-            indexName={indexName}
-            title={title}
-            globalSettings={globalSettings}
-            stores={stores}
-            currentStore={currentStore}
-         />
+      <AppProviders {...appProps}>
+         <ProductListView productList={productList} indexName={indexName} />
       </AppProviders>
    );
 
-   return {
-      props: {
-         csrfToken,
+   const pageProps: AppPageProps = {
+      productList,
+      indexName,
+      layoutProps: {
          globalSettings,
          currentStore,
          stores,
          title,
-         productList,
-         indexName,
-         serverState,
-         url,
       },
+      appProps: {
+         ...appProps,
+         algolia: appProps.algolia
+            ? {
+                 ...appProps.algolia,
+                 serverState,
+              }
+            : undefined,
+      },
+   };
+
+   return {
+      props: pageProps,
    };
 };
 
-const ProductListPage: NextPageWithLayout<PageProps> = ({
-   productList,
-   url,
-   serverState,
-   indexName,
-}) => {
-   return (
-      <ProductListView
-         productList={productList}
-         indexName={indexName}
-         url={url}
-         serverState={serverState}
-      />
-   );
+const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
+   return <ProductListView {...pageProps} />;
 };
 
 ProductListPage.getLayout = function getLayout(page, pageProps) {
-   return <Layout {...pageProps}>{page}</Layout>;
+   return <Layout {...pageProps.layoutProps}>{page}</Layout>;
 };
 
 export default ProductListPage;

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -1,15 +1,17 @@
-import { AppProviders, Layout, WithLayoutProps } from '@components/common';
+import {
+   AppProviders,
+   Layout,
+   WithProvidersProps,
+   WithLayoutProps,
+   AppProvidersProps,
+} from '@components/common';
 import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
 import { IFIXIT_ORIGIN } from '@config/env';
-import {
-   generateCSRFToken,
-   setCSRFCookie,
-   WithCSRFProps,
-} from '@ifixit/auth-sdk';
+import { generateCSRFToken, setCSRFCookie } from '@ifixit/auth-sdk';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -17,7 +19,7 @@ import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
 
 type PageProps = WithLayoutProps<ProductListViewProps>;
-type AppPageProps = WithCSRFProps<PageProps>;
+type AppPageProps = WithProvidersProps<PageProps>;
 
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
@@ -57,53 +59,54 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.req.url}`;
    const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+
+   const appProps: AppProvidersProps = {
+      csrfToken,
+      algolia: {
+         indexName,
+         url,
+         routing: true,
+         apiKey: productList.algolia.apiKey,
+      },
+   };
+
    const serverState = await getServerState(
-      <AppProviders csrfToken={csrfToken}>
-         <ProductListPage
-            productList={productList}
-            url={url}
-            indexName={indexName}
-            title={title}
-            globalSettings={globalSettings}
-            stores={stores}
-            currentStore={currentStore}
-         />
+      <AppProviders {...appProps}>
+         <ProductListView productList={productList} indexName={indexName} />
       </AppProviders>
    );
 
-   return {
-      props: {
-         csrfToken,
+   const pageProps: AppPageProps = {
+      productList,
+      indexName,
+      layoutProps: {
          globalSettings,
          currentStore,
          stores,
          title,
-         productList,
-         indexName,
-         serverState,
-         url,
       },
+      appProps: {
+         ...appProps,
+         algolia: appProps.algolia
+            ? {
+                 ...appProps.algolia,
+                 serverState,
+              }
+            : undefined,
+      },
+   };
+
+   return {
+      props: pageProps,
    };
 };
 
-const ProductListPage: NextPageWithLayout<PageProps> = ({
-   productList,
-   url,
-   serverState,
-   indexName,
-}) => {
-   return (
-      <ProductListView
-         productList={productList}
-         indexName={indexName}
-         url={url}
-         serverState={serverState}
-      />
-   );
+const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
+   return <ProductListView {...pageProps} />;
 };
 
 ProductListPage.getLayout = function getLayout(page, pageProps) {
-   return <Layout {...pageProps}>{page}</Layout>;
+   return <Layout {...pageProps.layoutProps}>{page}</Layout>;
 };
 
 export default ProductListPage;

--- a/frontend/pages/Store/[handle].tsx
+++ b/frontend/pages/Store/[handle].tsx
@@ -1,15 +1,17 @@
-import { AppProviders, Layout, WithLayoutProps } from '@components/common';
+import {
+   AppProviders,
+   AppProvidersProps,
+   Layout,
+   WithLayoutProps,
+   WithProvidersProps,
+} from '@components/common';
 import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
 import { IFIXIT_ORIGIN } from '@config/env';
-import {
-   generateCSRFToken,
-   setCSRFCookie,
-   WithCSRFProps,
-} from '@ifixit/auth-sdk';
+import { generateCSRFToken, setCSRFCookie } from '@ifixit/auth-sdk';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -17,7 +19,7 @@ import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
 
 type PageProps = WithLayoutProps<ProductListViewProps>;
-type AppPageProps = WithCSRFProps<PageProps>;
+type AppPageProps = WithProvidersProps<PageProps>;
 
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
@@ -64,53 +66,54 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.req.url}`;
    const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+
+   const appProps: AppProvidersProps = {
+      csrfToken,
+      algolia: {
+         indexName,
+         url,
+         routing: true,
+         apiKey: productList.algolia.apiKey,
+      },
+   };
+
    const serverState = await getServerState(
-      <AppProviders csrfToken={csrfToken}>
-         <ProductListPage
-            productList={productList}
-            url={url}
-            indexName={indexName}
-            title={title}
-            globalSettings={globalSettings}
-            stores={stores}
-            currentStore={currentStore}
-         />
+      <AppProviders {...appProps}>
+         <ProductListView productList={productList} indexName={indexName} />
       </AppProviders>
    );
 
-   return {
-      props: {
-         csrfToken,
+   const pageProps: AppPageProps = {
+      productList,
+      indexName,
+      layoutProps: {
          globalSettings,
          currentStore,
          stores,
          title,
-         productList,
-         indexName,
-         serverState,
-         url,
       },
+      appProps: {
+         ...appProps,
+         algolia: appProps.algolia
+            ? {
+                 ...appProps.algolia,
+                 serverState,
+              }
+            : undefined,
+      },
+   };
+
+   return {
+      props: pageProps,
    };
 };
 
-const ProductListPage: NextPageWithLayout<PageProps> = ({
-   productList,
-   url,
-   serverState,
-   indexName,
-}) => {
-   return (
-      <ProductListView
-         productList={productList}
-         indexName={indexName}
-         url={url}
-         serverState={serverState}
-      />
-   );
+const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
+   return <ProductListView {...pageProps} />;
 };
 
 ProductListPage.getLayout = function getLayout(page, pageProps) {
-   return <Layout {...pageProps}>{page}</Layout>;
+   return <Layout {...pageProps.layoutProps}>{page}</Layout>;
 };
 
 export default ProductListPage;

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -1,15 +1,17 @@
-import { AppProviders, Layout, WithLayoutProps } from '@components/common';
+import {
+   AppProviders,
+   AppProvidersProps,
+   Layout,
+   WithLayoutProps,
+   WithProvidersProps,
+} from '@components/common';
 import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
 import { IFIXIT_ORIGIN } from '@config/env';
-import {
-   generateCSRFToken,
-   setCSRFCookie,
-   WithCSRFProps,
-} from '@ifixit/auth-sdk';
+import { generateCSRFToken, setCSRFCookie } from '@ifixit/auth-sdk';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -17,7 +19,7 @@ import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
 
 type PageProps = WithLayoutProps<ProductListViewProps>;
-type AppPageProps = WithCSRFProps<PageProps>;
+type AppPageProps = WithProvidersProps<PageProps>;
 
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
@@ -64,53 +66,54 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.req.url}`;
    const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+
+   const appProps: AppProvidersProps = {
+      csrfToken,
+      algolia: {
+         indexName,
+         url,
+         routing: true,
+         apiKey: productList.algolia.apiKey,
+      },
+   };
+
    const serverState = await getServerState(
-      <AppProviders csrfToken={csrfToken}>
-         <ProductListPage
-            productList={productList}
-            url={url}
-            indexName={indexName}
-            title={title}
-            globalSettings={globalSettings}
-            stores={stores}
-            currentStore={currentStore}
-         />
+      <AppProviders {...appProps}>
+         <ProductListView productList={productList} indexName={indexName} />
       </AppProviders>
    );
 
-   return {
-      props: {
-         csrfToken,
+   const pageProps: AppPageProps = {
+      productList,
+      indexName,
+      layoutProps: {
          globalSettings,
          currentStore,
          stores,
          title,
-         productList,
-         indexName,
-         serverState,
-         url,
       },
+      appProps: {
+         ...appProps,
+         algolia: appProps.algolia
+            ? {
+                 ...appProps.algolia,
+                 serverState,
+              }
+            : undefined,
+      },
+   };
+
+   return {
+      props: pageProps,
    };
 };
 
-const ProductListPage: NextPageWithLayout<PageProps> = ({
-   productList,
-   url,
-   serverState,
-   indexName,
-}) => {
-   return (
-      <ProductListView
-         productList={productList}
-         indexName={indexName}
-         url={url}
-         serverState={serverState}
-      />
-   );
+const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
+   return <ProductListView {...pageProps} />;
 };
 
 ProductListPage.getLayout = function getLayout(page, pageProps) {
-   return <Layout {...pageProps}>{page}</Layout>;
+   return <Layout {...pageProps.layoutProps}>{page}</Layout>;
 };
 
 export default ProductListPage;

--- a/frontend/pages/Tools/index.tsx
+++ b/frontend/pages/Tools/index.tsx
@@ -1,15 +1,17 @@
-import { AppProviders, Layout, WithLayoutProps } from '@components/common';
+import {
+   AppProviders,
+   AppProvidersProps,
+   Layout,
+   WithLayoutProps,
+   WithProvidersProps,
+} from '@components/common';
 import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
 import { IFIXIT_ORIGIN } from '@config/env';
-import {
-   generateCSRFToken,
-   setCSRFCookie,
-   WithCSRFProps,
-} from '@ifixit/auth-sdk';
+import { generateCSRFToken, setCSRFCookie } from '@ifixit/auth-sdk';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -17,7 +19,7 @@ import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
 
 type PageProps = WithLayoutProps<ProductListViewProps>;
-type AppPageProps = WithCSRFProps<PageProps>;
+type AppPageProps = WithProvidersProps<PageProps>;
 
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
@@ -57,53 +59,54 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.req.url}`;
    const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+
+   const appProps: AppProvidersProps = {
+      csrfToken,
+      algolia: {
+         indexName,
+         url,
+         routing: true,
+         apiKey: productList.algolia.apiKey,
+      },
+   };
+
    const serverState = await getServerState(
-      <AppProviders csrfToken={csrfToken}>
-         <ProductListPage
-            productList={productList}
-            url={url}
-            indexName={indexName}
-            title={title}
-            globalSettings={globalSettings}
-            stores={stores}
-            currentStore={currentStore}
-         />
+      <AppProviders {...appProps}>
+         <ProductListView productList={productList} indexName={indexName} />
       </AppProviders>
    );
 
-   return {
-      props: {
-         csrfToken,
+   const pageProps: AppPageProps = {
+      productList,
+      indexName,
+      layoutProps: {
          globalSettings,
          currentStore,
          stores,
          title,
-         productList,
-         indexName,
-         serverState,
-         url,
       },
+      appProps: {
+         ...appProps,
+         algolia: appProps.algolia
+            ? {
+                 ...appProps.algolia,
+                 serverState,
+              }
+            : undefined,
+      },
+   };
+
+   return {
+      props: pageProps,
    };
 };
 
-const ProductListPage: NextPageWithLayout<PageProps> = ({
-   productList,
-   url,
-   serverState,
-   indexName,
-}) => {
-   return (
-      <ProductListView
-         productList={productList}
-         indexName={indexName}
-         url={url}
-         serverState={serverState}
-      />
-   );
+const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
+   return <ProductListView {...pageProps} />;
 };
 
 ProductListPage.getLayout = function getLayout(page, pageProps) {
-   return <Layout {...pageProps}>{page}</Layout>;
+   return <Layout {...pageProps.layoutProps}>{page}</Layout>;
 };
 
 export default ProductListPage;

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -9,7 +9,7 @@ type AppPropsWithLayout = AppProps & {
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
    const getLayout = Component.getLayout ?? ((page) => page);
    return (
-      <AppProviders csrfToken={pageProps.csrfToken}>
+      <AppProviders {...pageProps.appProps}>
          {getLayout(<Component {...pageProps} />, pageProps)}
       </AppProviders>
    );

--- a/packages/auth-sdk/csrf.ts
+++ b/packages/auth-sdk/csrf.ts
@@ -2,10 +2,6 @@ import cookie from 'cookie';
 import crypto from 'crypto';
 import type { GetServerSidePropsContext } from 'next';
 
-export type WithCSRFProps<T> = T & {
-   csrfToken: string;
-};
-
 export function generateCSRFToken(): string {
    return crypto.randomBytes(64).toString('hex');
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3926,8 +3926,8 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /algoliasearch-helper/3.8.2_algoliasearch@4.13.1:
-    resolution: {integrity: sha512-AXxiF0zT9oYwl8ZBgU/eRXvfYhz7cBA5YrLPlw9inZHdaYF0QEya/f1Zp1mPYMXc1v6VkHwBq4pk6/vayBLICg==}
+  /algoliasearch-helper/3.9.0_algoliasearch@4.13.1:
+    resolution: {integrity: sha512-siWWl8QYJ3sh1yzJf9h/cHHpZC8wuPoPdVx5OtQ8X62ruUembTwvsLYoicrL7pF7fsYxdyvJfV9Yb2/nrVGrfg==}
     peerDependencies:
       algoliasearch: '>= 3.1 < 5'
     dependencies:
@@ -7213,8 +7213,8 @@ packages:
       through: 2.3.8
     dev: true
 
-  /instantsearch.js/4.40.6_algoliasearch@4.13.1:
-    resolution: {integrity: sha512-Yjy7k9Ct+8TmHKTsKGUVZ2gXxjpv8eCjHP7vxC109MgQrgA5N0cJ/QP3H4lQP3nGA5csXgCrq8UlusFZ94eIkQ==}
+  /instantsearch.js/4.42.0_algoliasearch@4.13.1:
+    resolution: {integrity: sha512-TTrMaINSwx8pB5CDZO9R3sigC/HQOoYeVLmF4tLXWOI1POUAlnItPGV48k4/5C6Pqsg6w6/K9a6X0vwXSNlACA==}
     peerDependencies:
       algoliasearch: '>= 3.1 < 5'
     dependencies:
@@ -7223,7 +7223,7 @@ packages:
       '@types/hogan.js': 3.0.1
       '@types/qs': 6.9.7
       algoliasearch: 4.13.1
-      algoliasearch-helper: 3.8.2_algoliasearch@4.13.1
+      algoliasearch-helper: 3.9.0_algoliasearch@4.13.1
       classnames: 2.2.6
       hogan.js: 3.0.2
       preact: 10.7.2
@@ -9926,7 +9926,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.17.9
       algoliasearch: 4.13.1
-      instantsearch.js: 4.40.6_algoliasearch@4.13.1
+      instantsearch.js: 4.42.0_algoliasearch@4.13.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-instantsearch-hooks: 6.26.0_b7c6bccee043686b2080156151f2feed
@@ -9941,7 +9941,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.17.9
       algoliasearch: 4.13.1
-      instantsearch.js: 4.40.6_algoliasearch@4.13.1
+      instantsearch.js: 4.42.0_algoliasearch@4.13.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-instantsearch-hooks: 6.26.0_b7c6bccee043686b2080156151f2feed
@@ -9955,8 +9955,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.17.9
       algoliasearch: 4.13.1
-      algoliasearch-helper: 3.8.2_algoliasearch@4.13.1
-      instantsearch.js: 4.40.6_algoliasearch@4.13.1
+      algoliasearch-helper: 3.9.0_algoliasearch@4.13.1
+      instantsearch.js: 4.42.0_algoliasearch@4.13.1
       react: 17.0.2
     dev: false
 


### PR DESCRIPTION
closes #345 

## Changelog

- Move InstantSearch provider up in the component tree hierarchy to avoid unnecessary re-renders
- Force InstantSearch provider to unmount when it re-render, so that internals do not get stuck in a broken state

## QA

1. Visit the Vercel PR preview (replace vercel.app with cominor.com)
2. Browse trough product lists, use refinements, use the browser back button and verify that the product list page does not break

