### PR TITLE
Make tools pages paths case insensitive

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -87,11 +87,11 @@ function withUniversalOptimization(plugins) {
    return {
       ...plugins,
       webpack(config, info) {
-         config = configureWebpack(config, info)
+         config = configureWebpack(config, info);
          config.optimization.minimize = true;
          return config;
-      }
-   }
+      },
+   };
 }
 
 // Make sure adding Sentry options is the last code to run before exporting, to
@@ -99,4 +99,4 @@ function withUniversalOptimization(plugins) {
 module.exports = withSentryConfig(
    withUniversalOptimization(withBundleAnalyzer(withTM(moduleExports))),
    SENTRY_AUTH_TOKEN ? sentryWebpackPluginOptions : undefined
-)
+);

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -43,6 +43,17 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
       };
    }
 
+   const lowercaseHandle = handle.toLowerCase();
+
+   if (lowercaseHandle !== handle) {
+      return {
+         redirect: {
+            destination: `/Tools/${lowercaseHandle}`,
+            permanent: true,
+         },
+      };
+   }
+
    const [globalSettings, stores, currentStore, productList] =
       await Promise.all([
          getGlobalSettings(),


### PR DESCRIPTION
closes #327 

## QA

1. Visit [Vercel preview](https://react-commerce-git-make-tools-pages-paths-case-in-01b5b9-ifixit.cominor.com/Tools)
2. Verify that tools categories paths are case insensitive (e.g.  `/Tools/gripping` vs `/Tools/Gripping`), that is the page is always redirected to the lowercase version 