### PR TITLE
Facets: Only show relevant ones on empty product list

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -110,12 +110,10 @@ export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
       }
 
       const hideWorksin = attribute === 'worksin' && emptyProductList;
-      const hideToolsCategory =
-         isPartsPage &&
-         attribute === 'facet_tags.Tool Category' &&
-         emptyProductList;
+      const hideToolCategory =
+         isPartsPage && attribute === 'facet_tags.Tool Category';
 
-      if (hideWorksin || hideToolsCategory) {
+      if (hideWorksin || hideToolCategory) {
          isHidden = true;
       }
 

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -101,23 +101,19 @@ export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
       let isHidden = !hasApplicableRefinements && !isProductListEmpty;
       const emptyProductList = isProductListEmpty && !hasApplicableRefinements;
 
-      let isPartsPage =
-         productList.type === ProductListType.AllParts ? true : false;
+      let isPartsPage = productList.type === ProductListType.AllParts;
 
       const ancestors = productList.ancestors;
       if (ancestors[ancestors.length - 1]) {
          const path = ancestors[ancestors.length - 1].path;
-         isPartsPage = path.includes('/Parts') ? true : false;
+         isPartsPage = path.includes('/Parts');
       }
 
-      const hideWorksin =
-         attribute === 'worksin' && emptyProductList ? true : false;
+      const hideWorksin = attribute === 'worksin' && emptyProductList;
       const hideToolsCategory =
          isPartsPage &&
          attribute === 'facet_tags.Tool Category' &&
-         emptyProductList
-            ? true
-            : false;
+         emptyProductList;
 
       if (hideWorksin || hideToolsCategory) {
          isHidden = true;

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -98,24 +98,21 @@ export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
       const isDisabled = isProductListEmpty || !hasApplicableRefinements;
 
       const formattedFacetName = formatFacetName(attribute);
-      let isHidden = !hasApplicableRefinements && !isProductListEmpty;
-      const emptyProductList = isProductListEmpty && !hasApplicableRefinements;
+      const productListEmptyState =
+         isProductListEmpty && !hasApplicableRefinements;
 
-      let isPartsPage = productList.type === ProductListType.AllParts;
+      const isPartsPage =
+         productList.type === ProductListType.AllParts ||
+         productList.type === ProductListType.DeviceParts;
 
-      const ancestors = productList.ancestors;
-      if (ancestors[ancestors.length - 1]) {
-         const path = ancestors[ancestors.length - 1].path;
-         isPartsPage = path.includes('/Parts');
-      }
-
-      const hideWorksin = attribute === 'worksin' && emptyProductList;
-      const hideToolCategory =
+      const isWorksin = attribute === 'worksin' && productListEmptyState;
+      const isToolCategoryOnPartsPage =
          isPartsPage && attribute === 'facet_tags.Tool Category';
 
-      if (hideWorksin || hideToolCategory) {
-         isHidden = true;
-      }
+      const isHidden =
+         (!hasApplicableRefinements && !isProductListEmpty) ||
+         isWorksin ||
+         isToolCategoryOnPartsPage;
 
       return (
          <AccordionItem

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -12,7 +12,7 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { formatFacetName } from '@helpers/algolia-helpers';
-import { ProductList } from '@models/product-list';
+import { ProductList, ProductListType } from '@models/product-list';
 import * as React from 'react';
 import { useHits } from 'react-instantsearch-hooks-web';
 import { FacetFilter } from './FacetFilter';
@@ -98,7 +98,21 @@ export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
       const isDisabled = isProductListEmpty || !hasApplicableRefinements;
 
       const formattedFacetName = formatFacetName(attribute);
-      const isHidden = !hasApplicableRefinements && !isProductListEmpty;
+      let isHidden = !hasApplicableRefinements && !isProductListEmpty;
+      let emptyProductList = isProductListEmpty && !hasApplicableRefinements;
+
+      let hideWorksin =
+         attribute === 'worksin' && emptyProductList ? true : false;
+      let hideToolsCategory =
+         productList.type === ProductListType.AllParts &&
+         attribute === 'facet_tags.Tool Category' &&
+         emptyProductList
+            ? true
+            : false;
+
+      if (hideWorksin || hideToolsCategory) {
+         isHidden = true;
+      }
 
       return (
          <AccordionItem

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -99,11 +99,11 @@ export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
 
       const formattedFacetName = formatFacetName(attribute);
       let isHidden = !hasApplicableRefinements && !isProductListEmpty;
-      let emptyProductList = isProductListEmpty && !hasApplicableRefinements;
+      const emptyProductList = isProductListEmpty && !hasApplicableRefinements;
 
-      let hideWorksin =
+      const hideWorksin =
          attribute === 'worksin' && emptyProductList ? true : false;
-      let hideToolsCategory =
+      const hideToolsCategory =
          productList.type === ProductListType.AllParts &&
          attribute === 'facet_tags.Tool Category' &&
          emptyProductList

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -101,10 +101,19 @@ export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
       let isHidden = !hasApplicableRefinements && !isProductListEmpty;
       const emptyProductList = isProductListEmpty && !hasApplicableRefinements;
 
+      let isPartsPage =
+         productList.type === ProductListType.AllParts ? true : false;
+
+      const ancestors = productList.ancestors;
+      if (ancestors[ancestors.length - 1]) {
+         const path = ancestors[ancestors.length - 1].path;
+         isPartsPage = path.includes('/Parts') ? true : false;
+      }
+
       const hideWorksin =
          attribute === 'worksin' && emptyProductList ? true : false;
       const hideToolsCategory =
-         productList.type === ProductListType.AllParts &&
+         isPartsPage &&
          attribute === 'facet_tags.Tool Category' &&
          emptyProductList
             ? true


### PR DESCRIPTION
This PR hides `Worksin` on both `/Parts` and `/Tools` and `Tools Category` on `/Parts` when the search query results in an empty product list state.

## QA
- `Tool Category` should now always be hidden on `/Parts` and its children. And on empty state:
   - `Tool Category` and `Worksin` should be hidden on `/Parts`
   - `Worksin` should be hidden on `/Tools`

Closes #500 

CC: @erinemay @jeffsnyder