### PR TITLE
Use the iFixit part_collection/devices API Endpoint to Grab Data

### DIFF
--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -8,7 +8,7 @@ export async function fetchDeviceWiki(
    const deviceHandle = getDeviceHandle(deviceTitle);
    try {
       const response = await fetch(
-         `${IFIXIT_ORIGIN}/api/2.0/wikis/CATEGORY/${deviceHandle}`,
+         `${IFIXIT_ORIGIN}/api/2.0/cart/part_collections/devices/${deviceHandle}`,
          {
             headers: {
                'Content-Type': 'application/json',

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -66,7 +66,7 @@ export async function findProductList(
          : null);
    const title =
       productList?.title ??
-      (deviceWiki?.title ? deviceWiki?.title + ' Parts' : '');
+      (deviceWiki?.deviceTitle ? deviceWiki?.deviceTitle + ' Parts' : '');
    const description =
       productList?.description ?? deviceWiki?.description ?? '';
 
@@ -208,14 +208,15 @@ type ApiProductList = NonNullable<
 function convertAncestorsToStrapiFormat(
    ancestors: any
 ): ApiProductList['parent'] | null {
-   const ancestor = ancestors.shift();
-   if (ancestor == null) {
+   const ancestor: DeviceWiki = { title: ancestors.shift() };
+   if (ancestor['title'] == null) {
       return null;
    } else if (ancestor['title'] === 'Root') {
       ancestor['type'] = 'all_parts';
       ancestor['title'] = 'All';
       ancestor['handle'] = 'Parts';
    }
+
    return {
       data: {
          attributes: {


### PR DESCRIPTION
## Overview
Basically #472 but merging to `main`. 
Theres a new `part_collections/device/` endpoint that is for this react-commerce app to interact with as it doesn't take as much time as the grabbing all of a wiki's data. This should make our website more efficient.

## CR
Did I forget any data that `productList` would need?

## QA
Do product lists still look correct and have all the relevant info as they do on master? Are the facets correct?

Connect https://github.com/iFixit/react-commerce/issues/379