### PR TITLE
Previous Page: Fix pagination link

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/Pagination.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/Pagination.tsx
@@ -70,7 +70,7 @@ export function Pagination(props: PaginationProps) {
                         aria-label="Go to previous page"
                         href={
                            pagination.hasPrevious
-                              ? createPageUrl(pagination.currentPage)
+                              ? createPageUrl(pagination.currentPage - 1)
                               : '#'
                         }
                         page="previous"


### PR DESCRIPTION
## Summary

Previously, the logic to generate the link for the previous button created the `pageUrl` for the `currentPage`. This PR changes that to `currentPage- 1`. 

## CR/QA
- Visit the [preview](https://react-commerce-git-pagination-fix-link-on-hover-ifixit.vercel.app/Parts?p=3)
- Make sure that when we hover over the previous page button the link that shows up is correct, ie, the link shows p={previous page#} instead of p={current page#}. Here are screenshots of the change locally:

<details><summary>Screenshot BEFORE Change</summary>
<img width="125" alt="Screenshot 2022-07-13 100538" src="https://user-images.githubusercontent.com/50181909/178790701-d59f9fb4-76ea-4357-8360-0bb24afc4c7d.png">

</details>

<details><summary>Screenshot AFTER Change</summary>

<img width="154" alt="Screenshot 2022-07-13 100435" src="https://user-images.githubusercontent.com/50181909/178790724-2dc5b47f-bf44-499f-b9b3-65648b51fd53.png">
</details>

Closes #428 

CC: @erinemay 