### PR TITLE
getProductListPath: Use /Shop for marketing links

### DIFF
--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -79,7 +79,7 @@ export function getProductListPath(
          return `/Tools/${productList.handle}`;
       }
       case ProductListType.Marketing: {
-         return `/Store/${productList.handle}`;
+         return `/Shop/${productList.handle}`;
       }
       default: {
          throw new Error(`unknown product list type: ${productList.type}`);


### PR DESCRIPTION
This change is for links we generate on the frontend, but I don't think we actually generate any marketing links anywhere. I made this change for correctness sake, but I don't think we can QA because we don't currently generate marketing links.

qa_req 0