### PR TITLE
Tools: Hide irrelevant facets

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -43,5 +43,18 @@ export function useFilteredFacets(productList: ProductList) {
       return usefulFacets;
    }, [facets, infoNames, isItemTypeProductList]);
 
+   if (productList.type === ProductListType.AllTools) {
+      const excludedToolsFacets = [
+         'facet_tags.Item Type',
+         'facet_tags.Capacity',
+         'device',
+         'facet_tags.Device Brand',
+         'facet_tags.Device Category',
+         'facet_tags.Device Type',
+         'facet_tags.OS',
+      ]
+      return facets.filter(facet => !excludedToolsFacets.includes(facet));
+   }
+
    return usefulFacets;
 }


### PR DESCRIPTION
## Summary
Previously, we included facets, such as `Device Brand`, that were not needed on the `/Tools` page. This PR adds changes such that these facets are hidden on `/Tools`:
- Device
- Device Brand
- Device Category
- Device Type
- Item Type
- OS
## CR/QA:
- Visit the preview and add `/Tools`. [Click here to go there directly](https://react-commerce-git-tools-hide-facets-ifixit.vercel.app/Tools)
- On the tools homepage make sure that the above facets are hidden.
- Additionally, I also checked `/Parts` to make sure that page wasn't broken.

Closes #375