### PR TITLE
Remove viewport meta tag warning

### DIFF
--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -65,7 +65,8 @@ export async function findProductList(
       return null;
    }
 
-   const deviceTitle = deviceWiki?.deviceTitle ?? productList?.deviceTitle ?? null;
+   const deviceTitle =
+      deviceWiki?.deviceTitle ?? productList?.deviceTitle ?? null;
    const handle = productList?.handle ?? '';
    const parents =
       productList?.parent ??

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppProviders } from '@components/common';
 import { AppProps } from 'next/app';
 import * as React from 'react';
 import NextNProgress from 'nextjs-progressbar';
+import Head from 'next/head';
 
 type AppPropsWithLayout = AppProps & {
    Component: NextPageWithLayout;
@@ -10,10 +11,18 @@ type AppPropsWithLayout = AppProps & {
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
    const getLayout = Component.getLayout ?? ((page) => page);
    return (
-      <AppProviders {...pageProps.appProps}>
-         <NextNProgress />
-         {getLayout(<Component {...pageProps} />, pageProps)}
-      </AppProviders>
+      <>
+         <Head>
+            <meta
+               name="viewport"
+               content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+            />
+         </Head>
+         <AppProviders {...pageProps.appProps}>
+            <NextNProgress />
+            {getLayout(<Component {...pageProps} />, pageProps)}
+         </AppProviders>
+      </>
    );
 }
 

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -15,10 +15,6 @@ class MyDocument extends Document {
                   href={`${IFIXIT_ORIGIN}/api/2.0/user`}
                   as="fetch"
                />
-               <meta
-                  name="viewport"
-                  content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-               />
             </Head>
             <body>
                <Main />


### PR DESCRIPTION
closes #586 

Move the viewport meta to `_app.tsx` as suggested by the remediation [here](https://nextjs.org/docs/messages/no-document-viewport-meta)

cc @masonmcelvain 

## QA
1. Visit the Vercel preview
2. Verify that there are no changes in functionalities
3. Verify that the viewport meta is still present
4. Verify that the console warning which appeared while compiling a page is not present anymore 