### PR TITLE
Search: Only render `<Configure>` once

### DIFF
--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -6,7 +6,6 @@ import { Configure, Index } from 'react-instantsearch-hooks-web';
 import { MetaTags } from './MetaTags';
 import { ProductListBreadcrumb } from './ProductListBreadcrumb';
 import { ProductListDeviceNavigation } from './ProductListDeviceNavigation';
-import { ProductListType } from '@models/product-list';
 import {
    BannerSection,
    FeaturedProductListSection,

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -67,13 +67,6 @@ export function FilterableProductsSection({ productList }: SectionProps) {
          data-testid="filterable-products-section"
          aria-labelledby="filterable-products-section-heading"
       >
-         {productList.type === ProductListType.DeviceItemTypeParts && (
-            <Configure
-               filters={`'facet_tags.Item Type': ${JSON.stringify(
-                  productList.itemType
-               )}`}
-            />
-         )}
          <Heading as="h2" id="filterable-products-section-heading" srOnly>
             Products
          </Heading>

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -4,19 +4,27 @@ import { ProductList, ProductListType } from '@models/product-list';
 type ProductListAttributes = {
    filters?: string | null;
    deviceTitle?: string | null;
+   type?: ProductListType | null;
+   itemType?: string | null;
 };
 
 export function computeProductListAlgoliaFilterPreset<
    T extends ProductListAttributes
 >(productList: T): string | undefined {
-   const { filters, deviceTitle } = productList;
+   const { filters, deviceTitle, itemType, type } = productList;
+   const conditions: string[] = [];
+
+   if (type && type === ProductListType.DeviceItemTypeParts && itemType) {
+      conditions.push(`'facet_tags.Item Type': ${JSON.stringify(itemType)}`);
+   }
+
    if (filters && filters.length > 0) {
-      return filters;
+      conditions.push(filters);
+   } else if (deviceTitle && deviceTitle.length > 0) {
+      conditions.push(`device:${JSON.stringify(deviceTitle)}`);
    }
-   if (deviceTitle && deviceTitle.length > 0) {
-      return `device:${JSON.stringify(deviceTitle)}`;
-   }
-   return undefined;
+
+   return conditions.length ? conditions.join(' AND ') : undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes a bug where only the search parameters passed to the most recently
rendered `<Configure>` get used.

Now we only ever render `<Configure>` once, and combine all the
necessary search parameters.

Search filter conditions are intersected using "AND":
https://www.algolia.com/doc/api-reference/api-parameters/filters/#boolean-operators

CC @erinemay 

Closes #391