### PR TITLE
Sentry: Add resolved url tag

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -1,0 +1,16 @@
+import { GetServerSideProps } from 'next';
+import { logAsync } from '@ifixit/helpers';
+import { setSentryPageContext } from '@ifixit/sentry';
+
+export function serverSidePropsWrapper<T>(
+   getServerSidePropsInternal: GetServerSideProps<T>
+): GetServerSideProps<T> {
+   return async (context) => {
+      return logAsync('getServerSideProps', () =>
+         getServerSidePropsInternal(context)
+      ).catch((err) => {
+         setSentryPageContext(context);
+         throw err;
+      });
+   };
+}

--- a/frontend/pages/Parts/[...deviceHandleItemType].tsx
+++ b/frontend/pages/Parts/[...deviceHandleItemType].tsx
@@ -16,6 +16,7 @@ import {
    encodeDeviceTitle,
 } from '@helpers/product-list-helpers';
 import { invariant } from '@ifixit/helpers';
+import { setSentryPageContext } from '@ifixit/sentry';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -28,6 +29,10 @@ type AppPageProps = WithProvidersProps<PageProps>;
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
+   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
+   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
+   setSentryPageContext({ url });
+
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -87,8 +92,6 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 
    const title = `iFixit | ${productList.title}`;
 
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
    const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {

--- a/frontend/pages/Parts/[...deviceHandleItemType].tsx
+++ b/frontend/pages/Parts/[...deviceHandleItemType].tsx
@@ -16,7 +16,7 @@ import {
    encodeDeviceTitle,
 } from '@helpers/product-list-helpers';
 import { invariant } from '@ifixit/helpers';
-import { setSentryPageContext } from '@ifixit/sentry';
+import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -29,10 +29,6 @@ type AppPageProps = WithProvidersProps<PageProps>;
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   setSentryPageContext({ url });
-
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -97,7 +93,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    const appProps: AppProvidersProps = {
       algolia: {
          indexName,
-         url,
+         url: urlFromContext(context),
          apiKey: productList.algolia.apiKey,
       },
    };

--- a/frontend/pages/Parts/[...deviceHandleItemType].tsx
+++ b/frontend/pages/Parts/[...deviceHandleItemType].tsx
@@ -10,6 +10,7 @@ import {
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
+import { serverSidePropsWrapper } from '@helpers/next-helpers';
 import {
    decodeDeviceTitle,
    decodeDeviceItemType,
@@ -26,7 +27,7 @@ import { getServerState } from 'react-instantsearch-hooks-server';
 type PageProps = WithLayoutProps<ProductListViewProps>;
 type AppPageProps = WithProvidersProps<PageProps>;
 
-export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
+const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
    context.res.setHeader(
@@ -128,6 +129,10 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
       props: pageProps,
    };
 };
+
+export const getServerSideProps = serverSidePropsWrapper(
+   getServerSidePropsInternal
+);
 
 const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
    return <ProductListView {...pageProps} />;

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -24,10 +24,6 @@ type AppPageProps = WithProvidersProps<PageProps>;
 const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   setSentryPageContext({ url });
-
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -57,7 +53,7 @@ const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    const appProps: AppProvidersProps = {
       algolia: {
          indexName,
-         url,
+         url: urlFromContext(context),
          apiKey: productList.algolia.apiKey,
       },
    };

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -16,6 +16,7 @@ import { getStoreByCode, getStoreList } from '@models/store';
 import { logAsync, logAsyncWrap } from '@ifixit/helpers';
 import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
+import { setSentryPageContext } from '@ifixit/sentry';
 
 type PageProps = WithLayoutProps<ProductListViewProps>;
 type AppPageProps = WithProvidersProps<PageProps>;
@@ -23,6 +24,10 @@ type AppPageProps = WithProvidersProps<PageProps>;
 const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
+   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
+   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
+   setSentryPageContext({ url });
+
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -47,8 +52,6 @@ const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
 
    const title = `iFixit | ${productList.title}`;
 
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
    const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -13,10 +13,11 @@ import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
-import { logAsync, logAsyncWrap } from '@ifixit/helpers';
+import { logAsync } from '@ifixit/helpers';
+import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
-import { setSentryPageContext } from '@ifixit/sentry';
+import { serverSidePropsWrapper } from '@helpers/next-helpers';
 
 type PageProps = WithLayoutProps<ProductListViewProps>;
 type AppPageProps = WithProvidersProps<PageProps>;
@@ -91,8 +92,9 @@ const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    };
 };
 
