### PR TITLE
Use absolute urls for links & relative urls for API requests

### DIFF
--- a/frontend/components/common/AppProviders.tsx
+++ b/frontend/components/common/AppProviders.tsx
@@ -1,5 +1,5 @@
 import { ChakraProvider, extendTheme } from '@chakra-ui/react';
-import { IFIXIT_ORIGIN } from '@config/env';
+import { ABSOLUTE_IFIXIT_ORIGIN, RELATIVE_IFIXIT_ORIGIN } from '@config/env';
 import { AppProvider } from '@ifixit/app';
 import { theme } from '@ifixit/ui';
 import Head from 'next/head';
@@ -58,7 +58,7 @@ export function AppProviders({
 
             <link
                rel="prefetch"
-               href={`${IFIXIT_ORIGIN}/api/2.0/user`}
+               href={`${RELATIVE_IFIXIT_ORIGIN}/api/2.0/user`}
                as="fetch"
             />
             <meta
@@ -71,7 +71,10 @@ export function AppProviders({
    );
 
    return (
-      <AppProvider ifixitOrigin={IFIXIT_ORIGIN}>
+      <AppProvider
+         relativeIfixitOrigin={RELATIVE_IFIXIT_ORIGIN}
+         absoluteIfixitOrigin={ABSOLUTE_IFIXIT_ORIGIN}
+      >
          <QueryClientProvider client={queryClient}>
             {algolia ? (
                <InstantSearchProvider {...algolia}>

--- a/frontend/components/common/Layout/index.tsx
+++ b/frontend/components/common/Layout/index.tsx
@@ -278,7 +278,7 @@ function HeaderUserMenu() {
    const appContext = useAppContext();
 
    if (user.data == null) {
-      return <NoUserLink href={`${appContext.ifixitOrigin}/login`} />;
+      return <NoUserLink href={`${appContext.absoluteIfixitOrigin}/login`} />;
    }
 
    return (
@@ -290,23 +290,25 @@ function HeaderUserMenu() {
                <MenuDivider />
                <MenuGroup>
                   <UserMenuLink
-                     href={`${appContext.ifixitOrigin}/User/Notifications/${user.data.id}/${user.data.username}`}
+                     href={`${appContext.absoluteIfixitOrigin}/User/Notifications/${user.data.id}/${user.data.username}`}
                   >
                      Notifications
                   </UserMenuLink>
                   <UserMenuLink
-                     href={`${appContext.ifixitOrigin}/User/${user.data.id}/${user.data.username}`}
+                     href={`${appContext.absoluteIfixitOrigin}/User/${user.data.id}/${user.data.username}`}
                   >
                      View Profile
                   </UserMenuLink>
-                  <UserMenuLink href={`${appContext.ifixitOrigin}/User/Orders`}>
+                  <UserMenuLink
+                     href={`${appContext.absoluteIfixitOrigin}/User/Orders`}
+                  >
                      Orders
                   </UserMenuLink>
                </MenuGroup>
                <MenuDivider />
                <MenuGroup>
                   <UserMenuLink
-                     href={`${appContext.ifixitOrigin}/Guide/logout`}
+                     href={`${appContext.absoluteIfixitOrigin}/Guide/logout`}
                   >
                      Log Out
                   </UserMenuLink>

--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -32,7 +32,7 @@ export function MetaTags({ productList }: MetaTagsProps) {
    }
    title += ' | iFixit';
    const itemTypeHandle = itemType ? `/${itemType}` : '';
-   const canonicalUrl = `${appContext.ifixitOrigin}${
+   const canonicalUrl = `${appContext.absoluteIfixitOrigin}${
       productList.path
    }${itemTypeHandle}${page > 1 ? `?${PRODUCT_LIST_PAGE_PARAM}=${page}` : ''}`;
    const imageUrl = productList.image?.url;

--- a/frontend/components/product-list/ProductListDeviceNavigation.tsx
+++ b/frontend/components/product-list/ProductListDeviceNavigation.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@chakra-ui/react';
 import { SecondaryNavbarItem, SecondaryNavbarLink } from '@components/common';
-import { IFIXIT_ORIGIN } from '@config/env';
+import { ABSOLUTE_IFIXIT_ORIGIN } from '@config/env';
 import { ProductList } from '@models/product-list';
 import NextLink from 'next/link';
 
@@ -15,12 +15,12 @@ export function ProductListDeviceNavigation({
    let guideUrl: string | undefined;
    let answersUrl: string | undefined;
    if (isRootProductList) {
-      guideUrl = `${IFIXIT_ORIGIN}/Guide`;
-      answersUrl = `${IFIXIT_ORIGIN}/Answers`;
+      guideUrl = `${ABSOLUTE_IFIXIT_ORIGIN}/Guide`;
+      answersUrl = `${ABSOLUTE_IFIXIT_ORIGIN}/Answers`;
    } else if (productList.deviceTitle && productList.deviceTitle.length > 0) {
       const deviceHandle = productList.deviceTitle.replace(/\s+/g, '_');
-      guideUrl = `${IFIXIT_ORIGIN}/Device/${deviceHandle}`;
-      answersUrl = `${IFIXIT_ORIGIN}/Answers/Device/${deviceHandle}`;
+      guideUrl = `${ABSOLUTE_IFIXIT_ORIGIN}/Device/${deviceHandle}`;
+      answersUrl = `${ABSOLUTE_IFIXIT_ORIGIN}/Answers/Device/${deviceHandle}`;
    }
 
    if (guideUrl == null || answersUrl == null) {

--- a/frontend/components/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/components/product-list/sections/FeaturedProductListSection.tsx
@@ -202,7 +202,9 @@ function ProductListItem({ product }: ProductListItemProps) {
                )}
             </ProductCardBadgeList>
             <ProductCardBody>
-               <LinkOverlay href={`${appContext.ifixitOrigin}${product.url}`}>
+               <LinkOverlay
+                  href={`${appContext.absoluteIfixitOrigin}${product.url}`}
+               >
                   <ProductCardTitle _groupHover={{ color: 'brand.500' }}>
                      {product.title}
                   </ProductCardTitle>

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -76,7 +76,9 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
                )}
             </ProductCardBadgeList>
             <ProductCardBody>
-               <LinkOverlay href={`${appContext.ifixitOrigin}${product.url}`}>
+               <LinkOverlay
+                  href={`${appContext.absoluteIfixitOrigin}${product.url}`}
+               >
                   <ProductCardTitle _groupHover={{ color: 'brand.500' }}>
                      {product.title}
                   </ProductCardTitle>

--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -246,7 +246,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                      }}
                   >
                      <LinkOverlay
-                        href={`${appContext.ifixitOrigin}${product.url}`}
+                        href={`${appContext.absoluteIfixitOrigin}${product.url}`}
                      >
                         <Button
                            as="div"

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -16,7 +16,7 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { Card } from '@components/ui';
-import { IFIXIT_ORIGIN } from '@config/env';
+import { ABSOLUTE_IFIXIT_ORIGIN } from '@config/env';
 import { getProductListTitle } from '@helpers/product-list-helpers';
 import { cypressWindowLog } from '@helpers/test-helpers';
 import { useLocalPreference } from '@ifixit/ui';
@@ -192,7 +192,7 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
                <Link
                   maxW="500px"
                   color="brand.500"
-                  href={`${IFIXIT_ORIGIN}/Search?query=${encodedQuery}`}
+                  href={`${ABSOLUTE_IFIXIT_ORIGIN}/Search?query=${encodedQuery}`}
                >
                   Search all of iFixit for&nbsp;
                   <Text as="span" fontWeight="bold">

--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -8,10 +8,16 @@ export const ALGOLIA_API_KEY = checkEnv(
    'ALGOLIA_API_KEY'
 );
 
-export const IFIXIT_ORIGIN = checkEnv(
+export const ABSOLUTE_IFIXIT_ORIGIN = checkEnv(
    process.env.NEXT_PUBLIC_IFIXIT_ORIGIN,
    'NEXT_PUBLIC_IFIXIT_ORIGIN'
 );
+
+export const RELATIVE_IFIXIT_ORIGIN = shouldUseRelativeOrigin(
+   ABSOLUTE_IFIXIT_ORIGIN
+)
+   ? ''
+   : ABSOLUTE_IFIXIT_ORIGIN;
 
 export const STRAPI_ORIGIN = checkEnv(
    process.env.NEXT_PUBLIC_STRAPI_ORIGIN,
@@ -49,4 +55,22 @@ function checkEnv(env: string | null | undefined, envName: string): string {
       throw new Error(`environment variable "${envName}" is not defined`);
    }
    return env;
+}
+
+function shouldUseRelativeOrigin(absoluteIfixitOrigin: string): boolean {
+   if (typeof window === 'undefined') {
+      return false;
+   }
+
+   function baseDomain(url: string): string | null {
+      const parsedUrl = new URL(url);
+      const host = parsedUrl.host.match(/[^.]+\.[^.]+$/);
+      return host ? host[0] : '';
+   }
+
+   const currentBaseDomain = baseDomain(window.location.origin);
+   return (
+      Boolean(currentBaseDomain) &&
+      currentBaseDomain === baseDomain(absoluteIfixitOrigin)
+   );
 }

--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -1,4 +1,4 @@
-import { IFIXIT_ORIGIN } from '@config/env';
+import { ABSOLUTE_IFIXIT_ORIGIN, RELATIVE_IFIXIT_ORIGIN } from '@config/env';
 
 export type DeviceWiki = Record<string, any>;
 
@@ -8,7 +8,7 @@ export async function fetchDeviceWiki(
    const deviceHandle = getDeviceHandle(deviceTitle);
    try {
       const response = await fetch(
-         `${IFIXIT_ORIGIN}/api/2.0/wikis/CATEGORY/${deviceHandle}`,
+         `${RELATIVE_IFIXIT_ORIGIN}/api/2.0/wikis/CATEGORY/${deviceHandle}`,
          {
             headers: {
                'Content-Type': 'application/json',
@@ -41,7 +41,9 @@ export function fetchMultipleDeviceImages(
    deviceTitles: string[],
    size: GuideImageSize
 ): Promise<MultipleDeviceApiResponse> {
-   const apiUrl = new URL(`${IFIXIT_ORIGIN}/api/2.0/wikis/topic_images`);
+   const apiUrl = new URL(
+      `${ABSOLUTE_IFIXIT_ORIGIN}/api/2.0/wikis/topic_images`
+   );
    apiUrl.searchParams.set('size', size);
    deviceTitles.forEach((deviceTitle) => {
       apiUrl.searchParams.append('t[]', deviceTitle);

--- a/frontend/models/posts.ts
+++ b/frontend/models/posts.ts
@@ -1,4 +1,4 @@
-import { IFIXIT_ORIGIN } from '@config/env';
+import { RELATIVE_IFIXIT_ORIGIN } from '@config/env';
 
 export interface Post {
    id: number;
@@ -15,7 +15,7 @@ export interface PostImage {
 
 export async function fetchPosts(tags: string[]): Promise<Post[]> {
    const response = await fetch(
-      `${IFIXIT_ORIGIN}/api/2.0/related_posts?data=${encodeURIComponent(
+      `${RELATIVE_IFIXIT_ORIGIN}/api/2.0/related_posts?data=${encodeURIComponent(
          JSON.stringify({ tags })
       )}`
    );

--- a/packages/app/__mocks__/index.tsx
+++ b/packages/app/__mocks__/index.tsx
@@ -6,7 +6,10 @@
 const app = jest.requireActual('../index.tsx');
 
 function useAppContext() {
-   return { ifixitOrigin: 'https://www.cominor.com' };
+   return {
+      relativeIfixitOrigin: 'https://www.cominor.com',
+      absoluteIfixitOrigin: 'https://www.cominor.com',
+   };
 }
 
 app.useAppContext = useAppContext;

--- a/packages/app/index.tsx
+++ b/packages/app/index.tsx
@@ -1,19 +1,25 @@
 import * as React from 'react';
 
 export type AppContext = {
-   ifixitOrigin: string;
+   relativeIfixitOrigin: string;
+   absoluteIfixitOrigin: string;
 };
 
 const AppContext = React.createContext<AppContext | null>(null);
 
 type AppProviderProps = React.PropsWithChildren<{
-   ifixitOrigin: string;
+   relativeIfixitOrigin: string;
+   absoluteIfixitOrigin: string;
 }>;
 
-export function AppProvider({ ifixitOrigin, children }: AppProviderProps) {
+export function AppProvider({
+   relativeIfixitOrigin,
+   absoluteIfixitOrigin,
+   children,
+}: AppProviderProps) {
    const value = React.useMemo(
-      (): AppContext => ({ ifixitOrigin }),
-      [ifixitOrigin]
+      (): AppContext => ({ relativeIfixitOrigin, absoluteIfixitOrigin }),
+      [relativeIfixitOrigin, absoluteIfixitOrigin]
    );
 
    return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -20,7 +20,7 @@ export function useAuthenticatedUser() {
    const appContext = useAppContext();
    const query = useQuery(
       userKeys.user,
-      () => fetchAuthenticatedUser(appContext.ifixitOrigin),
+      () => fetchAuthenticatedUser(appContext.relativeIfixitOrigin),
       {
          retryOnMount: false,
          staleTime: Infinity,

--- a/packages/cart-sdk/hooks/use-checkout.ts
+++ b/packages/cart-sdk/hooks/use-checkout.ts
@@ -108,7 +108,7 @@ function useDraftOrderCheckout() {
    const appContext = useAppContext();
    const client = useIFixitApiClient();
    const shopifyClient = useShopifyStorefrontClient();
-   const ssoRoute = `${appContext.ifixitOrigin}/User/sso/shopify/${shopifyClient.shopDomain}?checkout=1`;
+   const ssoRoute = `${appContext.absoluteIfixitOrigin}/User/sso/shopify/${shopifyClient.shopDomain}?checkout=1`;
    return async () => {
       const result = await client.post('cart/order/draftOrder');
       const returnToUrl = new URL(result.invoiceUrl);
@@ -123,7 +123,7 @@ function useStandardCheckout() {
    const cart = useCart();
    const user = useAuthenticatedUser();
    const shopifyClient = useShopifyStorefrontClient();
-   const ssoRoute = `${appContext.ifixitOrigin}/User/sso/shopify/${shopifyClient.shopDomain}?checkout=1`;
+   const ssoRoute = `${appContext.absoluteIfixitOrigin}/User/sso/shopify/${shopifyClient.shopDomain}?checkout=1`;
    const isUserLoggedIn = user.data != null;
    const createCheckout = useCreateCheckout();
    const updateCheckout = useUpdateCheckout();

--- a/packages/ifixit-api-client/index.tsx
+++ b/packages/ifixit-api-client/index.tsx
@@ -69,9 +69,9 @@ export function useIFixitApiClient() {
 
    const client = React.useMemo(() => {
       return new IFixitAPIClient({
-         origin: appContext.ifixitOrigin,
+         origin: appContext.relativeIfixitOrigin,
       });
-   }, [appContext.ifixitOrigin]);
+   }, [appContext.relativeIfixitOrigin]);
 
    return client;
 }

--- a/packages/newsletter-sdk/index.tsx
+++ b/packages/newsletter-sdk/index.tsx
@@ -35,7 +35,7 @@ export function useSubscribeToNewsletter(): [Subscription, SubscribeFn] {
             status: SubscriptionStatus.Subscribing,
          }));
          try {
-            await subscribeToNewsletter(appContext.ifixitOrigin, email);
+            await subscribeToNewsletter(appContext.relativeIfixitOrigin, email);
             setState(() => ({
                status: SubscriptionStatus.Subscribed,
                error: undefined,

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -223,7 +223,7 @@ export function CartDrawer() {
                            <SimpleGrid columns={2} spacing="2.5" w="full">
                               <Button
                                  as="a"
-                                 href={`${appContext.ifixitOrigin}/cart/view`}
+                                 href={`${appContext.absoluteIfixitOrigin}/cart/view`}
                                  variant="outline"
                                  onClick={onClose}
                               >

--- a/packages/ui/cart/drawer/CartLineItem.tsx
+++ b/packages/ui/cart/drawer/CartLineItem.tsx
@@ -106,7 +106,7 @@ export function CartLineItem({ lineItem }: CartLineItemProps) {
                   <VStack align="flex-start" pt="1">
                      <Flex direction="column">
                         <Link
-                           href={`${appContext.ifixitOrigin}/Store/Product/${lineItem.itemcode}`}
+                           href={`${appContext.absoluteIfixitOrigin}/Store/Product/${lineItem.itemcode}`}
                            isExternal
                            fontWeight="bold"
                            fontSize="xs"

--- a/packages/ui/header/Search.tsx
+++ b/packages/ui/header/Search.tsx
@@ -20,7 +20,7 @@ export const DesktopHeaderSearchForm = forwardRef<FlexProps, 'form'>(
             ref={ref}
             as="form"
             method="GET"
-            action={`${appContext.ifixitOrigin}/Search`}
+            action={`${appContext.absoluteIfixitOrigin}/Search`}
             flexGrow={1}
             mx="8"
             display={{
@@ -41,7 +41,7 @@ export const MobileHeaderSearchForm = forwardRef<FlexProps, 'form'>(
             ref={ref}
             as="form"
             method="GET"
-            action={`${appContext.ifixitOrigin}/Search`}
+            action={`${appContext.absoluteIfixitOrigin}/Search`}
             flexGrow={1}
             mr="1"
             {...props}


### PR DESCRIPTION
We want to use relative origins on API requests so we don't get blocked
by CORS on previews.

We'll use absolute urls everywhere else, particularly when linking to
other pages. If we try to use a relative url with the JS URL()
constructor, it will throw an error, so we need to use absolute links in
those cases.

## Background

This is meant to have the intended effect of https://github.com/iFixit/react-commerce/pull/393 without causing the bug described here: https://github.com/iFixit/react-commerce/issues/489.

Closes #498