### PR TITLE
Add Google Analytics to Collections pages

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -5,5 +5,8 @@ NEXT_PUBLIC_SHOPIFY_STOREFRONT_VERSION=2021-07
 STRAPI_IMAGE_DOMAIN=ifixit-dev-strapi-uploads.s3.us-west-1.amazonaws.com
 SENTRY_DSN=https://95ab6917c0234f80b99bb0be8e720355@o186239.ingest.sentry.io/6475315
 NEXT_PUBLIC_MATOMO_URL=https://matomo.ubreakit.com
-NEXT_PUBLIC_GA_URL=https://www.google-analytics.com/analytics_debug.js
 NEXT_PUBLIC_GA_KEY=UA-30506-1
+# If we want to test Google Analytics in dev DEBUG should be true and URL should be
+# https://www.google-analytics.com/analytics_debug.js
+NEXT_PUBLIC_GA_DEBUG=false
+NEXT_PUBLIC_GA_URL=

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -5,3 +5,5 @@ NEXT_PUBLIC_SHOPIFY_STOREFRONT_VERSION=2021-07
 STRAPI_IMAGE_DOMAIN=ifixit-dev-strapi-uploads.s3.us-west-1.amazonaws.com
 SENTRY_DSN=https://95ab6917c0234f80b99bb0be8e720355@o186239.ingest.sentry.io/6475315
 NEXT_PUBLIC_MATOMO_URL=https://matomo.ubreakit.com
+NEXT_PUBLIC_GA_URL=https://www.google-analytics.com/analytics_debug.js
+NEXT_PUBLIC_GA_KEY=UA-30506-1

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -6,5 +6,6 @@ STRAPI_IMAGE_DOMAIN=ifixit-strapi-uploads.s3.amazonaws.com
 SENTRY_DSN=https://003ddade86504df5aa49247ba36031e7@o186239.ingest.sentry.io/6469069
 SENTRY_AUTH_TOKEN=
 NEXT_PUBLIC_MATOMO_URL=https://minerva.ifixit.com
-NEXT_PUBLIC_GA_URL=https://www.google-analytics.com/analytics.js
 NEXT_PUBLIC_GA_KEY=UA-30506-1
+NEXT_PUBLIC_GA_DEBUG=false
+NEXT_PUBLIC_GA_URL=https://www.google-analytics.com/analytics.js

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -6,3 +6,5 @@ STRAPI_IMAGE_DOMAIN=ifixit-strapi-uploads.s3.amazonaws.com
 SENTRY_DSN=https://003ddade86504df5aa49247ba36031e7@o186239.ingest.sentry.io/6469069
 SENTRY_AUTH_TOKEN=
 NEXT_PUBLIC_MATOMO_URL=https://minerva.ifixit.com
