### PR TITLE
Mitigate #385 for iPhone devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ The `frontend` directory is structured as follows:
 
 ### Install Prerequisites
 
-- npm v8
-- pnpm v6
-- node v16
-- yarn
+-  npm v8
+-  pnpm v6
+-  node v16
+-  yarn
 
 Here's one way you can get all the right versions installed and setup:
 
 1. Install [nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 2. `nvm use`
-    - run this command in the project root to install compatible versions of `node` and `npm`
+   -  run this command in the project root to install compatible versions of `node` and `npm`
 3. `npm install -g pnpm@6.32.1`
-    - installs version 6 of `pnpm`
-    - :warning: The project is based on `pnpm@6`: some dependencies still have problems with v7
-  
+   -  installs version 6 of `pnpm`
+   -  :warning: The project is based on `pnpm@6`: some dependencies still have problems with v7
+
 ### Install
 
 This command will install both backend and frontend dependencies:
@@ -52,13 +52,15 @@ pnpm install:all
 2. Copy `frontend/.env.local.example` to `frontend/.env.local`
 
 ### Fill in the Algolia API Key
+
 In `frontend/.env.local` fill in `ALGOLIA_API_KEY` by either:
 
-* Copying the `Search API Key` [from Aloglia](https://www.algolia.com/account/api-keys/all?applicationId=XQEP3AD9ZT)
-   - :warning: You may need to ask for access to our Aloglia
+-  Copying the `Search API Key` [from Aloglia](https://www.algolia.com/account/api-keys/all?applicationId=XQEP3AD9ZT)
 
+   -  :warning: You may need to ask for access to our Aloglia
 
-* Or copy the dev key from cominor:
+-  Or copy the dev key from cominor:
+
 ```sh
 cat /etc/dozuki/algolia-keys.json | jq --raw-output .searchApiKey
 ```
@@ -74,6 +76,7 @@ pnpm dev
 ```
 
 ### Working with the Frontend (Next.js)
+
 After running the dev server, you can access the site at `http://localhost:3000/Parts` or `http://localhost:3000/Tools`
 
 :warning: `http://localhost:3000/` is not yet routed and will 404.

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -46,7 +46,7 @@ export function ProductListView({
          <PageContentWrapper py="10">
             <VStack align="stretch" spacing="12">
                <Index indexName={indexName}>
-                  <Configure filters={filters} hitsPerPage={18}/>
+                  <Configure filters={filters} hitsPerPage={18} />
                   <MetaTags productList={productList} />
                   <HeroSection productList={productList} />
                   {productList.children.length > 0 && (

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
@@ -10,6 +10,7 @@ import {
    IconButton,
    Portal,
    Text,
+   useBreakpointValue,
    useSafeLayoutEffect,
    VStack,
 } from '@chakra-ui/react';
@@ -297,13 +298,21 @@ function FacetPanel({ attribute, isOpen, productList }: FacetPanelProps) {
 }
 
 function useLockBodyScroll(lock: boolean) {
+   const responsiveDisplayValue =
+      useBreakpointValue({
+         base: 'none',
+         sm: 'block',
+      }) || 'block';
    useSafeLayoutEffect(() => {
       const originalStyle = window.getComputedStyle(document.body).overflow;
+      const nextContainer = document.getElementById('__next');
       if (lock) {
          document.body.style.overflow = 'hidden';
+         nextContainer!.style.display = responsiveDisplayValue;
       }
       return () => {
+         nextContainer!.style.display = 'block';
          document.body.style.overflow = originalStyle;
       };
-   }, [lock]);
+   }, [lock, responsiveDisplayValue]);
 }


### PR DESCRIPTION
closes #385

As agreed in the weekly meeting, we are going to mitigate the issue experienced by iOS users hiding the underlying body on small devices as soon as the drawer is shown. 

cc @sterlinghirsh 

## QA

1. Open [Vercel Preview](https://react-commerce-git-vertical-scrollbar-in-mobile-filter-ifixit.cominor.com/Parts) on a iOS mobile device
2. Verify that even in Safari - portrait mode - when the browser UI is not fully visible (i.e. the address bar is retracted, and the toolbar bar fully collapsed), the issue described in #385 is not present anymore

