### PR TITLE
Export KIP Banner from WIP Branch

### DIFF
--- a/packages/homepage-kpis/PageContentWrapper.tsx
+++ b/packages/homepage-kpis/PageContentWrapper.tsx
@@ -1,0 +1,21 @@
+import { Box, BoxProps } from '@chakra-ui/react';
+import * as React from 'react';
+
+export type PageContentWrapperProps = React.PropsWithChildren<{
+   className?: string;
+}>;
+
+export function PageContentWrapper(props: BoxProps) {
+   return (
+      <Box
+         w={{ base: 'full', lg: '960px', xl: '1100px' }}
+         mx="auto"
+         px={{
+            base: 0,
+            sm: 6,
+            lg: 0,
+         }}
+         {...props}
+      />
+   );
+}

--- a/packages/homepage-kpis/index.tsx
+++ b/packages/homepage-kpis/index.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  Box,
+  SimpleGrid,
+  Stat,
+  StatHelpText,
+  StatNumber,
+} from '@chakra-ui/react';
+import { PageContentWrapper } from './PageContentWrapper';
+
+interface Stat {
+   value: string;
+   label: string;
+}
+
+export interface StatsSectionProps {
+  data: SectionData;
+}
+
+export interface SectionData {
+   type: 'Stats';
+   id: string;
+   stats: Stat[];
+}
+
+export function StatsSection({ data: { stats } }: StatsSectionProps) {
+  return (
+     <Box
+        as="section"
+        position="relative"
+        w="full"
+        bg="blue.50"
+        borderWidth={1}
+        borderColor="blue.100"
+     >
+        <PageContentWrapper>
+           <SimpleGrid
+              columns={{
+                 base: 1,
+                 sm: 2,
+                 lg: 4,
+              }}
+              spacing="10"
+              py="10"
+           >
+              {stats.map((stat, index) => (
+                 <Stats
+                    key={index}
+                    number={stat.value}
+                    helpText={stat.label}
+                 />
+              ))}
+           </SimpleGrid>
+        </PageContentWrapper>
+     </Box>
+  );
+}
+
+interface StatsProps {
+  number: string;
+  helpText: string;
+}
+
+function Stats({ number, helpText }: StatsProps) {
+  return (
+     <Stat
+        sx={{
+           dl: {
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+           },
+        }}
+     >
+        <StatNumber color="blue.500" fontSize="3xl">
+           {number}
+        </StatNumber>
+        <StatHelpText m="0">{helpText}</StatHelpText>
+     </Stat>
+  );
+}

--- a/packages/homepage-kpis/index.tsx
+++ b/packages/homepage-kpis/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {
-  Box,
-  SimpleGrid,
-  Stat,
-  StatHelpText,
-  StatNumber,
+   Box,
+   SimpleGrid,
+   Stat,
+   StatHelpText,
+   StatNumber,
 } from '@chakra-ui/react';
 import { PageContentWrapper } from './PageContentWrapper';
 
