### PR TITLE
iFixit Origin: use relative urls if on same origin

### DIFF
--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -8,10 +8,14 @@ export const ALGOLIA_API_KEY = checkEnv(
    'ALGOLIA_API_KEY'
 );
 
-export const IFIXIT_ORIGIN = checkEnv(
+const NEXT_PUBLIC_IFIXIT_ORIGIN = checkEnv(
    process.env.NEXT_PUBLIC_IFIXIT_ORIGIN,
    'NEXT_PUBLIC_IFIXIT_ORIGIN'
 );
+
+export const IFIXIT_ORIGIN = shouldUseRelativeOrigin(NEXT_PUBLIC_IFIXIT_ORIGIN) ?
+   "" :
+   NEXT_PUBLIC_IFIXIT_ORIGIN;
 
 export const STRAPI_ORIGIN = checkEnv(
    process.env.NEXT_PUBLIC_STRAPI_ORIGIN,
@@ -29,4 +33,19 @@ function checkEnv(env: string | null | undefined, envName: string): string {
       throw new Error(`environment variable "${envName}" is not defined`);
    }
    return env;
+}
+
+function shouldUseRelativeOrigin(ifixitOrigin: string): boolean {
+   if (typeof window === 'undefined') {
+      return false;
+   }
+
+   function baseDomain(url: string): string|null {
+      const parsedURl = new URL(url);
+      const host = parsedURl.host.match(/[^.]+\.[^.]+$/);
+      return host ? host[0] : "";
+   }
+
+   const currentBaseDomain = baseDomain(window.location.origin);
+   return Boolean(currentBaseDomain) && currentBaseDomain === baseDomain(ifixitOrigin);
 }


### PR DESCRIPTION
Effectively, if we are running the app on the same base domain as the
urls of the API, then we should use relative urls in for all front-end
API requests.

Backend requests still need to the full url because there is no "origin"
as they aren't in the context of a browser.

Determine if we should use relatively urls by comapring the base domain
of IFIXIT_ORIGIN and the base domain of the current url. We are using
base domain here so we allow using relative urls when on language
subdomains like es.ifixit.com (where IFIXIT_ORIGIN === www.ifixit.com).

Closes https://github.com/iFixit/ifixit/issues/43646