### PR TITLE
Empty Tile: Get rid of it

### DIFF
--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -46,7 +46,7 @@ export function ProductListView({
          <PageContentWrapper py="10">
             <VStack align="stretch" spacing="12">
                <Index indexName={indexName}>
-                  <Configure filters={filters} />
+                  <Configure filters={filters} hitsPerPage={18}/>
                   <MetaTags productList={productList} />
                   <HeroSection productList={productList} />
                   {productList.children.length > 0 && (

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -20,7 +20,6 @@ export function ProductGrid({ children }: ProductGridProps) {
    return (
       <SimpleGrid
          data-testid="grid-view-products"
-         bg="gray.100"
          borderBottomColor="gray.100"
          borderBottomWidth="1px"
          columns={{
@@ -46,7 +45,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
       useProductSearchHitPricing(product);
 
    return (
-      <LinkBox as="article" display="block" w="full" role="group">
+      <LinkBox as="article" display="block" w="full" role="group" borderWidth={"thin"} borderColor={"gray.100"}>
          <ProductCard h="full">
             <ProductCardImage src={product.image_url} alt={product.title} />
             <ProductCardBadgeList>

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -45,7 +45,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
       useProductSearchHitPricing(product);
 
    return (
-      <LinkBox as="article" display="block" w="full" role="group" borderWidth={"thin"} borderColor={"gray.100"}>
+      <LinkBox as="article" display="block" w="full" role="group" borderWidth="thin" borderColor="gray.100">
          <ProductCard h="full">
             <ProductCardImage src={product.image_url} alt={product.title} />
             <ProductCardBadgeList>

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -45,7 +45,18 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
       useProductSearchHitPricing(product);
 
    return (
-      <LinkBox as="article" display="block" w="full" role="group" borderWidth="thin" borderColor="gray.100">
+      <LinkBox
+         as="article"
+         display="block"
+         w="full"
+         role="group"
+         borderTop="0"
+         borderRight="1px"
+         borderLeft="0"
+         borderBottom="1px"
+         borderRightColor="gray.100"
+         borderBottomColor="gray.100"
+      >
          <ProductCard h="full">
             <ProductCardImage src={product.image_url} alt={product.title} />
             <ProductCardBadgeList>


### PR DESCRIPTION
## Summary:

Previously, when switched to grid view, an empty tile appeared if we scrolled all the way to the bottom. This PR gets rid of that tile.

## CR/QA:
- We had a `bg` color set to `gray.100` for the `<SimpleGrid`.
- While this was adding borders between each individual link box, if there was no link box displayed we could see an empty tile in the grid.
- I decided to get rid of that `bg` color and add borders to each individual `LinkBox`.
   - This took care of both things:
      - The empty tile
      - The border around the linkboxes.



<details><summary>Screenshot BEFORE Change</summary>
<img width="844" alt="Screenshot 2022-07-12 184823" src="https://user-images.githubusercontent.com/50181909/178639084-67eb6495-8871-44e9-8193-77c2b72c8ddb.png">
</details>

<details><summary>Screenshot AFTER Change</summary>
<img width="762" alt="Screenshot 2022-07-12 184640" src="https://user-images.githubusercontent.com/50181909/178639013-061ea517-fd85-48ec-bb53-b92f3722d872.png">
</details>


Closes #410 

CC: @jordycosta   