### PR TITLE
Algolia: Drop unused hook (make much faster!)

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -1,15 +1,10 @@
 import * as React from 'react';
-import { useDynamicWidgets } from 'react-instantsearch-hooks-web';
 import { ProductList, ProductListType } from '@models/product-list';
 import { formatFacetName } from '@helpers/algolia-helpers';
 
 export const MAX_VALUES_PER_FACET = 200;
 
 export function useFacets() {
-   const { attributesToRender } = useDynamicWidgets({
-      maxValuesPerFacet: MAX_VALUES_PER_FACET,
-   });
-
    return [
       'facet_tags.Capacity',
       'facet_tags.Device Brand',
@@ -23,7 +18,6 @@ export function useFacets() {
       'price_range',
       'worksin',
    ];
-   // return attributesToRender;
 }
 
 export function useFilteredFacets(productList: ProductList) {


### PR DESCRIPTION
OMG, this was causing our server-side algolia query (and react dom
rendering) to happen twice. This was effectively doubling our response
times.

See this line in algolia's getServerState():
https://github.com/algolia/react-instantsearch/blob/affcbb58ee5c63345cc9424ad8ab566f3a01c9f9/packages/react-instantsearch-hooks-server/src/getServerState.tsx#L48-L49

Connect https://github.com/ifixit/ifixit/issues/43498