### PR TITLE
Make Sure "Back to Shopping" Button isn't on Page When Not Visible

### DIFF
--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -163,7 +163,8 @@ export function CartDrawer() {
                            </AnimatePresence>
                         </Box>
                      </ScaleFade>
-                     <ScaleFade
+                     <Collapse
+                        animateOpacity
                         in={cart.data != null && cart.data.totalNumItems === 0}
                      >
                         <VStack spacing="5" p="5">
@@ -179,7 +180,7 @@ export function CartDrawer() {
                               Back to shopping
                            </Button>
                         </VStack>
-                     </ScaleFade>
+                     </Collapse>
                   </DrawerBody>
 
                   <Collapse


### PR DESCRIPTION
## Overview

Previously, we would not have the "Back to Shopping" button and associated text elements visible but they would still be interactable. This has been fixed by making that section now collapse instead of not being rendered.

## QA
Are the aforementioned buttons and text not in the drawer anymore when they shouldn't be (having items in the cart)?

I've changed the `scalefade` section to a `collapse` section, which you can see how these animate differently [here](https://chakra-ui.com/docs/components/transitions/usage#scalefade-transition) and [here](https://chakra-ui.com/docs/components/transitions/usage#scalefade-transition) respectively. This is seen when your cart is clear and the "Back to Shopping" button is valid again. If this isn't acceptable design lmk, but I feel like it is ok.

Closes: #444 