### PR TITLE
No Results Search: Add link to main search

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
    "printWidth": 80,
    "tabWidth": 3,
-   "singleQuote": true
+   "singleQuote": true,
+   "endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This command will start Strapi dev server and Next.js dev server:
 pnpm dev
 ```
 
-> :warning: Don't forget to create `.env.local` file with the required secrets (see `.env.local.example`)
+> :warning: Don't forget to create `backend/.env` and `frontend/.env.local` files with the required secrets (see `.env.example` and `.env.local.example`)
 
 -  Use an API key from [Sentry](https://sentry.io/settings/account/api/auth-tokens/) for `SENTRY_AUTH_TOKEN`.
 

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -9,10 +9,13 @@ import {
    Heading,
    HStack,
    Icon,
+   Link,
    Text,
    VStack,
 } from '@chakra-ui/react';
 import { Card } from '@components/ui';
+import { IFIXIT_ORIGIN } from '@config/env';
+import { getProductListTitle } from '@helpers/product-list-helpers';
 import { cypressWindowLog } from '@helpers/test-helpers';
 import { useLocalPreference } from '@ifixit/ui';
 import {
@@ -86,7 +89,7 @@ export function FilterableProductsSection({ productList }: SectionProps) {
             </FacetCard>
             <Card flex={1}>
                {isEmpty ? (
-                  <ProductListEmptyState />
+                  <ProductListEmptyState productList={productList} />
                ) : viewType === ProductViewType.Grid ? (
                   <>
                      <ProductGrid>
@@ -155,7 +158,11 @@ function useScrollIntoViewEffect(deps: React.DependencyList) {
    return ref;
 }
 
-const ProductListEmptyState = () => {
+type EmptyStateProps = {
+   productList: TProductList;
+};
+
+const ProductListEmptyState = ({ productList }: EmptyStateProps) => {
    const clearRefinements = useClearRefinements();
 
    const currentRefinements = useCurrentRefinements();
@@ -166,21 +173,34 @@ const ProductListEmptyState = () => {
 
    const isFiltered = hasRefinements || hasSearchQuery;
 
+   const title = getProductListTitle(productList);
+   const encodedQuery = encodeURIComponent(searchBox.query);
+
    if (isFiltered) {
       return (
-         <VStack pt="16" pb="20">
+         <VStack pt="16" pb="20" px="2" textAlign="center">
             <Icon
                as={SearchEmptyStateIllustration}
                boxSize="200px"
                opacity="0.8"
             />
-            <Text fontSize="lg" fontWeight="bold" w="full" textAlign="center">
-               No results found
+            <Text fontSize="lg" fontWeight="bold" w="full">
+               No matching products found in {title}
             </Text>
-            <Text maxW="500px" color="gray.500" textAlign="center" px="2">
+            <Text maxW="500px" color="gray.500">
                Try adjusting your search or filter to find what you&apos;re
                looking for.
             </Text>
+            <Link
+               maxW="500px"
+               color="brand.500"
+               href={`${IFIXIT_ORIGIN}/Search?query=${encodedQuery}`}
+            >
+               Search all of iFixit for&nbsp;
+               <Text as="span" fontWeight="bold">
+                  {searchBox.query}
+               </Text>
+            </Link>
             <Box pt="8">
                <Button
                   colorScheme="brand"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
    "scripts": {
       "dev": "concurrently -n \"Next,codegen\" -c \"blue,magenta\" \"pnpm run dev:next\" \"pnpm run dev:codegen\"",
       "dev:next": "next dev",
-      "dev:codegen": "DOTENV_CONFIG_PATH=./.env.development graphql-codegen -r dotenv/config --config codegen.yml --watch",
+      "dev:codegen": "cross-env DOTENV_CONFIG_PATH=./.env.development graphql-codegen -r dotenv/config --config codegen.yml --watch",
       "build": "next build",
       "start": "next start",
       "type-check": "tsc --pretty --noEmit",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
    },
    "scripts": {
       "install:all": "pnpm install && npm run install:backend",
-      "install:backend": "cd backend; yarn install",
+      "install:backend": "cd backend && yarn install",
       "dev:backend": "cd backend && pnpm run dev",
       "dev:frontend": "wait-on http://localhost:1337/_health && cd frontend && npm run dev",
       "dev": "cross-env FORCE_COLOR=1 npm-run-all -l -p dev:*",


### PR DESCRIPTION
When a user searches but does't find any results, this changes the no-results page to clarify that they're only searching within their given page. There's now a link to the main iFixit search with their query pre-filled, too.

I also added a couple changes in the project setup to fix some issues I encountered while setting this up on windows.

Closes #401