### PR TITLE
Remove layout shifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ The `frontend` directory is structured as follows:
 
 ### Install Prerequisites
 
-- npm v8
-- pnpm v6
-- node v16
-- yarn
+-  npm v8
+-  pnpm v6
+-  node v16
+-  yarn
 
 Here's one way you can get all the right versions installed and setup:
 
 1. Install [nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 2. `nvm use`
-    - run this command in the project root to install compatible versions of `node` and `npm`
+   -  run this command in the project root to install compatible versions of `node` and `npm`
 3. `npm install -g pnpm@6.32.1`
-    - installs version 6 of `pnpm`
-    - :warning: The project is based on `pnpm@6`: some dependencies still have problems with v7
-  
+   -  installs version 6 of `pnpm`
+   -  :warning: The project is based on `pnpm@6`: some dependencies still have problems with v7
+
 ### Install
 
 This command will install both backend and frontend dependencies:
@@ -52,13 +52,15 @@ pnpm install:all
 2. Copy `frontend/.env.local.example` to `frontend/.env.local`
 
 ### Fill in the Algolia API Key
+
 In `frontend/.env.local` fill in `ALGOLIA_API_KEY` by either:
 
-* Copying the `Search API Key` [from Aloglia](https://www.algolia.com/account/api-keys/all?applicationId=XQEP3AD9ZT)
-   - :warning: You may need to ask for access to our Aloglia
+-  Copying the `Search API Key` [from Aloglia](https://www.algolia.com/account/api-keys/all?applicationId=XQEP3AD9ZT)
 
+   -  :warning: You may need to ask for access to our Aloglia
 
-* Or copy the dev key from cominor:
+-  Or copy the dev key from cominor:
+
 ```sh
 cat /etc/dozuki/algolia-keys.json | jq --raw-output .searchApiKey
 ```
@@ -74,6 +76,7 @@ pnpm dev
 ```
 
 ### Working with the Frontend (Next.js)
+
 After running the dev server, you can access the site at `http://localhost:3000/Parts` or `http://localhost:3000/Tools`
 
 :warning: `http://localhost:3000/` is not yet routed and will 404.

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -46,7 +46,7 @@ export function ProductListView({
          <PageContentWrapper py="10">
             <VStack align="stretch" spacing="12">
                <Index indexName={indexName}>
-                  <Configure filters={filters} hitsPerPage={18}/>
+                  <Configure filters={filters} hitsPerPage={18} />
                   <MetaTags productList={productList} />
                   <HeroSection productList={productList} />
                   {productList.children.length > 0 && (

--- a/frontend/components/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/components/product-list/sections/ProductListChildrenSection.tsx
@@ -25,7 +25,7 @@ export function ProductListChildrenSection({
       childrenHeading,
       children: productListChildren,
    } = productList;
-   const [showingMore, setShowingMore] = React.useState(false);
+   const [isShowingMore, setShowingMore] = React.useState(false);
 
    const gridRef = React.useRef<HTMLDivElement>(null);
    const maskMaxHeight = React.useMemo(
@@ -33,10 +33,10 @@ export function ProductListChildrenSection({
          computeMaskMaxHeight(
             60,
             16,
-            showingMore,
+            isShowingMore,
             gridRef.current?.clientHeight
          ),
-      [showingMore]
+      [isShowingMore]
    );
 
    const showMoreVisibility = React.useMemo(
@@ -101,7 +101,7 @@ export function ProductListChildrenSection({
                ml="-8px"
                display="block"
             >
-               {showingMore ? 'Show less' : 'Show more'}
+               {isShowingMore ? 'Show less' : 'Show more'}
             </Button>
          </Box>
       </Box>
@@ -182,11 +182,11 @@ const ChildLink = ({ child }: ChildLinkProps) => {
 const computeMaskMaxHeight = (
    pixelLinkHeight: number,
    pixelGap: number,
-   showingMore: boolean,
+   isShowingMore: boolean,
    maxHeight = 10000
 ) => {
    const shadowMargin = 4;
-   if (showingMore) {
+   if (isShowingMore) {
       return `${maxHeight + shadowMargin}px`;
    }
    return {


### PR DESCRIPTION
closes #411 

To remove the layout shift we are now rendering all the model button elements and we are masking them adjusting the `maxHeight` of an additional external div.

#QA
1. Open the vercel preview
3. Verify that #411 is fixed (eventually throttling the connection to better inspect first load)