### PR TITLE
Redirect Device Pages If Capitalization Isn't Right

### DIFF
--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -56,13 +56,13 @@ export async function findProductList(
       }),
       fetchDeviceWiki(filterDeviceTitle),
    ]);
-   const productList = result.productLists?.data?.[0]?.attributes;
 
+   const productList = result.productLists?.data?.[0]?.attributes;
    if (productList == null && deviceWiki == null) {
       return null;
    }
 
-   const deviceTitle = productList?.deviceTitle ?? filterDeviceTitle;
+   const deviceTitle = deviceWiki?.deviceTitle ?? productList?.deviceTitle;
    const handle = productList?.handle ?? '';
    const parents =
       productList?.parent ??

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -65,7 +65,7 @@ export async function findProductList(
       return null;
    }
 
-   const deviceTitle = deviceWiki?.deviceTitle ?? productList?.deviceTitle;
+   const deviceTitle = deviceWiki?.deviceTitle ?? productList?.deviceTitle ?? null;
    const handle = productList?.handle ?? '';
    const parents =
       productList?.parent ??


### PR DESCRIPTION
## Overview
This got super easy after #556 
We want to now 1.) handle iFixit only devices (ghost devices) redirect to the correct capitalization 2.) prioritize iFixit's capitalization over Strapi's. This will make it easier to link from iFixit to the store so they don't have to check strapi for the official url, etc.

## QA
While testing watch out for permanent redirecting (308s and the like). You may have to clear your browsers cache (or in the code change the `[...deviceHandleItemType].tsx` redirect calls permanent attribute to false)
You should test an device not in strapi (`/Phone` is what I use) and make sure that even if you mess around with the capitalization it reroutes back to the correct URL. Also make sure that iFixit data is prioritized over strapi's, so maybe change some local strapi data to be miscapitalized and then make sure the iFixit data is used instead.

Closes: #571