### PR TITLE
Tests: Deflake collection scroll test

### DIFF
--- a/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
+++ b/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
@@ -22,7 +22,7 @@ describe('collections scroll', () => {
          .isWithinViewport(user.getByDataTestId('collections-search-box'));
 
       // Check that url parameter contains ?p after clicking next page
-      user.location().should((loc) => {
+      user.location({ timeout: 2000 }).should((loc) => {
          expect(loc.search).to.have.string('?p=');
       });
    });


### PR DESCRIPTION
## Background
Noticed  `collections_scroll.spec.ts` test flakiness in https://github.com/iFixit/react-commerce/runs/7243330272.

<details> <summary> screenshot </summary>

![collections scroll -- should scroll to the top of the page after clicking next page (failed)](https://user-images.githubusercontent.com/58952979/178092240-c05cbd74-ba05-4b38-b842-78425790b2a8.png)
</details>


## Summary
When the user clicks on the pagination button, we add the page `?p=...` param in the URL. 
Sometimes the param is not added instantly, so this pull adds `2s` timeout when checking for the URL. 

## QA 
Passing cypress ci tests would be QA.

qa_req 0 

