### PR TITLE
Facets: Custom sort order

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/RefinementList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/RefinementList.tsx
@@ -13,6 +13,7 @@ import {
    useRefinementList,
    UseRefinementListProps,
 } from 'react-instantsearch-hooks-web';
+import { useSortBy } from './useSortBy';
 
 export type RefinementListProps = UseRefinementListProps;
 
@@ -20,7 +21,7 @@ export function RefinementList(props: RefinementListProps) {
    const { items, refine, isShowingMore, toggleShowMore, canToggleShowMore } =
       useRefinementList({
          ...props,
-         sortBy: getSortBy(props),
+         sortBy: useSortBy(props),
       });
 
    return (
@@ -57,63 +58,6 @@ export function RefinementList(props: RefinementListProps) {
          )}
       </Box>
    );
-}
-
-const getSortBy = (props: RefinementListProps) => {
-   switch (props.attribute) {
-      case 'price_range':
-         return sortByPriceRange;
-      case 'facet_tags.Capacity':
-         return sortByCapacityHighToLow;
-      default:
-         return props.sortBy;
-   }
-};
-
-const sortByPriceRange: RefinementListProps['sortBy'] = (a, b) => {
-   const aAvg = avg(a.escapedValue);
-   const bAvg = avg(b.escapedValue);
-
-   if (aAvg == null && bAvg == null) {
-      return 0;
-   }
-   if (aAvg == null) {
-      return 1;
-   }
-   if (bAvg == null) {
-      return -1;
-   }
-   return aAvg - bAvg;
-};
-
-function avg(x: string): number | null {
-   const nums = x.match(/\d+/g);
-   if (nums == null) {
-      return null;
-   }
-   return nums.reduce((x, y) => x + parseFloat(y), 0) / nums.length;
-}
-
-const sortByCapacityHighToLow: RefinementListProps['sortBy'] = (a, b) => {
-   return capacityToBytes(b.escapedValue) - capacityToBytes(a.escapedValue);
-};
-
-const unitToBytes = {
-   B: 1,
-   KB: 1024,
-   MB: 1024 ** 2,
-   GB: 1024 ** 3,
-   TB: 1024 ** 4,
-   PB: 1024 ** 5,
-};
-
-function capacityToBytes(x: string): number {
-   const size = parseFloat(x);
-   if (isNaN(size)) {
-      return 0;
-   }
-   const unit = (x.match(/[KMGTP]?B/)?.[0] ?? 'B') as keyof typeof unitToBytes;
-   return size * (unitToBytes[unit] ?? 1);
 }
 
 type RefinementListItemProps = {

--- a/frontend/components/product-list/sections/FilterableProductsSection/RefinementMenu.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/RefinementMenu.tsx
@@ -6,6 +6,7 @@ import {
    UseRefinementListProps,
 } from 'react-instantsearch-hooks-web';
 import NextLink from 'next/link';
+import { useSortBy } from './useSortBy';
 
 export type RefinementMenuProps = UseRefinementListProps & {
    createURL: (value: string) => string;
@@ -18,7 +19,10 @@ export function RefinementMenu({
    ...otherProps
 }: RefinementMenuProps) {
    const { items, isShowingMore, toggleShowMore, canToggleShowMore } =
-      useRefinementList(otherProps);
+      useRefinementList({
+         ...otherProps,
+         sortBy: useSortBy(otherProps),
+      });
 
    return (
       <Box>

--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -8,14 +8,15 @@ export function useFacets() {
    });
 
    return [
-      'facet_tags.Item Type',
       'facet_tags.Capacity',
-      'device',
       'facet_tags.Device Brand',
       'facet_tags.Device Category',
       'facet_tags.Device Type',
+      'facet_tags.Item Type',
       'facet_tags.OS',
       'facet_tags.Part or Kit',
+      'facet_tags.Tool Category',
+      'device',
       'price_range',
       'worksin',
    ];

--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useDynamicWidgets } from 'react-instantsearch-hooks-web';
 import { ProductList, ProductListType } from '@models/product-list';
+import { formatFacetName } from '@helpers/algolia-helpers';
 
 export function useFacets() {
    const { attributesToRender } = useDynamicWidgets({
@@ -34,15 +35,65 @@ export function useFilteredFacets(productList: ProductList) {
       );
    }, [productList.wikiInfo]);
 
+   const sortBy = React.useMemo(() => {
+      return sortFacets(productList.type);
+   }, [productList.type]);
+
    const usefulFacets = React.useMemo(() => {
-      const usefulFacets = facets.slice().filter((facet) => {
-         if (facet === 'facet_tags.Item Type' && isItemTypeProductList) {
-            return false;
-         }
-         return !infoNames.has(facet);
-      });
+      const usefulFacets = facets
+         .slice()
+         .filter((facet) => {
+            if (facet === 'facet_tags.Item Type' && isItemTypeProductList) {
+               return false;
+            }
+            return !infoNames.has(facet);
+         })
+         .sort(sortBy);
       return usefulFacets;
-   }, [facets, infoNames, isItemTypeProductList]);
+   }, [facets, infoNames, isItemTypeProductList, sortBy]);
 
    return usefulFacets;
+}
+
+const partsFacetRanking = new Map([
+   ['facet_tags.Item Type', 1],
+   ['facet_tags.Part or Kit', 2],
+]);
+
+const toolsFacetRanking = new Map([
+   ['facet_tags.Tool Category', 1],
+   ['price_range', 2],
+]);
+
+function sortFacets(productListType: ProductListType) {
+   switch (productListType) {
+      case ProductListType.AllParts:
+      case ProductListType.DeviceParts:
+      case ProductListType.DeviceItemTypeParts:
+         return sortFacetsWithRanking(partsFacetRanking);
+      case ProductListType.AllTools:
+      case ProductListType.ToolsCategory:
+         return sortFacetsWithRanking(toolsFacetRanking);
+      default:
+         return sortFacetsAlphabetically;
+   }
+}
+
+function sortFacetsWithRanking(ranking: Map<string, number>) {
+   return (a: string, b: string): number => {
+      if (ranking.get(a) && ranking.get(b)) {
+         return ranking.get(a)! - ranking.get(b)!;
+      } else if (ranking.get(a)) {
+         return -1;
+      } else if (ranking.get(b)) {
+         return 1;
+      } else {
+         return sortFacetsAlphabetically(a, b);
+      }
+   };
+}
+
+const enCollator = new Intl.Collator('en');
+function sortFacetsAlphabetically(a: string, b: string) {
+   return enCollator.compare(formatFacetName(a), formatFacetName(b));
 }

