### PR TITLE
parts and tools:  Redirect to Parts and Tools

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -71,6 +71,12 @@ const moduleExports = {
             destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/sitemap/marketing.xml`,
             permanent: true,
          },
+         {
+            source: '/parts*',
+            destination: '/Parts*',
+            permanent: true,
+         },
+
       ];
    },
    images: {

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -72,13 +72,13 @@ const moduleExports = {
             permanent: true,
          },
          {
-            source: '/parts*',
-            destination: '/Parts*',
+            source: '/parts/:path*',
+            destination: '/Parts/:path*',
             permanent: true,
          },
          {
-            source: '/tools*',
-            destination: '/Tools*',
+            source: '/tools/:path*',
+            destination: '/Tools/:path*',
             permanent: true,
          },
       ];

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -76,7 +76,11 @@ const moduleExports = {
             destination: '/Parts*',
             permanent: true,
          },
-
+         {
+            source: '/tools*',
+            destination: '/Tools*',
+            permanent: true,
+         },
       ];
    },
    images: {


### PR DESCRIPTION
Previously, `www.ifixit.com/parts` and `www.ifixit.cam/Parts` would load different pages. That shouldn't be the case and it was happening due to the lower case `parts`. This PR redirects `/parts` to `/Parts`. I noticed the same thing for `/tools` so I added a redirect for that as well [ `/tools` -> `/Tools`].

Closes https://github.com/ifixit/ifixit/issues/43952

CC: @sterlinghirsh 