### PR TITLE
Fix broken fast refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ tmp
 **/.rush/temp
 
 tsconfig.tsbuildinfo
+
+.env.local

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Here's one way you can get all the right versions installed and setup:
 
 This command will install both backend and frontend dependencies:
 
+Copy `.env.local.example` to `.env.local` and fill in the values.
+
 ```sh
 pnpm install:all
 ```

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -82,21 +82,9 @@ const moduleExports = {
    }),
 };
 
-function withUniversalOptimization(plugins) {
-   const configureWebpack = plugins.webpack || ((config, info) => config);
-   return {
-      ...plugins,
-      webpack(config, info) {
-         config = configureWebpack(config, info);
-         config.optimization.minimize = true;
-         return config;
-      },
-   };
-}
-
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
 module.exports = withSentryConfig(
-   withUniversalOptimization(withBundleAnalyzer(withTM(moduleExports))),
+   withBundleAnalyzer(withTM(moduleExports)),
    SENTRY_AUTH_TOKEN ? sentryWebpackPluginOptions : undefined
 );

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
       "node": ">= 16.14.2"
    },
    "scripts": {
-      "install:all": "export $(cat .env) && pnpm install && npm run install:backend",
+      "install:all": "export $(cat .env.local) && pnpm install && npm run install:backend",
       "install:backend": "cd backend && yarn install",
       "dev:backend": "cd backend && pnpm run dev",
       "dev:frontend": "wait-on http://localhost:1337/_health && cd frontend && npm run dev",


### PR DESCRIPTION
#348 broke [Fast Refresh](https://nextjs.org/docs/basic-features/fast-refresh), so here I'm proposing to drop `withUniversalOptimization` to fix it. This [comment](https://github.com/vercel/next.js/issues/8956#issuecomment-557871585) from Next.js core member says:

```
Minification is disabled by default for serverless bundles as it significantly increases 
build times and doesn't give any significant benefits when deploying serverless bundles.
```

@andyg0808 do you have better insights about this? 

## Changelog

1. Fix fast refresh
2. Update readme to reflect new dependencies install requirements

## QA

1. Clone the process locally
3. Install dependencies
4. Run dev server
5. Try to change a component and verify that you can see changes applied in the browser almost instantly (less than 1 sec)

