### PR TITLE
Subscribed: Hide the text box

### DIFF
--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -304,7 +304,7 @@ function NewsletterForm({
                         position={'absolute'}
                         top="2"
                         left="0"
-                        right="0"
+                        right="5"
                      >
                         <Icon as={RiCheckFill} boxSize="5" mb="-5px" mr="6px" />
                         Subscribed!

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -310,22 +310,26 @@ function NewsletterForm({
                         Subscribed!
                      </Text>
                   )}
-                  <Button
-                     width="50%"
-                     type="submit"
-                     data-testid="footer-newsletter-subscribe-button"
-                     isLoading={
-                        subscription.status === SubscriptionStatus.Subscribing
-                     }
-                     disabled={subscription.status !== SubscriptionStatus.Idle}
-                     colorScheme="brand"
-                     visibility={isSubscribed ? 'hidden' : undefined}
-                  >
-                     {subscribeLabel}
-                  </Button>
                </HStack>
                <FormErrorMessage>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
+            <Button
+               width="50%"
+               type="submit"
+               data-testid="footer-newsletter-subscribe-button"
+               isLoading={
+                  subscription.status === SubscriptionStatus.Subscribing
+               }
+               disabled={subscription.status !== SubscriptionStatus.Idle}
+               colorScheme="brand"
+               visibility={isSubscribed ? 'hidden' : undefined}
+               display={{
+                  base: isSubscribed ? 'none' : undefined,
+                  xl: 'block',
+               }}
+            >
+               {subscribeLabel}
+            </Button>
          </FooterNewsletterForm>
       </FooterNewsletter>
    );

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -2,9 +2,11 @@ import noImageFixie from '@assets/images/no-image-fixie.jpeg';
 import {
    Button,
    FormErrorMessage,
+   HStack,
    Icon,
    Menu,
    MenuList,
+   position,
    Text,
 } from '@chakra-ui/react';
 import {
@@ -274,8 +276,8 @@ function NewsletterForm({
       [subscribe]
    );
 
-   const subscribeDirection =
-      subscription.status !== SubscriptionStatus.Subscribed ? 'row' : 'column';
+   const isSubscribed = subscription.status === SubscriptionStatus.Subscribed;
+
    return (
       <FooterNewsletter>
          <FooterNewsletterCopy>

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -319,7 +319,7 @@ function NewsletterForm({
                      colorScheme="brand"
                      visibility={isSubscribed ? 'hidden' : undefined}
                   >
-                     Subscribe
+                     {subscribeLabel}
                   </Button>
                </HStack>
                <FormErrorMessage>{subscription.error}</FormErrorMessage>

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -286,50 +286,44 @@ function NewsletterForm({
                {description}
             </FooterNewsletterDescription>
          </FooterNewsletterCopy>
-         <FooterNewsletterForm
-            onSubmit={onSubscribe}
-            direction={{ base: subscribeDirection, xl: 'row' }}
-         >
+         <FooterNewsletterForm onSubmit={onSubscribe}>
             <FooterNewsletterFormControl isInvalid={subscription.error != null}>
                <FooterNewsletterEmailLabel>
                   Enter your email
                </FooterNewsletterEmailLabel>
-               <FooterNewsletterEmailInput
-                  ref={inputRef}
-                  disabled={subscription.status !== SubscriptionStatus.Idle}
-                  placeholder={emailPlaceholder}
-                  hidden={subscription.status === SubscriptionStatus.Subscribed}
-               />
-               {subscription.status === SubscriptionStatus.Subscribed && (
-                  <Text align="center">
-                     <Icon as={RiCheckFill} boxSize="5" mb="-5px" />
-                     Subscribed!
-                  </Text>
-               )}
+               <HStack>
+                  <FooterNewsletterEmailInput
+                     ref={inputRef}
+                     disabled={subscription.status !== SubscriptionStatus.Idle}
+                     placeholder={emailPlaceholder}
+                     hidden={isSubscribed}
+                  />
+                  {isSubscribed && (
+                     <Text
+                        align="center"
+                        position={'absolute'}
+                        top="2"
+                        left="0"
+                        right="0"
+                     >
+                        <Icon as={RiCheckFill} boxSize="5" mb="-5px" mr="6px" />
+                        Subscribed!
+                     </Text>
+                  )}
+                  <Button
+                     type="submit"
+                     isLoading={
+                        subscription.status === SubscriptionStatus.Subscribing
+                     }
+                     disabled={subscription.status !== SubscriptionStatus.Idle}
+                     colorScheme="brand"
+                     visibility={isSubscribed ? 'hidden' : undefined}
+                  >
+                     Subscribe
+                  </Button>
+               </HStack>
                <FormErrorMessage>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
-            <Button
-               type="submit"
-               height={
-                  subscription.status === SubscriptionStatus.Subscribed
-                     ? 0
-                     : '40px'
-               }
-               isLoading={
-                  subscription.status === SubscriptionStatus.Subscribing
-               }
-               disabled={subscription.status !== SubscriptionStatus.Idle}
-               colorScheme="brand"
-               visibility={
-                  subscription.status === SubscriptionStatus.Subscribed
-                     ? 'hidden'
-                     : undefined
-               }
-            >
-               {subscription.status !== SubscriptionStatus.Subscribed
-                  ? subscribeLabel
-                  : 'Subscribe'}
-            </Button>
          </FooterNewsletterForm>
       </FooterNewsletter>
    );

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -310,8 +310,8 @@ function NewsletterForm({
                         Subscribed!
                      </Text>
                   )}
-                  <FormErrorMessage>{subscription.error}</FormErrorMessage>
                </HStack>
+               <FormErrorMessage>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
             <Button
                width="50%"

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -247,6 +247,38 @@ export function LayoutFooter({
    );
 }
 
+export interface FooterNewsletterOnSubscribeProps {
+   title: string;
+   description: string;
+   isSubscribed: boolean;
+}
+
+function FooterNewsletterOnSubscribe({
+   title,
+   description,
+   isSubscribed,
+}: FooterNewsletterOnSubscribeProps) {
+   if (isSubscribed) {
+      return (
+         <FooterNewsletterCopy paddingRight={{ xl: '114.15px' }}>
+            <FooterNewsletterTitle>{title}</FooterNewsletterTitle>
+            <FooterNewsletterDescription>
+               {description}
+            </FooterNewsletterDescription>
+         </FooterNewsletterCopy>
+      );
+   } else {
+      return (
+         <FooterNewsletterCopy>
+            <FooterNewsletterTitle>{title}</FooterNewsletterTitle>
+            <FooterNewsletterDescription>
+               {description}
+            </FooterNewsletterDescription>
+         </FooterNewsletterCopy>
+      );
+   }
+}
+
 export interface NewsletterFormProps {
    title: string;
    description: string;
@@ -276,12 +308,11 @@ function NewsletterForm({
 
    return (
       <FooterNewsletter>
-         <FooterNewsletterCopy>
-            <FooterNewsletterTitle>{title}</FooterNewsletterTitle>
-            <FooterNewsletterDescription>
-               {description}
-            </FooterNewsletterDescription>
-         </FooterNewsletterCopy>
+         <FooterNewsletterOnSubscribe
+            title={title}
+            description={description}
+            isSubscribed={subscription.status === SubscriptionStatus.Subscribed}
+         />
          <FooterNewsletterForm onSubmit={onSubscribe}>
             <FooterNewsletterFormControl isInvalid={subscription.error != null}>
                <FooterNewsletterEmailLabel>
@@ -306,7 +337,6 @@ function NewsletterForm({
                isLoading={
                   subscription.status === SubscriptionStatus.Subscribing
                }
-               loadingText="Subscribing"
                disabled={subscription.status !== SubscriptionStatus.Idle}
                hidden={subscription.status === SubscriptionStatus.Subscribed}
                flexShrink={0}

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -286,32 +286,18 @@ function NewsletterForm({
                {description}
             </FooterNewsletterDescription>
          </FooterNewsletterCopy>
-         <FooterNewsletterForm onSubmit={onSubscribe}>
+         <FooterNewsletterForm onSubmit={onSubscribe} position="relative">
             <FooterNewsletterFormControl isInvalid={subscription.error != null}>
                <FooterNewsletterEmailLabel hidden={isSubscribed}>
                   Enter your email
                </FooterNewsletterEmailLabel>
-               <HStack>
-                  <FooterNewsletterEmailInput
-                     ref={inputRef}
-                     disabled={subscription.status !== SubscriptionStatus.Idle}
-                     placeholder={emailPlaceholder}
-                     visibility={isSubscribed ? 'hidden' : 'visible'}
-                  />
-                  {isSubscribed && (
-                     <Text
-                        align="center"
-                        position={'absolute'}
-                        top="2"
-                        left="0"
-                        right="5"
-                     >
-                        <Icon as={RiCheckFill} boxSize="5" mb="-5px" mr="6px" />
-                        Subscribed!
-                     </Text>
-                  )}
-               </HStack>
-               <FormErrorMessage height={2}>{subscription.error}</FormErrorMessage>
+               <FooterNewsletterEmailInput
+                  ref={inputRef}
+                  disabled={subscription.status !== SubscriptionStatus.Idle}
+                  placeholder={emailPlaceholder}
+                  visibility={isSubscribed ? 'hidden' : 'visible'}
+               />
+               <FormErrorMessage>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
             <Button
                width="50%"
@@ -324,13 +310,29 @@ function NewsletterForm({
                disabled={subscription.status !== SubscriptionStatus.Idle}
                colorScheme="brand"
                visibility={isSubscribed ? 'hidden' : undefined}
-               display={{
-                  base: isSubscribed ? 'none' : undefined,
-                  xl: 'block',
-               }}
             >
                {subscribeLabel}
             </Button>
+            {isSubscribed && (
+               <Text
+                  align="center"
+                  position={'absolute'}
+                  top="0"
+                  left="0"
+                  right="5"
+                  bottom="0"
+                  lineHeight="10"
+               >
+                  <Icon
+                     as={RiCheckFill}
+                     boxSize="5"
+                     mb="-5px"
+                     mr="6px"
+                     ml="12px"
+                  />
+                  Subscribed!
+               </Text>
+            )}
          </FooterNewsletterForm>
       </FooterNewsletter>
    );

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -274,6 +274,8 @@ function NewsletterForm({
       [subscribe]
    );
 
+   const subscribeDirection =
+      subscription.status !== SubscriptionStatus.Subscribed ? 'row' : 'column';
    return (
       <FooterNewsletter>
          <FooterNewsletterCopy>
@@ -282,7 +284,10 @@ function NewsletterForm({
                {description}
             </FooterNewsletterDescription>
          </FooterNewsletterCopy>
-         <FooterNewsletterForm onSubmit={onSubscribe}>
+         <FooterNewsletterForm
+            onSubmit={onSubscribe}
+            direction={{ base: subscribeDirection, xl: 'row' }}
+         >
             <FooterNewsletterFormControl isInvalid={subscription.error != null}>
                <FooterNewsletterEmailLabel>
                   Enter your email
@@ -293,28 +298,35 @@ function NewsletterForm({
                   placeholder={emailPlaceholder}
                   hidden={subscription.status === SubscriptionStatus.Subscribed}
                />
-               <FormErrorMessage>{subscription.error}</FormErrorMessage>
                {subscription.status === SubscriptionStatus.Subscribed && (
                   <Text align="center">
                      <Icon as={RiCheckFill} boxSize="5" mb="-5px" />
                      Subscribed!
                   </Text>
                )}
+               <FormErrorMessage>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
             <Button
                type="submit"
+               height={
+                  subscription.status === SubscriptionStatus.Subscribed
+                     ? 0
+                     : '40px'
+               }
                isLoading={
                   subscription.status === SubscriptionStatus.Subscribing
                }
-               loadingText="Subscribing"
                disabled={subscription.status !== SubscriptionStatus.Idle}
-               hidden={subscription.status === SubscriptionStatus.Subscribed}
-               flexShrink={0}
                colorScheme="brand"
+               visibility={
+                  subscription.status === SubscriptionStatus.Subscribed
+                     ? 'hidden'
+                     : undefined
+               }
             >
                {subscription.status !== SubscriptionStatus.Subscribed
                   ? subscribeLabel
-                  : undefined}
+                  : 'Subscribe'}
             </Button>
          </FooterNewsletterForm>
       </FooterNewsletter>

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -311,8 +311,9 @@ function NewsletterForm({
                      </Text>
                   )}
                   <Button
+                     width="50%"
                      type="submit"
-                     data-testid = "submit-button"
+                     data-testid="submit-button"
                      isLoading={
                         subscription.status === SubscriptionStatus.Subscribing
                      }

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -312,6 +312,7 @@ function NewsletterForm({
                   )}
                   <Button
                      type="submit"
+                     data-testid = "submit-button"
                      isLoading={
                         subscription.status === SubscriptionStatus.Subscribing
                      }

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -247,38 +247,6 @@ export function LayoutFooter({
    );
 }
 
-export interface FooterNewsletterOnSubscribeProps {
-   title: string;
-   description: string;
-   isSubscribed: boolean;
-}
-
-function FooterNewsletterOnSubscribe({
-   title,
-   description,
-   isSubscribed,
-}: FooterNewsletterOnSubscribeProps) {
-   if (isSubscribed) {
-      return (
-         <FooterNewsletterCopy paddingRight={{ xl: '114.15px' }}>
-            <FooterNewsletterTitle>{title}</FooterNewsletterTitle>
-            <FooterNewsletterDescription>
-               {description}
-            </FooterNewsletterDescription>
-         </FooterNewsletterCopy>
-      );
-   } else {
-      return (
-         <FooterNewsletterCopy>
-            <FooterNewsletterTitle>{title}</FooterNewsletterTitle>
-            <FooterNewsletterDescription>
-               {description}
-            </FooterNewsletterDescription>
-         </FooterNewsletterCopy>
-      );
-   }
-}
-
 export interface NewsletterFormProps {
    title: string;
    description: string;
@@ -308,11 +276,12 @@ function NewsletterForm({
 
    return (
       <FooterNewsletter>
-         <FooterNewsletterOnSubscribe
-            title={title}
-            description={description}
-            isSubscribed={subscription.status === SubscriptionStatus.Subscribed}
-         />
+         <FooterNewsletterCopy>
+            <FooterNewsletterTitle>{title}</FooterNewsletterTitle>
+            <FooterNewsletterDescription>
+               {description}
+            </FooterNewsletterDescription>
+         </FooterNewsletterCopy>
          <FooterNewsletterForm onSubmit={onSubscribe}>
             <FooterNewsletterFormControl isInvalid={subscription.error != null}>
                <FooterNewsletterEmailLabel>
@@ -337,6 +306,7 @@ function NewsletterForm({
                isLoading={
                   subscription.status === SubscriptionStatus.Subscribing
                }
+               loadingText="Subscribing"
                disabled={subscription.status !== SubscriptionStatus.Idle}
                hidden={subscription.status === SubscriptionStatus.Subscribed}
                flexShrink={0}

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -313,7 +313,7 @@ function NewsletterForm({
                   <Button
                      width="50%"
                      type="submit"
-                     data-testid="submit-button"
+                     data-testid="footer-newsletter-subscribe-button"
                      isLoading={
                         subscription.status === SubscriptionStatus.Subscribing
                      }

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -288,7 +288,7 @@ function NewsletterForm({
          </FooterNewsletterCopy>
          <FooterNewsletterForm onSubmit={onSubscribe} position="relative">
             <FooterNewsletterFormControl isInvalid={subscription.error != null}>
-               <FooterNewsletterEmailLabel hidden={isSubscribed}>
+               <FooterNewsletterEmailLabel>
                   Enter your email
                </FooterNewsletterEmailLabel>
                <FooterNewsletterEmailInput
@@ -300,8 +300,6 @@ function NewsletterForm({
                <FormErrorMessage>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
             <Button
-               width="50%"
-               bottom={subscription.error ? '2' : '0'}
                type="submit"
                data-testid="footer-newsletter-subscribe-button"
                isLoading={

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -310,8 +310,8 @@ function NewsletterForm({
                         Subscribed!
                      </Text>
                   )}
+                  <FormErrorMessage>{subscription.error}</FormErrorMessage>
                </HStack>
-               <FormErrorMessage>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
             <Button
                width="50%"

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -2,11 +2,9 @@ import noImageFixie from '@assets/images/no-image-fixie.jpeg';
 import {
    Button,
    FormErrorMessage,
-   HStack,
    Icon,
    Menu,
    MenuList,
-   position,
    Text,
 } from '@chakra-ui/react';
 import {

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -288,7 +288,7 @@ function NewsletterForm({
          </FooterNewsletterCopy>
          <FooterNewsletterForm onSubmit={onSubscribe}>
             <FooterNewsletterFormControl isInvalid={subscription.error != null}>
-               <FooterNewsletterEmailLabel>
+               <FooterNewsletterEmailLabel hidden={isSubscribed}>
                   Enter your email
                </FooterNewsletterEmailLabel>
                <HStack>
@@ -296,7 +296,7 @@ function NewsletterForm({
                      ref={inputRef}
                      disabled={subscription.status !== SubscriptionStatus.Idle}
                      placeholder={emailPlaceholder}
-                     hidden={isSubscribed}
+                     visibility={isSubscribed ? 'hidden' : 'visible'}
                   />
                   {isSubscribed && (
                      <Text

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -5,6 +5,7 @@ import {
    Icon,
    Menu,
    MenuList,
+   Text,
 } from '@chakra-ui/react';
 import {
    FacebookLogo,
@@ -293,6 +294,12 @@ function NewsletterForm({
                   hidden={subscription.status === SubscriptionStatus.Subscribed}
                />
                <FormErrorMessage>{subscription.error}</FormErrorMessage>
+               {subscription.status === SubscriptionStatus.Subscribed && (
+                  <Text align="center">
+                     <Icon as={RiCheckFill} boxSize="5" mb="-5px" />
+                     Subscribed!
+                  </Text>
+               )}
             </FooterNewsletterFormControl>
             <Button
                type="submit"
@@ -301,17 +308,13 @@ function NewsletterForm({
                }
                loadingText="Subscribing"
                disabled={subscription.status !== SubscriptionStatus.Idle}
-               leftIcon={
-                  subscription.status === SubscriptionStatus.Subscribed ? (
-                     <Icon as={RiCheckFill} boxSize="5" mb="-2px" />
-                  ) : undefined
-               }
+               hidden={subscription.status === SubscriptionStatus.Subscribed}
                flexShrink={0}
                colorScheme="brand"
             >
                {subscription.status !== SubscriptionStatus.Subscribed
                   ? subscribeLabel
-                  : 'Subscribed!'}
+                  : undefined}
             </Button>
          </FooterNewsletterForm>
       </FooterNewsletter>

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -290,6 +290,7 @@ function NewsletterForm({
                   ref={inputRef}
                   disabled={subscription.status !== SubscriptionStatus.Idle}
                   placeholder={emailPlaceholder}
+                  hidden={subscription.status === SubscriptionStatus.Subscribed}
                />
                <FormErrorMessage>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
@@ -308,7 +309,7 @@ function NewsletterForm({
                flexShrink={0}
                colorScheme="brand"
             >
-               {subscription.status === SubscriptionStatus.Idle
+               {subscription.status !== SubscriptionStatus.Subscribed
                   ? subscribeLabel
                   : 'Subscribed!'}
             </Button>

--- a/frontend/components/common/Layout/Footer.tsx
+++ b/frontend/components/common/Layout/Footer.tsx
@@ -311,10 +311,11 @@ function NewsletterForm({
                      </Text>
                   )}
                </HStack>
-               <FormErrorMessage>{subscription.error}</FormErrorMessage>
+               <FormErrorMessage height={2}>{subscription.error}</FormErrorMessage>
             </FooterNewsletterFormControl>
             <Button
                width="50%"
+               bottom={subscription.error ? '2' : '0'}
                type="submit"
                data-testid="footer-newsletter-subscribe-button"
                isLoading={

--- a/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
@@ -25,10 +25,8 @@ describe('subscribe to newsletter', () => {
       });
       user.findByLabelText(/enter your email/i).type('test@example.com');
       user.findByRole('button', { name: /subscribe|join/i }).click();
-      user
-         .findByRole('button', { name: /subscribed/i })
-         .should('be.visible')
-         .should('be.disabled');
+      user.findByText('Subscribed!').should('be.visible');
+      user.findByRole('button', { name: /subscribed/i }).should('not.exist');
       user.findByText(/please insert a valid email/i).should('not.exist');
    });
 

--- a/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
@@ -26,9 +26,7 @@ describe('subscribe to newsletter', () => {
       user.findByLabelText(/enter your email/i).type('test@example.com');
       user.findByRole('button', { name: /subscribe|join/i }).click();
       user.findByText('Subscribed!').should('be.visible');
-      user
-         .findByRole('button', { name: /subscribe/i })
-         .should('not.be.visible');
+      user.findByTestId('submit-button').should('not.be.visible')
       user.findByText(/please insert a valid email/i).should('not.exist');
    });
 

--- a/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
@@ -26,7 +26,9 @@ describe('subscribe to newsletter', () => {
       user.findByLabelText(/enter your email/i).type('test@example.com');
       user.findByRole('button', { name: /subscribe|join/i }).click();
       user.findByText('Subscribed!').should('be.visible');
-      user.findByTestId('footer-newsletter-subscribe-button').should('not.be.visible');
+      user
+         .findByTestId('footer-newsletter-subscribe-button')
+         .should('not.be.visible');
       user.findByText(/please insert a valid email/i).should('not.exist');
    });
 

--- a/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
@@ -26,7 +26,7 @@ describe('subscribe to newsletter', () => {
       user.findByLabelText(/enter your email/i).type('test@example.com');
       user.findByRole('button', { name: /subscribe|join/i }).click();
       user.findByText('Subscribed!').should('be.visible');
-      user.findByTestId('submit-button').should('not.be.visible')
+      user.findByTestId('submit-button').should('not.be.visible');
       user.findByText(/please insert a valid email/i).should('not.exist');
    });
 

--- a/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
@@ -26,7 +26,9 @@ describe('subscribe to newsletter', () => {
       user.findByLabelText(/enter your email/i).type('test@example.com');
       user.findByRole('button', { name: /subscribe|join/i }).click();
       user.findByText('Subscribed!').should('be.visible');
-      user.findByRole('button', { name: /subscribed/i }).should('not.exist');
+      user
+         .findByRole('button', { name: /subscribe/i })
+         .should('not.be.visible');
       user.findByText(/please insert a valid email/i).should('not.exist');
    });
 

--- a/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/test/cypress/integration/product-list/newsletter_subscribe.spec.ts
@@ -26,7 +26,7 @@ describe('subscribe to newsletter', () => {
       user.findByLabelText(/enter your email/i).type('test@example.com');
       user.findByRole('button', { name: /subscribe|join/i }).click();
       user.findByText('Subscribed!').should('be.visible');
-      user.findByTestId('submit-button').should('not.be.visible');
+      user.findByTestId('footer-newsletter-subscribe-button').should('not.be.visible');
       user.findByText(/please insert a valid email/i).should('not.exist');
    });
 

--- a/packages/ui/footer/index.tsx
+++ b/packages/ui/footer/index.tsx
@@ -459,7 +459,7 @@ export const FooterNewsletterDescription = forwardRef<TextProps, 'div'>(
 export const FooterNewsletterForm = forwardRef<StackProps, 'form'>(
    (props, ref) => {
       return (
-         <Stack
+         <HStack
             ref={ref}
             as="form"
             data-testid="footer-newsletter-form"

--- a/packages/ui/footer/index.tsx
+++ b/packages/ui/footer/index.tsx
@@ -472,7 +472,7 @@ export const FooterNewsletterForm = forwardRef<StackProps, 'form'>(
                base: 'center',
                md: 'flex-end',
             }}
-            align="center"
+            align="flex-start"
             {...props}
          />
       );

--- a/packages/ui/footer/index.tsx
+++ b/packages/ui/footer/index.tsx
@@ -459,7 +459,7 @@ export const FooterNewsletterDescription = forwardRef<TextProps, 'div'>(
 export const FooterNewsletterForm = forwardRef<StackProps, 'form'>(
    (props, ref) => {
       return (
-         <HStack
+         <Stack
             ref={ref}
             as="form"
             data-testid="footer-newsletter-form"
@@ -472,7 +472,7 @@ export const FooterNewsletterForm = forwardRef<StackProps, 'form'>(
                base: 'center',
                md: 'flex-end',
             }}
-            align="flex-start"
+            align="center"
             {...props}
          />
       );


### PR DESCRIPTION
Previously, when the user successfully subscribed, we would disable the text box and that would cause the cursor to change to the
disabled state making it look like there was an error. This PR fixes this by hiding the entry text box on subscription.

Before:
<img width="425" alt="Screenshot 2022-08-03 150440" src="https://user-images.githubusercontent.com/50181909/182720624-e09dfbd9-5e34-4b8b-8cf4-2c0dc48506ae.png">




With this PR:

<img width="439" alt="Screenshot 2022-08-03 150221" src="https://user-images.githubusercontent.com/50181909/182720364-aa96c502-ea31-42c6-be05-6f5544a27088.png">


Closes #480 

CC: @sterlinghirsh @erinemay 