### PR TITLE
@ifixit/ui: Add `build` and `clean` scripts

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,10 @@
    "main": "./index.tsx",
    "types": "./index.tsx",
    "license": "MIT",
+   "scripts": {
+      "build": "",
+      "clean": ""
+   },
    "dependencies": {
       "@ifixit/app": "workspace:*",
       "@ifixit/cart-sdk": "workspace:*"


### PR DESCRIPTION
Our main monorepo requires these for all dependencies of our main package. Now that we're wanting to start using the `@ifixit/ui` package from that main package, we need them.

qa_req 0