### PR TITLE
Tools: Hide irrelevant facets

### DIFF
--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -52,7 +52,10 @@ export function ProductListView({
                   {productList.children.length > 0 && (
                      <ProductListChildrenSection productList={productList} />
                   )}
-                  <FilterableProductsSection wikiInfo={productList.wikiInfo} title={productList.handle}/>
+                  <FilterableProductsSection
+                     wikiInfo={productList.wikiInfo}
+                     title={productList.handle}
+                  />
                </Index>
                {productList.sections.map((section, index) => {
                   switch (section.type) {

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -52,7 +52,7 @@ export function ProductListView({
                   {productList.children.length > 0 && (
                      <ProductListChildrenSection productList={productList} />
                   )}
-                  <FilterableProductsSection wikiInfo={productList.wikiInfo} />
+                  <FilterableProductsSection wikiInfo={productList.wikiInfo} title={productList.handle}/>
                </Index>
                {productList.sections.map((section, index) => {
                   switch (section.type) {

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -25,7 +25,7 @@ type FacetsAccordianProps = {
 };
 
 export function FacetsAccordion(props: FacetsAccordianProps) {
-   const wikiInfo  = props.wikiInfo;
+   const wikiInfo = props.wikiInfo;
    const title = props.title;
    const facets = useFilteredFacets(wikiInfo, title);
    const countRefinements = useCountRefinements();

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -21,11 +21,13 @@ import { useFilteredFacets } from './useFacets';
 
 type FacetsAccordianProps = {
    wikiInfo: WikiInfoEntry[];
+   title: string;
 };
 
 export function FacetsAccordion(props: FacetsAccordianProps) {
-   const { wikiInfo } = props;
-   const facets = useFilteredFacets(wikiInfo);
+   const wikiInfo  = props.wikiInfo;
+   const title = props.title;
+   const facets = useFilteredFacets(wikiInfo, title);
    const countRefinements = useCountRefinements();
 
    return (

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -39,7 +39,7 @@ type SectionProps = {
 };
 
 export function FilterableProductsSection(props: SectionProps) {
-   const  wikiInfo  = props.wikiInfo;
+   const wikiInfo = props.wikiInfo;
    const title = props.title;
    const { hits } = useHits<ProductSearchHit>();
    const [viewType, setViewType] = useLocalPreference(
@@ -74,7 +74,7 @@ export function FilterableProductsSection(props: SectionProps) {
          <CurrentRefinements />
          <HStack mt="4" align="flex-start" spacing={{ base: 0, md: 4 }}>
             <FacetCard>
-               <FacetsAccordion wikiInfo={wikiInfo} title={title}/>
+               <FacetsAccordion wikiInfo={wikiInfo} title={title} />
             </FacetCard>
             <Card flex={1}>
                {isEmpty ? (

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -35,10 +35,12 @@ const PRODUCT_VIEW_TYPE_STORAGE_KEY = 'productViewType';
 
 type SectionProps = {
    wikiInfo: WikiInfoEntry[];
+   title: string;
 };
 
 export function FilterableProductsSection(props: SectionProps) {
-   const { wikiInfo } = props;
+   const  wikiInfo  = props.wikiInfo;
+   const title = props.title;
    const { hits } = useHits<ProductSearchHit>();
    const [viewType, setViewType] = useLocalPreference(
       PRODUCT_VIEW_TYPE_STORAGE_KEY,
@@ -72,7 +74,7 @@ export function FilterableProductsSection(props: SectionProps) {
          <CurrentRefinements />
          <HStack mt="4" align="flex-start" spacing={{ base: 0, md: 4 }}>
             <FacetCard>
-               <FacetsAccordion wikiInfo={wikiInfo} />
+               <FacetsAccordion wikiInfo={wikiInfo} title={title}/>
             </FacetCard>
             <Card flex={1}>
                {isEmpty ? (

--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -36,8 +36,8 @@ export function useFilteredFacets(wikiInfo: WikiInfoEntry[], title?: string) {
       return usefulFacets;
    }, [facets, infoNames]);
 
-   if (title !== null && title === "Tools") {
-      return facets.slice(7,10);
+   if (title !== null && title === 'Tools') {
+      return facets.slice(7, 10);
    }
 
    return usefulFacets;

--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -22,7 +22,7 @@ export function useFacets() {
    // return attributesToRender;
 }
 
-export function useFilteredFacets(wikiInfo: WikiInfoEntry[]) {
+export function useFilteredFacets(wikiInfo: WikiInfoEntry[], title?: string) {
    const facets = useFacets();
 
    const infoNames = React.useMemo(() => {
@@ -35,6 +35,10 @@ export function useFilteredFacets(wikiInfo: WikiInfoEntry[]) {
          .filter((facet) => !infoNames.has(facet));
       return usefulFacets;
    }, [facets, infoNames]);
+
+   if (title !== null && title === "Tools") {
+      return facets.slice(7,10);
+   }
 
    return usefulFacets;
 }


### PR DESCRIPTION
## Summary

Previously, we included facets, such as `Device Brand`, that were not needed on the `/Tools` page. This PR adds changes such that these facets are hidden on `/Tools`:
- Device
- Device Brand
- Device Category
- Device Type
- Item Type
- OS

## CR/QA:
- Visit the preview and add `/Tools`.
- On the tools homepage make sure that the above facets are hidden.
- Additionally, I also checked `/Parts` to make sure that page wasn't broken.

Closes #375 