+NEXT_PUBLIC_GA_URL=https://www.google-analytics.com/analytics.js
+NEXT_PUBLIC_GA_KEY=UA-30506-1

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -17,23 +17,11 @@ export function GoogleAnalytics() {
 
                   let createOptions = {'legacyCookieDomain': 'ifixit.com'};
 
-                  // Logged in?
-                  // createOptions.userId = '<userid>';
-
                   ga('create', '${GA_KEY}', 'auto', 'ifixit', createOptions);
                   ga('ifixit.set', 'anonymizeIp', true);
 
-                  // Logged in? One of '0', '1'
-                  // ga('ifixit.set', 'dimension1', 'LOGGED_IN');
-
                   // Do not lazy load.
                   ga('ifixit.set', 'dimension2', '0');
-
-                  // Customer type? One of: 'regular', 'pro', 'wholesale'
-                  // ga('ifixit.set', 'dimension4', 'CUSTOMER_TYPE');
-
-                  // Userid? Ex: '418937'
-                  ga('ifixit.set', 'dimension5', 'USER_ID');
 
                   // Load the enhanced ecommerce plug-in.
                   ga('ifixit.require', 'ec');

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -1,0 +1,48 @@
+import { GA_URL, GA_KEY } from '@config/env';
+import Head from 'next/head';
+
+export function GoogleAnalytics() {
+   return GA_URL ? (
+      <Head>
+         <script
+            dangerouslySetInnerHTML={{
+               __html: `
+                  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                  })(window,document,'script', '${GA_URL}','ga');
+
+                  // If not on live site:
+                  // window.ga_debug = {trace: true};
+
+                  let createOptions = {'legacyCookieDomain': 'ifixit.com'};
+
+                  // Logged in?
+                  // createOptions.userId = '<userid>';
+
+                  ga('create', '${GA_KEY}', 'auto', 'ifixit', createOptions);
+                  ga('ifixit.set', 'anonymizeIp', true);
+
+                  // Logged in? One of '0', '1'
+                  // ga('ifixit.set', 'dimension1', 'LOGGED_IN');
+
+                  // Do not lazy load.
+                  ga('ifixit.set', 'dimension2', '0');
+
+                  // Customer type? One of: 'regular', 'pro', 'wholesale'
+                  // ga('ifixit.set', 'dimension4', 'CUSTOMER_TYPE');
+
+                  // Userid? Ex: '418937'
+                  ga('ifixit.set', 'dimension5', 'USER_ID');
+
+                  // Load the enhanced ecommerce plug-in.
+                  ga('ifixit.require', 'ec');
+
+                  // Enable Remarketing and Advertising Reporting Features in GA
+                  ga('ifixit.require', 'displayfeatures');
+               `,
+            }}
+         />
+      </Head>
+   ) : null;
+}

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -1,4 +1,4 @@
-import { GA_URL, GA_KEY } from '@config/env';
+import { GA_URL, GA_KEY, GA_DEBUG } from '@config/env';
 import Head from 'next/head';
 
 export function GoogleAnalytics() {
@@ -12,8 +12,9 @@ export function GoogleAnalytics() {
                   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
                   })(window,document,'script', '${GA_URL}','ga');
 
-                  // If not on live site:
-                  // window.ga_debug = {trace: true};
+                  if (${GA_DEBUG} === true) {
+                     window.ga_debug = {trace: true};
+                  }
 
                   let createOptions = {'legacyCookieDomain': 'ifixit.com'};
 

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -16,9 +16,7 @@ export function GoogleAnalytics() {
                      window.ga_debug = {trace: true};
                   }
 
-                  let createOptions = {'legacyCookieDomain': 'ifixit.com'};
-
-                  ga('create', '${GA_KEY}', 'auto', 'ifixit', createOptions);
+                  ga('create', '${GA_KEY}', 'auto', 'ifixit', {'legacyCookieDomain': 'ifixit.com'});
                   ga('ifixit.set', 'anonymizeIp', true);
 
                   // Do not lazy load.

--- a/frontend/components/analytics/index.ts
+++ b/frontend/components/analytics/index.ts
@@ -1,1 +1,2 @@
 export * from './Matomo';
+export * from './GoogleAnalytics';

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -1,5 +1,5 @@
 import { Flex, VStack } from '@chakra-ui/react';
-import { Matomo } from '@components/analytics';
+import { Matomo, GoogleAnalytics } from '@components/analytics';
 import { PageContentWrapper, SecondaryNavbar } from '@components/common';
 import { computeProductListAlgoliaFilterPreset } from '@helpers/product-list-helpers';
 import {
@@ -77,6 +77,7 @@ export function ProductListView({
                   <Configure filters={filters} hitsPerPage={18} />
                   <MetaTags productList={productList} />
                   <Matomo />
+                  <GoogleAnalytics />
                   <HeroSection productList={productList} />
                   {productList.children.length > 0 && (
                      <ProductListChildrenSection productList={productList} />

--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -37,6 +37,11 @@ export const GA_KEY = checkEnv(
    'NEXT_PUBLIC_GA_KEY'
 );
 
+export const GA_DEBUG = checkEnv(
+   process.env.NEXT_PUBLIC_GA_DEBUG,
+   'NEXT_PUBLIC_GA_DEBUG'
+);
+
 function checkEnv(env: string | null | undefined, envName: string): string {
    if (env == null) {
       if (process.browser) {

--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -27,6 +27,16 @@ export const MATOMO_URL = checkEnv(
    'NEXT_PUBLIC_MATOMO_URL'
 );
 
+export const GA_URL = checkEnv(
+   process.env.NEXT_PUBLIC_GA_URL,
+   'NEXT_PUBLIC_GA_URL'
+);
+
+export const GA_KEY = checkEnv(
+   process.env.NEXT_PUBLIC_GA_KEY,
+   'NEXT_PUBLIC_GA_KEY'
+);
+
 function checkEnv(env: string | null | undefined, envName: string): string {
    if (env == null) {
       if (process.browser) {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -38,6 +38,8 @@ const moduleExports = {
       NEXT_PUBLIC_STRAPI_ORIGIN: process.env.NEXT_PUBLIC_STRAPI_ORIGIN,
       SENTRY_DSN: process.env.SENTRY_DSN,
       NEXT_PUBLIC_MATOMO_URL: process.env.NEXT_PUBLIC_MATOMO_URL,
+      NEXT_PUBLIC_GA_URL: process.env.NEXT_PUBLIC_GA_URL,
+      NEXT_PUBLIC_GA_KEY: process.env.NEXT_PUBLIC_GA_KEY,
    },
    async rewrites() {
       return [


### PR DESCRIPTION
I copied the GA config from `UI/templates/google_analytics_create.phtml` in the main repo.

This leaves out a couple configuration options: `userid`, `loggedIn`, `customerType` cause Jeff Snyder doesn't use them and doesn't think they're necessary for launch.

QA
---
With the production config the GA JS should show up in the `<head>` on every page and mostly match the JS on the old product list pages.

Closes https://github.com/iFixit/react-commerce/issues/483