### PR TITLE
Don't Resort Facets When One is Selected

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/useSortBy.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useSortBy.ts
@@ -63,6 +63,6 @@ export function useSortBy(
       case 'facet_tags.Item Type':
          return sortAlphabetically;
       default:
-         return props.sortBy;
+         return ["count:desc", "name:asc"];
    }
 }


### PR DESCRIPTION
## Overview

We were previously using to the default sorting of algolia for facets, which would sort by `isRefined`, then `count:desc` and `name:asc`. This would rearrange our facets when you would select them, and wasn't consistent with our custom sorting for specific facets. This makes sure we no longer sort by `isRefined` by default.

## QA

Make sure that when clicking on facets that aren't `price_range`, `Capacity`, or `Item Type`, they no longer resort and still work as expected

Closes: #635 