### PR TITLE
Have Single Select Refinement UI Change Look Somewhat Smoother 

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -32,16 +32,19 @@ export function RefinementSingleSelect({
          sortBy: useSortBy(otherProps),
       });
 
-   const onClickSingleSelect = (newSelected: RefinementListItem) => {
-      refine(newSelected.value);
+   const onClickSingleSelect = React.useCallback(
+      (newSelected: RefinementListItem) => {
+         refine(newSelected.value);
 
-      const oldSelected: RefinementListItem | undefined = items.find(
-         (item) => item.isRefined
-      );
-      if (oldSelected && oldSelected !== newSelected) {
-         refine(oldSelected.value);
-      }
-   };
+         const oldSelected: RefinementListItem | undefined = items.find(
+            (item) => item.isRefined
+         );
+         if (oldSelected && oldSelected !== newSelected) {
+            refine(oldSelected.value);
+         }
+      },
+      [items, refine]
+   );
    return (
       <Box>
          <VStack align="stretch" spacing="1" role="listbox">

--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -14,7 +14,6 @@ import { useSortBy } from './useSortBy';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { ProductList, ProductListType } from '@models/product-list';
 import { encodeDeviceItemType } from '@helpers/product-list-helpers';
-import { useDecoupledState } from '@ifixit/ui';
 
 type RefinementSingleSelectProps = UseRefinementListProps & {
    productList: ProductList;
@@ -96,7 +95,6 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
    onClose,
    onClick,
 }: SingleSelectItemProps) {
-   const [isRefined, setIsRefined] = useDecoupledState(item.isRefined);
    const { createURL } = useCurrentRefinements();
    const shouldBeLink =
       attribute === 'facet_tags.Item Type' &&
@@ -109,7 +107,6 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
          as={shouldBeLink ? 'a' : 'button'}
          onClick={(event) => {
             event.preventDefault();
-            setIsRefined((current) => !current);
             onClick && onClick(item);
             onClose?.();
          }}
@@ -149,8 +146,8 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
       <HStack
          key={item.label}
          justify="space-between"
-         color={isRefined ? 'brand.500' : 'inherit'}
-         fontWeight={isRefined ? 'bold' : 'inherit'}
+         color={item.isRefined ? 'brand.500' : 'inherit'}
+         fontWeight={item.isRefined ? 'bold' : 'inherit'}
       >
          {RefinementTitle}
          <Text size="sm" fontFamily="sans-serif" color={'gray.500'}>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -14,6 +14,7 @@ import { useSortBy } from './useSortBy';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { ProductList, ProductListType } from '@models/product-list';
 import { encodeDeviceItemType } from '@helpers/product-list-helpers';
+import { useDecoupledState } from '@ifixit/ui';
 
 type RefinementSingleSelectProps = UseRefinementListProps & {
    productList: ProductList;
@@ -30,6 +31,7 @@ export function RefinementSingleSelect({
          ...otherProps,
          sortBy: useSortBy(otherProps),
       });
+
    const onClickSingleSelect = (newSelected: RefinementListItem) => {
       refine(newSelected.value);
 
@@ -91,6 +93,7 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
    onClose,
    onClick,
 }: SingleSelectItemProps) {
+   const [isRefined, setIsRefined] = useDecoupledState(item.isRefined);
    const { createURL } = useCurrentRefinements();
    const shouldBeLink =
       attribute === 'facet_tags.Item Type' &&
@@ -103,6 +106,7 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
          as={shouldBeLink ? 'a' : 'button'}
          onClick={(event) => {
             event.preventDefault();
+            setIsRefined((current) => !current);
             onClick && onClick(item);
             onClose?.();
          }}
@@ -142,8 +146,8 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
       <HStack
          key={item.label}
          justify="space-between"
-         color={item.isRefined ? 'brand.500' : 'inherit'}
-         fontWeight={item.isRefined ? 'bold' : 'inherit'}
+         color={isRefined ? 'brand.500' : 'inherit'}
+         fontWeight={isRefined ? 'bold' : 'inherit'}
       >
          {RefinementTitle}
          <Text size="sm" fontFamily="sans-serif" color={'gray.500'}>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -6,7 +6,6 @@ import {
    RefinementListItem,
 } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 import {
-   useClearRefinements,
    useCurrentRefinements,
    UseRefinementListProps,
 } from 'react-instantsearch-hooks-web';
@@ -14,7 +13,6 @@ import NextLink from 'next/link';
 import { useSortBy } from './useSortBy';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { ProductList, ProductListType } from '@models/product-list';
-import { useDecoupledState } from '@ifixit/ui';
 import { encodeDeviceItemType } from '@helpers/product-list-helpers';
 
 type RefinementSingleSelectProps = UseRefinementListProps & {
@@ -33,15 +31,12 @@ export function RefinementSingleSelect({
          sortBy: useSortBy(otherProps),
       });
    const onClickSingleSelect = (newSelected: RefinementListItem) => {
+      refine(newSelected.value);
+
       const oldSelected: RefinementListItem | undefined = items.find(
          (item) => item.isRefined
       );
-
-      newSelected.isRefined = !newSelected.isRefined;
-      refine(newSelected.value);
-
       if (oldSelected && oldSelected !== newSelected) {
-         oldSelected.isRefined = !oldSelected?.isRefined;
          refine(oldSelected.value);
       }
    };
@@ -55,7 +50,6 @@ export function RefinementSingleSelect({
                      item={item}
                      attribute={otherProps.attribute}
                      productListType={productList.type}
-                     refine={refine}
                      onClose={onClose}
                      onClick={onClickSingleSelect}
                   />
@@ -86,7 +80,6 @@ type SingleSelectItemProps = {
    item: RefinementListRenderState['items'][0];
    attribute: string;
    productListType: ProductListType;
-   refine: RefinementListRenderState['refine'];
    onClose?: () => void;
    onClick?: (newSelected: RefinementListItem) => void;
 };
@@ -95,14 +88,9 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
    item,
    attribute,
    productListType,
-   refine,
    onClose,
    onClick,
 }: SingleSelectItemProps) {
-   const [isRefined, setIsRefined] = useDecoupledState(item.isRefined);
-   const { refine: clearRefinements } = useClearRefinements({
-      includedAttributes: [attribute],
-   });
    const { createURL } = useCurrentRefinements();
    const shouldBeLink =
       attribute === 'facet_tags.Item Type' &&
@@ -154,8 +142,8 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
       <HStack
          key={item.label}
          justify="space-between"
-         color={isRefined ? 'brand.500' : 'inherit'}
-         fontWeight={isRefined ? 'bold' : 'inherit'}
+         color={item.isRefined ? 'brand.500' : 'inherit'}
+         fontWeight={item.isRefined ? 'bold' : 'inherit'}
       >
          {RefinementTitle}
          <Text size="sm" fontFamily="sans-serif" color={'gray.500'}>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -1,7 +1,10 @@
 import { Box, Button, HStack, Icon, VStack, Text } from '@chakra-ui/react';
 import React from 'react';
 import { HiSelector } from 'react-icons/hi';
-import { RefinementListRenderState } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
+import {
+   RefinementListRenderState,
+   RefinementListItem,
+} from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 import {
    useClearRefinements,
    useCurrentRefinements,
@@ -29,6 +32,19 @@ export function RefinementSingleSelect({
          ...otherProps,
          sortBy: useSortBy(otherProps),
       });
+   const onClickSingleSelect = (newSelected: RefinementListItem) => {
+      const oldSelected: RefinementListItem | undefined = items.find(
+         (item) => item.isRefined
+      );
+
+      newSelected.isRefined = !newSelected.isRefined;
+      refine(newSelected.value);
+
+      if (oldSelected && oldSelected !== newSelected) {
+         oldSelected.isRefined = !oldSelected?.isRefined;
+         refine(oldSelected.value);
+      }
+   };
    return (
       <Box>
          <VStack align="stretch" spacing="1" role="listbox">
@@ -41,6 +57,7 @@ export function RefinementSingleSelect({
                      productListType={productList.type}
                      refine={refine}
                      onClose={onClose}
+                     onClick={onClickSingleSelect}
                   />
                );
             })}
@@ -71,6 +88,7 @@ type SingleSelectItemProps = {
    productListType: ProductListType;
    refine: RefinementListRenderState['refine'];
    onClose?: () => void;
+   onClick?: (newSelected: RefinementListItem) => void;
 };
 
 const SingleSelectItem = React.memo(function SingleSelectItem({
@@ -79,6 +97,7 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
    productListType,
    refine,
    onClose,
+   onClick,
 }: SingleSelectItemProps) {
    const [isRefined, setIsRefined] = useDecoupledState(item.isRefined);
    const { refine: clearRefinements } = useClearRefinements({
@@ -96,9 +115,7 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
          as={shouldBeLink ? 'a' : 'button'}
          onClick={(event) => {
             event.preventDefault();
-            clearRefinements();
-            !isRefined && refine(item.value);
-            setIsRefined((current) => !current);
+            onClick && onClick(item);
             onClose?.();
          }}
          _hover={{


### PR DESCRIPTION
## Overview

When we used to swap single select refinements we would sometimes have the no-refinements selection blip on the screen for a half second (see the issue #526 for an example). This pr helps make it smoother while we try to figure out whats wrong with vercel and #617. It does this by adding in the new refinement before removing the old refinement.

## CR
This isn't a bad pattern for react right?

## QA
Make sure that pages have less of the blip of wrong results when switching single select refinements (note that even on master this blip disappears on switching if youve already switched between the two refinements on a page load. it must be caching the refinement results in the browser). Make sure that refinements are working as intended. 

Connects #526