### PR TITLE
Revert  #393: "iFixit Origin: use relative urls if on same origin"

### DIFF
--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -8,14 +8,10 @@ export const ALGOLIA_API_KEY = checkEnv(
    'ALGOLIA_API_KEY'
 );
 
-const NEXT_PUBLIC_IFIXIT_ORIGIN = checkEnv(
+export const IFIXIT_ORIGIN = checkEnv(
    process.env.NEXT_PUBLIC_IFIXIT_ORIGIN,
    'NEXT_PUBLIC_IFIXIT_ORIGIN'
 );
-
-export const IFIXIT_ORIGIN = shouldUseRelativeOrigin(NEXT_PUBLIC_IFIXIT_ORIGIN)
-   ? ''
-   : NEXT_PUBLIC_IFIXIT_ORIGIN;
 
 export const STRAPI_ORIGIN = checkEnv(
    process.env.NEXT_PUBLIC_STRAPI_ORIGIN,
@@ -38,22 +34,4 @@ function checkEnv(env: string | null | undefined, envName: string): string {
       throw new Error(`environment variable "${envName}" is not defined`);
    }
    return env;
-}
-
-function shouldUseRelativeOrigin(ifixitOrigin: string): boolean {
-   if (typeof window === 'undefined') {
-      return false;
-   }
-
-   function baseDomain(url: string): string | null {
-      const parsedUrl = new URL(url);
-      const host = parsedUrl.host.match(/[^.]+\.[^.]+$/);
-      return host ? host[0] : '';
-   }
-
-   const currentBaseDomain = baseDomain(window.location.origin);
-   return (
-      Boolean(currentBaseDomain) &&
-      currentBaseDomain === baseDomain(ifixitOrigin)
-   );
 }


### PR DESCRIPTION
This is causing issues in production because we are unable to build
absolute urls with the ifixit origin. In production, we shouldn't have the CORS problem because we'll be on www.ifixit.com.

See https://github.com/iFixit/react-commerce/issues/489#issuecomment-1195598782

## QA

Smoke test that all basic features are working. We will probably see CORS errors in the previews as detailed in https://github.com/iFixit/ifixit/issues/43646

CC @danielbeardsley @dhmacs 

Connects #489