### PR TITLE
Discount Flair : Make it visible always

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -53,7 +53,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
    const quantityAvailable = Math.max(0, product.quantity_available);
 
    const showProBadge = product.is_pro > 0;
-   const showDiscountBadge = quantityAvailable > 0 && isDiscounted;
+   const showDiscountBadge = isDiscounted;
    const showLifetimeWarrantyBadge = product.lifetime_warranty;
    const showOemPartnershipBadge = product.oem_partnership;
    const showBadges =


### PR DESCRIPTION
Since we always want to display the  flairs, regardless of whether an item is in stock or not [ie the `quantityAvailable` > 0 or not], lets get rid of the check and assign the boolean value simply based on whether the item is discounted or not. This is similar to #471 

## QA
- Visit the prod [preview](https://react-commerce-prod-git-fix-missing-discount-flair-ifixit.vercel.app/Parts/PC_Laptop/Batteries?p=4)
- Make sure the discount flair is visible as desired for the different items [The flair should now be visible for [https://www.ifixit.com/Store/PC-Laptop/Lenovo-ThinkPad-X1-Yoga-1st-Gen-and-X1-Carbon-4th-Gen-56Wh-Battery/IF245-154?o=2](https://www.ifixit.com/Store/PC-Laptop/Lenovo-ThinkPad-X1-Yoga-1st-Gen-and-X1-Carbon-4th-Gen-56Wh-Battery/IF245-154?o=2)]

Closes #613 

@jeffsnyder