### PR TITLE
Facets: Fix item type urls

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/RefinementMenu.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/RefinementMenu.tsx
@@ -12,6 +12,7 @@ import { useSortBy } from './useSortBy';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { ProductList } from '@models/product-list';
 import { useDevicePartsItemType } from './useDevicePartsItemType';
+import { encodeDeviceItemType } from '@helpers/product-list-helpers';
 
 export type RefinementMenuProps = UseRefinementListProps & {
    productList: ProductList;
@@ -90,12 +91,18 @@ const MenuItem = React.memo(function RefinementListItem({
       includedAttributes: [attribute],
    });
    const { createURL } = useCurrentRefinements();
-   const href = createURL({
-      attribute,
-      type: 'disjunctive',
-      value,
-      label,
-   });
+   const url = new URL(
+      createURL({
+         attribute,
+         type: 'disjunctive',
+         value,
+         label,
+      })
+   );
+   // The url created by InstantSearch doesn't have the correct item type slug.
+   const path = url.pathname.split('/').filter((part) => part !== '');
+   const itemTypeHandle = encodeDeviceItemType(value);
+   const href = `${url.origin}/${path[0]}/${path[1]}/${itemTypeHandle}${url.search}`;
    return (
       <HStack
          key={label}


### PR DESCRIPTION
I noticed that the item type facet urls were linking to the wrong place, typically the current window.location.href.

![image](https://user-images.githubusercontent.com/52104630/180813091-d3feffbf-878e-40b2-9cdf-8a4bacd96c79.png)

## Fix

The item type urls were previously all the same as window.location.href,
indicating that something wasn't working right with InstantSearch's
`createURL()`. A quick solution is to just add the correct item type
slug ourselves.

## QA

Make sure the item type urls always link to the right place now.

## Background

Bug introduced in #431, thought I could have sworn they were linking to the right place in that pull.

CC @sterlinghirsh @erinemay 