--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -36,7 +36,7 @@ export function useFilteredFacets(productList: ProductList) {
    }, [productList.wikiInfo]);
 
    const sortBy = React.useMemo(() => {
-      return sortFacets(productList.type);
+      return getFacetComparator(productList.type);
    }, [productList.type]);
 
    const usefulFacets = React.useMemo(() => {
@@ -65,7 +65,7 @@ const toolsFacetRanking = new Map([
    ['price_range', 2],
 ]);
 
-function sortFacets(productListType: ProductListType) {
+function getFacetComparator(productListType: ProductListType) {
    switch (productListType) {
       case ProductListType.AllParts:
       case ProductListType.DeviceParts:

--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -55,14 +55,16 @@ export function useFilteredFacets(productList: ProductList) {
    return usefulFacets;
 }
 
+// Higher number == closer to top, default is 0
 const partsFacetRanking = new Map([
-   ['facet_tags.Item Type', 1],
-   ['facet_tags.Part or Kit', 2],
+   ['facet_tags.Item Type', 2],
+   ['facet_tags.Part or Kit', 1],
 ]);
 
+// Higher number == closer to top, default is 0
 const toolsFacetRanking = new Map([
-   ['facet_tags.Tool Category', 1],
-   ['price_range', 2],
+   ['facet_tags.Tool Category', 2],
+   ['price_range', 1],
 ]);
 
 function getFacetComparator(productListType: ProductListType) {
@@ -81,15 +83,9 @@ function getFacetComparator(productListType: ProductListType) {
 
 function sortFacetsWithRanking(ranking: Map<string, number>) {
    return (a: string, b: string): number => {
-      if (ranking.get(a) && ranking.get(b)) {
-         return ranking.get(a)! - ranking.get(b)!;
-      } else if (ranking.get(a)) {
-         return -1;
-      } else if (ranking.get(b)) {
-         return 1;
-      } else {
-         return sortFacetsAlphabetically(a, b);
-      }
+      const aRank = ranking.get(a) || 0;
+      const bRank = ranking.get(b) || 0;
+      return bRank - aRank || sortFacetsAlphabetically(a, b);
    };
 }
 

--- a/frontend/components/product-list/sections/FilterableProductsSection/useSortBy.ts
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useSortBy.ts
@@ -1,0 +1,60 @@
+import { UseRefinementListProps } from 'react-instantsearch-hooks-web';
+
+const sortByPriceRange: UseRefinementListProps['sortBy'] = (a, b) => {
+   const aAvg = avg(a.escapedValue);
+   const bAvg = avg(b.escapedValue);
+
+   if (aAvg == null && bAvg == null) {
+      return 0;
+   }
+   if (aAvg == null) {
+      return 1;
+   }
+   if (bAvg == null) {
+      return -1;
+   }
+   return aAvg - bAvg;
+};
+
+function avg(x: string): number | null {
+   const nums = x.match(/\d+/g);
+   if (nums == null) {
+      return null;
+   }
+   return nums.reduce((x, y) => x + parseFloat(y), 0) / nums.length;
+}
+
+const sortByCapacityHighToLow: UseRefinementListProps['sortBy'] = (a, b) => {
+   return capacityToBytes(b.escapedValue) - capacityToBytes(a.escapedValue);
+};
+
+const unitToBytes = {
+   B: 1,
+   KB: 1024,
+   MB: 1024 ** 2,
+   GB: 1024 ** 3,
+   TB: 1024 ** 4,
+   PB: 1024 ** 5,
+};
+
+function capacityToBytes(x: string): number {
+   const size = parseFloat(x);
+   if (isNaN(size)) {
+      return 0;
+   }
+   const unit = (x.match(/[KMGTP]?B/)?.[0] ?? 'B') as keyof typeof unitToBytes;
+   return size * (unitToBytes[unit] ?? 1);
+}
+
+export function useSortBy(
+   props: UseRefinementListProps
+): UseRefinementListProps['sortBy'] {
+   switch (props.attribute) {
+      case 'price_range':
+         return sortByPriceRange;
+      case 'facet_tags.Capacity':
+         return sortByCapacityHighToLow;
+      default:
+         return props.sortBy;
+   }
+}

--- a/frontend/components/product-list/sections/FilterableProductsSection/useSortBy.ts
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useSortBy.ts
@@ -46,6 +46,12 @@ function capacityToBytes(x: string): number {
    return size * (unitToBytes[unit] ?? 1);
 }
 
+const enCollator = new Intl.Collator('en');
+
+const sortAlphabetically: UseRefinementListProps['sortBy'] = (a, b) => {
+   return enCollator.compare(a.escapedValue, b.escapedValue);
+};
+
 export function useSortBy(
    props: UseRefinementListProps
 ): UseRefinementListProps['sortBy'] {
@@ -54,6 +60,8 @@ export function useSortBy(
          return sortByPriceRange;
       case 'facet_tags.Capacity':
          return sortByCapacityHighToLow;
+      case 'facet_tags.Item Type':
+         return sortAlphabetically;
       default:
          return props.sortBy;
    }


### PR DESCRIPTION
Algolia's Facet Display doesn't work for nested facets like facet_tags. This adds code to customize the sort order.

It also adds code to alphabetize the "Item Type" refinement list items (aka facet options).

## QA
Make sure the facet accordions are sorted as spec'd on desktop and mobile. Check it across parts pages, tools pages, and other pages (ie marketing).

Also make sure the item type facet options are alphabetized.

CC @sterlinghirsh 

Closes #390 