### PR TITLE
Tools Homepage: Hide Parts/Guides/Answers

### DIFF
--- a/frontend/components/product-list/ProductListDeviceNavigation.tsx
+++ b/frontend/components/product-list/ProductListDeviceNavigation.tsx
@@ -1,7 +1,7 @@
 import { Flex } from '@chakra-ui/react';
 import { SecondaryNavbarItem, SecondaryNavbarLink } from '@components/common';
 import { IFIXIT_ORIGIN } from '@config/env';
-import { ProductList } from '@models/product-list';
+import { ProductList, ProductListType } from '@models/product-list';
 import NextLink from 'next/link';
 
 export interface ProductListDeviceNavigationProps {
@@ -12,6 +12,9 @@ export function ProductListDeviceNavigation({
    productList,
 }: ProductListDeviceNavigationProps) {
    const isRootProductList = productList.ancestors.length === 0;
+   if (productList.type === ProductListType.AllTools) {
+      return null;
+   }
    let guideUrl: string | undefined;
    let answersUrl: string | undefined;
    if (isRootProductList) {

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -6,7 +6,7 @@ import { Configure, Index } from 'react-instantsearch-hooks-web';
 import { MetaTags } from './MetaTags';
 import { ProductListBreadcrumb } from './ProductListBreadcrumb';
 import { ProductListDeviceNavigation } from './ProductListDeviceNavigation';
-import {Enum_Productlist_Type} from '@lib/strapi-sdk';
+import { ProductListType } from '@models/product-list';
 import {
    BannerSection,
    FeaturedProductListSection,
@@ -40,7 +40,7 @@ export function ProductListView({
                   px={{ base: 3, sm: 0 }}
                >
                   <ProductListBreadcrumb productList={productList} />
-                  {productList.type.toString() !== Enum_Productlist_Type.AllTools.toString() && (
+                  {productList.type !== ProductListType.AllTools && (
                      <ProductListDeviceNavigation productList={productList} />
                   )}
                </Flex>

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -39,7 +39,9 @@ export function ProductListView({
                   px={{ base: 3, sm: 0 }}
                >
                   <ProductListBreadcrumb productList={productList} />
-                  <ProductListDeviceNavigation productList={productList} />
+                  {productList.title !== 'Repair Tools' && (
+                     <ProductListDeviceNavigation productList={productList} />
+                  )}
                </Flex>
             </PageContentWrapper>
          </SecondaryNavbar>

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -6,7 +6,7 @@ import { Configure, Index } from 'react-instantsearch-hooks-web';
 import { MetaTags } from './MetaTags';
 import { ProductListBreadcrumb } from './ProductListBreadcrumb';
 import { ProductListDeviceNavigation } from './ProductListDeviceNavigation';
-import { ProductListType } from '@models/product-list';
+import {Enum_Productlist_Type} from '@lib/strapi-sdk';
 import {
    BannerSection,
    FeaturedProductListSection,
@@ -40,7 +40,7 @@ export function ProductListView({
                   px={{ base: 3, sm: 0 }}
                >
                   <ProductListBreadcrumb productList={productList} />
-                  {productList.type !== ProductListType.AllTools && (
+                  {productList.type.toString() !== Enum_Productlist_Type.AllTools.toString() && (
                      <ProductListDeviceNavigation productList={productList} />
                   )}
                </Flex>

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -40,9 +40,7 @@ export function ProductListView({
                   px={{ base: 3, sm: 0 }}
                >
                   <ProductListBreadcrumb productList={productList} />
-                  {productList.type !== ProductListType.AllTools && (
-                     <ProductListDeviceNavigation productList={productList} />
-                  )}
+                  <ProductListDeviceNavigation productList={productList} />
                </Flex>
             </PageContentWrapper>
          </SecondaryNavbar>

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -6,6 +6,7 @@ import { Configure, Index } from 'react-instantsearch-hooks-web';
 import { MetaTags } from './MetaTags';
 import { ProductListBreadcrumb } from './ProductListBreadcrumb';
 import { ProductListDeviceNavigation } from './ProductListDeviceNavigation';
+import { ProductListType } from '@models/product-list';
 import {
    BannerSection,
    FeaturedProductListSection,
@@ -39,7 +40,7 @@ export function ProductListView({
                   px={{ base: 3, sm: 0 }}
                >
                   <ProductListBreadcrumb productList={productList} />
-                  {productList.title !== 'Repair Tools' && (
+                  {productList.type !== ProductListType.AllTools && (
                      <ProductListDeviceNavigation productList={productList} />
                   )}
                </Flex>


### PR DESCRIPTION
## Summary
Previously, Parts/Guides/Answers was visible on the `/Tools` page. This PR hides it from the `/Tools` page.

## CR/QA
Make sure that Parts, Guides and Answer is not visible on `/Tools`.

Closes #376 