### PR TITLE
Empty collection text: Add link to parent category

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -221,6 +221,15 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
             pt="16"
             pb="20"
             borderRadius={{ base: 'none', sm: 'lg' }}
+            sx={{
+               a: {
+                  color: 'brand.500',
+                  transition: 'color 300ms',
+                  '&:hover': {
+                     color: 'brand.600',
+                  },
+               },
+            }}
             {...otherProps}
          >
             <VStack>
@@ -240,7 +249,11 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
                <Text maxW="500px" color="gray.500" textAlign="center" px="2">
                   This collection does not have products.
                </Text>
-               {parentCategory && <Link href={parentCategory.path}>Return to parent category</Link>}
+               {parentCategory && (
+                  <Link href={parentCategory.path}>
+                     Return to parent category
+                  </Link>
+               )}
             </VStack>
          </Card>
       );

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -252,7 +252,7 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
                </Text>
                {parentCategory && (
                   <Link href={parentCategory.path}>
-                     Return to parent category
+                     Return to {parentCategory.title}
                   </Link>
                )}
             </VStack>

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -167,7 +167,8 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
       const title = getProductListTitle(productList, itemType);
       const encodedQuery = encodeURIComponent(searchBox.query);
 
-      const parentCategory = productList.ancestors.at(-1);
+      const ancestors = productList.ancestors;
+      const parentCategory = ancestors[ancestors.length - 1];
 
       if (isFiltered) {
          return (

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -167,6 +167,8 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
       const title = getProductListTitle(productList, itemType);
       const encodedQuery = encodeURIComponent(searchBox.query);
 
+      const parentCategory = productList.ancestors.at(-1);
+
       if (isFiltered) {
          return (
             <VStack
@@ -236,9 +238,9 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
                   Empty collection
                </Text>
                <Text maxW="500px" color="gray.500" textAlign="center" px="2">
-                  This collection does not have products. Try to navigate to
-                  subcategories to find what you are looking for.
+                  This collection does not have products.
                </Text>
+               {parentCategory && <Link href={parentCategory.path}>Return to parent category</Link>}
             </VStack>
          </Card>
       );


### PR DESCRIPTION
Add a link to the parent category with the text `Return to parent category` on empty collection pages.
This replaces the "Try to navigate to subcategories..." text that was there previously.

Closes: #460 