### PR TITLE
Tests: Add tests for products on /Parts

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -129,7 +129,6 @@ export function ProductListItem({ product }: ProductListItemProps) {
                      {product.title}
                   </Heading>
                   <Text
-                     data-testid="product-short-desc"
                      noOfLines={3}
                      fontSize={{
                         base: 'sm',

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -129,6 +129,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                      {product.title}
                   </Heading>
                   <Text
+                     data-testid="product-short-desc"
                      noOfLines={3}
                      fontSize={{
                         base: 'sm',

--- a/frontend/test/cypress/integration/product-list/parts_results_view.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_results_view.spec.ts
@@ -18,26 +18,6 @@ describe('parts page results view', () => {
    });
 
    /**
-    * In ProductListItem, we set noOfLines prop to 3
-    * to truncate the product description text. This
-    * tests each product description to be less than 4
-    * lines.
-    */
-   it('product description is truncated', () => {
-      // Counting text lines https://stackoverflow.com/questions/783899
-      user.get('[data-testid="product-short-desc"]').each((descriptionDiv) => {
-         const divHeight = descriptionDiv.outerHeight() ?? 0;
-         const lineHeigth = parseInt(descriptionDiv.css('lineHeight'));
-         const noOfLines = divHeight / lineHeigth;
-
-         expect(noOfLines).to.be.below(
-            4,
-            'Product description text is more than 3 lines!'
-         );
-      });
-   });
-
-   /**
     * TODO: Unskip when the new product page is implemented
     *
     * We can link to the old product page by setting

--- a/frontend/test/cypress/integration/product-list/parts_results_view.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_results_view.spec.ts
@@ -5,7 +5,7 @@ describe('parts page results view', () => {
       user.visit('/Parts');
    });
 
-   it('all products have price visible', () => {
+   it('all products have a visible price', () => {
       user
          .findByTestId('list-view-products')
          .children('article')

--- a/frontend/test/cypress/integration/product-list/parts_results_view.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_results_view.spec.ts
@@ -1,0 +1,63 @@
+describe('parts page results view', () => {
+   const user = cy;
+
+   beforeEach(() => {
+      user.visit('/Parts');
+   });
+
+   it('all products have price visible', () => {
+      user
+         .findByTestId('list-view-products')
+         .children('article')
+         .each((productListItem) => {
+            user
+               .wrap(productListItem)
+               .findByTestId('product-price')
+               .should('be.visible');
+         });
+   });
+
+   /**
+    * In ProductListItem, we set noOfLines prop to 3
+    * to truncate the product description text. This
+    * tests each product description to be less than 4
+    * lines.
+    */
+   it('product description is truncated', () => {
+      // Counting text lines https://stackoverflow.com/questions/783899
+      user.get('[data-testid="product-short-desc"]').each((descriptionDiv) => {
+         const divHeight = descriptionDiv.outerHeight() ?? 0;
+         const lineHeigth = parseInt(descriptionDiv.css('lineHeight'));
+         const noOfLines = divHeight / lineHeigth;
+
+         expect(noOfLines).to.be.below(
+            4,
+            'Product description text is more than 3 lines!'
+         );
+      });
+   });
+
+   /**
+    * TODO: Unskip when the new product page is implemented
+    *
+    * We can link to the old product page by setting
+    * `chromeWebSecurity: false` but it will disable
+    * cors for all cypress tests, thus skipped.
+    */
+   it.skip('product View button directs to the product page', () => {
+      user
+         .contains('.chakra-button', 'View')
+         .parent()
+         .then((link) => {
+            // Find the first product View button and click
+            user.wrap(link).click();
+
+            // Assert the current window url is the same as button link
+            user
+               .location('href', { timeout: 20000 })
+               .should('equal', link.attr('href'));
+         });
+   });
+});
+
+export {};


### PR DESCRIPTION
## Summary
Adds test for the Results view on /Parts page. From https://github.com/iFixit/react-commerce/issues/124:

> Results view
    - Body
        - [ ] Assert these are truncated to the desired length
    - Price
         - [ ] Ensure we display the price data the component is provided
    - View button
         - [ ] Ensure the button directs the user to the link that the component was provided 

## QA Notes
Please re-run the E2E tests / cypress-run ci check and make sure it passes.

Connects: https://github.com/iFixit/react-commerce/issues/124 and https://github.com/iFixit/ifixit/issues/43590