### PR TITLE
Use `metaTitle` from Strapi

### DIFF
--- a/frontend/components/product-list/MetaTags.tsx
+++ b/frontend/components/product-list/MetaTags.tsx
@@ -30,7 +30,8 @@ export function MetaTags({ productList }: MetaTagsProps) {
       refinementAttributes[0] === 'facet_tags.Item Type';
    const isFiltered = currentRefinements.items.length > 0 && !isItemTypeFilter;
    const itemType = useDevicePartsItemType(productList);
-   let title = getProductListTitle(productList, itemType);
+   let title =
+      productList.metaTitle || getProductListTitle(productList, itemType);
    if (!isFiltered && page > 1) {
       title += ` - Page ${page}`;
    }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -1512,6 +1512,7 @@ export type GetProductListQuery = {
             tagline?: Maybe<string>;
             description: string;
             metaDescription?: Maybe<string>;
+            metaTitle?: Maybe<string>;
             filters?: Maybe<string>;
             childrenHeading?: Maybe<string>;
             image?: Maybe<{
@@ -2669,6 +2670,7 @@ export const GetProductListDocument = `
         tagline
         description
         metaDescription
+        metaTitle
         filters
         image {
           data {

--- a/frontend/lib/strapi-sdk/operations/getProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/getProductList.graphql
@@ -14,6 +14,7 @@ query getProductList($filters: ProductListFiltersInput) {
             tagline
             description
             metaDescription
+            metaTitle
             filters
             image {
                data {

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -97,6 +97,7 @@ export async function findProductList(
       tagline: productList?.tagline ?? null,
       description: description,
       metaDescription: productList?.metaDescription ?? null,
+      metaTitle: productList?.metaTitle ?? null,
       filters: productList?.filters ?? null,
       image: null,
       ancestors,

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -53,6 +53,7 @@ export interface BaseProductList {
    tagline: string | null;
    description: string;
    metaDescription: string | null;
+   metaTitle: string | null;
    filters: string | null;
    image: ProductListImage | null;
    ancestors: ProductListAncestor[];


### PR DESCRIPTION
Uses the `metaTitle` field in the `<title>` of the `<head>`, and nowhere else on the page. This field was added to Strapi in https://github.com/iFixit/react-commerce/pull/550.

## QA
Pages with a value in `metaTitle` should have the value in the `<title>` tag, otherwise it should default to the normal device title. You can edit the `metaTitle` in Strapi here: https://collections--add-meta-title-to-strapi.govinor.com/admin

Closes #539 