### PR TITLE
Tests: Cypress add auto retry and deflake tests

### DIFF
--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -6,5 +6,8 @@
    "screenshotsFolder": "test/cypress/screenshots",
    "videosFolder": "test/cypress/videos",
    "video": false,
-   "supportFile": "test/cypress/support/index.ts"
+   "supportFile": "test/cypress/support/index.ts",
+   "retries": {
+      "runMode": 2
+   }
 }

--- a/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
+++ b/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
@@ -4,8 +4,7 @@
 describe('collections scroll', () => {
    const user = cy;
    beforeEach(() => {
-      user.intercept('/1/indexes/**').as('search');
-      user.visit('/Tools');
+      user.loadCollectionPageByPath('/Tools');
    });
 
    it.skip('should scroll to the top of the page after clicking next page', () => {

--- a/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
+++ b/frontend/test/cypress/integration/product-list/collections_scroll.spec.ts
@@ -7,7 +7,7 @@ describe('collections scroll', () => {
       user.loadCollectionPageByPath('/Tools');
    });
 
-   it.skip('should scroll to the top of the page after clicking next page', () => {
+   it('should scroll to the top of the page after clicking next page', () => {
       user.findByTestId('collections-search-box').should('be.visible');
       user.findByTestId('next-page').click();
 

--- a/frontend/test/cypress/integration/product-list/collections_view_button.spec.ts
+++ b/frontend/test/cypress/integration/product-list/collections_view_button.spec.ts
@@ -1,7 +1,7 @@
 describe('collection display', () => {
    const user = cy;
    beforeEach(() => {
-      user.visit('/Tools');
+      user.loadCollectionPageByPath('/Tools');
    });
 
    it('should display grid view when selected', () => {

--- a/frontend/test/cypress/integration/product-list/filters.spec.ts
+++ b/frontend/test/cypress/integration/product-list/filters.spec.ts
@@ -1,20 +1,7 @@
 describe('product list filters', () => {
    const user = cy;
    beforeEach(() => {
-      cy.intercept('/1/indexes/**').as('search');
-      // Here we stub the user api request so we don't depend on ifixit api
-      cy.intercept(
-         { method: 'GET', url: '/api/2.0/user' },
-         {
-            userid: 1,
-            algoliaApiKeyProduct: null,
-            username: 'john',
-            unique_username: 'john123',
-         }
-      ).as('user-api');
-      user.visit('/Parts');
-      user.wait('@user-api');
-      user.window().its('userLoaded').should('be.true');
+      user.loadCollectionPageByPath('/Parts');
    });
 
    it('should help user filter', () => {

--- a/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
@@ -1,19 +1,7 @@
 describe('subscribe to newsletter', () => {
    const user = cy;
    beforeEach(() => {
-      // Here we stub the user api request so we don't depend on ifixit api
-      cy.intercept(
-         { method: 'GET', url: '/api/2.0/user' },
-         {
-            userid: 1,
-            algoliaApiKeyProduct: null,
-            username: 'john',
-            unique_username: 'john123',
-         }
-      ).as('user-api');
-      user.visit('/Parts');
-      user.wait('@user-api');
-      user.window().its('userLoaded').should('be.true');
+      user.loadCollectionPageByPath('/Parts');
    });
 
    it('requires an email', () => {

--- a/frontend/test/cypress/integration/product-list/parts_page_devices.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_devices.spec.ts
@@ -12,7 +12,11 @@ describe('parts page devices', () => {
       user.get('body').then(($body) => {
          const device = $body.find('a[href="/Parts/Mac"]');
          if (!device.is(':visible')) {
-            user.get('button').contains('Show more').click();
+            user
+               .get('button', { timeout: 10000 })
+               .contains('Show more')
+               .should('be.visible')
+               .click();
          }
          device[0].click();
       });

--- a/frontend/test/cypress/integration/product-list/parts_page_devices.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_devices.spec.ts
@@ -2,7 +2,7 @@ describe('parts page devices', () => {
    const user = cy;
 
    beforeEach(() => {
-      user.visit('/Parts');
+      user.loadCollectionPageByPath('/Parts');
    });
 
    it('should navigate until the last device page', () => {

--- a/frontend/test/cypress/integration/product-list/parts_page_search.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_search.spec.ts
@@ -4,8 +4,7 @@ describe('parts page search', () => {
    const user = cy;
 
    beforeEach(() => {
-      user.intercept('/1/indexes/**').as('search');
-      user.visit('/Parts');
+      user.loadCollectionPageByPath('/Parts');
    });
 
    it('should show results when the search term exists', () => {

--- a/frontend/test/cypress/integration/product-list/parts_page_search.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_search.spec.ts
@@ -32,7 +32,7 @@ describe('parts page search', () => {
          });
    });
 
-   it.skip("should show no results when search term doesn't exist", () => {
+   it("should show no results when search term doesn't exist", () => {
       user
          .findByTestId('collections-search-box')
          .should('be.visible')

--- a/frontend/test/cypress/integration/product-list/parts_page_search.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_search.spec.ts
@@ -11,6 +11,7 @@ describe('parts page search', () => {
       user
          .findByTestId('collections-search-box')
          .should('be.visible')
+         .should('not.be.disabled')
          .type('iphone');
 
       // Wait for search result to be updated
@@ -31,15 +32,15 @@ describe('parts page search', () => {
          });
    });
 
-   it("should show no results when search term doesn't exist", () => {
+   it.skip("should show no results when search term doesn't exist", () => {
       user
          .findByTestId('collections-search-box')
          .should('be.visible')
+         .should('not.be.disabled')
          .type('asdasasdadasd');
 
       // Wait for search result to be updated
       user.wait('@search');
-      user.wait(2000);
 
       // Check that url parameter contains ?q after searching
       user.location({ timeout: 2000 }).should((loc) => {

--- a/frontend/test/cypress/integration/product-list/parts_results_view.spec.ts
+++ b/frontend/test/cypress/integration/product-list/parts_results_view.spec.ts
@@ -2,7 +2,7 @@ describe('parts page results view', () => {
    const user = cy;
 
    beforeEach(() => {
-      user.visit('/Parts');
+      user.loadCollectionPageByPath('/Parts');
    });
 
    it('all products have a visible price', () => {

--- a/frontend/test/cypress/support/commands.ts
+++ b/frontend/test/cypress/support/commands.ts
@@ -17,3 +17,20 @@ Cypress.Commands.add(
       });
    }
 );
+
+Cypress.Commands.add('loadCollectionPageByPath', (path: string) => {
+   cy.intercept('/1/indexes/**').as('search');
+   // Here we stub the user api request so we don't depend on ifixit api
+   cy.intercept(
+      { method: 'GET', url: '/api/2.0/user' },
+      {
+         userid: 1,
+         algoliaApiKeyProduct: null,
+         username: 'john',
+         unique_username: 'john123',
+      }
+   ).as('user-api');
+   cy.visit(path);
+   cy.wait('@user-api');
+   cy.window().its('userLoaded').should('be.true');
+});

--- a/frontend/test/cypress/support/index.d.ts
+++ b/frontend/test/cypress/support/index.d.ts
@@ -3,5 +3,6 @@
 declare namespace Cypress {
    interface Chainable {
       isWithinViewport(element: any): Chainable;
+      loadCollectionPageByPath(path: string): Chainable;
    }
 }


### PR DESCRIPTION
## Summary of changes
1. Added cypress retries to cypress config, [ref](https://docs.cypress.io/guides/guides/test-retries#Global-Configuration). Now failed tests will retry 2 times. 
Hopefully, this will prevent flaky tests or help to catch them
2. Moved common intercepts and wait statements from [here](https://github.com/iFixit/react-commerce/pull/359/commits/bd074d7b61213badc1e45473c4a7dd60259964d4#diff-e81662fc335a428ae62a3c659b1e32d31f596711ef35d4a019a9291e546798c6R4-R15) to a custom cypress command for reusability. 
Now, we can simply do `cy.loadCollectionPageByPath('/Parts')` or `cy.loadCollectionPageByPath('/Tools')`.


## QA Notes
Please re-run the cypress tests ci check and make sure they don't fail.
