### PR TITLE
Revert #341: Cache for only 10 sec, not 10 min

### DIFF
--- a/frontend/pages/Parts/[...deviceHandleItemType].tsx
+++ b/frontend/pages/Parts/[...deviceHandleItemType].tsx
@@ -30,7 +30,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 ) => {
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=600, stale-while-revalidate=1200'
+      'public, s-maxage=10, stale-while-revalidate=600'
    );
 
    const { deviceHandleItemType } = context.params || {};

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -25,7 +25,7 @@ const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
 ) => {
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=600, stale-while-revalidate=1200'
+      'public, s-maxage=10, stale-while-revalidate=600'
    );
 
    const [globalSettings, stores, currentStore, productList] = await logAsync(

--- a/frontend/pages/Shop/[handle].tsx
+++ b/frontend/pages/Shop/[handle].tsx
@@ -25,7 +25,7 @@ const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
 ) => {
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=600, stale-while-revalidate=1200'
+      'public, s-maxage=10, stale-while-revalidate=600'
    );
 
    const { handle } = context.params || {};

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 ) => {
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=600, stale-while-revalidate=1200'
+      'public, s-maxage=10, stale-while-revalidate=600'
    );
 
    const { handle } = context.params || {};

--- a/frontend/pages/Tools/index.tsx
+++ b/frontend/pages/Tools/index.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 ) => {
    context.res.setHeader(
       'Cache-Control',
-      'public, s-maxage=600, stale-while-revalidate=1200'
+      'public, s-maxage=10, stale-while-revalidate=600'
    );
 
    const [globalSettings, stores, currentStore, productList] =


### PR DESCRIPTION
We were setting the max age of the cache to 10 min when we were on Cloudfront because Cloudfront doesn't respect the SWR header.

Now that we're on Vercel, we can drop max age back to 10 seconds and set a 10 minute SWR.

https://vercel.com/docs/concepts/edge-network/caching#serverless-functions---lambdas

## QA

Not sure that we need it here?

## Background

Motivation: https://github.com/iFixit/react-commerce/pull/551#issuecomment-1203982043
#341

CC @danielbeardsley @dhmacs 
qa_req 0