### PR TITLE
Next Links: add progress bar for transitions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
       "lodash": "4.17.21",
       "lru-cache": "^7.10.1",
       "next": "11.1.3",
+      "nextjs-progressbar": "0.0.14",
       "query-string": "7.0.1",
       "react": "17.0.2",
       "react-dom": "17.0.2",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { AppProviders } from '@components/common';
 import { AppProps } from 'next/app';
 import * as React from 'react';
+import NextNProgress from 'nextjs-progressbar';
 
 type AppPropsWithLayout = AppProps & {
    Component: NextPageWithLayout;
@@ -10,6 +11,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
    const getLayout = Component.getLayout ?? ((page) => page);
    return (
       <AppProviders {...pageProps.appProps}>
+         <NextNProgress />
          {getLayout(<Component {...pageProps} />, pageProps)}
       </AppProviders>
    );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,7 @@ importers:
       lru-cache: ^7.10.1
       next: 11.1.3
       next-transpile-modules: 9.0.0
+      nextjs-progressbar: 0.0.14
       prettier: 2.3.2
       query-string: 7.0.1
       react: 17.0.2
@@ -122,6 +123,7 @@ importers:
       lodash: 4.17.21
       lru-cache: 7.10.1
       next: 11.1.3_d2d3f5d29d8bc921bbe8ef8bb649cedb
+      nextjs-progressbar: 0.0.14_next@11.1.3+react@17.0.2
       query-string: 7.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -9254,6 +9256,18 @@ packages:
       - webpack
     dev: false
 
+  /nextjs-progressbar/0.0.14_next@11.1.3+react@17.0.2:
+    resolution: {integrity: sha512-AXYXHDN6M52AwFnGqH/vlwyo0gbC9zM7QS/4ryOTI0RUqfze5FJl8uSrxKJMzK6hGFdDeQXcZoWsLGXeCVtTwg==}
+    peerDependencies:
+      next: '>= 6.0.0'
+      react: '>= 16.0.0'
+    dependencies:
+      next: 11.1.3_d2d3f5d29d8bc921bbe8ef8bb649cedb
+      nprogress: 0.2.0
+      prop-types: 15.8.1
+      react: 17.0.2
+    dev: false
+
   /nice-try/1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
@@ -9414,6 +9428,10 @@ packages:
       console-control-strings: 1.1.0
       gauge: 2.7.4
       set-blocking: 2.0.0
+    dev: false
+
+  /nprogress/0.2.0:
+    resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
     dev: false
 
   /nth-check/1.0.2:


### PR DESCRIPTION
Previously, clicking a link gave no indication that something was
happening. I often thought I mis-clicked. Much googling around gave a few how-to's and some junk blog posts but definitely very little chatter about what seems to be a major usability issue.

Now at least we have a progress bar on top. The design doesn't mesh 100%
but it's better than no feedback. Easy to change later.

Adds 3.2kb of gzipped js:
https://bundlephobia.com/package/nextjs-progressbar@0.0.14

Closes #362 