### PR TITLE
Add item type product lists

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -23,7 +23,7 @@
             }
          },
          "type": "enumeration",
-         "enum": ["parts", "tools", "marketing"],
+         "enum": ["all-parts", "parts", "all-tools", "tools", "marketing"],
          "default": "parts",
          "required": false
       },

--- a/backend/src/plugins/seed/server/seed/data/product-lists.json
+++ b/backend/src/plugins/seed/server/seed/data/product-lists.json
@@ -13,7 +13,7 @@
       "publishedAt": "2022-01-18T21:11:28.491Z",
       "locale": "en",
       "sortPriority": null,
-      "type": "marketing",
+      "type": "all-parts",
       "legacyDescription": null,
       "parent": null,
       "sections": [
@@ -11893,7 +11893,7 @@
       "publishedAt": "2022-03-01T23:10:36.821Z",
       "locale": "en",
       "sortPriority": 0,
-      "type": "marketing",
+      "type": "all-tools",
       "legacyDescription": null,
       "parent": null,
       "sections": []

--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -1,8 +1,8 @@
 import { PRODUCT_LIST_PAGE_PARAM } from '@config/constants';
+import { getProductListTitle } from '@helpers/product-list-helpers';
 import { useAppContext } from '@ifixit/app';
 import { ProductList } from '@models/product-list';
 import Head from 'next/head';
-import * as React from 'react';
 import {
    useCurrentRefinements,
    usePagination,
@@ -18,7 +18,7 @@ export function MetaTags({ productList }: MetaTagsProps) {
    const pagination = usePagination();
    const page = pagination.currentRefinement + 1;
    const isFiltered = currentRefinements.items.length > 0;
-   let title = productList.title;
+   let title = getProductListTitle(productList);
    if (!isFiltered && page > 1) {
       title += ` - Page ${page}`;
    }

--- a/frontend/components/product-list/ProductListBreadcrumb.tsx
+++ b/frontend/components/product-list/ProductListBreadcrumb.tsx
@@ -11,7 +11,7 @@ import {
    MenuList,
    Text,
 } from '@chakra-ui/react';
-import { ProductList } from '@models/product-list';
+import { ProductList, ProductListType } from '@models/product-list';
 import NextLink from 'next/link';
 import * as React from 'react';
 import { HiChevronRight, HiDotsHorizontal } from 'react-icons/hi';
@@ -24,9 +24,15 @@ export function ProductListBreadcrumb({
    productList,
    ...otherProps
 }: ProductListBreadcrumbProps) {
+   const { ancestors } = productList;
    const reverseAncestorList = React.useMemo(() => {
-      return [...productList.ancestors].reverse();
-   }, [productList.ancestors]);
+      return [...ancestors].reverse();
+   }, [ancestors]);
+
+   let currentItemTitle = productList.title;
+   if (productList.type === ProductListType.DeviceItemTypeParts) {
+      currentItemTitle = productList.itemType;
+   }
 
    return (
       <Breadcrumb
@@ -58,7 +64,7 @@ export function ProductListBreadcrumb({
          }}
          {...otherProps}
       >
-         {productList.ancestors.map((ancestor) => (
+         {ancestors.map((ancestor) => (
             <BreadcrumbItem
                key={ancestor.handle}
                borderRadius="md"
@@ -123,7 +129,7 @@ export function ProductListBreadcrumb({
                whiteSpace="nowrap"
                isTruncated
             >
-               {productList.title}
+               {currentItemTitle}
             </Text>
          </BreadcrumbItem>
       </Breadcrumb>

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -52,7 +52,7 @@ export function ProductListView({
                   {productList.children.length > 0 && (
                      <ProductListChildrenSection productList={productList} />
                   )}
-                  <FilterableProductsSection wikiInfo={productList.wikiInfo} />
+                  <FilterableProductsSection productList={productList} />
                </Index>
                {productList.sections.map((section, index) => {
                   switch (section.type) {

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetFilter.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetFilter.tsx
@@ -1,0 +1,61 @@
+import { getProductListPath } from '@helpers/product-list-helpers';
+import { ProductList, ProductListType } from '@models/product-list';
+import * as React from 'react';
+import { RefinementList } from './RefinementList';
+import { RefinementMenu } from './RefinementMenu';
+
+type FacetFilterProps = {
+   attribute: string;
+   productList: ProductList;
+};
+
+export function FacetFilter({ attribute, productList }: FacetFilterProps) {
+   const createItemTypeURL = React.useCallback(
+      (itemType: string) => {
+         return getProductListPath({
+            ...productList,
+            type: ProductListType.DeviceItemTypeParts,
+            itemType,
+         });
+      },
+      [productList]
+   );
+   switch (attribute) {
+      case 'facet_tags.Item Type': {
+         switch (productList.type) {
+            case ProductListType.DeviceParts:
+            case ProductListType.DeviceItemTypeParts:
+               return (
+                  <RefinementMenu
+                     attribute={attribute}
+                     showMore
+                     showMoreLimit={200}
+                     createURL={createItemTypeURL}
+                     activeValue={
+                        productList.type === ProductListType.DeviceItemTypeParts
+                           ? productList.itemType
+                           : undefined
+                     }
+                  />
+               );
+            default:
+               return (
+                  <RefinementList
+                     attribute={attribute}
+                     showMore
+                     showMoreLimit={200}
+                  />
+               );
+         }
+      }
+      default: {
+         return (
+            <RefinementList
+               attribute={attribute}
+               showMore
+               showMoreLimit={200}
+            />
+         );
+      }
+   }
+}

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
@@ -14,25 +14,29 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { formatFacetName } from '@helpers/algolia-helpers';
-import { WikiInfoEntry } from '@models/product-list/types';
+import { ProductList } from '@models/product-list';
 import * as React from 'react';
 import { HiArrowLeft, HiChevronRight } from 'react-icons/hi';
 import {
    useClearRefinements,
    useRefinementList,
 } from 'react-instantsearch-hooks-web';
-import { RefinementList } from './RefinementList';
+import { FacetFilter } from './FacetFilter';
 import { useCountRefinements } from './useCountRefinements';
 import { useFilteredFacets } from './useFacets';
 
 type FacetsDrawerProps = {
    isOpen: boolean;
    onClose: () => void;
-   wikiInfo: WikiInfoEntry[];
+   productList: ProductList;
 };
 
-export function FacetsDrawer({ isOpen, onClose, wikiInfo }: FacetsDrawerProps) {
-   const facets = useFilteredFacets(wikiInfo);
+export function FacetsDrawer({
+   isOpen,
+   onClose,
+   productList,
+}: FacetsDrawerProps) {
+   const facets = useFilteredFacets(productList);
    const [currentFacet, setCurrentFacet] = React.useState<string | null>(null);
    const countRefinements = useCountRefinements();
 
@@ -139,6 +143,7 @@ export function FacetsDrawer({ isOpen, onClose, wikiInfo }: FacetsDrawerProps) {
                               key={facet}
                               attribute={facet}
                               isOpen={facet === currentFacet}
+                              productList={productList}
                            />
                         );
                      })}
@@ -272,9 +277,10 @@ function FacetListItem({
 type FacetPanelProps = {
    attribute: string;
    isOpen: boolean;
+   productList: ProductList;
 };
 
-function FacetPanel({ attribute, isOpen }: FacetPanelProps) {
+function FacetPanel({ attribute, isOpen, productList }: FacetPanelProps) {
    return (
       <Box
          position="absolute"
@@ -289,11 +295,7 @@ function FacetPanel({ attribute, isOpen }: FacetPanelProps) {
          p="5"
       >
          <VStack align="stretch" spacing="3">
-            <RefinementList
-               attribute={attribute}
-               showMore
-               showMoreLimit={200}
-            />
+            <FacetFilter attribute={attribute} productList={productList} />
          </VStack>
       </Box>
    );

--- a/frontend/components/product-list/sections/FilterableProductsSection/RefinementMenu.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/RefinementMenu.tsx
@@ -1,0 +1,100 @@
+import { Box, Button, HStack, Icon, VStack, Text } from '@chakra-ui/react';
+import React from 'react';
+import { HiSelector } from 'react-icons/hi';
+import {
+   useRefinementList,
+   UseRefinementListProps,
+} from 'react-instantsearch-hooks-web';
+import NextLink from 'next/link';
+
+export type RefinementMenuProps = UseRefinementListProps & {
+   createURL: (value: string) => string;
+   activeValue?: string;
+};
+
+export function RefinementMenu({
+   createURL,
+   activeValue,
+   ...otherProps
+}: RefinementMenuProps) {
+   const { items, isShowingMore, toggleShowMore, canToggleShowMore } =
+      useRefinementList(otherProps);
+
+   return (
+      <Box>
+         <VStack align="stretch" spacing="1" role="listbox">
+            {items.map((item) => {
+               return (
+                  <MenuItem
+                     key={item.label}
+                     label={item.label}
+                     value={item.value}
+                     isRefined={item.value === activeValue}
+                     count={item.count}
+                     createURL={createURL}
+                  />
+               );
+            })}
+         </VStack>
+         {canToggleShowMore && (
+            <Button
+               variant="ghost"
+               fontWeight="normal"
+               leftIcon={
+                  <Icon as={HiSelector} boxSize="6" color="gray.600" ml="-1" />
+               }
+               mt="3"
+               p="0"
+               w="full"
+               justifyContent="flex-start"
+               onClick={toggleShowMore}
+            >
+               {isShowingMore ? 'Show less' : 'Show more'}
+            </Button>
+         )}
+      </Box>
+   );
+}
+
+type MenuItemProps = {
+   label: string;
+   value: string;
+   isRefined: boolean;
+   count: number;
+   createURL: (value: string) => string;
+};
+
+const MenuItem = React.memo(function RefinementListItem({
+   label,
+   count,
+   value,
+   createURL,
+   isRefined,
+}: MenuItemProps) {
+   return (
+      <HStack
+         key={label}
+         justify="space-between"
+         color={isRefined ? 'brand.500' : 'inherit'}
+         fontWeight={isRefined ? 'bold' : 'inherit'}
+      >
+         <NextLink href={createURL(value)} passHref>
+            <Text
+               as="a"
+               _hover={{
+                  textDecoration: 'underline',
+               }}
+            >
+               {label}
+            </Text>
+         </NextLink>
+         <Text
+            size="sm"
+            fontFamily="sans-serif"
+            color={isRefined ? 'brand.500' : 'gray.500'}
+         >
+            {count}
+         </Text>
+      </HStack>
+   );
+});

--- a/frontend/components/product-list/sections/FilterableProductsSection/Toolbar.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/Toolbar.tsx
@@ -13,8 +13,7 @@ import {
    Text,
    useDisclosure,
 } from '@chakra-ui/react';
-import { WikiInfoEntry } from '@models/product-list/types';
-import * as React from 'react';
+import { ProductList } from '@models/product-list';
 import { HiOutlineMenu, HiOutlineViewGrid } from 'react-icons/hi';
 import { useHits } from 'react-instantsearch-hooks-web';
 import { FacetsDrawer } from './FacetsDrawer';
@@ -27,12 +26,12 @@ export enum ProductViewType {
 
 export type ToolbarProps = {
    viewType: ProductViewType;
+   productList: ProductList;
    onViewTypeChange: (viewType: ProductViewType) => void;
-   wikiInfo: WikiInfoEntry[];
 };
 
 export function Toolbar(props: ToolbarProps) {
-   const { viewType, onViewTypeChange, wikiInfo } = props;
+   const { viewType, onViewTypeChange, productList } = props;
    const drawer = useDisclosure({
       defaultIsOpen: false,
    });
@@ -41,7 +40,7 @@ export function Toolbar(props: ToolbarProps) {
          <FacetsDrawer
             isOpen={drawer.isOpen}
             onClose={drawer.onClose}
-            wikiInfo={wikiInfo}
+            productList={productList}
          />
          <Stack
             justify={{ md: 'space-between' }}

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -15,10 +15,14 @@ import {
 import { Card } from '@components/ui';
 import { cypressWindowLog } from '@helpers/test-helpers';
 import { useLocalPreference } from '@ifixit/ui';
-import { ProductSearchHit } from '@models/product-list';
-import { WikiInfoEntry } from '@models/product-list/types';
+import {
+   ProductList as TProductList,
+   ProductListType,
+   ProductSearchHit,
+} from '@models/product-list';
 import * as React from 'react';
 import {
+   Configure,
    useClearRefinements,
    useCurrentRefinements,
    useHits,
@@ -34,11 +38,10 @@ import { ProductViewType, Toolbar } from './Toolbar';
 const PRODUCT_VIEW_TYPE_STORAGE_KEY = 'productViewType';
 
 type SectionProps = {
-   wikiInfo: WikiInfoEntry[];
+   productList: TProductList;
 };
 
-export function FilterableProductsSection(props: SectionProps) {
-   const { wikiInfo } = props;
+export function FilterableProductsSection({ productList }: SectionProps) {
    const { hits } = useHits<ProductSearchHit>();
    const [viewType, setViewType] = useLocalPreference(
       PRODUCT_VIEW_TYPE_STORAGE_KEY,
@@ -61,18 +64,25 @@ export function FilterableProductsSection(props: SectionProps) {
          data-testid="filterable-products-section"
          aria-labelledby="filterable-products-section-heading"
       >
+         {productList.type === ProductListType.DeviceItemTypeParts && (
+            <Configure
+               filters={`'facet_tags.Item Type': ${JSON.stringify(
+                  productList.itemType
+               )}`}
+            />
+         )}
          <Heading as="h2" id="filterable-products-section-heading" srOnly>
             Products
          </Heading>
          <Toolbar
             viewType={viewType}
+            productList={productList}
             onViewTypeChange={setViewType}
-            wikiInfo={wikiInfo}
          />
          <CurrentRefinements />
          <HStack mt="4" align="flex-start" spacing={{ base: 0, md: 4 }}>
             <FacetCard>
-               <FacetsAccordion wikiInfo={wikiInfo} />
+               <FacetsAccordion productList={productList} />
             </FacetCard>
             <Card flex={1}>
                {isEmpty ? (

--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useDynamicWidgets } from 'react-instantsearch-hooks-web';
-import { WikiInfoEntry } from '@models/product-list/types';
+import { ProductList, ProductListType } from '@models/product-list';
 
 export function useFacets() {
    const { attributesToRender } = useDynamicWidgets({
@@ -8,12 +8,12 @@ export function useFacets() {
    });
 
    return [
+      'facet_tags.Item Type',
       'facet_tags.Capacity',
       'device',
       'facet_tags.Device Brand',
       'facet_tags.Device Category',
       'facet_tags.Device Type',
-      'facet_tags.Item Type',
       'facet_tags.OS',
       'facet_tags.Part or Kit',
       'price_range',
@@ -22,19 +22,26 @@ export function useFacets() {
    // return attributesToRender;
 }
 
-export function useFilteredFacets(wikiInfo: WikiInfoEntry[]) {
+export function useFilteredFacets(productList: ProductList) {
    const facets = useFacets();
+   const isItemTypeProductList =
+      productList.type === ProductListType.DeviceItemTypeParts;
 
    const infoNames = React.useMemo(() => {
-      return new Set(wikiInfo.map((info) => `facet_tags.${info.name}`));
-   }, [wikiInfo]);
+      return new Set(
+         productList.wikiInfo.map((info) => `facet_tags.${info.name}`)
+      );
+   }, [productList.wikiInfo]);
 
    const usefulFacets = React.useMemo(() => {
-      const usefulFacets = facets
-         .slice()
-         .filter((facet) => !infoNames.has(facet));
+      const usefulFacets = facets.slice().filter((facet) => {
+         if (facet === 'facet_tags.Item Type' && isItemTypeProductList) {
+            return false;
+         }
+         return !infoNames.has(facet);
+      });
       return usefulFacets;
-   }, [facets, infoNames]);
+   }, [facets, infoNames, isItemTypeProductList]);
 
    return usefulFacets;
 }

--- a/frontend/components/product-list/sections/HeroSection.tsx
+++ b/frontend/components/product-list/sections/HeroSection.tsx
@@ -10,8 +10,9 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { DEFAULT_ANIMATION_DURATION_MS } from '@config/constants';
+import { getProductListTitle } from '@helpers/product-list-helpers';
 import { useIsMounted } from '@ifixit/ui';
-import { ProductList } from '@models/product-list';
+import { ProductList, ProductListType } from '@models/product-list';
 import * as React from 'react';
 import { usePagination } from 'react-instantsearch-hooks-web';
 import snarkdown from 'snarkdown';
@@ -23,17 +24,28 @@ export interface HeroSectionProps {
 export function HeroSection({ productList }: HeroSectionProps) {
    const pagination = usePagination();
    const page = pagination.currentRefinement + 1;
+   const isItemTypeProductList =
+      productList.type === ProductListType.DeviceItemTypeParts;
    const hasDescription =
       productList.description != null &&
       productList.description.length > 0 &&
-      page === 1;
+      page === 1 &&
+      !isItemTypeProductList;
+   const hasTagline =
+      productList.tagline != null &&
+      productList.tagline.length > 0 &&
+      page === 1 &&
+      !isItemTypeProductList;
+
+   const title = getProductListTitle(productList);
+
    return (
       <VStack flex={1} align="flex-start">
          <HeroTitle>
-            {productList.title}
+            {title}
             {page > 1 ? ` - Page ${page}` : ''}
          </HeroTitle>
-         {productList.tagline && productList.tagline.length > 0 && page === 1 && (
+         {hasTagline && (
             <Text
                as="h2"
                fontWeight="bold"

--- a/frontend/components/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/components/product-list/sections/ProductListChildrenSection.tsx
@@ -11,8 +11,9 @@ import {
    useBreakpointValue,
    VStack,
 } from '@chakra-ui/react';
-import { useIsMounted } from '@ifixit/ui';
 import { IfixitImage } from '@components/ifixit-image';
+import { useIsMounted } from '@ifixit/ui';
+import { ProductList } from '@models/product-list';
 import NextLink from 'next/link';
 import * as React from 'react';
 
@@ -20,29 +21,13 @@ export type ProductListChildrenSectionProps = {
    productList: ProductList;
 };
 
-interface ProductList {
-   deviceTitle: string | null;
-   children: ProductListChild[];
-   childrenHeading: string | null;
-}
-
-interface ProductListChild {
-   title: string;
-   handle: string;
-   path: string;
-   image?: {
-      url: string;
-      alt?: string;
-   } | null;
-}
-
 export function ProductListChildrenSection({
    productList,
 }: ProductListChildrenSectionProps) {
    const {
-      children: productListChildren,
       deviceTitle,
       childrenHeading,
+      children: productListChildren,
    } = productList;
    const [shouldShowMore, setShouldShowMore] = React.useState(false);
    const responsiveVisibleChildrenCount = useBreakpointValue(
@@ -142,7 +127,7 @@ export function ProductListChildrenSection({
 }
 
 interface ChildLinkProps {
-   child: ProductListChild;
+   child: ProductList['children'][0];
 }
 
 const ChildLink = ({ child }: ChildLinkProps) => {
@@ -182,7 +167,7 @@ const ChildLink = ({ child }: ChildLinkProps) => {
                      >
                         <IfixitImage
                            src={child.image.url}
-                           alt={child.image.alt}
+                           alt={child.image.alternativeText ?? ''}
                            objectFit="cover"
                            layout="fill"
                            sizes="20vw"

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -1,3 +1,6 @@
+import { invariant } from '@ifixit/helpers';
+import { ProductList, ProductListType } from '@models/product-list';
+
 type ProductListAttributes = {
    filters?: string | null;
    deviceTitle?: string | null;
@@ -14,4 +17,99 @@ export function computeProductListAlgoliaFilterPreset<
       return `device:${JSON.stringify(deviceTitle)}`;
    }
    return undefined;
+}
+
+/**
+ * Convert URL slug to product list device title
+ */
+export function decodeDeviceItemType(itemTypeHandle: string): string {
+   return itemTypeHandle.replace(/_+/g, ' ');
+}
+
+/**
+ * Convert URL slug to product list device title
+ */
+export function encodeDeviceItemType(itemType: string): string {
+   return itemType.replace(/\s+/g, '_');
+}
+
+/**
+ * Convert URL slug to product list device title
+ */
+export function decodeDeviceTitle(handle: string): string {
+   return handle.replace(/_+/g, ' ');
+}
+
+/**
+ * Convert URL slug to product list device title
+ */
+export function encodeDeviceTitle(deviceTitle: string): string {
+   return deviceTitle.replace(/\s+/g, '_');
+}
+
+type ProductListPathAttributes = Pick<
+   ProductList,
+   'type' | 'handle' | 'deviceTitle'
+> & {
+   itemType?: string;
+};
+
+export function getProductListPath(
+   productList: ProductListPathAttributes
+): string {
+   switch (productList.type) {
+      case ProductListType.AllParts: {
+         return '/Parts';
+      }
+      case ProductListType.DeviceParts: {
+         invariant(
+            productList.deviceTitle != null,
+            'device product list does not have device title'
+         );
+         const deviceHandle = encodeDeviceTitle(productList.deviceTitle);
+         return `/Parts/${deviceHandle}`;
+      }
+      case ProductListType.DeviceItemTypeParts: {
+         invariant(
+            productList.deviceTitle != null,
+            'device product list does not have device title'
+         );
+         invariant(
+            productList.itemType != null,
+            'device item type product list does not have item type'
+         );
+         const deviceHandle = encodeDeviceTitle(productList.deviceTitle);
+         const itemTypeHandle = encodeDeviceItemType(productList.itemType);
+         return `/Parts/${deviceHandle}/${itemTypeHandle}`;
+      }
+      case ProductListType.AllTools: {
+         return '/Tools';
+      }
+      case ProductListType.ToolsCategory: {
+         return `/Tools/${productList.handle}`;
+      }
+      case ProductListType.Marketing: {
+         return `/Store/${productList.handle}`;
+      }
+      default: {
+         throw new Error(`unknown product list type: ${productList.type}`);
+      }
+   }
+}
+
+type ProductListTitleAttributes = {
+   type: ProductListType;
+   itemType?: string;
+   title: string;
+};
+
+export function getProductListTitle(
+   productList: ProductListTitleAttributes
+): string {
+   if (productList.type === ProductListType.DeviceItemTypeParts) {
+      return `${productList.title.replace(/parts$/i, '').trim()} ${
+         productList.itemType
+      }`;
+   }
+   return productList.title;
 }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -214,6 +214,8 @@ export type DateTimeFilterInput = {
 };
 
 export enum Enum_Productlist_Type {
+   AllParts = 'all_parts',
+   AllTools = 'all_tools',
    Marketing = 'marketing',
    Parts = 'parts',
    Tools = 'tools',

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -24,11 +24,28 @@ export type WikiInfoEntry = {
    inheritedFrom: string | null;
 };
 
-export interface ProductList {
+export enum ProductListType {
+   AllParts = 'parts',
+   DeviceParts = 'device-parts',
+   DeviceItemTypeParts = 'device-item-type-parts',
+   AllTools = 'tools',
+   ToolsCategory = 'tools-category',
+   Marketing = 'marketing',
+}
+
+export type ProductList =
+   | AllPartsProductList
+   | DevicePartsProductList
+   | DeviceItemTypePartsProductList
+   | AllToolsProductList
+   | ToolsCategoryProductList
+   | MarketingProductList;
+
+export interface BaseProductList {
    title: string;
    handle: string;
-   path: string;
    deviceTitle: string | null;
+   path: string;
    tagline: string | null;
    description: string;
    metaDescription: string | null;
@@ -43,6 +60,35 @@ export interface ProductList {
    };
    wikiInfo: WikiInfoEntry[];
 }
+
+interface AllPartsProductList extends BaseProductList {
+   type: ProductListType.AllParts;
+}
+
+interface DevicePartsProductList extends BaseProductList {
+   type: ProductListType.DeviceParts;
+}
+
+interface DeviceItemTypePartsProductList extends BaseProductList {
+   type: ProductListType.DeviceItemTypeParts;
+   itemType: string;
+}
+
+interface AllToolsProductList extends BaseProductList {
+   type: ProductListType.AllTools;
+}
+
+interface ToolsCategoryProductList extends BaseProductList {
+   type: ProductListType.ToolsCategory;
+}
+
+interface MarketingProductList extends BaseProductList {
+   type: ProductListType.Marketing;
+}
+
+export type ProductListOptions = {
+   itemType?: string;
+};
 
 export interface ProductListAncestor {
    title: string;

--- a/frontend/pages/Parts/[deviceHandle]/[itemTypeHandle].tsx
+++ b/frontend/pages/Parts/[deviceHandle]/[itemTypeHandle].tsx
@@ -11,6 +11,10 @@ import {
 } from '@components/product-list';
 import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
 import { IFIXIT_ORIGIN } from '@config/env';
+import {
+   decodeDeviceItemType,
+   decodeDeviceTitle,
+} from '@helpers/product-list-helpers';
 import { generateCSRFToken, setCSRFCookie } from '@ifixit/auth-sdk';
 import { invariant } from '@ifixit/helpers';
 import { getGlobalSettings } from '@models/global-settings';
@@ -37,19 +41,31 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
       origin: IFIXIT_ORIGIN,
    });
 
-   const { handle } = context.params || {};
-   invariant(typeof handle === 'string', 'tools category handle is required');
+   const { deviceHandle, itemTypeHandle } = context.params || {};
+
+   invariant(typeof deviceHandle === 'string', 'device handle is required');
+   invariant(
+      typeof itemTypeHandle === 'string',
+      'item type handle is required'
+   );
+
+   const deviceTitle = decodeDeviceTitle(deviceHandle);
 
    const [globalSettings, stores, currentStore, productList] =
       await Promise.all([
          getGlobalSettings(),
          getStoreList(),
          getStoreByCode('us'),
-         findProductList({
-            handle: {
-               eq: handle,
+         findProductList(
+            {
+               deviceTitle: {
+                  eq: deviceTitle,
+               },
             },
-         }),
+            {
+               itemType: decodeDeviceItemType(itemTypeHandle),
+            }
+         ),
       ]);
 
    if (productList == null) {

--- a/frontend/pages/Parts/[deviceHandle]/index.tsx
+++ b/frontend/pages/Parts/[deviceHandle]/index.tsx
@@ -11,9 +11,11 @@ import {
 } from '@components/product-list';
 import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
 import { IFIXIT_ORIGIN } from '@config/env';
+import { decodeDeviceTitle } from '@helpers/product-list-helpers';
 import { generateCSRFToken, setCSRFCookie } from '@ifixit/auth-sdk';
+import { invariant } from '@ifixit/helpers';
 import { getGlobalSettings } from '@models/global-settings';
-import { findProductList, getDeviceTitle } from '@models/product-list';
+import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
 import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
@@ -36,25 +38,17 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
       origin: IFIXIT_ORIGIN,
    });
 
-   const { handle } = context.params || {};
-   if (typeof handle !== 'string') {
-      return {
-         notFound: true,
-      };
-   }
+   const { deviceHandle } = context.params || {};
+   invariant(typeof deviceHandle === 'string', 'device handle is required');
 
-   const deviceTitle = getDeviceTitle(handle);
+   const deviceTitle = decodeDeviceTitle(deviceHandle);
 
    const [globalSettings, stores, currentStore, productList] =
       await Promise.all([
          getGlobalSettings(),
          getStoreList(),
          getStoreByCode('us'),
-         findProductList({
-            deviceTitle: {
-               eq: deviceTitle,
-            },
-         }),
+         findProductList({ deviceTitle: { eq: deviceTitle } }),
       ]);
 
    if (productList == null) {

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -1,9 +1,9 @@
 import {
    AppProviders,
-   Layout,
-   WithProvidersProps,
-   WithLayoutProps,
    AppProvidersProps,
+   Layout,
+   WithLayoutProps,
+   WithProvidersProps,
 } from '@components/common';
 import {
    ProductListView,
@@ -41,11 +41,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
          getGlobalSettings(),
          getStoreList(),
          getStoreByCode('us'),
-         findProductList({
-            handle: {
-               eq: 'Parts',
-            },
-         }),
+         findProductList({ handle: { eq: 'Parts' } }),
       ]);
 
    if (productList == null) {

--- a/frontend/test/cypress/integration/product-list/filters.spec.ts
+++ b/frontend/test/cypress/integration/product-list/filters.spec.ts
@@ -7,7 +7,7 @@ describe('product list filters', () => {
 
    it('should help user filter', () => {
       user
-         .findAllByTestId(/facet-accordion-item-.*/i)
+         .findAllByTestId(/collapsed-facet-accordion-item-.*/i)
          .first()
          .as('first-facet-accordion-item')
          .next()


### PR DESCRIPTION
closes #354 
fixes #370 

⚠️ After merging this, strapi.ifixit.com needs to be redeployed since the product list type enum has been updated.
The product lists should have `type` set to:
- All parts product list: `all-parts`
- Device parts product list: `parts`
- All tools product list: `all-tools`
- Tools category product list: `tools`
An unset `type` field is assumed as a device parts product list.

cc @sterlinghirsh 

## QA

1. Open [Vercel Preview](https://react-commerce-git-add-item-type-product-lists-ifixit.cominor.com/Parts)
2. Verify than when in device parts product lists you can use the "item type" facet to navigate to the corresponding device item type product list (e.g. iPhone batteries)
3. Verify that the bug described by #370 is fixed