### PR TITLE
Breadcrumbs: Display on desktop tool category pages

### DIFF
--- a/frontend/components/product-list/ProductListDeviceNavigation.tsx
+++ b/frontend/components/product-list/ProductListDeviceNavigation.tsx
@@ -1,15 +1,16 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, FlexProps } from '@chakra-ui/react';
 import { SecondaryNavbarItem, SecondaryNavbarLink } from '@components/common';
 import { IFIXIT_ORIGIN } from '@config/env';
 import { ProductList } from '@models/product-list';
 import NextLink from 'next/link';
 
-export interface ProductListDeviceNavigationProps {
+type ProductListDeviceNavigationProps = FlexProps & {
    productList: ProductList;
-}
+};
 
 export function ProductListDeviceNavigation({
    productList,
+   ...flexProps
 }: ProductListDeviceNavigationProps) {
    const isRootProductList = productList.ancestors.length === 0;
    let guideUrl: string | undefined;
@@ -37,6 +38,7 @@ export function ProductListDeviceNavigation({
             md: '0',
          }}
          bg="white"
+         {...flexProps}
       >
          <SecondaryNavbarItem isCurrent>Parts</SecondaryNavbarItem>
          <SecondaryNavbarItem>

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -67,9 +67,8 @@ export function ProductListView({
             </PageContentWrapper>
          </SecondaryNavbar>
          <SecondaryNavbar
-            hidden={isRootProductList}
             display={{
-               base: 'initial',
+               base: isRootProductList ? 'none' : 'initial',
                sm: 'none',
             }}
          >

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -32,16 +32,16 @@ export function ProductListView({
 }: ProductListViewProps) {
    const filters = computeProductListAlgoliaFilterPreset(productList);
    const isRootProductList = productList.ancestors.length === 0;
+   const isAllToolsPage = productList.type === ProductListType.AllTools;
    const isToolPage =
-      productList.type === ProductListType.AllTools ||
-      productList.type === ProductListType.ToolsCategory;
+      isAllToolsPage || productList.type === ProductListType.ToolsCategory;
 
    return (
       <>
          <SecondaryNavbar
             display={{
                base: isToolPage ? 'none' : 'initial',
-               sm: 'initial',
+               sm: isAllToolsPage ? 'none' : 'initial',
             }}
          >
             <PageContentWrapper h="full">

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -59,7 +59,10 @@ export function ProductListView({
                      }}
                      productList={productList}
                   />
-                  <ProductListDeviceNavigation productList={productList} />
+                  <ProductListDeviceNavigation
+                     productList={productList}
+                     hidden={isToolPage}
+                  />
                </Flex>
             </PageContentWrapper>
          </SecondaryNavbar>

--- a/frontend/components/product-list/ProductListView.tsx
+++ b/frontend/components/product-list/ProductListView.tsx
@@ -38,7 +38,12 @@ export function ProductListView({
 
    return (
       <>
-         <SecondaryNavbar hidden={isToolPage}>
+         <SecondaryNavbar
+            display={{
+               base: isToolPage ? 'none' : 'initial',
+               sm: 'initial',
+            }}
+         >
             <PageContentWrapper h="full">
                <Flex
                   h="full"


### PR DESCRIPTION
These were unintentionally hidden in #466. This adds back breadcrumbs on /Tools/Category pages.

CC @erinemay 

Closes #502 