@@ -14,7 +14,7 @@ interface Stat {
 }
 
 export interface StatsSectionProps {
-  data: SectionData;
+   data: SectionData;
 }
 
 export interface SectionData {
@@ -24,58 +24,58 @@ export interface SectionData {
 }
 
 export function StatsSection({ data: { stats } }: StatsSectionProps) {
-  return (
-     <Box
-        as="section"
-        position="relative"
-        w="full"
-        bg="blue.50"
-        borderWidth={1}
-        borderColor="blue.100"
-     >
-        <PageContentWrapper>
-           <SimpleGrid
-              columns={{
-                 base: 1,
-                 sm: 2,
-                 lg: 4,
-              }}
-              spacing="10"
-              py="10"
-           >
-              {stats.map((stat, index) => (
-                 <Stats
-                    key={index}
-                    number={stat.value}
-                    helpText={stat.label}
-                 />
-              ))}
-           </SimpleGrid>
-        </PageContentWrapper>
-     </Box>
-  );
+   return (
+      <Box
+         as="section"
+         position="relative"
+         w="full"
+         bg="blue.50"
+         borderWidth={1}
+         borderColor="blue.100"
+      >
+         <PageContentWrapper>
+            <SimpleGrid
+               columns={{
+                  base: 1,
+                  sm: 2,
+                  lg: 4,
+               }}
+               spacing="10"
+               py="10"
+            >
+               {stats.map((stat, index) => (
+                  <Stats
+                     key={index}
+                     number={stat.value}
+                     helpText={stat.label}
+                  />
+               ))}
+            </SimpleGrid>
+         </PageContentWrapper>
+      </Box>
+   );
 }
 
 interface StatsProps {
-  number: string;
-  helpText: string;
+   number: string;
+   helpText: string;
 }
 
 function Stats({ number, helpText }: StatsProps) {
-  return (
-     <Stat
-        sx={{
-           dl: {
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-           },
-        }}
-     >
-        <StatNumber color="blue.500" fontSize="3xl">
-           {number}
-        </StatNumber>
-        <StatHelpText m="0">{helpText}</StatHelpText>
-     </Stat>
-  );
+   return (
+      <Stat
+         sx={{
+            dl: {
+               display: 'flex',
+               flexDirection: 'column',
+               alignItems: 'center',
+            },
+         }}
+      >
+         <StatNumber color="blue.500" fontSize="3xl">
+            {number}
+         </StatNumber>
+         <StatHelpText m="0">{helpText}</StatHelpText>
+      </Stat>
+   );
 }

--- a/packages/homepage-kpis/package.json
+++ b/packages/homepage-kpis/package.json
@@ -1,0 +1,20 @@
+{
+   "name": "@ifixit/homepage-kpis",
+   "version": "0.0.0",
+   "main": "./index.tsx",
+   "types": "./index.tsx",
+   "license": "MIT",
+   "devDependencies": {
+      "@types/react": "17.0.37",
+      "@types/react-dom": "17.0.11",
+      "@ifixit/tsconfig": "workspace:*",
+      "typescript": "4.5.3"
+   },
+   "dependencies": {
+      "@ifixit/commerce-frontend": "workspace:*",
+      "@chakra-ui/react": "1.8.8"
+   },
+   "peerDependencies": {
+      "react": "*"
+   }
+}

--- a/packages/homepage-kpis/tsconfig.json
+++ b/packages/homepage-kpis/tsconfig.json
@@ -1,0 +1,5 @@
+{
+   "extends": "@ifixit/tsconfig/react-library.json",
+   "include": ["."],
+   "exclude": ["dist", "build", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,23 @@ importers:
       '@ifixit/tsconfig': link:../tsconfig
       typescript: 4.5.3
 
+  packages/homepage-kpis:
+    specifiers:
+      '@chakra-ui/react': 1.8.8
+      '@ifixit/commerce-frontend': workspace:*
+      '@ifixit/tsconfig': workspace:*
+      '@types/react': 17.0.37
+      '@types/react-dom': 17.0.11
+      typescript: 4.5.3
+    dependencies:
+      '@chakra-ui/react': 1.8.8_@types+react@17.0.37
+      '@ifixit/commerce-frontend': link:../../frontend
+    devDependencies:
+      '@ifixit/tsconfig': link:../tsconfig
+      '@types/react': 17.0.37
+      '@types/react-dom': 17.0.11
+      typescript: 4.5.3
+
   packages/icons:
     specifiers:
       '@ifixit/tsconfig': workspace:*
@@ -2231,6 +2248,34 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/accordion/1.4.11_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-d/gvSgGwcZaJXxXqGmecpAgko/tUYb5vR0E0B2/V/z9AVbS8ei//fbiO9+8Ouyl/K46oWHWYj5vt8iTadlZleg==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/descendant': 2.1.3
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/transition': 1.4.8
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
+  /@chakra-ui/alert/1.3.7_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-fFpJYBpHOIK/BX4BVl/xafYiDBUW+Bq/gUYDOo4iAiO4vHgxo74oa+yOwSRNlNjAgIX7pi2ridsYQALKyWyxxQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/alert/1.3.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-fFpJYBpHOIK/BX4BVl/xafYiDBUW+Bq/gUYDOo4iAiO4vHgxo74oa+yOwSRNlNjAgIX7pi2ridsYQALKyWyxxQ==}
     peerDependencies:
@@ -2249,8 +2294,20 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
+    dev: false
+
+  /@chakra-ui/avatar/1.3.11_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-/eRRK48Er92/QWAfWhxsJIN0gZBBvk+ew4Hglo+pxt3/NDnfTF2yPE7ZN29Dl6daPNbyTOpoksMwaU2mZIqLgA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/image': 1.1.10_@chakra-ui+system@1.12.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/avatar/1.3.11_ec02b824bed6ab9ca8725186341c5110:
@@ -2266,6 +2323,17 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/breadcrumb/1.3.6_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-iXxienBO6RUnJEcDvyDWyRt+mzPyl7/b6N8i0vrjGKGLpgtayJFvIdo33tFcvx6TCy7V9hiE3HTtZnNomWdR6A==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/breadcrumb/1.3.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-iXxienBO6RUnJEcDvyDWyRt+mzPyl7/b6N8i0vrjGKGLpgtayJFvIdo33tFcvx6TCy7V9hiE3HTtZnNomWdR6A==}
     peerDependencies:
@@ -2276,6 +2344,19 @@ packages:
       '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/button/1.5.10_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-IVEOrleI378CckAa3b3CTUHMPZRfpy6LPwn1Mx3sMpHEkDTKu8zJcjgEvCE8HYzNC1KbwBsa1PfTgk40ui6EtA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/spinner': 1.2.6_@chakra-ui+system@1.12.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/button/1.5.10_ec02b824bed6ab9ca8725186341c5110:
@@ -2309,6 +2390,30 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/checkbox/1.7.1_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-9Io97yn8OrdaIynCj+3Z/neJV7lTT1MtcdYh3BKMd7WnoJDkRY/GlBM8zsdgC5Wvm+ZQ1M83t0YvRPKLLzusyA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/form-control': 1.6.0_@chakra-ui+system@1.12.1
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+      '@chakra-ui/visually-hidden': 1.1.6_@chakra-ui+system@1.12.1
+    dev: false
+
+  /@chakra-ui/clickable/1.2.6:
+    resolution: {integrity: sha512-89SsrQwwwAadcl/bN8nZqqaaVhVNFdBXqQnxVy1t07DL5ezubmNb5SgFh9LDznkm9YYPQhaGr3W6HFro7iAHMg==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/clickable/1.2.6_react@17.0.2:
     resolution: {integrity: sha512-89SsrQwwwAadcl/bN8nZqqaaVhVNFdBXqQnxVy1t07DL5ezubmNb5SgFh9LDznkm9YYPQhaGr3W6HFro7iAHMg==}
     peerDependencies:
@@ -2317,6 +2422,17 @@ packages:
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/close-button/1.2.7_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-cYTxfgrIlPU4IZm1sehZXxx/TNQBk9c3LBPvTpywEM8GVRGINh4YLq8WiMaPtO+TDNBnKoWS/jS4IHnR+abADw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/close-button/1.2.7_ec02b824bed6ab9ca8725186341c5110:
@@ -2331,6 +2447,16 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/color-mode/1.4.8:
+    resolution: {integrity: sha512-iD4126DVQi06c6ARr3uf3R2rtEu8aBVjW8rhZ+lOsV26Z15iCJA7OAut13Xu06fcZvgjSB/ChDy6Sx9sV9UjHA==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-env': 1.1.6
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/color-mode/1.4.8_react@17.0.2:
     resolution: {integrity: sha512-iD4126DVQi06c6ARr3uf3R2rtEu8aBVjW8rhZ+lOsV26Z15iCJA7OAut13Xu06fcZvgjSB/ChDy6Sx9sV9UjHA==}
     peerDependencies:
@@ -2340,6 +2466,16 @@ packages:
       '@chakra-ui/react-env': 1.1.6_react@17.0.2
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/control-box/1.1.6_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-EUcq5f854puG6ZA6wAWl4107OPl8+bj4MMHJCa48BB0qec0U8HCEtxQGnFwJmaYLalIAjMfHuY3OwO2A3Hi9hA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/control-box/1.1.6_ec02b824bed6ab9ca8725186341c5110:
@@ -2353,6 +2489,15 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/counter/1.2.10:
+    resolution: {integrity: sha512-HQd09IuJ4z8M8vWajH+99jBWWSHDesQZmnN95jUg3HKOuNleLaipf2JFdrqbO1uWQyHobn2PM6u+B+JCAh2nig==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/counter/1.2.10_react@17.0.2:
     resolution: {integrity: sha512-HQd09IuJ4z8M8vWajH+99jBWWSHDesQZmnN95jUg3HKOuNleLaipf2JFdrqbO1uWQyHobn2PM6u+B+JCAh2nig==}
     peerDependencies:
@@ -2361,6 +2506,13 @@ packages:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/css-reset/1.1.3:
+    resolution: {integrity: sha512-AgfrE7bRTJvNi/4zIfacI/kBHmHmHEIeQtHwCvk/0qM9V2gK1VM3ctYlnibf7BTh17F/UszweOGRb1lHSPfWjw==}
+    peerDependencies:
+      '@emotion/react': '>=10.0.35'
+      react: '>=16.8.6'
     dev: false
 
   /@chakra-ui/css-reset/1.1.3_79c1490562c3c65ef55eb132a37e39b4:
@@ -2373,6 +2525,14 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/descendant/2.1.3:
+    resolution: {integrity: sha512-aNYNv99gEPENCdw2N5y3FvL5wgBVcLiOzJ2TxSwb4EVYszbgBZ8Ry1pf7lkoSfysdxD0scgy2cVyxO8TsYTU4g==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/react-utils': 1.2.3
+    dev: false
+
   /@chakra-ui/descendant/2.1.3_react@17.0.2:
     resolution: {integrity: sha512-aNYNv99gEPENCdw2N5y3FvL5wgBVcLiOzJ2TxSwb4EVYszbgBZ8Ry1pf7lkoSfysdxD0scgy2cVyxO8TsYTU4g==}
     peerDependencies:
@@ -2380,6 +2540,18 @@ packages:
     dependencies:
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/editable/1.4.2_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-a5zKghA/IvG7yNkmFl7Z9c2KSsf0FgyijsNPTg/4S5jxyz13QJtoTg40tdpyaxHHCT25y25iUcV4FYCj6Jd01w==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/editable/1.4.2_ec02b824bed6ab9ca8725186341c5110:
@@ -2407,6 +2579,30 @@ packages:
       - '@types/react'
     dev: false
 
+  /@chakra-ui/focus-lock/1.2.6_@types+react@17.0.37:
+    resolution: {integrity: sha512-ZJNE1oNdUM1aGWuCJ+bxFa/d3EwxzfMWzTKzSvKDK50GWoUQQ10xFTT9nY/yFpkcwhBvx1KavxKf44mIhIbSog==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/utils': 1.10.4
+      react-focus-lock: 2.5.2_@types+react@17.0.37
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /@chakra-ui/form-control/1.6.0_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-MtUE98aocP2QTgvyyJ/ABuG33mhT3Ox56phKreG3HzbUKByMwrbQSm1QcAgyYdqSZ9eKB2tXx+qgGNh+avAfDA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/form-control/1.6.0_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-MtUE98aocP2QTgvyyJ/ABuG33mhT3Ox56phKreG3HzbUKByMwrbQSm1QcAgyYdqSZ9eKB2tXx+qgGNh+avAfDA==}
     peerDependencies:
@@ -2421,6 +2617,17 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/hooks/1.9.1:
+    resolution: {integrity: sha512-SEeh1alDKzrP9gMLWMnXOUDBQDKF/URL6iTmkumTn6vhawWNla6sPrcMyoCzWdMzwUhZp3QNtCKbUm7dxBXvPw==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/utils': 1.10.4
+      compute-scroll-into-view: 1.0.14
+      copy-to-clipboard: 3.3.1
+    dev: false
+
   /@chakra-ui/hooks/1.9.1_react@17.0.2:
     resolution: {integrity: sha512-SEeh1alDKzrP9gMLWMnXOUDBQDKF/URL6iTmkumTn6vhawWNla6sPrcMyoCzWdMzwUhZp3QNtCKbUm7dxBXvPw==}
     peerDependencies:
@@ -2431,6 +2638,16 @@ packages:
       compute-scroll-into-view: 1.0.14
       copy-to-clipboard: 3.3.1
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/icon/2.0.5_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/icon/2.0.5_ec02b824bed6ab9ca8725186341c5110:
@@ -2444,6 +2661,17 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/image/1.1.10_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-PJZmhQ/R1PgdMyCRjALfoyq1FNh/WzMAw70sliHLtLcb9hBXniwQZuckYfUshCkUoFBj/ow9d4byn9Culdpk7Q==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/image/1.1.10_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-PJZmhQ/R1PgdMyCRjALfoyq1FNh/WzMAw70sliHLtLcb9hBXniwQZuckYfUshCkUoFBj/ow9d4byn9Culdpk7Q==}
     peerDependencies:
@@ -2454,6 +2682,18 @@ packages:
       '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/input/1.4.6_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-Ljy/NbOhh9cNQxKTWQRsT4aQiXs2vVya+Cj5NpMAz08NFFjPZovsTawhI7m6ejT5Vsh76QYjh2rOLLI3fWqQQw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/form-control': 1.6.0_@chakra-ui+system@1.12.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/input/1.4.6_ec02b824bed6ab9ca8725186341c5110:
@@ -2469,6 +2709,18 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/layout/1.8.0_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-GJtEKez5AZu0XQTxI6a6jwA/hMDD36pP0HBxBOGuHP1hWCebDzMjraiMfWiP9w7hKERFE4j19kocHxIXyocfJA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/layout/1.8.0_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-GJtEKez5AZu0XQTxI6a6jwA/hMDD36pP0HBxBOGuHP1hWCebDzMjraiMfWiP9w7hKERFE4j19kocHxIXyocfJA==}
     peerDependencies:
@@ -2482,6 +2734,14 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/live-region/1.1.6:
+    resolution: {integrity: sha512-9gPQHXf7oW0jXyT5R/JzyDMfJ3hF70TqhN8bRH4fMyfNr2Se+SjztMBqCrv5FS5rPjcCeua+e0eArpoB3ROuWQ==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/live-region/1.1.6_react@17.0.2:
     resolution: {integrity: sha512-9gPQHXf7oW0jXyT5R/JzyDMfJ3hF70TqhN8bRH4fMyfNr2Se+SjztMBqCrv5FS5rPjcCeua+e0eArpoB3ROuWQ==}
     peerDependencies:
@@ -2489,6 +2749,19 @@ packages:
     dependencies:
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/media-query/2.0.4_3b90fb8c149f821077ff1088415c94a6:
+    resolution: {integrity: sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      '@chakra-ui/theme': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/react-env': 1.1.6
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/media-query/2.0.4_95e3ae800e8ec2b9db829252af6af6dc:
@@ -2524,6 +2797,45 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/menu/1.8.11_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-8K65xItPsdMvSfuGWYIGigOF/QMcy7+D48UIEO/Hu0u0ckd11/JXbpSIFPddH5fYedclJ18PGRohTne487OVjQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/clickable': 1.2.6
+      '@chakra-ui/descendant': 2.1.3
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/popper': 2.4.3
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/transition': 1.4.8
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
+  /@chakra-ui/modal/1.11.1_3d4bf4e9a36e97d042ea12722a2eb1e7:
+    resolution: {integrity: sha512-B2BBDonHb04vbPLAWgko1JYBwgW8ZNSLyhTJK+rbrCsRSgazuLTcwq4hdyJqrYNWtaQEfSwpAXqJ7joMZdv59A==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+      react-dom: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/close-button': 1.2.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/focus-lock': 1.2.6_@types+react@17.0.37
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/portal': 1.3.10
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/transition': 1.4.8
+      '@chakra-ui/utils': 1.10.4
+      aria-hidden: 1.1.3
+      react-remove-scroll: 2.4.1_@types+react@17.0.37
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /@chakra-ui/modal/1.11.1_6dafe5f9078aa265899836c510d1cd9b:
     resolution: {integrity: sha512-B2BBDonHb04vbPLAWgko1JYBwgW8ZNSLyhTJK+rbrCsRSgazuLTcwq4hdyJqrYNWtaQEfSwpAXqJ7joMZdv59A==}
     peerDependencies:
@@ -2549,6 +2861,21 @@ packages:
       - '@types/react'
     dev: false
 
+  /@chakra-ui/number-input/1.4.7_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-LorGRZFMipom8vCUEbLi2s7bTHF2Fgiu766W0jTbzMje+8Z1ZoRQunH9OZWQnxnWQTUfUM2KBW8KwToYh1ojfQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/counter': 1.2.10
+      '@chakra-ui/form-control': 1.6.0_@chakra-ui+system@1.12.1
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/number-input/1.4.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-LorGRZFMipom8vCUEbLi2s7bTHF2Fgiu766W0jTbzMje+8Z1ZoRQunH9OZWQnxnWQTUfUM2KBW8KwToYh1ojfQ==}
     peerDependencies:
@@ -2563,6 +2890,19 @@ packages:
       '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/pin-input/1.7.10_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-Uz5vFK+ZevQtdYHBkddSFCrY44bweXLanpSv9X/D0pWpdML09qfPiKX4ydGzfRoS2u4L8NUtN86IcvdOQLhHQg==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/descendant': 2.1.3
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/pin-input/1.7.10_ec02b824bed6ab9ca8725186341c5110:
@@ -2596,6 +2936,30 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/popover/1.11.9_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-hJ1/Lwukox3ryTN7W1wnj+nE44utfLwQYvfUSdatt5dznnh8k0P6Wx7Hmjm1cYffRavBhqzwua/QZDWjJN9N0g==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/close-button': 1.2.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/popper': 2.4.3
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
+  /@chakra-ui/popper/2.4.3:
+    resolution: {integrity: sha512-TGzFnYt3mtIVkIejtYIAu4Ka9DaYLzMR4NgcqI6EtaTvgK7Xep+6RTiY/Nq+ZT3l/eaNUwqHRFoNrDUg1XYasA==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/react-utils': 1.2.3
+      '@popperjs/core': 2.11.5
+    dev: false
+
   /@chakra-ui/popper/2.4.3_react@17.0.2:
     resolution: {integrity: sha512-TGzFnYt3mtIVkIejtYIAu4Ka9DaYLzMR4NgcqI6EtaTvgK7Xep+6RTiY/Nq+ZT3l/eaNUwqHRFoNrDUg1XYasA==}
     peerDependencies:
@@ -2604,6 +2968,17 @@ packages:
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
       '@popperjs/core': 2.11.5
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/portal/1.3.10:
+    resolution: {integrity: sha512-t2KQ6MXbyf1qFYxWw/bs//CnwD+Clq7mbsP1Y7g+THCz2FvlLlMj45BWocLB30NoNyA8WCS2zyMBszW2/qvDiA==}
+    peerDependencies:
+      react: '>=16.8.6'
+      react-dom: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/portal/1.3.10_react-dom@17.0.2+react@17.0.2:
@@ -2619,6 +2994,17 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /@chakra-ui/progress/1.2.6_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-thaHRIYTVktgV78vJMNwzfCX+ickhSpn2bun6FtGVUphFx4tjV+ggz+IGohm6AH2hapskoR1mQU2iNZb6BK0hQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/progress/1.2.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-thaHRIYTVktgV78vJMNwzfCX+ickhSpn2bun6FtGVUphFx4tjV+ggz+IGohm6AH2hapskoR1mQU2iNZb6BK0hQ==}
     peerDependencies:
@@ -2629,6 +3015,22 @@ packages:
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/provider/1.7.14:
+    resolution: {integrity: sha512-FCA33CZy/jFzExglKMioeri8sr9NtDTcNVPnx95ZJiA7WpfFo0xuZ6/fMC4DwIQPkJKbSIZBXYLZ3U10Ntylrw==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0
+      '@emotion/styled': ^11.0.0
+      react: '>=16.8.6'
+      react-dom: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/css-reset': 1.1.3
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/portal': 1.3.10
+      '@chakra-ui/react-env': 1.1.6
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/provider/1.7.14_c84e354a724f4213aa6539fdea9d08aa:
@@ -2651,6 +3053,20 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /@chakra-ui/radio/1.5.1_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-zO5eShz+j68A7935jJ2q5u3brX/bjPEGh9Pj2+bnKbmC9Vva6jEzBSJsAx9n4WbkAzR3xDMGWsbpivFp8X1tJw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/form-control': 1.6.0_@chakra-ui+system@1.12.1
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+      '@chakra-ui/visually-hidden': 1.1.6_@chakra-ui+system@1.12.1
+    dev: false
+
   /@chakra-ui/radio/1.5.1_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-zO5eShz+j68A7935jJ2q5u3brX/bjPEGh9Pj2+bnKbmC9Vva6jEzBSJsAx9n4WbkAzR3xDMGWsbpivFp8X1tJw==}
     peerDependencies:
@@ -2666,6 +3082,14 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/react-env/1.1.6:
+    resolution: {integrity: sha512-L90LNvCfe04FTkN9OPok/o2e60zLJNBH8Im/5dUHvqy7dXLXok8ZDad5vEL46XmGbhe7O8fbxhG6FmAYdcCHrQ==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/react-env/1.1.6_react@17.0.2:
     resolution: {integrity: sha512-L90LNvCfe04FTkN9OPok/o2e60zLJNBH8Im/5dUHvqy7dXLXok8ZDad5vEL46XmGbhe7O8fbxhG6FmAYdcCHrQ==}
     peerDependencies:
@@ -2673,6 +3097,14 @@ packages:
     dependencies:
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/react-utils/1.2.3:
+    resolution: {integrity: sha512-r8pUwCVVB7UPhb0AiRa9ZzSp4xkMz64yIeJ4O4aGy4WMw7TRH4j4QkbkE1YC9tQitrXrliOlvx4WWJR4VyiGpw==}
+    peerDependencies:
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/react-utils/1.2.3_react@17.0.2:
@@ -2749,6 +3181,77 @@ packages:
       - '@types/react'
     dev: false
 
+  /@chakra-ui/react/1.8.8_@types+react@17.0.37:
+    resolution: {integrity: sha512-/XqL25J0i0h+usAXBngn/RTG2u1oQRzbhHe9tNHwFyNbx/izIADhQW/6ji06QU0KtaRIU77XvgSAyTtMJY1KmA==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0
+      '@emotion/styled': ^11.0.0
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+      react-dom: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/accordion': 1.4.11_@chakra-ui+system@1.12.1
+      '@chakra-ui/alert': 1.3.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/avatar': 1.3.11_@chakra-ui+system@1.12.1
+      '@chakra-ui/breadcrumb': 1.3.6_@chakra-ui+system@1.12.1
+      '@chakra-ui/button': 1.5.10_@chakra-ui+system@1.12.1
+      '@chakra-ui/checkbox': 1.7.1_@chakra-ui+system@1.12.1
+      '@chakra-ui/close-button': 1.2.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/control-box': 1.1.6_@chakra-ui+system@1.12.1
+      '@chakra-ui/counter': 1.2.10
+      '@chakra-ui/css-reset': 1.1.3
+      '@chakra-ui/editable': 1.4.2_@chakra-ui+system@1.12.1
+      '@chakra-ui/form-control': 1.6.0_@chakra-ui+system@1.12.1
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/image': 1.1.10_@chakra-ui+system@1.12.1
+      '@chakra-ui/input': 1.4.6_@chakra-ui+system@1.12.1
+      '@chakra-ui/layout': 1.8.0_@chakra-ui+system@1.12.1
+      '@chakra-ui/live-region': 1.1.6
+      '@chakra-ui/media-query': 2.0.4_3b90fb8c149f821077ff1088415c94a6
+      '@chakra-ui/menu': 1.8.11_@chakra-ui+system@1.12.1
+      '@chakra-ui/modal': 1.11.1_3d4bf4e9a36e97d042ea12722a2eb1e7
+      '@chakra-ui/number-input': 1.4.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/pin-input': 1.7.10_@chakra-ui+system@1.12.1
+      '@chakra-ui/popover': 1.11.9_@chakra-ui+system@1.12.1
+      '@chakra-ui/popper': 2.4.3
+      '@chakra-ui/portal': 1.3.10
+      '@chakra-ui/progress': 1.2.6_@chakra-ui+system@1.12.1
+      '@chakra-ui/provider': 1.7.14
+      '@chakra-ui/radio': 1.5.1_@chakra-ui+system@1.12.1
+      '@chakra-ui/react-env': 1.1.6
+      '@chakra-ui/select': 1.2.11_@chakra-ui+system@1.12.1
+      '@chakra-ui/skeleton': 1.2.14_@chakra-ui+theme@1.14.1
+      '@chakra-ui/slider': 1.5.11_@chakra-ui+system@1.12.1
+      '@chakra-ui/spinner': 1.2.6_@chakra-ui+system@1.12.1
+      '@chakra-ui/stat': 1.2.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/switch': 1.3.10_@chakra-ui+system@1.12.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/table': 1.3.6_@chakra-ui+system@1.12.1
+      '@chakra-ui/tabs': 1.6.10_@chakra-ui+system@1.12.1
+      '@chakra-ui/tag': 1.2.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/textarea': 1.2.11_@chakra-ui+system@1.12.1
+      '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
+      '@chakra-ui/toast': 1.5.9_@chakra-ui+system@1.12.1
+      '@chakra-ui/tooltip': 1.5.1_@chakra-ui+system@1.12.1
+      '@chakra-ui/transition': 1.4.8
+      '@chakra-ui/utils': 1.10.4
+      '@chakra-ui/visually-hidden': 1.1.6_@chakra-ui+system@1.12.1
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /@chakra-ui/select/1.2.11_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-6Tis1+ZrRjQeWhQfziQn3ZdPphV5ccafpZOhiPdTcM2J1XcXOlII+9rHxvaW+jx7zQ5ly5o8kd7iXzalDgl5wA==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/form-control': 1.6.0_@chakra-ui+system@1.12.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/select/1.2.11_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-6Tis1+ZrRjQeWhQfziQn3ZdPphV5ccafpZOhiPdTcM2J1XcXOlII+9rHxvaW+jx7zQ5ly5o8kd7iXzalDgl5wA==}
     peerDependencies:
@@ -2759,6 +3262,21 @@ packages:
       '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/skeleton/1.2.14_@chakra-ui+theme@1.14.1:
+    resolution: {integrity: sha512-R0v4DfQ2yjXCJf9SzhTmDb2PLx5//LxsRbjjgRa8qJCR4MZaGswPrekp4dP8YjY8aEYzuZbvHU12T3vqZBk2GA==}
+    peerDependencies:
+      '@chakra-ui/theme': '>=1.0.0'
+      '@emotion/react': ^11.0.0
+      '@emotion/styled': ^11.0.0
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/media-query': 2.0.4_3b90fb8c149f821077ff1088415c94a6
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/skeleton/1.2.14_d713f7ab5012ba0f57775c6ca1ede6c2:
@@ -2779,6 +3297,18 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/slider/1.5.11_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-THkGU2BsA6XMosXcEVQkWVRftqUIAKCb+y4iEpR3C2ztqL7Fl/CbIGwyr5majhPhKc275rb8dfxwp8R0L0ZIiQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/slider/1.5.11_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-THkGU2BsA6XMosXcEVQkWVRftqUIAKCb+y4iEpR3C2ztqL7Fl/CbIGwyr5majhPhKc275rb8dfxwp8R0L0ZIiQ==}
     peerDependencies:
@@ -2792,6 +3322,17 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/spinner/1.2.6_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-GoUCccN120fGRVgUtfuwcEjeoaxffB+XsgpxX7jhWloXf8b6lkqm68bsxX4Ybb2vGN1fANI98/45JmrnddZO/A==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+      '@chakra-ui/visually-hidden': 1.1.6_@chakra-ui+system@1.12.1
+    dev: false
+
   /@chakra-ui/spinner/1.2.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-GoUCccN120fGRVgUtfuwcEjeoaxffB+XsgpxX7jhWloXf8b6lkqm68bsxX4Ybb2vGN1fANI98/45JmrnddZO/A==}
     peerDependencies:
@@ -2802,6 +3343,18 @@ packages:
       '@chakra-ui/utils': 1.10.4
       '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/stat/1.2.7_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-m76jumFW1N+mCG4ytrUz9Mh09nZtS4OQcADEvOslfdI5StwwuzasTA1tueaelPzdhBioMwFUWL05Fr1fXbPJ/Q==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+      '@chakra-ui/visually-hidden': 1.1.6_@chakra-ui+system@1.12.1
     dev: false
 
   /@chakra-ui/stat/1.2.7_ec02b824bed6ab9ca8725186341c5110:
@@ -2838,6 +3391,32 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/switch/1.3.10_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-V6qDLY6oECCbPyu7alWWOAhSBI4+SAuT6XW/zEQbelkwuUOiGO1ax67rTXOmZ59A2AaV1gqQFxDh8AcbvwO5XQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/checkbox': 1.7.1_@chakra-ui+system@1.12.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
+  /@chakra-ui/system/1.12.1:
+    resolution: {integrity: sha512-Rp09/rMuPA3hF38OJxeQciGO9N0Ie1GxwHRAw1AFA/TY3fVyK9pNI5oN+J/1cAxq7v9yKdIr1YfnruJTI9xfEg==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0
+      '@emotion/styled': ^11.0.0
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/color-mode': 1.4.8
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/styled-system': 1.19.0
+      '@chakra-ui/utils': 1.10.4
+      react-fast-compare: 3.2.0
+    dev: false
+
   /@chakra-ui/system/1.12.1_922a85da57e3646a57465b7970b0de85:
     resolution: {integrity: sha512-Rp09/rMuPA3hF38OJxeQciGO9N0Ie1GxwHRAw1AFA/TY3fVyK9pNI5oN+J/1cAxq7v9yKdIr1YfnruJTI9xfEg==}
     peerDependencies:
@@ -2855,6 +3434,16 @@ packages:
       react-fast-compare: 3.2.0
     dev: false
 
+  /@chakra-ui/table/1.3.6_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-7agZAgAeDFKviqStvixqnLAH54+setzhx67EztioZTr5Xu+6hQ4rotfJbu8L4i587pcbNg98kCEXEkidjw0XRQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/table/1.3.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-7agZAgAeDFKviqStvixqnLAH54+setzhx67EztioZTr5Xu+6hQ4rotfJbu8L4i587pcbNg98kCEXEkidjw0XRQ==}
     peerDependencies:
@@ -2864,6 +3453,20 @@ packages:
       '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/tabs/1.6.10_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-ClOOHT3Wnf3l9X4F2S6ysPsHMDgKSTgkXpB9Qe0odwpT49ZXNjSAYYaXzO16l+Eq/m2u1HzLkXVsL42HIeOiNQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/clickable': 1.2.6
+      '@chakra-ui/descendant': 2.1.3
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/tabs/1.6.10_ec02b824bed6ab9ca8725186341c5110:
@@ -2881,6 +3484,17 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@chakra-ui/tag/1.2.7_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-RKrKOol4i/CnpFfo3T9LMm1abaqM+5Bs0soQLbo1iJBbBACY09sWXrQYvveQ2GYzU/OrAUloHqqmKjyVGOlNtg==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/icon': 2.0.5_@chakra-ui+system@1.12.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/tag/1.2.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-RKrKOol4i/CnpFfo3T9LMm1abaqM+5Bs0soQLbo1iJBbBACY09sWXrQYvveQ2GYzU/OrAUloHqqmKjyVGOlNtg==}
     peerDependencies:
@@ -2891,6 +3505,17 @@ packages:
       '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
+    dev: false
+
+  /@chakra-ui/textarea/1.2.11_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-RDWbMyC87/AFRX98EnVum5eig/7hhcvS1BrqW5lvmTgrpr7KVr80Dfa8hUj58Iq37Z7AqZijDPkBn/zg7bPdIg==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/form-control': 1.6.0_@chakra-ui+system@1.12.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/textarea/1.2.11_ec02b824bed6ab9ca8725186341c5110:
@@ -2910,7 +3535,7 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1
       '@chakra-ui/utils': 1.10.4
       '@ctrl/tinycolor': 3.4.1
     dev: false
@@ -2921,7 +3546,7 @@ packages:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
       '@chakra-ui/anatomy': 1.3.0_@chakra-ui+system@1.12.1
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
     dev: false
@@ -2947,6 +3572,24 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /@chakra-ui/toast/1.5.9_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-rns04bGdMcG7Ijg45L+PfuEW4rCd0Ycraix4EJQhcl9RXI18G9sphmlp9feidhZAkI6Ukafq1YvyvkBfkKnIzQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+      react-dom: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/alert': 1.3.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/close-button': 1.2.7_@chakra-ui+system@1.12.1
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
+      '@chakra-ui/transition': 1.4.8
+      '@chakra-ui/utils': 1.10.4
+      '@reach/alert': 0.13.2
+    dev: false
+
   /@chakra-ui/tooltip/1.5.1_52a57b03b5c9e77bb025e741e8f26457:
     resolution: {integrity: sha512-EUAlDdlCBt63VpEVtj/RkFjHQVN/xA9gEAumngQdi1Sp+OXPYCBM9GwSY0NwrM1RfKBnhPSH9wz7FwredJWeaw==}
     peerDependencies:
@@ -2967,6 +3610,32 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
+  /@chakra-ui/tooltip/1.5.1_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-EUAlDdlCBt63VpEVtj/RkFjHQVN/xA9gEAumngQdi1Sp+OXPYCBM9GwSY0NwrM1RfKBnhPSH9wz7FwredJWeaw==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+      react-dom: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/hooks': 1.9.1
+      '@chakra-ui/popper': 2.4.3
+      '@chakra-ui/portal': 1.3.10
+      '@chakra-ui/react-utils': 1.2.3
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
+      '@chakra-ui/visually-hidden': 1.1.6_@chakra-ui+system@1.12.1
+    dev: false
+
+  /@chakra-ui/transition/1.4.8:
+    resolution: {integrity: sha512-5uc8LEuCH7+0h++wqAav/EktTHOjbLDSTXQlU9fzPIlNNgyf2eXrHVN2AGMGKiMR9Z4gS7umQjZ54r0w/mZ/Fw==}
+    peerDependencies:
+      framer-motion: 3.x || 4.x || 5.x || 6.x
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/utils': 1.10.4
+    dev: false
+
   /@chakra-ui/transition/1.4.8_framer-motion@6.2.7+react@17.0.2:
     resolution: {integrity: sha512-5uc8LEuCH7+0h++wqAav/EktTHOjbLDSTXQlU9fzPIlNNgyf2eXrHVN2AGMGKiMR9Z4gS7umQjZ54r0w/mZ/Fw==}
     peerDependencies:
@@ -2985,6 +3654,16 @@ packages:
       css-box-model: 1.2.1
       framesync: 5.3.0
       lodash.mergewith: 4.6.2
+    dev: false
+
+  /@chakra-ui/visually-hidden/1.1.6_@chakra-ui+system@1.12.1:
+    resolution: {integrity: sha512-Xzy5bA0UA+IyMgwJizQYSEdgz8cC/tHdmFB3CniXzmpKTSK8mJddeEBl+cGbXHBzxEUhH7xF1eaS41O+0ezWEQ==}
+    peerDependencies:
+      '@chakra-ui/system': '>=1.0.0'
+      react: '>=16.8.6'
+    dependencies:
+      '@chakra-ui/system': 1.12.1
+      '@chakra-ui/utils': 1.10.4
     dev: false
 
   /@chakra-ui/visually-hidden/1.1.6_ec02b824bed6ab9ca8725186341c5110:
@@ -4131,6 +4810,18 @@ packages:
     resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
     dev: false
 
+  /@reach/alert/0.13.2:
+    resolution: {integrity: sha512-LDz83AXCrClyq/MWe+0vaZfHp1Ytqn+kgL5VxG7rirUvmluWaj/snxzfNPWn0Ma4K2YENmXXRC/iHt5X95SqIg==}
+    peerDependencies:
+      react: ^16.8.0 || 17.x
+      react-dom: ^16.8.0 || 17.x
+    dependencies:
+      '@reach/utils': 0.13.2
+      '@reach/visually-hidden': 0.13.2
+      prop-types: 15.8.1
+      tslib: 2.4.0
+    dev: false
+
   /@reach/alert/0.13.2_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-LDz83AXCrClyq/MWe+0vaZfHp1Ytqn+kgL5VxG7rirUvmluWaj/snxzfNPWn0Ma4K2YENmXXRC/iHt5X95SqIg==}
     peerDependencies:
@@ -4145,6 +4836,17 @@ packages:
       tslib: 2.4.0
     dev: false
 
+  /@reach/utils/0.13.2:
+    resolution: {integrity: sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==}
+    peerDependencies:
+      react: ^16.8.0 || 17.x
+      react-dom: ^16.8.0 || 17.x
+    dependencies:
+      '@types/warning': 3.0.0
+      tslib: 2.4.0
+      warning: 4.0.3
+    dev: false
+
   /@reach/utils/0.13.2_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==}
     peerDependencies:
@@ -4156,6 +4858,16 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       tslib: 2.4.0
       warning: 4.0.3
+    dev: false
+
+  /@reach/visually-hidden/0.13.2:
+    resolution: {integrity: sha512-sPZwNS0/duOuG0mYwE5DmgEAzW9VhgU3aIt1+mrfT/xiT9Cdncqke+kRBQgU708q/Ttm9tWsoHni03nn/SuPTQ==}
+    peerDependencies:
+      react: ^16.8.0 || 17.x
+      react-dom: ^16.8.0 || 17.x
+    dependencies:
+      prop-types: 15.8.1
+      tslib: 2.4.0
     dev: false
 
   /@reach/visually-hidden/0.13.2_react-dom@17.0.2+react@17.0.2:
@@ -11058,6 +11770,14 @@ packages:
       minimist: 1.2.6
       strip-json-comments: 2.0.1
 
+  /react-clientside-effect/1.2.5:
+    resolution: {integrity: sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==}
+    peerDependencies:
+      react: ^15.3.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.17.9
+    dev: false
+
   /react-clientside-effect/1.2.5_react@17.0.2:
     resolution: {integrity: sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==}
     peerDependencies:
@@ -11094,6 +11814,21 @@ packages:
       react-clientside-effect: 1.2.5_react@17.0.2
       use-callback-ref: 1.3.0_@types+react@17.0.1+react@17.0.2
       use-sidecar: 1.1.2_@types+react@17.0.1+react@17.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /react-focus-lock/2.5.2_@types+react@17.0.37:
+    resolution: {integrity: sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.17.9
+      focus-lock: 0.9.2
+      prop-types: 15.8.1
+      react-clientside-effect: 1.2.5
+      use-callback-ref: 1.3.0_@types+react@17.0.37
+      use-sidecar: 1.1.2_@types+react@17.0.37
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -11199,6 +11934,21 @@ packages:
       tslib: 2.4.0
     dev: false
 
+  /react-remove-scroll-bar/2.3.0_@types+react@17.0.37:
+    resolution: {integrity: sha512-v2vf8kgrRph5FQeLVZjSOmM0g3ZiBxwMk98VXhsiJDSPeRDUaXJrzYDk2Hhoe6qLggrhWtAXJZVxUwXmRXa93g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.37
+      react-style-singleton: 2.2.0_@types+react@17.0.37
+      tslib: 2.4.0
+    dev: false
+
   /react-remove-scroll/2.4.1_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==}
     engines: {node: '>=8.5.0'}
@@ -11218,6 +11968,24 @@ packages:
       use-sidecar: 1.1.2_@types+react@17.0.1+react@17.0.2
     dev: false
 
+  /react-remove-scroll/2.4.1_@types+react@17.0.37:
+    resolution: {integrity: sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==}
+    engines: {node: '>=8.5.0'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0
+      react: ^16.8.0 || ^17.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.37
+      react-remove-scroll-bar: 2.3.0_@types+react@17.0.37
+      react-style-singleton: 2.2.0_@types+react@17.0.37
+      tslib: 1.14.1
+      use-callback-ref: 1.3.0_@types+react@17.0.37
+      use-sidecar: 1.1.2_@types+react@17.0.37
+    dev: false
+
   /react-style-singleton/2.2.0_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-nK7mN92DMYZEu3cQcAhfwE48NpzO5RpxjG4okbSqRRbfal9Pk+fG2RdQXTMp+f6all1hB9LIJSt+j7dCYrU11g==}
     engines: {node: '>=10'}
@@ -11233,6 +12001,23 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 17.0.2
+      tslib: 2.4.0
+    dev: false
+
+  /react-style-singleton/2.2.0_@types+react@17.0.37:
+    resolution: {integrity: sha512-nK7mN92DMYZEu3cQcAhfwE48NpzO5RpxjG4okbSqRRbfal9Pk+fG2RdQXTMp+f6all1hB9LIJSt+j7dCYrU11g==}
+    engines: {node: '>=10'}
+    deprecated: wrong managing of dynamic styles
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.37
+      get-nonce: 1.0.1
+      invariant: 2.2.4
       tslib: 2.4.0
     dev: false
 
@@ -12759,6 +13544,20 @@ packages:
       tslib: 2.4.0
     dev: false
 
+  /use-callback-ref/1.3.0_@types+react@17.0.37:
+    resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.37
+      tslib: 2.4.0
+    dev: false
+
   /use-isomorphic-layout-effect/1.1.2_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
@@ -12785,6 +13584,21 @@ packages:
       '@types/react': 17.0.1
       detect-node-es: 1.1.0
       react: 17.0.2
+      tslib: 2.4.0
+    dev: false
+
+  /use-sidecar/1.1.2_@types+react@17.0.37:
+    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.37
+      detect-node-es: 1.1.0
       tslib: 2.4.0
     dev: false
 


### PR DESCRIPTION
## Background
Our updated footer does not include our KPIs, but we still want to show them on the homepage. We have a KPI banner in a WIP branch, so let's grab that and put it in its own package to be used in IFixit/ifixit.

This is the first pull for [IFixit/ifixit: #42248](https://github.com/iFixit/ifixit/issues/42248)

## Summary of Changes
1. Made a new package called 'homepage-kpis'
2. Copied over the `StatsSection` component from WIP branch ([add-store-home-page](https://github.com/iFixit/react-commerce/compare/main...add-store-home-page#diff-73027adcba3536a56ebd1902baa816a9b6906230de97856338c2f2f37de0654e))
3. Copied `PageContentWrapper` into package
4. Ran `pnpm install`