### PR TITLE
Handle deviceTitles with Multiple Spaces In Them

### DIFF
--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -42,14 +42,14 @@ export function encodeDeviceItemType(itemType: string): string {
  * Convert URL slug to product list device title
  */
 export function decodeDeviceTitle(handle: string): string {
-   return handle.replace(/_+/g, ' ');
+   return handle.replace(/_/g, ' ');
 }
 
 /**
  * Convert URL slug to product list device title
  */
 export function encodeDeviceTitle(deviceTitle: string): string {
-   return deviceTitle.replace(/\s+/g, '_');
+   return deviceTitle.replace(/\s/g, '_');
 }
 
 type ProductListPathAttributes = Pick<

--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -1,3 +1,4 @@
+import { encodeDeviceTitle } from '@helpers/product-list-helpers';
 import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
 import { invariant } from '@ifixit/helpers';
 
@@ -7,7 +8,7 @@ export async function fetchDeviceWiki(
    client: IFixitAPIClient,
    deviceTitle: string
 ): Promise<DeviceWiki | null> {
-   const deviceHandle = getDeviceHandle(deviceTitle);
+   const deviceHandle = encodeDeviceTitle(deviceTitle);
    try {
       invariant(
          deviceHandle.length > 0,
@@ -47,11 +48,4 @@ export function fetchMultipleDeviceImages(
    return client
       .get(`wikis/topic_images?` + params.toString())
       .catch(() => ({ images: {} }));
-}
-
-/**
- * Convert product list device title to a URL friendly slug
- */
-export function getDeviceHandle(deviceTitle: string): string {
-   return deviceTitle.replace(/\s+/g, '_');
 }

--- a/frontend/templates/product-list/sections/FilterableProductsSection/useSortBy.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useSortBy.ts
@@ -63,6 +63,6 @@ export function useSortBy(
       case 'facet_tags.Item Type':
          return sortAlphabetically;
       default:
-         return ["count:desc", "name:asc"];
+         return ['count:desc', 'name:asc'];
    }
 }


### PR DESCRIPTION
## Overview

We have some sentry errors like [this](https://sentry.io/organizations/ifixit/issues/3504489498/events/053ed493b7db4427868e074dec9ddc18/?project=6469069) where the page was failing because we had multiple spaces in the `deviceTitle`/`wiki_title`. This change makes sure when we encode/decode `deviceTitle` we maintain a character per space.

## QA

Make sure that you can click on `Samsung Galaxy A8+ (2018)` from [here](http://localhost:3000/Parts/Samsung_Galaxy_A) and it now works instead of 404ing. Also make sure other pages aren't broken i guess.

Connects: #632