### PR TITLE
Report failing SDK queries to Sentry

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/index.ts
+++ b/frontend/lib/shopify-storefront-sdk/index.ts
@@ -1,4 +1,5 @@
 import { getSdk, Requester } from './generated/sdk';
+import * as Sentry from '@sentry/nextjs';
 export * from './generated/sdk';
 
 export type ShopCredentials = {
@@ -42,6 +43,16 @@ export function getShopifyStorefrontSdk(shop: ShopCredentials) {
          result.errors.map((error: any) => {
             const code = error.extensions?.code || 'UNKNOWN';
             console.error(`\t[${code}]`, error.message);
+         });
+         Sentry.withScope((scope) => {
+            scope.setExtra('query', doc);
+            scope.setExtra('variables', variables);
+            scope.setExtra('errors', result.errors);
+            Sentry.captureException(
+               new Error(
+                  'Shopify Storefront SDK GraphQL query failed with errors'
+               )
+            );
          });
       }
       throw new Error(


### PR DESCRIPTION
Adds Sentry reporting for failed GraphQL queries in our Strapi and Shopify Storefront SDKs.

## QA

It's difficult to mock graphql errors in practice, this is better suited for a test case. Since we'll see these errors in Sentry, we can decide if we more more/less metadata as events start rolling in.

qa_req 0

## Background

Our Strapi and Storefront SDKs use GraphQL to talk to their respective APIs. If the queries failed with errors in the response, we were logging them but not reporting them to Sentry.

https://github.com/iFixit/react-commerce/pull/643#discussion_r952791331
