### PR TITLE
Model highlight: Fix the highlight that was getting cut off

### DIFF
--- a/frontend/components/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/components/product-list/sections/ProductListChildrenSection.tsx
@@ -82,7 +82,8 @@ export function ProductListChildrenSection({
                   md: 3,
                   lg: 4,
                }}
-               spacing="4"
+               spacing="3"
+               p={1}
             >
                {productListChildren.map((child) => {
                   return <ChildLink key={child.handle} child={child} />;

--- a/frontend/components/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/components/product-list/sections/ProductListChildrenSection.tsx
@@ -83,7 +83,7 @@ export function ProductListChildrenSection({
                   lg: 4,
                }}
                spacing="3"
-               p={1}
+               pt={1}
             >
                {productListChildren.map((child) => {
                   return <ChildLink key={child.handle} child={child} />;


### PR DESCRIPTION
## Summary

Previously, the model buttons were getting weirdly cut off on the top. This PR  fixes it by adding some padding and fixing the space within the grid accordingly.

## CR/QA
CR:
- The spacing was altered because when the padding was added, the buttons moved down and were getting cut off by the `Show More` toggle like shown here:

<img width="188" alt="Screenshot 2022-07-26 133923" src="https://user-images.githubusercontent.com/50181909/181107732-1ca2adda-b4d6-4409-aea0-ef652892f4ec.png">

- In order to fix this^, the spacing was reduced when the padding was added.

QA:
- Visit the preview
- Make sure that the highlight isn't cut off
   - At the top
   - By the toggle
   - And when when expanded, by the `Show Less` toggle.

Closes #477 

CC: @jordycosta 