### PR TITLE
Filter bubble: Fix for single select

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -19,6 +19,8 @@ import { FacetFilter } from './FacetFilter';
 import { useCountRefinements } from './useCountRefinements';
 import { MAX_VALUES_PER_FACET, useFilteredFacets } from './useFacets';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
+import { RefinementDisplayType } from '@models/product-list/types';
+import { getRefinementDisplayType } from '@helpers/product-list-helpers';
 
 type FacetsAccordianProps = {
    productList: ProductList;
@@ -114,6 +116,10 @@ export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
          isWorksin ||
          isToolCategoryOnPartsPage;
 
+      const isSingleSelectFacet =
+         getRefinementDisplayType(attribute) ===
+         RefinementDisplayType.SingleSelect;
+
       return (
          <AccordionItem
             ref={ref}
@@ -137,7 +143,10 @@ export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
                   {formattedFacetName}
                </Box>
                <HStack>
-                  {refinedCount > 0 && (
+                  {isSingleSelectFacet && refinedCount && (
+                     <Box w="2" h="2" borderRadius="full" bg="brand.500"></Box>
+                  )}
+                  {!isSingleSelectFacet && refinedCount > 0 && (
                      <Text
                         rounded="full"
                         bg="gray.600"

--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
@@ -26,6 +26,8 @@ import { FacetFilter } from './FacetFilter';
 import { useCountRefinements } from './useCountRefinements';
 import { MAX_VALUES_PER_FACET, useFilteredFacets } from './useFacets';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
+import { RefinementDisplayType } from '@models/product-list/types';
+import { getRefinementDisplayType } from '@helpers/product-list-helpers';
 
 type FacetsDrawerProps = {
    isOpen: boolean;
@@ -269,6 +271,10 @@ function FacetListItem({
       return null;
    }
 
+   const isSingleSelectFacet =
+      getRefinementDisplayType(attribute) ===
+      RefinementDisplayType.SingleSelect;
+
    return (
       <Box pl="4" onClick={() => onSelect(attribute)}>
          <Flex py="4" pl="1.5" justify="space-between" align="center" pr="4">
@@ -276,7 +282,10 @@ function FacetListItem({
                {formatFacetName(attribute)}
             </Text>
             <HStack>
-               {refinedCount > 0 && (
+               {isSingleSelectFacet && refinedCount && (
+                  <Box w="2" h="2" borderRadius="full" bg="brand.500"></Box>
+               )}
+               {!isSingleSelectFacet && refinedCount > 0 && (
                   <Text
                      rounded="full"
                      bg="gray.600"


### PR DESCRIPTION
Previously, we displayed the `1` bubble when we had a facet select for the [single select facet categories](https://github.com/iFixit/react-commerce/pull/476). We don't want that anymore because in case of single select that number will always be a 1. Instead we want something of this sort:
<img width="190" alt="Screenshot 2022-08-03 112849" src="https://user-images.githubusercontent.com/50181909/182682494-82d75bca-45c7-473f-a2f0-b2c962f9f344.png">

## QA
- We only want this for single select facet categories [ie everything except for `Capacity` and `Price Range`].
   -  `Capacity` and `Price Range` should still display the count as before when the options under these categories are selected [where count = # of options selected]
- Visit the preview
- Make sure the blue bubble [refer screenshot] is visible when we select an option for single select categories on desktop and mobile
- Price Range and Capacity should still display the number

Closes #522 

CC: @masonmcelvain  
