### PR TITLE
Images: Add custom loaders for Guide and Cart images

### DIFF
--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -6,6 +6,7 @@ interface SizeMapEntry {
 }
 type SizeMap = Array<SizeMapEntry>;
 
+// These should be sorted in order of ascending width.
 const guideImageSizeMap: SizeMap = [
    { name: 'mini', width: 56 },
    { name: 'thumbnail', width: 96 },

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -85,7 +85,8 @@ const cartImageSizeMap: SizeMap = {
 };
 
 const getImageSize = (width: number, sizeMap: SizeMap, defaultSize: string) => {
-   for (const [sizeName, size] of Object.entries(sizeMap)) {
+   const sortedSizes = Object.entries(sizeMap).sort((a, b) => a[1] - b[1]);
+   for (const [sizeName, size] of sortedSizes) {
       if (width < size) {
          return sizeName;
       }

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -32,16 +32,19 @@ const cartImageSizeMap: SizeMap = [
 
 export function IfixitImage(props: ImageProps) {
    let loader = props.loader;
+   let unoptimized = props.unoptimized;
 
    if (typeof props.src === 'string') {
       if (isGuideImage(props.src)) {
          loader = getImageLoader(guideImageSizeMap, 'huge');
       } else if (isCartImage(props.src)) {
          loader = getImageLoader(cartImageSizeMap, 'large');
+      } else if (isStrapiImage(props.src)) {
+         unoptimized = true;
       }
    }
 
-   return <Image {...props} loader={loader} />;
+   return <Image {...props} unoptimized={unoptimized} loader={loader} />;
 }
 
 function isGuideImage(src: string) {

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -52,38 +52,39 @@ const cartImageLoader: ImageLoader = ({
    quality,
 }: ImageLoaderProps) => {
    const baseSrc = src.replace(/\.[^/.]+$/, '');
-   const sizeName = getImageSize(width, cartImageSizeMap, 'size1000');
+   const sizeName = getImageSize(width, cartImageSizeMap, 'large');
    return baseSrc.concat('.', sizeName, `?width=${width}`);
 };
 
-type SizeMapEntry = [number, string];
-type SizeMap = Array<SizeMapEntry>;
+interface SizeMap {
+   [index: string]: number;
+}
 
-const guideImageSizeMap: SizeMap = [
-   [56, 'mini'],
-   [96, 'thumbnail'],
-   [140, '140x105'],
-   [200, '200x150'],
-   [300, 'standard'],
-   [440, '440x330'],
-   [592, 'medium'],
-   [800, 'large'],
-   [1600, 'huge'],
-];
+const guideImageSizeMap: SizeMap = {
+   mini: 56,
+   thumbnail: 96,
+   '140x105': 140,
+   '200x150': 200,
+   standard: 300,
+   '440x330': 440,
+   medium: 592,
+   large: 800,
+   huge: 1600,
+};
 
-const cartImageSizeMap: SizeMap = [
-   [41, 'mini'],
-   [70, 'thumbnail'],
-   [110, 'size110'],
-   [170, 'size170'],
-   [250, 'size250'],
-   [400, 'size400'],
-   [600, 'medium'],
-   [1000, 'size1000'],
-];
+const cartImageSizeMap: SizeMap = {
+   mini: 41,
+   thumbnail: 70,
+   size110: 110,
+   size170: 170,
+   size250: 250,
+   size400: 400,
+   medium: 600,
+   size1000: 1000,
+};
 
 const getImageSize = (width: number, sizeMap: SizeMap, defaultSize: string) => {
-   for (const [size, sizeName] of sizeMap) {
+   for (const [sizeName, size] of Object.entries(sizeMap)) {
       if (width < size) {
          return sizeName;
       }

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -8,7 +8,7 @@ export function IfixitImage(props: ImageProps) {
       if (isGuideImage(props.src)) {
          loader = guideImageLoader;
       } else if (isCartImage(props.src)) {
-         unoptimized = true;
+         loader = cartImageLoader;
       } else if (isStrapiImage(props.src)) {
          unoptimized = true;
       }
@@ -45,6 +45,16 @@ const guideImageLoader: ImageLoader = ({
    return baseSrc.concat('.', sizeName);
 };
 
+const cartImageLoader: ImageLoader = ({
+   src,
+   width,
+   quality,
+}: ImageLoaderProps) => {
+   const baseSrc = src.replace(/\.[^/.]+$/, '');
+   const sizeName = getImageSize(width, cartImageSizeMap, 'size1000');
+   return baseSrc.concat('.', sizeName);
+};
+
 type SizeMapEntry = [number, string];
 type SizeMap = Array<SizeMapEntry>;
 
@@ -58,6 +68,17 @@ const guideImageSizeMap: SizeMap = [
    [592, 'medium'],
    [800, 'large'],
    [1600, 'huge'],
+];
+
+const cartImageSizeMap: SizeMap = [
+   [41, 'mini'],
+   [70, 'thumbnail'],
+   [110, 'size110'],
+   [170, 'size170'],
+   [250, 'size250'],
+   [400, 'size400'],
+   [600, 'medium'],
+   [1000, 'size1000'],
 ];
 
 const getImageSize = (width: number, sizeMap: SizeMap, defaultSize: string) => {

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -1,20 +1,17 @@
 import Image, { ImageProps, ImageLoader, ImageLoaderProps } from 'next/image';
 
 export function IfixitImage(props: ImageProps) {
-   const unoptimized = props.unoptimized;
-   let loader;
+   let loader = props.loader;
 
    if (typeof props.src === 'string') {
       if (isGuideImage(props.src)) {
          loader = guideImageLoader;
       } else if (isCartImage(props.src)) {
          loader = cartImageLoader;
-      } else if (isStrapiImage(props.src)) {
-         // Use default loader unless unoptimized
       }
    }
 
-   return <Image {...props} unoptimized={unoptimized} loader={loader} />;
+   return <Image {...props} loader={loader} />;
 }
 
 function isGuideImage(src: string) {

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -1,7 +1,7 @@
 import Image, { ImageProps, ImageLoader, ImageLoaderProps } from 'next/image';
 
 export function IfixitImage(props: ImageProps) {
-   let unoptimized = props.unoptimized;
+   const unoptimized = props.unoptimized;
    let loader;
 
    if (typeof props.src === 'string') {
@@ -10,7 +10,7 @@ export function IfixitImage(props: ImageProps) {
       } else if (isCartImage(props.src)) {
          loader = cartImageLoader;
       } else if (isStrapiImage(props.src)) {
-         unoptimized = true;
+         // Use default loader unless unoptimized
       }
    }
 

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -1,32 +1,34 @@
 import Image, { ImageProps, ImageLoader, ImageLoaderProps } from 'next/image';
 
-interface SizeMap {
-   [index: string]: number;
+interface SizeMapEntry {
+   width: number;
+   name: string;
 }
+type SizeMap = Array<SizeMapEntry>;
 
-const guideImageSizeMap: SizeMap = {
-   mini: 56,
-   thumbnail: 96,
-   '140x105': 140,
-   '200x150': 200,
-   standard: 300,
-   '440x330': 440,
-   medium: 592,
-   large: 800,
-   huge: 1600,
-};
+const guideImageSizeMap: SizeMap = [
+   { name: 'mini', width: 56 },
+   { name: 'thumbnail', width: 96 },
+   { name: '140x105', width: 140 },
+   { name: '200x150', width: 200 },
+   { name: 'standard', width: 300 },
+   { name: '440x330', width: 440 },
+   { name: 'medium', width: 592 },
+   { name: 'large', width: 800 },
+   { name: 'huge', width: 1600 },
+];
 
-const cartImageSizeMap: SizeMap = {
-   mini: 41,
-   thumbnail: 70,
-   size110: 110,
-   size170: 170,
-   size250: 250,
-   size400: 400,
-   medium: 600,
-   size1000: 1000,
-   large: 3000,
-};
+const cartImageSizeMap: SizeMap = [
+   { name: 'mini', width: 41 },
+   { name: 'thumbnail', width: 70 },
+   { name: 'size110', width: 110 },
+   { name: 'size170', width: 170 },
+   { name: 'size250', width: 250 },
+   { name: 'size400', width: 400 },
+   { name: 'medium', width: 600 },
+   { name: 'size1000', width: 1000 },
+   { name: 'large', width: 3000 },
+];
 
 export function IfixitImage(props: ImageProps) {
    let loader = props.loader;
@@ -74,10 +76,9 @@ function getImageSize(
    sizeMap: SizeMap,
    defaultSize: string
 ): string {
-   const sortedSizes = Object.entries(sizeMap).sort((a, b) => a[1] - b[1]);
-   for (const [sizeName, size] of sortedSizes) {
-      if (width < size) {
-         return sizeName;
+   for (const size of sizeMap) {
+      if (width < size.width) {
+         return size.name;
       }
    }
    return defaultSize;

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -1,5 +1,33 @@
 import Image, { ImageProps, ImageLoader, ImageLoaderProps } from 'next/image';
 
+interface SizeMap {
+   [index: string]: number;
+}
+
+const guideImageSizeMap: SizeMap = {
+   mini: 56,
+   thumbnail: 96,
+   '140x105': 140,
+   '200x150': 200,
+   standard: 300,
+   '440x330': 440,
+   medium: 592,
+   large: 800,
+   huge: 1600,
+};
+
+const cartImageSizeMap: SizeMap = {
+   mini: 41,
+   thumbnail: 70,
+   size110: 110,
+   size170: 170,
+   size250: 250,
+   size400: 400,
+   medium: 600,
+   size1000: 1000,
+   large: 3000,
+};
+
 export function IfixitImage(props: ImageProps) {
    let loader = props.loader;
 
@@ -40,34 +68,6 @@ function getImageLoader(sizeMap: SizeMap, defaultSize: string): ImageLoader {
       return baseSrc.concat('.', sizeName, `?width=${width}`);
    };
 }
-
-interface SizeMap {
-   [index: string]: number;
-}
-
-const guideImageSizeMap: SizeMap = {
-   mini: 56,
-   thumbnail: 96,
-   '140x105': 140,
-   '200x150': 200,
-   standard: 300,
-   '440x330': 440,
-   medium: 592,
-   large: 800,
-   huge: 1600,
-};
-
-const cartImageSizeMap: SizeMap = {
-   mini: 41,
-   thumbnail: 70,
-   size110: 110,
-   size170: 170,
-   size250: 250,
-   size400: 400,
-   medium: 600,
-   size1000: 1000,
-   large: 3000,
-};
 
 const getImageSize = (width: number, sizeMap: SizeMap, defaultSize: string) => {
    const sortedSizes = Object.entries(sizeMap).sort((a, b) => a[1] - b[1]);

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -81,6 +81,7 @@ const cartImageSizeMap: SizeMap = {
    size400: 400,
    medium: 600,
    size1000: 1000,
+   large: 3000,
 };
 
 const getImageSize = (width: number, sizeMap: SizeMap, defaultSize: string) => {

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -5,9 +5,9 @@ export function IfixitImage(props: ImageProps) {
 
    if (typeof props.src === 'string') {
       if (isGuideImage(props.src)) {
-         loader = guideImageLoader;
+         loader = getImageLoader(guideImageSizeMap, 'huge');
       } else if (isCartImage(props.src)) {
-         loader = cartImageLoader;
+         loader = getImageLoader(cartImageSizeMap, 'large');
       }
    }
 
@@ -32,26 +32,14 @@ function isStrapiImage(src: string) {
    );
 }
 
-const guideImageLoader: ImageLoader = ({
-   src,
-   width,
-   quality,
-}: ImageLoaderProps) => {
-   const baseSrc = src.replace(/\.[^/.]+$/, '');
-   const sizeName = getImageSize(width, guideImageSizeMap, 'huge');
-   // We don't use the ?width param server-side, but it gets rid of a nextjs warning
-   return baseSrc.concat('.', sizeName, `?width=${width}`);
-};
-
-const cartImageLoader: ImageLoader = ({
-   src,
-   width,
-   quality,
-}: ImageLoaderProps) => {
-   const baseSrc = src.replace(/\.[^/.]+$/, '');
-   const sizeName = getImageSize(width, cartImageSizeMap, 'large');
-   return baseSrc.concat('.', sizeName, `?width=${width}`);
-};
+function getImageLoader(sizeMap: SizeMap, defaultSize: string): ImageLoader {
+   return ({ src, width }: ImageLoaderProps) => {
+      const baseSrc = src.replace(/\.[^/.]+$/, '');
+      const sizeName = getImageSize(width, sizeMap, defaultSize);
+      // We don't use the ?width param server-side, but it gets rid of a nextjs warning
+      return baseSrc.concat('.', sizeName, `?width=${width}`);
+   };
+}
 
 interface SizeMap {
    [index: string]: number;

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -42,7 +42,8 @@ const guideImageLoader: ImageLoader = ({
 }: ImageLoaderProps) => {
    const baseSrc = src.replace(/\.[^/.]+$/, '');
    const sizeName = getImageSize(width, guideImageSizeMap, 'huge');
-   return baseSrc.concat('.', sizeName);
+   // We don't use the ?width param server-side, but it gets rid of a nextjs warning
+   return baseSrc.concat('.', sizeName, `?width=${width}`);
 };
 
 const cartImageLoader: ImageLoader = ({
@@ -52,7 +53,7 @@ const cartImageLoader: ImageLoader = ({
 }: ImageLoaderProps) => {
    const baseSrc = src.replace(/\.[^/.]+$/, '');
    const sizeName = getImageSize(width, cartImageSizeMap, 'size1000');
-   return baseSrc.concat('.', sizeName);
+   return baseSrc.concat('.', sizeName, `?width=${width}`);
 };
 
 type SizeMapEntry = [number, string];

--- a/frontend/components/ifixit-image/ifixit-image.tsx
+++ b/frontend/components/ifixit-image/ifixit-image.tsx
@@ -69,7 +69,11 @@ function getImageLoader(sizeMap: SizeMap, defaultSize: string): ImageLoader {
    };
 }
 
-const getImageSize = (width: number, sizeMap: SizeMap, defaultSize: string) => {
+function getImageSize(
+   width: number,
+   sizeMap: SizeMap,
+   defaultSize: string
+): string {
    const sortedSizes = Object.entries(sizeMap).sort((a, b) => a[1] - b[1]);
    for (const [sizeName, size] of sortedSizes) {
       if (width < size) {
@@ -77,4 +81,4 @@ const getImageSize = (width: number, sizeMap: SizeMap, defaultSize: string) => {
       }
    }
    return defaultSize;
-};
+}


### PR DESCRIPTION
Add custom loaders for Guide and Cart images that load the smallest size larger than the required width for the image.

CR
---
I was torn on whether or not to deduplicate the logic between `guideImageLoader` and `cartImageLoader`. Ultimately I decided that doing so would add too much complexity for two 3-line functions.

~~I turned on optimizations for Strapi images using the default loader based on this comment: https://github.com/iFixit/react-commerce/issues/361#issuecomment-1178375740~~

QA
---
Guide and Cart images should now have a `srcset` to allow loading of larger sizes only when needed.
~~Strapi images now use the default Next.js image loader.~~ Strapi images are unchanged.
I'm not sure how to test Strapi images on local dev, but please do so.

Closes: #361 