### PR TITLE
Fix Images and Part Collections API calls

### DIFF
--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -13,14 +13,7 @@ export async function fetchDeviceWiki(
          deviceHandle.length > 0,
          'deviceHandle cannot be a blank string'
       );
-      const response = await client.get(
-         `cart/part_collections/devices/${deviceHandle}`
-      );
-      if (!response.ok) {
-         return null;
-      }
-      const payload = await response.json();
-      return response.ok ? payload : null;
+      return await client.get(`cart/part_collections/devices/${deviceHandle}`);
    } catch (error: any) {
       return null;
    }
@@ -53,7 +46,6 @@ export function fetchMultipleDeviceImages(
    });
    return client
       .get(`wikis/topic_images?` + params.toString())
-      .then((response) => response.json())
       .catch(() => ({ images: {} }));
 }
 

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -32,9 +32,7 @@ export function useAuthenticatedUser() {
 async function fetchAuthenticatedUser(
    apiClient: IFixitAPIClient
 ): Promise<User | null> {
-   const response = await apiClient.get('user');
-
-   const payload = await response.json();
+   const payload = await apiClient.get('user');
    invariant(isRecord(payload), 'unexpected api response');
    invariant(typeof payload.userid === 'number', 'User ID is not a number');
    invariant(


### PR DESCRIPTION
## Overview

We introduced logs in #457, and this makes sure that the places that use `iFixtAPIClient` now can handle the response's format. Before our failures were basically nulling out and thus making it so no information gotten from the api was being used in the pages. This makes sure that we expect the appropriate data formats so we don't default to nulls.

## CR

Uh I think this should work but make sure that nothing I'm doing is funky. You know, the usual.

## QA
Make sure the normal pages work and load the pictures for the children again. Also make sure that pages that aren't in strapi are loading correctly from the iFixit API and stuff. You can use `Asus_Phone` and `Phone` for this. 
You also need to test authenticating a user in react-commerce.

Closes: #577