### PR TITLE
Update cypress workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,3 @@ jobs:
            with:
               name: cypress-screenshots
               path: frontend/test/cypress/screenshots
-         # Test run video was always captured, so this action uses "always()" condition
-         - uses: actions/upload-artifact@v2
-           if: always()
-           with:
-              name: cypress-videos
-              path: frontend/test/cypress/videos

--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -5,5 +5,6 @@
    "pluginsFile": "test/cypress/plugins/index.js",
    "screenshotsFolder": "test/cypress/screenshots",
    "videosFolder": "test/cypress/videos",
+   "video": false,
    "supportFile": "test/cypress/support/index.ts"
 }


### PR DESCRIPTION
## Summary of changes

1. Dropped recording for cypress videos because they weren't working properly (frozen at the beginning) and slowing down the ci. Seems like an [existing cypress issue for this](https://github.com/cypress-io/github-action/issues/483). We still have the screenshots on failures, so I believe this should be fine.

## QA 

In `E2E tests / cypress-run` ci check, `Cypress run` step, make sure there are no video processing logs like the following:
```
  (Video)
-Started processing:Compressing to 32 CRF
-Finished processing:/home/runner/work/react-commerce/react-commerce/frontend/te(36 seconds)
st/cypress/videos/product-list/collections_scroll.spec.ts.m
p4
    Compression progress:  100%
```