### PR TITLE
Unique Username: Add a null check 

### DIFF
--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -5,7 +5,7 @@ import { useQuery } from 'react-query';
 type User = {
    id: number;
    username: string;
-   handle: string;
+   handle: string | null;
    thumbnail: string | null;
    is_pro: boolean;
    discountTier: string | null;
@@ -38,10 +38,6 @@ async function fetchAuthenticatedUser(apiOrigin: string): Promise<User | null> {
       invariant(
          typeof payload.username === 'string',
          'User username is not a string'
-      );
-      invariant(
-         typeof payload.unique_username === 'string',
-         'User handle is not a string'
       );
       let thumbnailUrl: string | null = null;
       if (

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -43,6 +43,10 @@ async function fetchAuthenticatedUser(apiOrigin: string): Promise<User | null> {
          typeof payload.unique_username === 'string',
          'User handle is not a string'
       );
+      invariant(
+         payload.unique_username !== null,
+         'User handle is null'
+      );
       let thumbnailUrl: string | null = null;
       if (
          isRecord(payload.image) &&

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -43,10 +43,6 @@ async function fetchAuthenticatedUser(apiOrigin: string): Promise<User | null> {
          typeof payload.unique_username === 'string',
          'User handle is not a string'
       );
-      invariant(
-         payload.unique_username !== null,
-         'User handle is null'
-      );
       let thumbnailUrl: string | null = null;
       if (
          isRecord(payload.image) &&

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -47,6 +47,11 @@ async function fetchAuthenticatedUser(apiOrigin: string): Promise<User | null> {
          thumbnailUrl = payload.image.thumbnail;
       }
 
+      const unique_username =
+         typeof payload.unique_username == 'string'
+            ? payload.unique_username
+            : null;
+
       const discountTier =
          typeof payload.discount_tier === 'string'
             ? payload.discount_tier
@@ -54,7 +59,7 @@ async function fetchAuthenticatedUser(apiOrigin: string): Promise<User | null> {
       return {
          id: payload.userid,
          username: payload.username,
-         handle: payload.unique_username,
+         handle: unique_username,
          thumbnail: thumbnailUrl,
          is_pro: discountTier != null,
          discountTier,

--- a/packages/ui/header/UserMenu.tsx
+++ b/packages/ui/header/UserMenu.tsx
@@ -87,7 +87,7 @@ export const UserMenuHeading = forwardRef<Omit<StackProps, 'children'>, 'div'>(
             <Text color="gray.900" fontWeight="semibold">
                {user?.username}
             </Text>
-            <Text color="gray.700">@{user?.handle}</Text>
+            {user?.handle && <Text color="gray.700">@{user?.handle}</Text>}
          </VStack>
       );
    }

--- a/packages/ui/header/UserMenu.tsx
+++ b/packages/ui/header/UserMenu.tsx
@@ -24,7 +24,7 @@ type UserMenuContext = {
 
 type User = {
    username: string;
-   handle: string;
+   handle: string | null;
    thumbnail: string | null;
 };
 


### PR DESCRIPTION
## Summary:

Previously, we did not check if the `unique_username` was null and the page could break. This PR fixes this so that the null case for `unique_username` is handled.

## CR/QA:
Users created with https://www.cominor.com/dev/create_user don't have unique usernames by default. 
Visit this branch's [preview](https://react-commerce-git-unique-username-check-for-null-ifixit.cominor.com/Parts) while logged in as a user without a unique username and confirm log in/out and appearance is the same for a user with a unique username.

Closes #372 

CC: @sterlinghirsh @dhmacs 