### PR TITLE
Fix google analytics

### DIFF
--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -1,7 +1,25 @@
 import { GA_URL, GA_KEY, GA_DEBUG } from '@config/env';
+import * as React from 'react';
 import Script from 'next/script';
+import { useRouter } from 'next/router';
 
 export function GoogleAnalytics() {
+   const router = useRouter();
+   React.useEffect(() => {
+      const handleRouteChange = (url: string) => {
+         if (typeof ga !== 'undefined') {
+            ga('ifixit.set', 'page', url);
+            ga('ifixit.send', 'pageview');
+         }
+      };
+      router.events.on('routeChangeComplete', handleRouteChange);
+      router.events.on('hashChangeComplete', handleRouteChange);
+      return () => {
+         router.events.off('routeChangeComplete', handleRouteChange);
+         router.events.off('hashChangeComplete', handleRouteChange);
+      };
+   }, [router?.events]);
+
    return GA_URL ? (
       <>
          <Script id="google-analytics" strategy="afterInteractive">
@@ -24,6 +42,7 @@ export function GoogleAnalytics() {
                // Enable Remarketing and Advertising Reporting Features in GA
                ga('ifixit.require', 'displayfeatures');
 
+               ga('ifixit.set', 'page', window.location.pathname);
                ga('ifixit.send', 'pageview');
             `}
          </Script>

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -1,35 +1,33 @@
 import { GA_URL, GA_KEY, GA_DEBUG } from '@config/env';
-import Head from 'next/head';
+import Script from 'next/script';
 
 export function GoogleAnalytics() {
    return GA_URL ? (
-      <Head>
-         <script
-            dangerouslySetInnerHTML={{
-               __html: `
-                  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      <>
+         <Script id="google-analytics" strategy="afterInteractive">
+            {`
+               window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 
-                  if (${GA_DEBUG} === true) {
-                     window.ga_debug = {trace: true};
-                  }
+               if (${GA_DEBUG} === true) {
+                  window.ga_debug = {trace: true};
+               }
 
-                  ga('create', '${GA_KEY}', 'auto', 'ifixit', {'legacyCookieDomain': 'ifixit.com'});
-                  ga('ifixit.set', 'anonymizeIp', true);
+               ga('create', '${GA_KEY}', 'auto', 'ifixit', {'legacyCookieDomain': 'ifixit.com'});
+               ga('ifixit.set', 'anonymizeIp', true);
 
-                  // Do not lazy load.
-                  ga('ifixit.set', 'dimension2', '0');
+               // Do not lazy load.
+               ga('ifixit.set', 'dimension2', '0');
 
-                  // Load the enhanced ecommerce plug-in.
-                  ga('ifixit.require', 'ec');
+               // Load the enhanced ecommerce plug-in.
+               ga('ifixit.require', 'ec');
 
-                  // Enable Remarketing and Advertising Reporting Features in GA
-                  ga('ifixit.require', 'displayfeatures');
+               // Enable Remarketing and Advertising Reporting Features in GA
+               ga('ifixit.require', 'displayfeatures');
 
-                  ga('ifixit.send', 'pageview');
-               `,
-            }}
-         />
-         <script async src={`${GA_URL}`}></script>
-      </Head>
+               ga('ifixit.send', 'pageview');
+            `}
+         </Script>
+         <Script src={`${GA_URL}`} strategy="afterInteractive" />
+      </>
    ) : null;
 }

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -7,10 +7,7 @@ export function GoogleAnalytics() {
          <script
             dangerouslySetInnerHTML={{
                __html: `
-                  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                  })(window,document,'script', '${GA_URL}','ga');
+                  window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 
                   if (${GA_DEBUG} === true) {
                      window.ga_debug = {trace: true};
@@ -32,6 +29,7 @@ export function GoogleAnalytics() {
                `,
             }}
          />
+         <script async src={`${GA_URL}`}></script>
       </Head>
    ) : null;
 }

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -48,7 +48,7 @@ export function GoogleAnalytics() {
                ga('ifixit.send', 'pageview');
             `}
          </Script>
-         <Script src={`${GA_URL}`} strategy="afterInteractive" />
+         <Script src={GA_URL} strategy="afterInteractive" />
       </>
    ) : null;
 }

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -3,6 +3,8 @@ import * as React from 'react';
 import Script from 'next/script';
 import { useRouter } from 'next/router';
 
+declare const ga: (command: string, hitType: string, url?: string) => void;
+
 export function GoogleAnalytics() {
    const router = useRouter();
    React.useEffect(() => {

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -27,6 +27,8 @@ export function GoogleAnalytics() {
 
                   // Enable Remarketing and Advertising Reporting Features in GA
                   ga('ifixit.require', 'displayfeatures');
+
+                  ga('ifixit.send', 'pageview');
                `,
             }}
          />


### PR DESCRIPTION
- Fixes a bug where page views weren't being tracked properly.
- Follows the Next.js [reference implementation](https://nextjs.org/docs/messages/next-script-for-ga#using-analyticsjs) of Google Analytics. Note that this puts the script in the `<body>`, and it was in the `<head>` before. This doesn't seem to make a difference functionally. I couldn't find a way to use the Next's `<Script>` component in the `<head>`.
- Sends a GA pageview when the Next router indicates that the route has changed.

## QA
- Install the Legacy Google Tag Manager extension on Chrome: https://chrome.google.com/webstore/detail/tag-assistant-legacy-by-g/kejbdjndbnbjgmefkgdddjlbokphdefk?hl=en
- Run react-commerce locally, and set `NEXT_PUBLIC_GA_URL=https://www.google-analytics.com/analytics.js` in `.env.development`.
- Click "Record" in the extension, and load any page of the app.
- When the page is finished loading, click "Stop Recording" in the extension. It should tell you the page was tracked properly. It will warn you that the script is in the `<body>` instead of the `<head>`, but as long as tracking works properly, I don't think this matters too much.

This is what it should look like:
![image](https://user-images.githubusercontent.com/52104630/183135668-904a6efe-77ac-44d7-9b14-77e80298ee58.png)

CC @sterlinghirsh @davidrans 

Closes #576 