### PR TITLE
Routing: Don't 404 on item type visits

### DIFF
--- a/frontend/pages/Parts/[...deviceHandleItemType].tsx
+++ b/frontend/pages/Parts/[...deviceHandleItemType].tsx
@@ -31,12 +31,14 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    );
 
    const { deviceHandleItemType } = context.params || {};
-   const [deviceHandle, ...rest] = Array.isArray(deviceHandleItemType)
+   const [deviceHandle, ...itemTypeAndRest] = Array.isArray(
+      deviceHandleItemType
+   )
       ? deviceHandleItemType
       : [];
 
    invariant(typeof deviceHandle === 'string', 'device handle is required');
-   if (rest?.length > 0) {
+   if (itemTypeAndRest?.length > 1) {
       return {
          notFound: true,
       };


### PR DESCRIPTION
Fixes a bug where a visit to /Parts/Device/Item_Type would 404. The item type slug is optional, but any extra path components after that should 404.

This bug was unintentionally introduced in https://github.com/iFixit/react-commerce/commit/c32b62fe8859fa04f68b4f6e855b0938120544fd (and I missed it in CR!).

Admittedly it was bad idea on my part to store the itemTypeHandle in an unused variable, and it got "cleaned up" in that commit. Now, we'll include it in the `...` and only 404 if there is > 1 extra path component.

## QA
Visit /Parts/iPhone_11/Adhesives and make sure it doesn't 404.

Closes #516