### PR TITLE
Matomo: Track interpage navigation

### DIFF
--- a/frontend/components/analytics/Matomo.tsx
+++ b/frontend/components/analytics/Matomo.tsx
@@ -2,24 +2,16 @@ import { MATOMO_URL } from '@config/env';
 import { useRouter } from 'next/router';
 import * as React from 'react';
 import Script from 'next/script';
-
-declare const _paq: string[][] | undefined;
+import { trackPageView } from '@ifixit/matomo';
 
 export function Matomo() {
    const router = useRouter();
    React.useEffect(() => {
-      const handleRouteChange = (url: string) => {
-         if (typeof window !== 'undefined' && _paq) {
-            _paq.push(['setCustomUrl', url]);
-            _paq.push(['setDocumentTitle', document.title]);
-            _paq.push(['trackPageView']);
-         }
-      };
-      router.events.on('routeChangeComplete', handleRouteChange);
-      router.events.on('hashChangeComplete', handleRouteChange);
+      router.events.on('routeChangeComplete', trackPageView);
+      router.events.on('hashChangeComplete', trackPageView);
       return () => {
-         router.events.off('routeChangeComplete', handleRouteChange);
-         router.events.off('hashChangeComplete', handleRouteChange);
+         router.events.off('routeChangeComplete', trackPageView);
+         router.events.off('hashChangeComplete', trackPageView);
       };
    }, [router?.events]);
 

--- a/frontend/components/analytics/Matomo.tsx
+++ b/frontend/components/analytics/Matomo.tsx
@@ -1,7 +1,28 @@
 import { MATOMO_URL } from '@config/env';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import * as React from 'react';
+
+declare const _paq: string[][] | undefined;
 
 export function Matomo() {
+   const router = useRouter();
+   React.useEffect(() => {
+      const handleRouteChange = (url: string) => {
+         if (typeof window !== 'undefined' && _paq) {
+            _paq.push(['setCustomUrl', url]);
+            _paq.push(['setDocumentTitle', document.title]);
+            _paq.push(['trackPageView']);
+         }
+      };
+      router.events.on('routeChangeComplete', handleRouteChange);
+      router.events.on('hashChangeComplete', handleRouteChange);
+      return () => {
+         router.events.off('routeChangeComplete', handleRouteChange);
+         router.events.off('hashChangeComplete', handleRouteChange);
+      };
+   }, [router?.events]);
+
    return MATOMO_URL ? (
       <Head>
          <script

--- a/frontend/components/analytics/Matomo.tsx
+++ b/frontend/components/analytics/Matomo.tsx
@@ -1,7 +1,7 @@
 import { MATOMO_URL } from '@config/env';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import * as React from 'react';
+import Script from 'next/script';
 
 declare const _paq: string[][] | undefined;
 
@@ -24,25 +24,20 @@ export function Matomo() {
    }, [router?.events]);
 
    return MATOMO_URL ? (
-      <Head>
-         <script
-            key="matomo-analytics"
-            dangerouslySetInnerHTML={{
-               __html: `
-                  var _paq = window._paq = window._paq || [];
-                  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-                  _paq.push(['trackPageView']);
-                  _paq.push(['enableLinkTracking']);
-                  (function() {
-                     var u='${MATOMO_URL}';
-                     _paq.push(['setTrackerUrl', u+'/minerva.php']);
-                     _paq.push(['setSiteId', '1']);
-                     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-                     g.async=true; g.src=u+'/minerva.php'; s.parentNode.insertBefore(g,s);
-                  })();
-               `,
-            }}
-         />
-      </Head>
+      <Script id="matomo-analytics" strategy="afterInteractive">
+         {`
+            var _paq = window._paq = window._paq || [];
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+               var u='${MATOMO_URL}';
+               _paq.push(['setTrackerUrl', u+'/minerva.php']);
+               _paq.push(['setSiteId', '1']);
+               var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+               g.async=true; g.src=u+'/minerva.php'; s.parentNode.insertBefore(g,s);
+            })();
+         `}
+      </Script>
    ) : null;
 }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,6 +6,7 @@ const withTM = require('next-transpile-modules')([
    '@ifixit/icons',
    '@ifixit/auth-sdk',
    '@ifixit/cart-sdk',
+   '@ifixit/matomo',
    '@ifixit/newsletter-sdk',
    '@ifixit/helpers',
    '@ifixit/ifixit-api-client',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
       "@ifixit/helpers": "workspace:*",
       "@ifixit/icons": "workspace:*",
       "@ifixit/ifixit-api-client": "workspace:*",
+      "@ifixit/matomo": "workspace:*",
       "@ifixit/newsletter-sdk": "workspace:*",
       "@ifixit/sentry": "workspace:*",
       "@ifixit/shopify-storefront-client": "workspace:*",

--- a/packages/matomo/index.tsx
+++ b/packages/matomo/index.tsx
@@ -1,0 +1,13 @@
+/**
+ * @see https://developer.matomo.org/api-reference/tracking-javascript
+ */
+
+declare const _paq: string[][] | undefined;
+
+export function trackPageView(url: string) {
+   if (typeof window !== 'undefined' && _paq) {
+      _paq.push(['setCustomUrl', url]);
+      _paq.push(['setDocumentTitle', document.title]);
+      _paq.push(['trackPageView']);
+   }
+}

--- a/packages/matomo/package.json
+++ b/packages/matomo/package.json
@@ -1,0 +1,12 @@
+{
+   "name": "@ifixit/matomo",
+   "version": "0.0.0",
+   "main": "./index.tsx",
+   "types": "./index.tsx",
+   "license": "MIT",
+   "dependencies": {},
+   "devDependencies": {
+      "@ifixit/tsconfig": "workspace:*",
+      "typescript": "4.5.3"
+   }
+}

--- a/packages/matomo/tsconfig.json
+++ b/packages/matomo/tsconfig.json
@@ -1,0 +1,5 @@
+{
+   "extends": "@ifixit/tsconfig/base.json",
+   "include": ["."],
+   "exclude": ["dist", "build", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
       '@ifixit/helpers': workspace:*
       '@ifixit/icons': workspace:*
       '@ifixit/ifixit-api-client': workspace:*
+      '@ifixit/matomo': workspace:*
       '@ifixit/newsletter-sdk': workspace:*
       '@ifixit/sentry': workspace:*
       '@ifixit/shopify-storefront-client': workspace:*
@@ -117,6 +118,7 @@ importers:
       '@ifixit/helpers': link:../packages/helpers
       '@ifixit/icons': link:../packages/icons
       '@ifixit/ifixit-api-client': link:../packages/ifixit-api-client
+      '@ifixit/matomo': link:../packages/matomo
       '@ifixit/newsletter-sdk': link:../packages/newsletter-sdk
       '@ifixit/sentry': link:../packages/sentry
       '@ifixit/shopify-storefront-client': link:../packages/shopify-storefront-client
@@ -280,6 +282,14 @@ importers:
       '@ifixit/tsconfig': link:../tsconfig
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
+      typescript: 4.5.3
+
+  packages/matomo:
+    specifiers:
+      '@ifixit/tsconfig': workspace:*
+      typescript: 4.5.3
+    devDependencies:
+      '@ifixit/tsconfig': link:../tsconfig
       typescript: 4.5.3
 
   packages/newsletter-sdk:


### PR DESCRIPTION
- Tracks navigation between pages in Matomo.
- Uses Next's `Script` component to run the Matomo script after the page is interactive. Consequently, the script is moved from the head to the body.

## QA
- Make sure the preview link you're using is added to matomo.ubreakit.com (see screenshot below)
- Click around through some links in the preview.
- Verify that the visits are recorded in the `Visits Log` in matomo's dashboard.
- Verify that navigation on `main` wasn't working, but it's working on this branch.
- Thanks! 🙏🏻 

![image](https://user-images.githubusercontent.com/52104630/183491871-735948dd-6cac-47d6-a78a-fa870dc14beb.png)

Closes #595 
Closes #495