### PR TITLE
Preserve product list description newlines

### DIFF
--- a/frontend/components/product-list/sections/HeroSection.tsx
+++ b/frontend/components/product-list/sections/HeroSection.tsx
@@ -137,7 +137,8 @@ type DescriptionRichTextProps = Omit<BoxProps, 'children'> & {
 const DescriptionRichText = forwardRef<DescriptionRichTextProps, 'div'>(
    ({ children, ...other }, ref) => {
       const html = React.useMemo(() => {
-         return snarkdown(children);
+         const preserveNewlines = children.trim().replace(/\n/g, '<br />');
+         return snarkdown(preserveNewlines);
       }, [children]);
 
       return (


### PR DESCRIPTION
Converts newlines to `<br />` tags before rendering product list descriptions from markdown to html.
Leading and trailing newlines are stripped.

## QA
- Visit the preview link, and choose a product list page.
- Find that product list in strapi admin: https://productlist-description-preserve-newlines.govinor.com/admin
- Edit the product list description to have newlines.
- The newlines in the UI should be one-to-one with the number of newlines in Strapi. (Leading and trailing newlines will be stripped).

CC @jeffsnyder

Closes #450
