### PR TITLE
Add env variable for Algolia index name

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -10,3 +10,4 @@ NEXT_PUBLIC_GA_KEY=UA-30506-1
 # https://www.google-analytics.com/analytics_debug.js
 NEXT_PUBLIC_GA_DEBUG=false
 NEXT_PUBLIC_GA_URL=
+NEXT_PUBLIC_ALGOLIA_PRODUCT_INDEX_NAME=dev_product_group_en

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -9,3 +9,6 @@ NEXT_PUBLIC_MATOMO_URL=https://minerva.ifixit.com
 NEXT_PUBLIC_GA_KEY=UA-30506-1
 NEXT_PUBLIC_GA_DEBUG=false
 NEXT_PUBLIC_GA_URL=https://www.google-analytics.com/analytics.js
+# This is being set to dev_product_group_en because we want all preview environments to use this by default.
+# We'll add an override in the Vercel dashboard to use the prod_product_group_en for the production environment.
+NEXT_PUBLIC_ALGOLIA_PRODUCT_INDEX_NAME=dev_product_group_en

--- a/frontend/config/constants.ts
+++ b/frontend/config/constants.ts
@@ -1,4 +1,3 @@
 export const PRODUCT_LIST_PAGE_PARAM = 'p';
 export const PRODUCT_LIST_QUERY_PARAM = 'q';
 export const DEFAULT_ANIMATION_DURATION_MS = 300;
-export const ALGOLIA_DEFAULT_INDEX_NAME = 'product_group_en';

--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -38,6 +38,11 @@ export const GA_DEBUG = checkEnv(
    'NEXT_PUBLIC_GA_DEBUG'
 );
 
+export const ALGOLIA_PRODUCT_INDEX_NAME = checkEnv(
+   process.env.NEXT_PUBLIC_ALGOLIA_PRODUCT_INDEX_NAME,
+   'NEXT_PUBLIC_ALGOLIA_PRODUCT_INDEX_NAME'
+);
+
 function checkEnv(env: string | null | undefined, envName: string): string {
    if (env == null) {
       if (process.browser) {

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -1,5 +1,8 @@
-import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
-import { ALGOLIA_API_KEY, ALGOLIA_APP_ID } from '@config/env';
+import {
+   ALGOLIA_API_KEY,
+   ALGOLIA_APP_ID,
+   ALGOLIA_PRODUCT_INDEX_NAME,
+} from '@config/env';
 import { Awaited, filterNullableItems } from '@helpers/application-helpers';
 import {
    getProductListPath,
@@ -18,6 +21,7 @@ import {
 } from '@lib/strapi-sdk';
 import algoliasearch from 'algoliasearch';
 import {
+   BaseProductList,
    ProductList,
    ProductListAncestor,
    ProductListChild,
@@ -25,7 +29,6 @@ import {
    ProductListSection,
    ProductListSectionType,
    ProductListType,
-   BaseProductList,
 } from './types';
 
 export { ProductListSectionType, ProductListType } from './types';
@@ -355,7 +358,7 @@ function createProductListSection(
                      : getImageFromStrapiImage(image, 'thumbnail'),
                filters: productList.filters ?? null,
                algolia: {
-                  indexName: ALGOLIA_DEFAULT_INDEX_NAME,
+                  indexName: ALGOLIA_PRODUCT_INDEX_NAME,
                   apiKey: algoliaApiKey,
                },
             },

--- a/frontend/pages/Parts/[...deviceHandleItemType].tsx
+++ b/frontend/pages/Parts/[...deviceHandleItemType].tsx
@@ -9,7 +9,7 @@ import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
-import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
+import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { decodeDeviceTitle } from '@helpers/product-list-helpers';
 import { invariant } from '@ifixit/helpers';
 import { getGlobalSettings } from '@models/global-settings';
@@ -31,9 +31,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    );
 
    const { deviceHandleItemType } = context.params || {};
-   const [deviceHandle, itemTypeHandle, ...rest] = Array.isArray(
-      deviceHandleItemType
-   )
+   const [deviceHandle, ...rest] = Array.isArray(deviceHandleItemType)
       ? deviceHandleItemType
       : [];
 
@@ -68,7 +66,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+   const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {
       algolia: {

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -9,7 +9,7 @@ import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
-import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
+import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -46,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+   const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {
       algolia: {

--- a/frontend/pages/Shop/[handle].tsx
+++ b/frontend/pages/Shop/[handle].tsx
@@ -9,7 +9,7 @@ import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
-import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
+import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { invariant } from '@ifixit/helpers';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
@@ -57,7 +57,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+   const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {
       algolia: {

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -9,7 +9,7 @@ import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
-import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
+import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { invariant } from '@ifixit/helpers';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
@@ -54,7 +54,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+   const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {
       algolia: {

--- a/frontend/pages/Tools/index.tsx
+++ b/frontend/pages/Tools/index.tsx
@@ -9,7 +9,7 @@ import {
    ProductListView,
    ProductListViewProps,
 } from '@components/product-list';
-import { ALGOLIA_DEFAULT_INDEX_NAME } from '@config/constants';
+import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -50,7 +50,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 
    const protocol = context.req.headers.referer?.split('://')[0] || 'https';
    const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   const indexName = ALGOLIA_DEFAULT_INDEX_NAME;
+   const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {
       algolia: {


### PR DESCRIPTION
This PR will let us use different Algolia index for different environments

## Changelog

- Refactor algolia index name from being a const to be an env variable
- Override production `NEXT_PUBLIC_ALGOLIA_PRODUCT_INDEX_NAME` env variable to  point to `product_group_en`

## QA

1. Open Vercel preview
2. Visit parts product list
3. Open dev tools network tab
4. Trigger an Algolia search (e.g. by clicking on a filter)
5. Inspect the request and verify that it's using `dev_product_group_en` index
    <img width="734" alt="image" src="https://user-images.githubusercontent.com/4640135/181250774-7a7bcb11-8ccd-4c13-b79e-7b30a58e3b6a.png">
