### PR TITLE
Add noindex meta tag for single item product lists

### DIFF
--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -27,9 +27,10 @@ export function MetaTags({ productList }: MetaTagsProps) {
       page > 1 ? `?${PRODUCT_LIST_PAGE_PARAM}=${page}` : ''
    }`;
    const imageUrl = productList.image?.url;
+   const shouldNoIndex = isFiltered || pagination.nbHits < 2;
    return (
       <Head>
-         {isFiltered ? (
+         {shouldNoIndex ? (
             <meta name="robots" content="noindex,nofollow" />
          ) : (
             <>


### PR DESCRIPTION
closes #355 

## QA

1. Open [Vercel preview](https://react-commerce-git-noindex-single-item-product-lists-ifixit.cominor.com/Parts/Toshiba_Chromebook_2)
2. Verify that single item product lists have a "noindex" meta tag (e.g. [Toshiba Chromebook CB35-B3340 Parts](https://react-commerce-git-noindex-single-item-product-lists-ifixit.cominor.com/Parts/Toshiba_Chromebook_2)
3. Verify that if a product list has more than 1 product then it doesn't have a "noindex" meta tag