### PR TITLE
strapi: Use long git ref for deploy

### DIFF
--- a/backend/build-docker-and-push
+++ b/backend/build-docker-and-push
@@ -2,8 +2,8 @@
 
 set -eu
 
-GIT_SHORT_REF=$(git rev-parse --short HEAD)
-DOCKER_TAG="strapi:$GIT_SHORT_REF"
+GIT_REF=$(git rev-parse HEAD)
+DOCKER_TAG="strapi:$GIT_REF"
 # iFixit AWS ECR for strapi
 ECR_TAG="884681002735.dkr.ecr.us-east-1.amazonaws.com/$DOCKER_TAG"
 


### PR DESCRIPTION
We ran into a problem where different versions of `git` had different length short refs (old version had 7 chars, new version had 8 chars).

Let's always use the long ref so we don't have that problem in the future.

## On deploy

We should be able to [redeploy](https://github.com/ifixit/server-templates/wiki/strapi) strapi

CC @danielbeardsley

Connects https://github.com/iFixit/server-templates/pull/3512

qa_req 0
