### PR TITLE
Product Search Box: Differentiate from header search box

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/SearchInput.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/SearchInput.tsx
@@ -33,6 +33,8 @@ export const SearchInput = forwardRef<SearchInputProps, 'div'>((props, ref) => {
       }
    }, [clear]);
 
+   console.log(props);
+
    return (
       <InputGroup ref={ref} {...props}>
          <InputLeftElement pointerEvents="none">
@@ -42,6 +44,7 @@ export const SearchInput = forwardRef<SearchInputProps, 'div'>((props, ref) => {
             ref={inputRef}
             data-testid="collections-search-box"
             bg="white"
+            placeholder={props.placeholder}
             tabIndex={0}
             onChange={(event) => refine(event.currentTarget.value)}
             defaultValue={query}

--- a/frontend/components/product-list/sections/FilterableProductsSection/SearchInput.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/SearchInput.tsx
@@ -33,8 +33,6 @@ export const SearchInput = forwardRef<SearchInputProps, 'div'>((props, ref) => {
       }
    }, [clear]);
 
-   console.log(props);
-
    return (
       <InputGroup ref={ref} {...props}>
          <InputLeftElement pointerEvents="none">

--- a/frontend/components/product-list/sections/FilterableProductsSection/SearchInput.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/SearchInput.tsx
@@ -42,7 +42,6 @@ export const SearchInput = forwardRef<SearchInputProps, 'div'>((props, ref) => {
             ref={inputRef}
             data-testid="collections-search-box"
             bg="white"
-            placeholder={"Search ${productList.title}"}
             tabIndex={0}
             onChange={(event) => refine(event.currentTarget.value)}
             defaultValue={query}

--- a/frontend/components/product-list/sections/FilterableProductsSection/SearchInput.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/SearchInput.tsx
@@ -42,7 +42,7 @@ export const SearchInput = forwardRef<SearchInputProps, 'div'>((props, ref) => {
             ref={inputRef}
             data-testid="collections-search-box"
             bg="white"
-            placeholder="Search"
+            placeholder={"Search ${productList.title}"}
             tabIndex={0}
             onChange={(event) => refine(event.currentTarget.value)}
             defaultValue={query}

--- a/frontend/components/product-list/sections/FilterableProductsSection/Toolbar.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/Toolbar.tsx
@@ -58,6 +58,7 @@ export function Toolbar(props: ToolbarProps) {
                   Filters
                </OpenFiltersButton>
                <SearchInput
+                  placeholder={`Search ${productList.title}`}
                   order={{
                      base: 3,
                      md: 2,

--- a/frontend/components/product-list/sections/FilterableProductsSection/Toolbar.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/Toolbar.tsx
@@ -13,6 +13,7 @@ import {
    Text,
    useDisclosure,
 } from '@chakra-ui/react';
+import { getProductListTitle } from '@helpers/product-list-helpers';
 import { ProductList } from '@models/product-list';
 import { HiOutlineMenu, HiOutlineViewGrid } from 'react-icons/hi';
 import { useHits } from 'react-instantsearch-hooks-web';
@@ -58,7 +59,7 @@ export function Toolbar(props: ToolbarProps) {
                   Filters
                </OpenFiltersButton>
                <SearchInput
-                  placeholder={`Search ${productList.title}`}
+                  placeholder={`Search ${getProductListTitle(productList)}`}
                   order={{
                      base: 3,
                      md: 2,


### PR DESCRIPTION
## Summary
Previously, we didn't have any clear indication that the 2 different search bars [the header search bar and the product search bar] would have different behaviors. This PR makes the distinction by including the title of the page in the product search bar.
<img width="247" alt="Screenshot 2022-07-08 015617" src="https://user-images.githubusercontent.com/50181909/177956338-575617c1-2445-43e8-9c5d-c2fcbc0bd95d.png">

## CR/QA
- Go to the preview
- Scroll to the product search bar
- Make sure that for each page the placeholder text says something [like here](https://github.com/iFixit/react-commerce/issues/386#issuecomment-1176496362)

Closes #386 
CC: @erinemay @sterlinghirsh 
