### PR TITLE
Mobile Filtering: Improve UX

### DIFF
--- a/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
+++ b/frontend/components/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
@@ -147,7 +147,6 @@ export function FacetsDrawer({
                            isOpen={facet === currentFacet}
                            productList={productList}
                            onClose={() => {
-                              onClose();
                               setCurrentFacet(null);
                            }}
                         />


### PR DESCRIPTION
In https://github.com/iFixit/react-commerce/commit/e905db9176b532d461d469711a0e3e0f64e49dbb, we made it so that the on mobile view, when we select a facet in the single select facet category, we close the drawer and get back to the product page. The issue with that is if the user needs to filter further, they have to repeat certain steps.

Instead, lets keep the behavior so that when the user selects a facet in the single select category, we bring the user back to the facet list instead of closing the drawer.

## QA
- On mobile/tablet view, make sure that when a single select facet is selected, it brings you back to the list of facets instead of exiting out.

**NOTE: https://github.com/iFixit/react-commerce/issues/579#issuecomment-1209078103 hasn't been implemented in this PR and if this scrolling problem still persists, then we will open a new issue for it.**

Closes #579 

CC: @jordycosta @masonmcelvain @sterlinghirsh 