### PR TITLE
Make tagline an h2

### DIFF
--- a/frontend/components/product-list/sections/HeroSection.tsx
+++ b/frontend/components/product-list/sections/HeroSection.tsx
@@ -34,9 +34,9 @@ export function HeroSection({ productList }: HeroSectionProps) {
             {page > 1 ? ` - Page ${page}` : ''}
          </HeroTitle>
          {productList.tagline && productList.tagline.length > 0 && page === 1 && (
-            <Text fontWeight="bold" fontSize="xl" px={{ base: 6, sm: 0 }}>
+            <h2>
                {productList.tagline}
-            </Text>
+            </h2>
          )}
          {hasDescription && (
             <HeroDescription>{productList.description}</HeroDescription>


### PR DESCRIPTION
## Summary

Previously, the tagline was a `<Text></Text>` and the sub-categories, ie the child titles, were `<h2></h2>`. This PR makes the taglines `h2` and the child title [sub categories] `spans`

## CR/QA
WAP

Closes #311 