### PR TITLE
Hide device children on unfiltered item type pages with no hits

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -129,7 +129,7 @@ export function InstantSearchProvider({
             return window.location;
          },
          createURL({ qsModule, routeState, location }) {
-            const baseUrl = getBaseOrigin(location)
+            const baseUrl = getBaseOrigin(location);
             const pathParts = location.pathname
                .split('/')
                .filter((part) => part !== '');
@@ -267,8 +267,8 @@ function getBaseOrigin(location: Location): string {
       // On the server, use the IFIXIT_ORIGIN url
       // This ensures that the SSR produces the correct links on Vercel
       // (where the Host header doesn't match the page URL.)
-      const publicOrigin = new URL(process.env.NEXT_PUBLIC_IFIXIT_ORIGIN)
-      return publicOrigin.origin
+      const publicOrigin = new URL(process.env.NEXT_PUBLIC_IFIXIT_ORIGIN);
+      return publicOrigin.origin;
    }
-   return location.origin
+   return location.origin;
 }

--- a/frontend/components/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/components/product-list/sections/ProductListChildrenSection.tsx
@@ -12,6 +12,8 @@ import { IfixitImage } from '@components/ifixit-image';
 import { ProductList } from '@models/product-list';
 import NextLink from 'next/link';
 import * as React from 'react';
+import { useCurrentRefinements, useHits } from 'react-instantsearch-hooks-web';
+import { useDevicePartsItemType } from './FilterableProductsSection/useDevicePartsItemType';
 
 export type ProductListChildrenSectionProps = {
    productList: ProductList;
@@ -55,7 +57,17 @@ export function ProductListChildrenSection({
       heading = `Choose a model of ${deviceTitle}`;
    }
 
-   return (
+   const { items } = useCurrentRefinements();
+   const { hits } = useHits();
+   const itemType = useDevicePartsItemType(productList);
+   const isUnfilteredItemTypeWithNoHits = React.useMemo(() => {
+      const nonItemTypeRefinements = items.filter(
+         (item) => item.attribute !== 'facet_tags.Item Type'
+      );
+      return !hits.length && itemType && !nonItemTypeRefinements.length;
+   }, [items, itemType, hits]);
+
+   return isUnfilteredItemTypeWithNoHits ? null : (
       <Box
          px={{
             base: 6,


### PR DESCRIPTION
Hides the device children links on item type pages (like /Parts/iPhone/Batteries) when there are no product results and there are no other refinements applied. This prevents crawlers from continuing to descend down the device tree, when we know they will keep hitting empty pages.

## QA
- Find a device that has children device links on `main`. You might have to go into [strapi admin](https://hide-children-on-no-hits-item-type.govinor.com/admin) for this branch and set the `parent` field for some devices in order to see them.
- Visit an item type page for this device that has no results.
  - One way to do this: Visit the device parts page, like /Parts/iPhone. Type gibberish as the last component, like /Parts/iPhone/asdf.
- On main, the children links should still show on the empty item type page. On this feature, they shouldn't appear.
- In any other conditions, the children device links should display as usual.

CC @sterlinghirsh 

Closes #462