### PR TITLE
Fix missing product list pagination

### DIFF
--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -16,7 +16,7 @@ export function MetaTags({ productList }: MetaTagsProps) {
    const appContext = useAppContext();
    const currentRefinements = useCurrentRefinements();
    const pagination = usePagination();
-   const page = pagination.currentRefinement;
+   const page = pagination.currentRefinement + 1;
    const isFiltered = currentRefinements.items.length > 0;
    let title = productList.title;
    if (!isFiltered && page > 1) {

--- a/frontend/components/product-list/sections/HeroSection.tsx
+++ b/frontend/components/product-list/sections/HeroSection.tsx
@@ -22,7 +22,7 @@ export interface HeroSectionProps {
 
 export function HeroSection({ productList }: HeroSectionProps) {
    const pagination = usePagination();
-   const page = pagination.currentRefinement;
+   const page = pagination.currentRefinement + 1;
    const hasDescription =
       productList.description != null &&
       productList.description.length > 0 &&


### PR DESCRIPTION
fixes #363 

## QA

1. Open [Vercel preview](https://react-commerce-git-fix-product-list-missing-description-ifixit.cominor.com/Parts)
2. Verify that product list description is displayed
3. Verify that for pages after the first one, product list description is not shown

cr_req 2