### PR TITLE
Tests: Collections parts page add tests

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/RangeInput.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/RangeInput.tsx
@@ -149,7 +149,7 @@ export function RangeInput(props: RangeInputProps) {
             </Box>
          </HStack>
          {!isValidRange && (
-            <FormErrorMessage data-test="input-error">
+            <FormErrorMessage data-testid="input-error">
                max should be higher than min
             </FormErrorMessage>
          )}

--- a/frontend/components/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/components/product-list/sections/ProductListChildrenSection.tsx
@@ -88,7 +88,7 @@ export function ProductListChildrenSection({
          <Text fontSize="lg" fontWeight="bold" mb="4">
             {heading}
          </Text>
-         <VStack spacing="4" align="stretch">
+         <VStack data-testid="product-list-devices" spacing="4" align="stretch">
             <SimpleGrid
                columns={{
                   base: 1,

--- a/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
+++ b/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
@@ -17,7 +17,7 @@ describe('collections scroll', () => {
       user.wait(3000);
 
        // When it scrolls to the top, the search bar should be visible
-      user.window().isWithinViewport(user.get('[data-testid=collections-search-box]'));
+      user.window().isWithinViewport(user.getBySel('collections-search-box'));
 
        // Check that url parameter contains ?p after clicking next page
       user.location().should((loc) => {

--- a/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
+++ b/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
@@ -16,13 +16,15 @@ describe('collections scroll', () => {
       user.wait('@search');
       user.wait(3000);
 
-       // When it scrolls to the top, the search bar should be visible
-      user.window().isWithinViewport(user.getBySel('collections-search-box'));
+      // When it scrolls to the top, the search bar should be visible
+      user
+         .window()
+         .isWithinViewport(user.getByDataTestId('collections-search-box'));
 
-       // Check that url parameter contains ?p after clicking next page
+      // Check that url parameter contains ?p after clicking next page
       user.location().should((loc) => {
-         expect(loc.search).to.have.string('?p=')
-      })
+         expect(loc.search).to.have.string('?p=');
+      });
    });
 });
 

--- a/frontend/test/cypress/integration/product-list/collections_view_button.spec.ts
+++ b/frontend/test/cypress/integration/product-list/collections_view_button.spec.ts
@@ -10,7 +10,7 @@ describe('collection display', () => {
 
       // Make sure the display property equals to grid
       user
-         .getBySel('grid-view-products')
+         .getByDataTestId('grid-view-products')
          .invoke('css', 'display')
          .should('equal', 'grid');
    });
@@ -24,7 +24,7 @@ describe('collection display', () => {
 
       // Make sure the display property equals to flex
       user
-         .getBySel('list-view-products')
+         .getByDataTestId('list-view-products')
          .invoke('css', 'display')
          .should('equal', 'flex');
    });

--- a/frontend/test/cypress/integration/product-list/collections_view_button.spec.ts
+++ b/frontend/test/cypress/integration/product-list/collections_view_button.spec.ts
@@ -10,7 +10,7 @@ describe('collection display', () => {
 
       // Make sure the display property equals to grid
       user
-         .get('[data-testid="grid-view-products"]')
+         .getBySel('grid-view-products')
          .invoke('css', 'display')
          .should('equal', 'grid');
    });
@@ -24,7 +24,7 @@ describe('collection display', () => {
 
       // Make sure the display property equals to flex
       user
-         .get('[data-testid="list-view-products"]')
+         .getBySel('list-view-products')
          .invoke('css', 'display')
          .should('equal', 'flex');
    });

--- a/frontend/test/cypress/integration/product-list/parts_page_devices.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_devices.spec.ts
@@ -5,39 +5,21 @@ describe('parts page devices', () => {
       user.visit('/Parts');
    });
 
-   it('should visit all devices on /Parts page', () => {
-      assertVisibleFilterAndProducts();
-      assertAvailableProducts();
-
-      const visitPageCount = 4;
-      user
-         .getBySel('product-list-devices')
-         .find('a')
-         .each((device, index) => {
-            // Only visit few device pages since it will take too long to visit all
-            if (index == visitPageCount)
-               return false;
-
-            let deviceLink = device.attr('href');
-            if (deviceLink) {
-               user.visit(deviceLink);
-               assertVisibleFilterAndProducts();
-
-               user.visit('/Parts');
-               assertVisibleFilterAndProducts();
-               // TODO: Call assertAvailableProducts() here when the seed data is updated.
-            }
-         });
-   });
-
    it('should navigate until the last device page', () => {
       assertVisibleFilterAndProducts();
       assertAvailableProducts();
 
-      user.get('button').contains('Show more').click();
-      user.get('a[href="/Parts/Mac"]').click({force: true});
+      user.get('body').then(($body) => {
+         const device = $body.find('a[href="/Parts/Mac"]');
+         if (!device.is(':visible')) {
+            user.get('button').contains('Show more').click();
+         }
+         device[0].click();
+      });
 
-      user.location('pathname', {timeout: 20000}).should('include', '/Parts/Mac');
+      user
+         .location('pathname', { timeout: 20000 })
+         .should('include', '/Parts/Mac');
       user.get('h1').contains('Mac Parts').should('be.visible');
 
       navigateUntilLastDevice();
@@ -46,38 +28,46 @@ describe('parts page devices', () => {
    });
 
    function assertVisibleFilterAndProducts() {
-      user.getBySel('filterable-products-section').should('be.visible');
-      user.getBySel('facets-accordion').scrollIntoView().should('be.visible');
+      user.getByDataTestId('filterable-products-section').should('be.visible');
+      user
+         .getByDataTestId('facets-accordion')
+         .scrollIntoView()
+         .should('be.visible');
    }
 
-   // Makes sure there are at least 1 product available
+   // Makes sure there is at least 1 product available
    function assertAvailableProducts() {
       user
-         .getBySel('list-view-products')
+         .getByDataTestId('list-view-products')
          .children('article')
          .its('length')
          .should('be.gte', 1);
    }
 
-   // Recursively navigate the first device until no sub-devices are left
+   // Recursively navigate to the first device until no sub-devices are left
    function navigateUntilLastDevice() {
-      user.get('body').then($body => {
-         if ($body.find('[data-testid="product-list-devices"]').length > 0) {   
-            user
-               .getBySel('product-list-devices')
-               .find('a')
-               .first()
-               .as('device')
-               .click();
-   
-            user.get('@device').should('have.attr', 'href').then((href) => {
-               user.location('pathname', {timeout: 20000})
-               .should('include', href);
-            })
-            assertVisibleFilterAndProducts();
-            navigateUntilLastDevice();
-         }
-     });
+      user.get('body').then(($body) => {
+         if ($body.find('[data-testid="product-list-devices"]').length <= 0)
+            return false;
+
+         user
+            .getByDataTestId('product-list-devices')
+            .find('a')
+            .first()
+            .as('device')
+            .click();
+
+         user
+            .get('@device')
+            .should('have.attr', 'href')
+            .then((href) => {
+               user
+                  .location('pathname', { timeout: 20000 })
+                  .should('include', href);
+            });
+         assertVisibleFilterAndProducts();
+         navigateUntilLastDevice();
+      });
    }
 });
 

--- a/frontend/test/cypress/integration/product-list/parts_page_devices.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_devices.spec.ts
@@ -1,0 +1,84 @@
+describe('parts page devices', () => {
+   const user = cy;
+
+   beforeEach(() => {
+      user.visit('/Parts');
+   });
+
+   it('should visit all devices on /Parts page', () => {
+      assertVisibleFilterAndProducts();
+      assertAvailableProducts();
+
+      const visitPageCount = 4;
+      user
+         .getBySel('product-list-devices')
+         .find('a')
+         .each((device, index) => {
+            // Only visit few device pages since it will take too long to visit all
+            if (index == visitPageCount)
+               return false;
+
+            let deviceLink = device.attr('href');
+            if (deviceLink) {
+               user.visit(deviceLink);
+               assertVisibleFilterAndProducts();
+
+               user.visit('/Parts');
+               assertVisibleFilterAndProducts();
+               // TODO: Call assertAvailableProducts() here when the seed data is updated.
+            }
+         });
+   });
+
+   it('should navigate until the last device page', () => {
+      assertVisibleFilterAndProducts();
+      assertAvailableProducts();
+
+      user.get('button').contains('Show more').click();
+      user.get('a[href="/Parts/Mac"]').click({force: true});
+
+      user.location('pathname', {timeout: 20000}).should('include', '/Parts/Mac');
+      user.get('h1').contains('Mac Parts').should('be.visible');
+
+      navigateUntilLastDevice();
+      assertVisibleFilterAndProducts();
+      assertAvailableProducts();
+   });
+
+   function assertVisibleFilterAndProducts() {
+      user.getBySel('filterable-products-section').should('be.visible');
+      user.getBySel('facets-accordion').scrollIntoView().should('be.visible');
+   }
+
+   // Makes sure there are at least 1 product available
+   function assertAvailableProducts() {
+      user
+         .getBySel('list-view-products')
+         .children('article')
+         .its('length')
+         .should('be.gte', 1);
+   }
+
+   // Recursively navigate the first device until no sub-devices are left
+   function navigateUntilLastDevice() {
+      user.get('body').then($body => {
+         if ($body.find('[data-testid="product-list-devices"]').length > 0) {   
+            user
+               .getBySel('product-list-devices')
+               .find('a')
+               .first()
+               .as('device')
+               .click();
+   
+            user.get('@device').should('have.attr', 'href').then((href) => {
+               user.location('pathname', {timeout: 20000})
+               .should('include', href);
+            })
+            assertVisibleFilterAndProducts();
+            navigateUntilLastDevice();
+         }
+     });
+   }
+});
+
+export {};

--- a/frontend/test/cypress/support/commands.ts
+++ b/frontend/test/cypress/support/commands.ts
@@ -13,3 +13,7 @@ Cypress.Commands.add('isWithinViewport', { prevSubject: true }, (selector: any) 
     expect(bounding.bottom).to.be.lessThan(bottomBoundOfWindow);
   });
 })
+
+Cypress.Commands.add('getBySel', (selector, ...args) => {
+  return cy.get(`[data-testid=${selector}]`, ...args)
+})

--- a/frontend/test/cypress/support/commands.ts
+++ b/frontend/test/cypress/support/commands.ts
@@ -1,19 +1,23 @@
 /// <reference path="../support/index.d.ts" />
 import '@testing-library/cypress/add-commands';
 
-Cypress.Commands.add('isWithinViewport', { prevSubject: true }, (selector: any) => {
-  cy.window().then((win) => {
-    const rightBoundOfWindow =  win.innerWidth;
-    const bottomBoundOfWindow =  win.innerHeight;
-    const bounding = selector[0].getBoundingClientRect();
+Cypress.Commands.add(
+   'isWithinViewport',
+   { prevSubject: true },
+   (selector: any) => {
+      cy.window().then((win) => {
+         const rightBoundOfWindow = win.innerWidth;
+         const bottomBoundOfWindow = win.innerHeight;
+         const bounding = selector[0].getBoundingClientRect();
 
-    expect(bounding.top).to.be.at.least(0);
-    expect(bounding.left).to.be.at.least(0);
-    expect(bounding.right).to.be.lessThan(rightBoundOfWindow);
-    expect(bounding.bottom).to.be.lessThan(bottomBoundOfWindow);
-  });
-})
+         expect(bounding.top).to.be.at.least(0);
+         expect(bounding.left).to.be.at.least(0);
+         expect(bounding.right).to.be.lessThan(rightBoundOfWindow);
+         expect(bounding.bottom).to.be.lessThan(bottomBoundOfWindow);
+      });
+   }
+);
 
-Cypress.Commands.add('getBySel', (selector, ...args) => {
-  return cy.get(`[data-testid=${selector}]`, ...args)
-})
+Cypress.Commands.add('getByDataTestId', (selector, ...args) => {
+   return cy.get(`[data-testid=${selector}]`, ...args);
+});

--- a/frontend/test/cypress/support/index.d.ts
+++ b/frontend/test/cypress/support/index.d.ts
@@ -3,5 +3,6 @@
 declare namespace Cypress {
     interface Chainable {
         isWithinViewport(element: any): Chainable;
+        getBySel(selector: any): Chainable;
     }
 }

--- a/frontend/test/cypress/support/index.d.ts
+++ b/frontend/test/cypress/support/index.d.ts
@@ -1,8 +1,8 @@
 // https://github.com/cypress-io/cypress-example-recipes/tree/master/examples/fundamentals__add-custom-command
 
 declare namespace Cypress {
-    interface Chainable {
-        isWithinViewport(element: any): Chainable;
-        getBySel(selector: any): Chainable;
-    }
+   interface Chainable {
+      isWithinViewport(element: any): Chainable;
+      getByDataTestId(selector: any): Chainable;
+   }
 }


### PR DESCRIPTION
## Summary

Adds a new test to the collection `/Parts` page. 
- ~The first test visits devices/models on `/Parts` page and asserts that the search filter and `filterable-products-section` section is visible (copy of `WDStorePagesSmokeTest -> testAllToplevelPartsPages` in iFixit/ifixt).~
- The second test clicks on a device (hard coded to `Mac Parts` for the moment), then navigates until the last device page and asserts that there is at least one product (`WDStorePagesSmokeTest -> testDrillDownUntilPartFound`).

## QA 

Please re-run the `E2E tests / cypress-run` ci check and make sure it passes.

Connects: https://github.com/iFixit/ifixit/issues/43590 and https://github.com/iFixit/react-commerce/issues/387