### PR TITLE
Sentry: Report when device handle is `data:image`

### DIFF
--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -25,6 +25,7 @@ import {
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { ParsedUrlQuery } from 'querystring';
 import { getServerState } from 'react-instantsearch-hooks-server';
+import * as Sentry from '@sentry/nextjs';
 import { ProductListView } from './ProductListView';
 
 export type ProductListTemplateProps = WithProvidersProps<
@@ -235,6 +236,12 @@ function getDevicePathSegments(
 ) {
    const { deviceHandleItemType } = context.params || {};
    if (Array.isArray(deviceHandleItemType)) {
+      if (deviceHandleItemType[0] === 'data:image') {
+         Sentry.withScope((scope) => {
+            scope.setExtra('context', context);
+            Sentry.captureException(new Error('data:image device handle'));
+         });
+      }
       return deviceHandleItemType;
    }
    return [];


### PR DESCRIPTION
We're seeing fetch's sent to our device wiki api that have a device of `data:image`.
https://sentry.io/share/issue/2fb1c3733997425ea19313d477f3d28e/

This is likely a bug in our frontend code, because we shouldn't be making requests like that. This will give us more "context" (pun intended) about what's causing the problem by creating a Sentry event with all the context info.

## CR

I chose to not change any behavior here until we get more context on what's going on, so this just does reporting for now.

## QA

Try to reproduce the original 404 and see if a Sentry event gets reported. If you can't, then we'll skip QA on this and hopefully get some more debug info when it's merged.

Connects #631
