### PR TITLE
fix: polishing guts and overflow styles

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -17,6 +17,8 @@ import { useProductSearchHitPricing } from './useProductSearchHitPricing';
 export type ProductGridProps = React.PropsWithChildren<unknown>;
 
 export function ProductGrid({ children }: ProductGridProps) {
+   const childrenCount = React.Children.count(children);
+
    return (
       <SimpleGrid
          data-testid="grid-view-products"
@@ -24,10 +26,26 @@ export function ProductGrid({ children }: ProductGridProps) {
          borderBottomWidth="1px"
          columns={{
             base: 2,
-            sm: 2,
             lg: 3,
          }}
          spacing="1px"
+         bg="gray.100"
+         _after={{
+            content: `""`,
+            bg: 'white',
+            gridRow: {
+               base: Math.ceil(childrenCount / 2),
+               lg: Math.ceil(childrenCount / 3),
+            },
+            gridColumnStart: {
+               base: (childrenCount % 2) + 1,
+               lg: (childrenCount % 3) + 1,
+            },
+            gridColumnEnd: {
+               base: 3,
+               lg: 4,
+            },
+         }}
       >
          {children}
       </SimpleGrid>
@@ -45,18 +63,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
       useProductSearchHitPricing(product);
 
    return (
-      <LinkBox
-         as="article"
-         display="block"
-         w="full"
-         role="group"
-         borderTop="0"
-         borderRight="1px"
-         borderLeft="0"
-         borderBottom="1px"
-         borderRightColor="gray.100"
-         borderBottomColor="gray.100"
-      >
+      <LinkBox as="article" display="block" w="full" role="group">
          <ProductCard h="full">
             <ProductCardImage src={product.image_url} alt={product.title} />
             <ProductCardBadgeList>

--- a/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/index.tsx
@@ -81,7 +81,7 @@ export function FilterableProductsSection({ productList }: SectionProps) {
             <FacetCard>
                <FacetsAccordion productList={productList} />
             </FacetCard>
-            <Card flex={1}>
+            <Card flex={1} overflow="hidden">
                <ProductListEmptyState
                   productList={productList}
                   hidden={!isEmpty}


### PR DESCRIPTION
closes #434
closes #449

We introduced a pseudo element to cover the gray background that we exploit for colouring the grid guts.
This allows to eliminate the problems described in #434

## QA
1. Open Vercel preview
2. Verify that all the issues described in #434 are not present anymore