### PR TITLE
Refactor product list links to point to new product page

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
       '@components(.+)': '<rootDir>/components/$1',
       '@templates(.+)': '<rootDir>/templates/$1',
       '@helpers(.+)': '<rootDir>/helpers/$1',
+      '@config(.+)': '<rootDir>/config/$1',
    },
    setupFilesAfterEnv: ['<rootDir>/test/jest/jest-setup.ts'],
    testPathIgnorePatterns: ['<rootDir>/(node_modules|.next|test/cypress)/'],

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -9,6 +9,7 @@ import {
    ProductCardRating,
    ProductCardTitle,
 } from '@components/common';
+import { flags } from '@config/flags';
 import { useAppContext } from '@ifixit/app';
 import { ProductSearchHit } from '@models/product-list';
 import * as React from 'react';
@@ -83,7 +84,13 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
                )}
             </ProductCardBadgeList>
             <ProductCardBody>
-               <LinkOverlay href={`${appContext.ifixitOrigin}${product.url}`}>
+               <LinkOverlay
+                  href={
+                     flags.PRODUCT_PAGE_ENABLED
+                        ? `/Products/${product.handle}`
+                        : `${appContext.ifixitOrigin}${product.url}`
+                  }
+               >
                   <ProductCardTitle _groupHover={{ color: 'brand.500' }}>
                      {product.title}
                   </ProductCardTitle>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -14,10 +14,11 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { ThemeTypings } from '@chakra-ui/styled-system';
+import { IfixitImage } from '@components/ifixit-image';
 import { Rating } from '@components/ui';
+import { flags } from '@config/flags';
 import { useAppContext } from '@ifixit/app';
 import { ProductSearchHit } from '@models/product-list';
-import { IfixitImage } from '@components/ifixit-image';
 import * as React from 'react';
 import { useProductSearchHitPricing } from './useProductSearchHitPricing';
 
@@ -246,7 +247,11 @@ export function ProductListItem({ product }: ProductListItemProps) {
                      }}
                   >
                      <LinkOverlay
-                        href={`${appContext.ifixitOrigin}${product.url}`}
+                        href={
+                           flags.PRODUCT_PAGE_ENABLED
+                              ? `/Products/${product.handle}`
+                              : `${appContext.ifixitOrigin}${product.url}`
+                        }
                      >
                         <Button
                            as="div"


### PR DESCRIPTION
This PR refactors product list to link to the new product page (if the product page flag is enabled)

## QA

1. Open [prod-like Vercel preview](https://react-commerce-prod-m8006kj4z-ifixit.vercel.app/Parts) (flag not enabled)
2. Go to `/Parts` and verify that products list links point to the current product pages
3. Visit [staging Vercel preview](https://react-commerce-g7rzb3hpz-ifixit.vercel.app/Parts) (flag is enabled)
4. Go to `/Parts` and verify that product list links point to the new product page stub
