### PR TITLE
Have findProductList() Make Async Calls in Parallel.

### DIFF
--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -7,6 +7,9 @@ export async function fetchDeviceWiki(
 ): Promise<DeviceWiki | null> {
    const deviceHandle = getDeviceHandle(deviceTitle);
    try {
+      if(!deviceHandle) {
+         throw new Error(`deviceHandle cannot be a blank string!`);
+      }
       const response = await fetch(
          `${IFIXIT_ORIGIN}/api/2.0/cart/part_collections/devices/${deviceHandle}`,
          {

--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -1,4 +1,5 @@
 import { IFIXIT_ORIGIN } from '@config/env';
+import { invariant } from '@ifixit/helpers';
 
 export type DeviceWiki = Record<string, any>;
 
@@ -7,9 +8,7 @@ export async function fetchDeviceWiki(
 ): Promise<DeviceWiki | null> {
    const deviceHandle = getDeviceHandle(deviceTitle);
    try {
-      if(!deviceHandle) {
-         throw new Error(`deviceHandle cannot be a blank string!`);
-      }
+      invariant(deviceHandle.length > 0, "deviceHandle cannot be a blank string");
       const response = await fetch(
          `${IFIXIT_ORIGIN}/api/2.0/cart/part_collections/devices/${deviceHandle}`,
          {

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -49,13 +49,12 @@ export async function findProductList(
 ): Promise<ProductList | null> {
    const deviceTitle = filters.deviceTitle?.eq ?? '';
 
-   const [result, deviceWiki] =
-      await Promise.all([
-         strapi.getProductList({
-            filters,
-         }),
-         fetchDeviceWiki(deviceTitle)
-      ]);
+   const [result, deviceWiki] = await Promise.all([
+      strapi.getProductList({
+         filters,
+      }),
+      fetchDeviceWiki(deviceTitle),
+   ]);
    const productList = result.productLists?.data?.[0]?.attributes;
 
    if (productList == null && deviceWiki == null) {

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -47,15 +47,16 @@ export type {
 export async function findProductList(
    filters: ProductListFiltersInput
 ): Promise<ProductList | null> {
-   const result = await strapi.getProductList({
-      filters,
-   });
+   const deviceTitle = filters.deviceTitle?.eq ?? '';
 
+   const [result, deviceWiki] =
+      await Promise.all([
+         strapi.getProductList({
+            filters,
+         }),
+         fetchDeviceWiki(deviceTitle)
+      ]);
    const productList = result.productLists?.data?.[0]?.attributes;
-
-   const deviceTitle =
-      productList?.deviceTitle ?? filters.deviceTitle?.eq ?? '';
-   const deviceWiki = deviceTitle ? await fetchDeviceWiki(deviceTitle) : null;
 
    if (productList == null && deviceWiki == null) {
       return null;


### PR DESCRIPTION
## Overview
Before, we had a call to strapi and a conditional call to iFixit API afterwards. This makes it so the two requests are done at the same time so we can cut out the overhead of the faster request. This should make the two calls take less time overall as one is not conditional on the other and they are practically always both called anyway.

## CR
Pretty simple

## QA
Do product lists still load? Are they any faster? I've found a slight improvement when running locally (~60 ms speed up) but couldn't find that same performance gain in lighthouse for whatever reason.

Closes: #525