### PR TITLE
Noindex collections pages without corresponding Strapi content

### DIFF
--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -36,7 +36,10 @@ export function MetaTags({ productList }: MetaTagsProps) {
       productList.path
    }${itemTypeHandle}${page > 1 ? `?${PRODUCT_LIST_PAGE_PARAM}=${page}` : ''}`;
    const imageUrl = productList.image?.url;
-   const shouldNoIndex = isFiltered || pagination.nbHits < 2;
+   const shouldNoIndex =
+      isFiltered ||
+      pagination.nbHits < 2 ||
+      productList.forceNoIndex;
    return (
       <Head>
          {shouldNoIndex ? (

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -118,6 +118,7 @@ export async function findProductList(
          apiKey: algoliaApiKey,
       },
       wikiInfo: deviceWiki?.info || [],
+      forceNoIndex: !productList,
    };
 
    return {

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -62,6 +62,7 @@ export interface BaseProductList {
       apiKey: string;
    };
    wikiInfo: WikiInfoEntry[];
+   forceNoIndex: boolean;
 }
 
 interface AllPartsProductList extends BaseProductList {


### PR DESCRIPTION
We have pages like `/Parts/Mac_Laptop` with no corresponding Strapi
content. And pages like `/Parts/iBook_G3` whose Strapi content is
unpublished.

In both of those cases, we want to noindex the Collections page.

QA
---
- Check that collections that aren't in Strapi, or are unpublished noindexed.
- Check that I didn't accidentally noindex anything important

Closes #514