### PR TITLE
InstantSearch: Render facets with URL from environment on the server

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -129,7 +129,7 @@ export function InstantSearchProvider({
             return window.location;
          },
          createURL({ qsModule, routeState, location }) {
-            const baseUrl = location.origin;
+            const baseUrl = getBaseOrigin(location)
             const pathParts = location.pathname
                .split('/')
                .filter((part) => part !== '');
@@ -260,4 +260,15 @@ function RefreshSearchResults({
       }
    }, [apiKey, prevApiKey]);
    return null;
+}
+
+function getBaseOrigin(location: Location): string {
+   if (typeof window === 'undefined' && process.env.NEXT_PUBLIC_IFIXIT_ORIGIN) {
+      // On the server, use the IFIXIT_ORIGIN url
+      // This ensures that the SSR produces the correct links on Vercel
+      // (where the Host header doesn't match the page URL.)
+      const publicOrigin = new URL(process.env.NEXT_PUBLIC_IFIXIT_ORIGIN)
+      return publicOrigin.origin
+   }
+   return location.origin
 }

--- a/frontend/components/product-list/sections/FilterableProductsSection/RefinementMenu.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/RefinementMenu.tsx
@@ -102,7 +102,7 @@ const MenuItem = React.memo(function RefinementListItem({
    // The url created by InstantSearch doesn't have the correct item type slug.
    const path = url.pathname.split('/').filter((part) => part !== '');
    const itemTypeHandle = encodeDeviceItemType(value);
-   const href = `${url.origin}/${path[0]}/${path[1]}/${itemTypeHandle}${url.search}`;
+   const href = `/${path[0]}/${path[1]}/${itemTypeHandle}${url.search}`;
    return (
       <HStack
          key={label}


### PR DESCRIPTION
We were having problems where the HTML page returned from the Vercel SSR included facet links pointing at the Vercel subdomain where it's actually hosted, instead of at `www.ifixit.com`. This switches things around to use the host from `NEXT_PUBLIC_IFIXIT_ORIGIN` when rendering on the server, which means that we're in full control of where the code thinks its origin is.

I didn't handle the case where `NEXT_PUBLIC_IFIXIT_ORIGIN` has a path on it; it doesn't seem currently relevant, and it's kinda a change from the previous behavior (which breaks up the `location` and uses it to generate the new URL; the path is handled separately).

## QA Notes
Check the page source on https://react-commerce-prod-git-instant-search-use-correc-eb6415-ifixit.vercel.app/Parts/Mac (use the `View Source` function in your browser; the inspector won't show what you need), search for `Adhesive` in the source, and verify that the `href` on the `a` tag you should find makes sense. If you're not sure, you should be able to try the same thing on https://react-commerce-prod.vercel.app/Parts/Mac and see how the output is different.

The thing you're searching for should look a bit like this:
![image](https://user-images.githubusercontent.com/1283490/181139506-6c64bc25-07d2-4a99-b584-b5250828abf2.png)


I'm a little unsure about why the branch preview version seems to have `www.cominor.com` configured as the server URL for `react-commerce-prod`, but given that it also doesn't seem to have all the products I'd have expected, I'm guessing it's not using a real prod config, despite the name.

Fixes ifixit/ifixit#43961
