### PR TITLE
Facets: Drop `device` facet

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -43,7 +43,7 @@ export function useFilteredFacets(productList: ProductList) {
       const usefulFacets = facets
          .slice()
          .filter((facet) => {
-            return !infoNames.has(facet);
+            return facet !== 'device' && !infoNames.has(facet);
          })
          .sort(sortBy);
       return usefulFacets;


### PR DESCRIPTION
We think there are too many device options too be helpful as a facet. We still want device to be searchable, so we'll keep indexing it in Algolia.

CC @jeffsnyder @sterlinghirsh 

Closes #553 
Closes #536