### PR TITLE
Fix SSR for item type product lists

### DIFF
--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -34,7 +34,7 @@ export function MetaTags({ productList }: MetaTagsProps) {
       title += ` - Page ${page}`;
    }
    title += ' | iFixit';
-   const itemTypeHandle = `/${encodeDeviceItemType(itemType ?? '')}`;
+   const itemTypeHandle = itemType ? `/${encodeDeviceItemType(itemType)}` : '';
    const canonicalUrl = `${appContext.ifixitOrigin}${
       productList.path
    }${itemTypeHandle}${page > 1 ? `?${PRODUCT_LIST_PAGE_PARAM}=${page}` : ''}`;

--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -28,18 +28,13 @@ export function MetaTags({ productList }: MetaTagsProps) {
       refinementAttributes.length === 1 &&
       refinementAttributes[0] === 'facet_tags.Item Type';
    const isFiltered = currentRefinements.items.length > 0 && !isItemTypeFilter;
-   // Use the original device item type on the server.
-   const algoliaDeviceItemType = useDevicePartsItemType(productList);
-   const itemType =
-      typeof window === 'undefined' && productList.deviceItemType
-         ? encodeDeviceItemType(productList.deviceItemType)
-         : encodeDeviceItemType(algoliaDeviceItemType ?? '');
+   const itemType = useDevicePartsItemType(productList);
    let title = getProductListTitle(productList, itemType);
    if (!isFiltered && page > 1) {
       title += ` - Page ${page}`;
    }
    title += ' | iFixit';
-   const itemTypeHandle = itemType ? `/${itemType}` : '';
+   const itemTypeHandle = `/${encodeDeviceItemType(itemType ?? '')}`;
    const canonicalUrl = `${appContext.ifixitOrigin}${
       productList.path
    }${itemTypeHandle}${page > 1 ? `?${PRODUCT_LIST_PAGE_PARAM}=${page}` : ''}`;

--- a/frontend/components/product-list/sections/FilterableProductsSection/useDevicePartsItemType.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useDevicePartsItemType.tsx
@@ -4,6 +4,7 @@ import { useCurrentRefinements } from 'react-instantsearch-hooks-web';
 
 type ProductListAttributes = {
    type?: ProductListType | null;
+   deviceItemType?: string | null;
 };
 
 export function useDevicePartsItemType<T extends ProductListAttributes>(
@@ -17,6 +18,10 @@ export function useDevicePartsItemType<T extends ProductListAttributes>(
       // `Item Type` is a single select, so just use the first value if it exists.
       return itemTypeRefinement?.refinements[0]?.value;
    }, [items]);
+   if (typeof window === 'undefined') {
+      // Use the device item type from the slug on the server.
+      return productList.deviceItemType ?? undefined;
+   }
    if (!itemType || productList.type !== ProductListType.DeviceParts) {
       return undefined;
    }


### PR DESCRIPTION
Modifies the `useDevicePartsItemType()` hook to use the item type from the slug on the server.

## Background

Algolia's `useCurrentRefinements()` hook doesn't include the 'Item Type' filter on page load, even when we visit an item type page like /Parts/iPhone/Batteries. This is unexpected because we explicitly add the 'Item Type' to the current UIState in the InstantSearchProvider. This approach is a workaround for this unexpected behavior.

Uses the fix in https://github.com/iFixit/react-commerce/pull/527 everywhere else.

## QA

A smoke test of the app. Notably, when you visit item type pages directly, you shouldn't see a flash of unfiltered results before the page finishes loading and you shouldn't see the "Parts" version of the title flash.

CC @sterlinghirsh @dhmacs 

Closes #531 