### PR TITLE
Fix multi line facet styling

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -104,6 +104,7 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
          _hover={{
             textDecoration: 'underline',
          }}
+         align="left"
       >
          {item.label}
       </Text>


### PR DESCRIPTION
When the facet title was very long, it did a weird wrapping thing and displayed itself. This PR fixes that.

## QA
For context this is how they were before

<img width="129" alt="Screenshot 2022-07-28 160926" src="https://user-images.githubusercontent.com/50181909/181652183-7c2e5233-231a-4e30-bbb2-a9ecce3dc87a.png">


This is how they look right now on main


<img width="137" alt="Screenshot 2022-07-28 160951" src="https://user-images.githubusercontent.com/50181909/181652205-d4af9b2b-5fcd-42f0-bc03-c6b1c35d6dfa.png">



This is how they look with the changes made in this PR


<img width="142" alt="Screenshot 2022-07-28 161020" src="https://user-images.githubusercontent.com/50181909/181652217-fe1703eb-efc7-4708-992a-e6b30a32555c.png">

Closes #530 

CC: @jeffsnyder