### PR TITLE
Product Search Hits: Use product `title` instead of `group_title`

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -47,10 +47,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
    return (
       <LinkBox as="article" display="block" w="full">
          <ProductCard h="full">
-            <ProductCardImage
-               src={product.image_url}
-               alt={product.group_title}
-            />
+            <ProductCardImage src={product.image_url} alt={product.title} />
             <ProductCardBadgeList>
                {product.is_pro > 0 && (
                   <Badge
@@ -69,7 +66,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
             </ProductCardBadgeList>
             <ProductCardBody>
                <LinkOverlay href={`${appContext.ifixitOrigin}${product.url}`}>
-                  <ProductCardTitle>{product.group_title}</ProductCardTitle>
+                  <ProductCardTitle>{product.title}</ProductCardTitle>
                </LinkOverlay>
                {(product.rating >= 4 || product.rating_count > 10) && (
                   <ProductCardRating

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -86,7 +86,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                {product.image_url ? (
                   <IfixitImage
                      src={product.image_url}
-                     alt={product.group_title}
+                     alt={product.title}
                      objectFit="contain"
                      width="180px"
                      height="180px"
@@ -94,7 +94,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                ) : (
                   <IfixitImage
                      src={placeholderImageUrl}
-                     alt={product.group_title}
+                     alt={product.title}
                      sizes="180px"
                   />
                )}
@@ -124,7 +124,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                         xl: 4,
                      }}
                   >
-                     {product.group_title}
+                     {product.title}
                   </Heading>
                   <Text
                      noOfLines={3}

--- a/frontend/components/product-list/sections/HeroSection.tsx
+++ b/frontend/components/product-list/sections/HeroSection.tsx
@@ -34,7 +34,12 @@ export function HeroSection({ productList }: HeroSectionProps) {
             {page > 1 ? ` - Page ${page}` : ''}
          </HeroTitle>
          {productList.tagline && productList.tagline.length > 0 && page === 1 && (
-            <Text as="h2" fontWeight="bold" fontSize="xl" px={{ base: 6, sm: 0 }}>
+            <Text
+               as="h2"
+               fontWeight="bold"
+               fontSize="xl"
+               px={{ base: 6, sm: 0 }}
+            >
                {productList.tagline}
             </Text>
          )}

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -1,7 +1,6 @@
 export interface ProductSearchHit {
    objectID: string;
    title: string;
-   group_title: string;
    handle: string;
    price_float: number;
    compare_at_price?: number;


### PR DESCRIPTION
Now that we are using product_group_en instead of product_en, the
group_title field now exists under the name `title`.

Usages of the product_en.title field should be replaceable with
product_group_en.title - I only saw it used in the alt text of images.

Closes #366 