### PR TITLE
Fix the missing productlist flairs

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -54,10 +54,8 @@ export function ProductListItem({ product }: ProductListItemProps) {
 
    const showProBadge = product.is_pro > 0;
    const showDiscountBadge = quantityAvailable > 0 && isDiscounted;
-   const showLifetimeWarrantyBadge =
-      quantityAvailable > 0 && product.lifetime_warranty;
-   const showOemPartnershipBadge =
-      quantityAvailable > 0 && product.oem_partnership;
+   const showLifetimeWarrantyBadge = product.lifetime_warranty;
+   const showOemPartnershipBadge = product.oem_partnership;
    const showBadges =
       showProBadge ||
       showDiscountBadge ||


### PR DESCRIPTION
## Summary

Previously, the flairs were missing when the product was out of stock or when it wasn't for sale. 
This PR makes it so that  those labels will always be visible if the product has a lifetime warranty and/or if it is a genuine part regardless of whether it's in stock or no.

## QA
Make sure the labels are present when expected.

Closes #471 