-export const getServerSideProps: GetServerSideProps<AppPageProps> =
-   logAsyncWrap('getServerSideProps', getServerSidePropsInternal);
+export const getServerSideProps = serverSidePropsWrapper(
+   getServerSidePropsInternal
+);
 
 const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
    return <ProductListView {...pageProps} />;

--- a/frontend/pages/Shop/[handle].tsx
+++ b/frontend/pages/Shop/[handle].tsx
@@ -11,6 +11,7 @@ import {
 } from '@components/product-list';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { invariant, logAsync, logAsyncWrap } from '@ifixit/helpers';
+import { setSentryPageContext } from '@ifixit/sentry';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -23,6 +24,10 @@ type AppPageProps = WithProvidersProps<PageProps>;
 const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
+   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
+   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
+   setSentryPageContext({ url });
+
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -66,8 +71,6 @@ const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
 
    const title = `iFixit | ${productList.title}`;
 
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
    const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {

--- a/frontend/pages/Shop/[handle].tsx
+++ b/frontend/pages/Shop/[handle].tsx
@@ -12,6 +12,7 @@ import {
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { invariant, logAsync, logAsyncWrap } from '@ifixit/helpers';
 import { setSentryPageContext } from '@ifixit/sentry';
+import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -24,10 +25,6 @@ type AppPageProps = WithProvidersProps<PageProps>;
 const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   setSentryPageContext({ url });
-
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -76,7 +73,7 @@ const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    const appProps: AppProvidersProps = {
       algolia: {
          indexName,
-         url,
+         url: urlFromContext(context),
          apiKey: productList.algolia.apiKey,
       },
    };

--- a/frontend/pages/Shop/[handle].tsx
+++ b/frontend/pages/Shop/[handle].tsx
@@ -10,8 +10,8 @@ import {
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
-import { invariant, logAsync, logAsyncWrap } from '@ifixit/helpers';
-import { setSentryPageContext } from '@ifixit/sentry';
+import { serverSidePropsWrapper } from '@helpers/next-helpers';
+import { invariant, logAsync } from '@ifixit/helpers';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
@@ -111,8 +111,9 @@ const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    };
 };
 
-export const getServerSideProps: GetServerSideProps<AppPageProps> =
-   logAsyncWrap('getServerSideProps', getServerSidePropsInternal);
+export const getServerSideProps = serverSidePropsWrapper(
+   getServerSidePropsInternal
+);
 
 const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
    return <ProductListView {...pageProps} />;

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -11,6 +11,7 @@ import {
 } from '@components/product-list';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { invariant } from '@ifixit/helpers';
+import { setSentryPageContext } from '@ifixit/sentry';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -23,6 +24,10 @@ type AppPageProps = WithProvidersProps<PageProps>;
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
+   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
+   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
+   setSentryPageContext({ url });
+
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -60,8 +65,6 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 
    const title = `iFixit | ${productList.title}`;
 
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
    const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -10,6 +10,7 @@ import {
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
+import { serverSidePropsWrapper } from '@helpers/next-helpers';
 import { invariant } from '@ifixit/helpers';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { getGlobalSettings } from '@models/global-settings';
@@ -21,7 +22,7 @@ import { getServerState } from 'react-instantsearch-hooks-server';
 type PageProps = WithLayoutProps<ProductListViewProps>;
 type AppPageProps = WithProvidersProps<PageProps>;
 
-export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
+const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
    context.res.setHeader(
@@ -101,6 +102,10 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
       props: pageProps,
    };
 };
+
+export const getServerSideProps = serverSidePropsWrapper(
+   getServerSidePropsInternal
+);
 
 const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
    return <ProductListView {...pageProps} />;

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -11,7 +11,7 @@ import {
 } from '@components/product-list';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { invariant } from '@ifixit/helpers';
-import { setSentryPageContext } from '@ifixit/sentry';
+import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -24,10 +24,6 @@ type AppPageProps = WithProvidersProps<PageProps>;
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   setSentryPageContext({ url });
-
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -70,7 +66,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    const appProps: AppProvidersProps = {
       algolia: {
          indexName,
-         url,
+         url: urlFromContext(context),
          apiKey: productList.algolia.apiKey,
       },
    };

--- a/frontend/pages/Tools/index.tsx
+++ b/frontend/pages/Tools/index.tsx
@@ -10,18 +10,18 @@ import {
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
-import { setSentryPageContext } from '@ifixit/sentry';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
+import { serverSidePropsWrapper } from '@helpers/next-helpers';
 
 type PageProps = WithLayoutProps<ProductListViewProps>;
 type AppPageProps = WithProvidersProps<PageProps>;
 
-export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
+const getServerSidePropsInternal: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
    context.res.setHeader(
@@ -89,6 +89,10 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
       props: pageProps,
    };
 };
+
+export const getServerSideProps = serverSidePropsWrapper(
+   getServerSidePropsInternal
+);
 
 const ProductListPage: NextPageWithLayout<PageProps> = (pageProps) => {
    return <ProductListView {...pageProps} />;

--- a/frontend/pages/Tools/index.tsx
+++ b/frontend/pages/Tools/index.tsx
@@ -14,6 +14,7 @@ import { setSentryPageContext } from '@ifixit/sentry';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
+import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { GetServerSideProps } from 'next';
 import { getServerState } from 'react-instantsearch-hooks-server';
 
@@ -23,10 +24,6 @@ type AppPageProps = WithProvidersProps<PageProps>;
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
-   setSentryPageContext({ url });
-
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -57,7 +54,7 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    const appProps: AppProvidersProps = {
       algolia: {
          indexName,
-         url,
+         url: urlFromContext(context),
          apiKey: productList.algolia.apiKey,
       },
    };

--- a/frontend/pages/Tools/index.tsx
+++ b/frontend/pages/Tools/index.tsx
@@ -10,6 +10,7 @@ import {
    ProductListViewProps,
 } from '@components/product-list';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
+import { setSentryPageContext } from '@ifixit/sentry';
 import { getGlobalSettings } from '@models/global-settings';
 import { findProductList } from '@models/product-list';
 import { getStoreByCode, getStoreList } from '@models/store';
@@ -22,6 +23,10 @@ type AppPageProps = WithProvidersProps<PageProps>;
 export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
    context
 ) => {
+   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
+   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
+   setSentryPageContext({ url });
+
    context.res.setHeader(
       'Cache-Control',
       'public, s-maxage=10, stale-while-revalidate=600'
@@ -47,8 +52,6 @@ export const getServerSideProps: GetServerSideProps<AppPageProps> = async (
 
    const title = `iFixit | ${productList.title}`;
 
-   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
-   const url = `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
    const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
 
    const appProps: AppProvidersProps = {

--- a/packages/helpers/index.tsx
+++ b/packages/helpers/index.tsx
@@ -41,20 +41,6 @@ export function logAsync<T>(
    return asyncFunction().finally(done);
 }
 
-/**
- * Wrap a promise-returning function and logs the time it takes to resolve
- * the promise.
- */
-export function logAsyncWrap<Args extends any[], T>(
-   name: string,
-   asyncFunction: (...args: Args) => Promise<T>
-): (...args: Args) => Promise<T> {
-   return (...args) => {
-      const done = time(name);
-      return asyncFunction(...args).finally(done);
-   };
-}
-
 export function logSync<T>(name: string, syncFunction: () => T): T {
    const done = time(name);
    const response = syncFunction();

--- a/packages/helpers/nextjs.tsx
+++ b/packages/helpers/nextjs.tsx
@@ -1,0 +1,6 @@
+import { GetServerSidePropsContext } from 'next';
+
+export function urlFromContext(context: GetServerSidePropsContext): string {
+   const protocol = context.req.headers.referer?.split('://')[0] || 'https';
+   return `${protocol}://${context.req.headers.host}${context.resolvedUrl}`;
+}

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -4,6 +4,10 @@
    "main": "./index.tsx",
    "types": "./index.tsx",
    "license": "MIT",
+   "exports": {
+      ".": "./index.tsx",
+      "./nextjs": "./nextjs.tsx"
+   },
    "devDependencies": {
       "@ifixit/tsconfig": "workspace:*",
       "typescript": "4.5.3"

--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -1,4 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
+import { urlFromContext } from '@ifixit/helpers/nextjs';
+import { GetServerSidePropsContext } from 'next';
 
 export const sentryFetch: typeof fetch = async (resource, options) => {
    const context = {
@@ -28,10 +30,7 @@ export const sentryFetch: typeof fetch = async (resource, options) => {
       });
 };
 
-type PageContextProps = {
-   url: string;
-};
-
-export const setSentryPageContext = ({ url }: PageContextProps) => {
-   Sentry.setTag('resolved_url', url);
+export const setSentryPageContext = (context: GetServerSidePropsContext) => {
+   Sentry.configureScope((scope) => scope.clear());
+   Sentry.setTag('resolved_url', urlFromContext(context));
 };

--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -27,3 +27,11 @@ export const sentryFetch: typeof fetch = async (resource, options) => {
          throw error;
       });
 };
+
+type PageContextProps = {
+   url: string;
+};
+
+export const setSentryPageContext = ({ url }: PageContextProps) => {
+   Sentry.setTag('resolved_url', url);
+};

--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -31,6 +31,5 @@ export const sentryFetch: typeof fetch = async (resource, options) => {
 };
 
 export const setSentryPageContext = (context: GetServerSidePropsContext) => {
-   Sentry.configureScope((scope) => scope.clear());
    Sentry.setTag('resolved_url', urlFromContext(context));
 };

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -5,7 +5,8 @@
    "types": "./index.tsx",
    "license": "MIT",
    "dependencies": {
-      "@sentry/nextjs": "^7.0.0"
+      "@ifixit/helpers": "workspace:*",
+      "@sentry/nextjs": "^7.8.1"
    },
    "peerDependencies": {
       "next": "11.1.3",

--- a/packages/sentry/tsconfig.json
+++ b/packages/sentry/tsconfig.json
@@ -1,5 +1,5 @@
 {
-   "extends": "@ifixit/tsconfig/base.json",
+   "extends": "@ifixit/tsconfig/react-library.json",
    "include": ["."],
    "exclude": ["dist", "build", "node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,11 +303,13 @@ importers:
 
   packages/sentry:
     specifiers:
+      '@ifixit/helpers': workspace:*
       '@ifixit/tsconfig': workspace:*
-      '@sentry/nextjs': ^7.0.0
+      '@sentry/nextjs': ^7.8.1
       typescript: 4.5.3
     dependencies:
-      '@sentry/nextjs': 7.0.0
+      '@ifixit/helpers': link:../helpers
+      '@sentry/nextjs': 7.8.1
     devDependencies:
       '@ifixit/tsconfig': link:../tsconfig
       typescript: 4.5.3
@@ -4216,16 +4218,6 @@ packages:
       rxjs: 6.6.7
     dev: true
 
-  /@sentry/browser/7.0.0:
-    resolution: {integrity: sha512-XJeQA/CIocrmShpfVcccJ2RvZbWZy+OustSbgLP5Vk+ZnzbqKQo1zQ92jO/dUoVIsl5dWpUaOKfT6gXmORf4vQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/core': 7.0.0
-      '@sentry/types': 7.0.0
-      '@sentry/utils': 7.0.0
-      tslib: 1.14.1
-    dev: false
-
   /@sentry/browser/7.8.1:
     resolution: {integrity: sha512-9JuagYqHyaZu/4RqyxrAgEHo71oV592XBuUKC33gajCVKWbyG3mNqudSMoHtdM1DrV9REZ4Elha7zFaE2cJX6g==}
     engines: {node: '>=8'}
@@ -4254,16 +4246,6 @@ packages:
       - supports-color
     dev: false
 
-  /@sentry/core/7.0.0:
-    resolution: {integrity: sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/hub': 7.0.0
-      '@sentry/types': 7.0.0
-      '@sentry/utils': 7.0.0
-      tslib: 1.14.1
-    dev: false
-
   /@sentry/core/7.8.1:
     resolution: {integrity: sha512-PRivbdIzApi/gSixAxozhOBTylSVdw/9VxaStYHd7JJGhs36KXkV8ylpbCmYO4ap7/Ue9/slzwpvPOJJzmzAgA==}
     engines: {node: '>=8'}
@@ -4274,31 +4256,12 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/hub/7.0.0:
-    resolution: {integrity: sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/types': 7.0.0
-      '@sentry/utils': 7.0.0
-      tslib: 1.14.1
-    dev: false
-
   /@sentry/hub/7.8.1:
     resolution: {integrity: sha512-AxwyGyS9Lp4XsURu4t8opa5vZ+NAB6I/n+B/Uix3YZea9z8jdWYAu9vsXSizOrtxekc/i7ZN4bnlNgXVHix0iA==}
     engines: {node: '>=8'}
     dependencies:
       '@sentry/types': 7.8.1
       '@sentry/utils': 7.8.1
-      tslib: 1.14.1
-    dev: false
-
-  /@sentry/integrations/7.0.0:
-    resolution: {integrity: sha512-5/JqYIBpe6lxMqxjsBr2NB2oWPe+46xolcXYSvgUYI7vryIiyW+jhXINma1hEPxXDHntiYN9aT4xzFgdNv1MHA==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/types': 7.0.0
-      '@sentry/utils': 7.0.0
-      localforage: 1.10.0
       tslib: 1.14.1
     dev: false
 
@@ -4312,8 +4275,8 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/nextjs/7.0.0:
-    resolution: {integrity: sha512-H0cV1rnippq3jBqnIF22wZLOaJzyPS/N2FrNxuvNLn+pY38mmtPF8kNpdTweDoM/RD7V7z+LuFE/uD8V75zZKQ==}
+  /@sentry/nextjs/7.8.1:
+    resolution: {integrity: sha512-YpDSbWXx/r0yasm9PEtrhECdrl1QYHOWtuyOZShIpxHZ+YcNmAUXhYp75fmxs5UU3+KOYT4jpTnzAtfQg8hCEw==}
     engines: {node: '>=8'}
     peerDependencies:
       next: ^10.0.8 || ^11.0 || ^12.0
@@ -4323,15 +4286,15 @@ packages:
       webpack:
         optional: true
     dependencies:
-      '@sentry/core': 7.0.0
-      '@sentry/hub': 7.0.0
-      '@sentry/integrations': 7.0.0
-      '@sentry/node': 7.0.0
-      '@sentry/react': 7.0.0
-      '@sentry/tracing': 7.0.0
-      '@sentry/types': 7.0.0
-      '@sentry/utils': 7.0.0
-      '@sentry/webpack-plugin': 1.18.9
+      '@sentry/core': 7.8.1
+      '@sentry/hub': 7.8.1
+      '@sentry/integrations': 7.8.1
+      '@sentry/node': 7.8.1
+      '@sentry/react': 7.8.1
+      '@sentry/tracing': 7.8.1
+      '@sentry/types': 7.8.1
+      '@sentry/utils': 7.8.1
+      '@sentry/webpack-plugin': 1.19.0
       tslib: 1.14.1
     transitivePeerDependencies:
       - encoding
@@ -4367,22 +4330,6 @@ packages:
       - supports-color
     dev: false
 
-  /@sentry/node/7.0.0:
-    resolution: {integrity: sha512-YfmPldRH2oO3OCsu5kqnzVbeMa2Tr9Qf4t8iy7AuYKPok5ossIeZCBzjTBRw/g0wJL+I5WsxHVrt2YUuLGYBSQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/core': 7.0.0
-      '@sentry/hub': 7.0.0
-      '@sentry/types': 7.0.0
-      '@sentry/utils': 7.0.0
-      cookie: 0.4.2
-      https-proxy-agent: 5.0.1
-      lru_map: 0.3.3
-      tslib: 1.14.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@sentry/node/7.8.1:
     resolution: {integrity: sha512-gQHeIip7QudeK1YWrLyZPc7nfirhbVDJ3gfCfL9mLT724Sk8gKd1kcpU1niI+wwIwY7SOpJqX4Oh/F0lRKjzDQ==}
     engines: {node: '>=8'}
@@ -4399,15 +4346,15 @@ packages:
       - supports-color
     dev: false
 
-  /@sentry/react/7.0.0:
-    resolution: {integrity: sha512-zF/fUjyWXAjycS6WEv4BntKpp/CzHr7Qv0qB1n1EITvdMAYWfJTOhXdIKF/U9Rq/OmM0Gd8SthFWaEAJWzCgZQ==}
+  /@sentry/react/7.8.1:
+    resolution: {integrity: sha512-+3ClAfIcXLWv+NnF8R/lnDX/0qde377GXobid+VCgCi24psqI5BCR1Aoa1BSBiKSgYJ0MV4tnQk0e3kGJlNqjw==}
     engines: {node: '>=8'}
     peerDependencies:
       react: 15.x || 16.x || 17.x || 18.x
     dependencies:
-      '@sentry/browser': 7.0.0
-      '@sentry/types': 7.0.0
-      '@sentry/utils': 7.0.0
+      '@sentry/browser': 7.8.1
+      '@sentry/types': 7.8.1
+      '@sentry/utils': 7.8.1
       hoist-non-react-statics: 3.3.2
       tslib: 1.14.1
     dev: false
@@ -4426,16 +4373,6 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/tracing/7.0.0:
-    resolution: {integrity: sha512-eUHER2RWzm9OtFKQZIr5EwTGM3IU0xJ7l60rnAEbgW5b1bzWC0k/J6EeXeBBfGq7wric/BjH0WKQOnixtXUBpw==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/hub': 7.0.0
-      '@sentry/types': 7.0.0
-      '@sentry/utils': 7.0.0
-      tslib: 1.14.1
-    dev: false
-
   /@sentry/tracing/7.8.1:
     resolution: {integrity: sha512-orNVCsMtQUKhvh7GmyJzjOhU6oT7lC7TRT7tTRlyXQVrUmfJZsthmBtyfrTC7QWJ9vXQ0mB4jab8kMT3xE4ltg==}
     engines: {node: '>=8'}
@@ -4446,22 +4383,9 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/types/7.0.0:
-    resolution: {integrity: sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA==}
-    engines: {node: '>=8'}
-    dev: false
-
   /@sentry/types/7.8.1:
     resolution: {integrity: sha512-LOoaeBXVI23Kh5SpIbxSRiJ6+eYZXVOFyPFH1T1mGBj95LPwRMqOdg0lUTmFJGBKbDGDB/YNjNnu1kQ7GrXBXw==}
     engines: {node: '>=8'}
-    dev: false
-
-  /@sentry/utils/7.0.0:
-    resolution: {integrity: sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==}
-    engines: {node: '>=8'}
-    dependencies:
-      '@sentry/types': 7.0.0
-      tslib: 1.14.1
     dev: false
 
   /@sentry/utils/7.8.1:
@@ -4470,16 +4394,6 @@ packages:
     dependencies:
       '@sentry/types': 7.8.1
       tslib: 1.14.1
-    dev: false
-
-  /@sentry/webpack-plugin/1.18.9:
-    resolution: {integrity: sha512-+TrenJrgFM0QTOwBnw0ZXWMvc0PiOebp6GN5EbGEx3JPCQqXOfXFzCaEjBtASKRgcNCL7zGly41S25YR6Hm+jw==}
-    engines: {node: '>= 8'}
-    dependencies:
-      '@sentry/cli': 1.74.4
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
     dev: false
 
   /@sentry/webpack-plugin/1.19.0:


### PR DESCRIPTION
Sometimes it's hard to tell which page a user was on when an error occurred, so adding it in a tag will be useful for debugging.

The resolved url is the url that the user requested (like /Parts/iPhone). This is different than `context.req.url`, which can be a link like /_next/data..., which is not the helpful for debugging.

## QA
Throw an error on any page while running local dev. It should get reported to react-commerce-dev in sentry, and have a `resolved_url` tag.