### PR TITLE
Add replacement guides

### DIFF
--- a/frontend/components/ui/IconBadge.tsx
+++ b/frontend/components/ui/IconBadge.tsx
@@ -1,0 +1,51 @@
+import {
+   Box,
+   Flex,
+   FlexProps,
+   forwardRef,
+   ThemeTypings,
+   useTheme,
+} from '@chakra-ui/react';
+import { IconDefinition } from '@fortawesome/pro-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export type IconBadgeProps = FlexProps & {
+   colorScheme?: ThemeTypings['colorSchemes'];
+   icon?: IconDefinition;
+};
+
+export const IconBadge = forwardRef<IconBadgeProps, 'div'>(
+   ({ children, colorScheme = 'gray', icon, ...props }, ref) => {
+      const theme = useTheme();
+      return (
+         <Flex
+            ref={ref}
+            bgColor={`${colorScheme}.100`}
+            borderColor={`${colorScheme}.300`}
+            borderWidth="1px"
+            py="1"
+            px="1.5"
+            fontWeight="semibold"
+            fontSize="sm"
+            lineHeight="1em"
+            color={`${colorScheme}.700`}
+            alignItems="center"
+            borderRadius="md"
+            flexShrink={0}
+            {...props}
+         >
+            {icon && (
+               <Box mr="1">
+                  <FontAwesomeIcon
+                     icon={icon}
+                     size="1x"
+                     color={theme.colors[colorScheme][500]}
+                     style={{ display: 'block' }}
+                  />
+               </Box>
+            )}
+            {children}
+         </Flex>
+      );
+   }
+);

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -1,3 +1,4 @@
 export * from './Card';
 export * from './Rating';
 export * from './ScreenOnlyLabel';
+export * from './IconBadge';

--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6194,6 +6194,7 @@ export type FindProductQuery = {
       prop65WarningType?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       prop65Chemicals?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       productVideos?: Maybe<{ __typename?: 'Metafield'; value: string }>;
+      replacementGuides?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       featuredImage?: Maybe<{ __typename?: 'Image'; id?: Maybe<string> }>;
       images: {
          __typename?: 'ImageConnection';
@@ -6269,6 +6270,9 @@ export const FindProductDocument = `
       value
     }
     productVideos: metafield(namespace: "ifixit", key: "product_videos") {
+      value
+    }
+    replacementGuides: metafield(namespace: "ifixit", key: "replacement_guides") {
       value
     }
     featuredImage {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -21,6 +21,12 @@ query findProduct($handle: String) {
       productVideos: metafield(namespace: "ifixit", key: "product_videos") {
          value
       }
+      replacementGuides: metafield(
+         namespace: "ifixit"
+         key: "replacement_guides"
+      ) {
+         value
+      }
       featuredImage {
          id
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,9 +30,11 @@
       "@core-ds/primitives": "2.4.5",
       "@emotion/react": "11.7.1",
       "@emotion/styled": "11.6.0",
-      "@fortawesome/fontawesome-svg-core": "6.1.1",
-      "@fortawesome/pro-duotone-svg-icons": "6.1.1",
       "@fortawesome/react-fontawesome": "0.2.0",
+      "@fortawesome/fontawesome-svg-core": "6.1.1",
+      "@fortawesome/free-solid-svg-icons": "6.1.1",
+      "@fortawesome/pro-solid-svg-icons": "6.1.1",
+      "@fortawesome/pro-duotone-svg-icons": "6.1.1",
       "@ifixit/app": "workspace:*",
       "@ifixit/auth-sdk": "workspace:*",
       "@ifixit/cart-sdk": "workspace:*",
@@ -67,7 +69,8 @@
       "react-instantsearch-hooks-web": "6.26.0",
       "react-query": "3.34.19",
       "sharp": "0.30.7",
-      "snarkdown": "2.0.0"
+      "snarkdown": "2.0.0",
+      "zod": "3.18.0"
    },
    "devDependencies": {
       "@babel/core": "7.17.9",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -3,6 +3,10 @@ import { AppProps } from 'next/app';
 import * as React from 'react';
 import NextNProgress from 'nextjs-progressbar';
 import Head from 'next/head';
+// Improve FontAwesome integration with Next.js https://fontawesome.com/v5/docs/web/use-with/react#next-js
+import { config } from '@fortawesome/fontawesome-svg-core';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+config.autoAddCss = false;
 
 type AppPropsWithLayout = AppProps & {
    Component: NextPageWithLayout;

--- a/frontend/templates/product-list/sections/FilterableProductsSection/useSortBy.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useSortBy.ts
@@ -63,6 +63,6 @@ export function useSortBy(
       case 'facet_tags.Item Type':
          return sortAlphabetically;
       default:
-         return ["count:desc", "name:asc"];
+         return ['count:desc', 'name:asc'];
    }
 }

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -17,6 +17,7 @@ import { findProduct, Product } from '@models/product';
 import { GetServerSideProps } from 'next';
 import { useSelectedVariant } from './hooks/useSelectedVariant';
 import { ProductSection } from './sections/ProductSection';
+import { ReplacementGuidesSection } from './sections/ReplacementGuidesSection';
 
 export type ProductTemplateProps = WithProvidersProps<
    WithLayoutProps<{
@@ -46,6 +47,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = ({
                selectedVariant={selectedVariant}
                onVariantChange={setSelectedVariantId}
             />
+            <ReplacementGuidesSection product={product} />
          </Box>
       </>
    );

--- a/frontend/templates/product/sections/ReplacementGuidesSection/index.tsx
+++ b/frontend/templates/product/sections/ReplacementGuidesSection/index.tsx
@@ -1,0 +1,267 @@
+import {
+   Box,
+   Divider,
+   Flex,
+   forwardRef,
+   Heading,
+   HStack,
+   SimpleGrid,
+   TagProps,
+   Text,
+} from '@chakra-ui/react';
+import { IfixitImage } from '@components/ifixit-image';
+import { IconBadge } from '@components/ui';
+import {
+   faClock,
+   faGauge,
+   faGaugeHigh,
+   faGaugeLow,
+   faGaugeMax,
+   faGaugeMin,
+} from '@fortawesome/pro-solid-svg-icons';
+import { PageContentWrapper } from '@ifixit/ui';
+import { Product } from '@models/product';
+
+export type ReplacementGuidesSectionProps = {
+   product: Product;
+};
+
+export function ReplacementGuidesSection({
+   product,
+}: ReplacementGuidesSectionProps) {
+   if (product.replacementGuides.length === 0) {
+      return null;
+   }
+
+   return (
+      <Box
+         my="16"
+         px={{
+            base: 5,
+            sm: 0,
+         }}
+      >
+         <PageContentWrapper>
+            <Heading
+               as="h2"
+               fontFamily="Archivo Black"
+               color="gray.700"
+               textAlign="center"
+               mb={{
+                  base: 6,
+                  md: 16,
+               }}
+               size="lg"
+            >
+               Replacement Guides
+            </Heading>
+            <SimpleGrid
+               columns={{
+                  base: 1,
+                  lg: 2,
+               }}
+               spacing="8"
+            >
+               {product.replacementGuides.map((guide) => {
+                  const hasBadges =
+                     isPresent(guide.difficulty) ||
+                     isPresent(guide.time_required);
+                  return (
+                     <Flex
+                        key={guide.id}
+                        minH={{
+                           base: 'auto',
+                           md: '150px',
+                        }}
+                        bg="white"
+                        overflow="hidden"
+                        borderColor="gray.300"
+                        borderWidth="1px"
+                        borderRadius="md"
+                        // align="center"
+                     >
+                        {guide.image_url && (
+                           <>
+                              <Flex
+                                 align="center"
+                                 justify="center"
+                                 width={{
+                                    base: '96px',
+                                    md: '176px',
+                                 }}
+                                 height={{
+                                    base: '96px',
+                                    md: 'full',
+                                 }}
+                                 my={{
+                                    base: 3,
+                                    md: 0,
+                                 }}
+                                 ml={{
+                                    base: 3,
+                                    md: 0,
+                                 }}
+                                 borderColor="gray.300"
+                                 borderWidth={{
+                                    base: '1px',
+                                    md: '0',
+                                 }}
+                                 borderRadius={{
+                                    base: 'md',
+                                    md: 'none',
+                                 }}
+                                 overflow="hidden"
+                                 flexGrow={0}
+                                 flexShrink={0}
+                                 position="relative"
+                              >
+                                 <IfixitImage
+                                    src={guide.image_url}
+                                    alt=""
+                                    objectFit="cover"
+                                    layout="fill"
+                                    sizes="20vw"
+                                    priority
+                                 />
+                              </Flex>
+                              <Divider
+                                 orientation="vertical"
+                                 display={{
+                                    base: 'none',
+                                    md: 'block',
+                                 }}
+                              />
+                           </>
+                        )}
+                        <Flex direction="column" px="3" py="3">
+                           <Text
+                              as="a"
+                              href={guide.guide_url}
+                              fontWeight="bold"
+                              fontSize="sm"
+                              lineHeight="short"
+                              noOfLines={3}
+                              flexShrink={0}
+                           >
+                              {guide.title}
+                           </Text>
+                           {isPresent(guide.summary) && (
+                              <Text
+                                 fontSize="sm"
+                                 mt="1"
+                                 flexShrink={0}
+                                 flexGrow={0}
+                                 noOfLines={1}
+                                 display={{
+                                    base: 'none',
+                                    md: '-webkit-box',
+                                 }}
+                              >
+                                 {guide.summary}
+                              </Text>
+                           )}
+                           {hasBadges && (
+                              <HStack mt="3">
+                                 {isPresent(guide.time_required) && (
+                                    <IconBadge icon={faClock}>
+                                       {guide.time_required}
+                                    </IconBadge>
+                                 )}
+                                 {isPresent(guide.difficulty) && (
+                                    <DifficultyBadge
+                                       difficulty={guide.difficulty}
+                                    />
+                                 )}
+                              </HStack>
+                           )}
+                        </Flex>
+                     </Flex>
+                  );
+               })}
+            </SimpleGrid>
+         </PageContentWrapper>
+      </Box>
+   );
+}
+
+function isPresent(text: any): text is string {
+   return typeof text === 'string' && text.length > 0;
+}
+
+type DifficultyBadgeProps = TagProps & {
+   difficulty: string;
+};
+
+const DifficultyBadge = forwardRef<DifficultyBadgeProps, 'div'>(
+   ({ difficulty, ...props }, ref) => {
+      switch (difficulty.toLowerCase()) {
+         case 'very easy': {
+            return (
+               <IconBadge
+                  ref={ref}
+                  {...props}
+                  colorScheme="green"
+                  icon={faGaugeMin}
+               >
+                  {difficulty}
+               </IconBadge>
+            );
+         }
+         case 'easy': {
+            return (
+               <IconBadge
+                  ref={ref}
+                  {...props}
+                  colorScheme="green"
+                  icon={faGaugeLow}
+               >
+                  {difficulty}
+               </IconBadge>
+            );
+         }
+         case 'moderate': {
+            return (
+               <IconBadge
+                  ref={ref}
+                  {...props}
+                  colorScheme="amber"
+                  icon={faGauge}
+               >
+                  {difficulty}
+               </IconBadge>
+            );
+         }
+         case 'difficult': {
+            return (
+               <IconBadge
+                  ref={ref}
+                  {...props}
+                  colorScheme="red"
+                  icon={faGaugeHigh}
+               >
+                  {difficulty}
+               </IconBadge>
+            );
+         }
+         case 'very difficult': {
+            return (
+               <IconBadge
+                  ref={ref}
+                  {...props}
+                  colorScheme="red"
+                  icon={faGaugeMax}
+               >
+                  {difficulty}
+               </IconBadge>
+            );
+         }
+         default: {
+            return (
+               <IconBadge ref={ref} {...props} icon={faGauge}>
+                  {difficulty}
+               </IconBadge>
+            );
+         }
+      }
+   }
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,9 @@ importers:
       '@emotion/react': 11.7.1
       '@emotion/styled': 11.6.0
       '@fortawesome/fontawesome-svg-core': 6.1.1
+      '@fortawesome/free-solid-svg-icons': 6.1.1
       '@fortawesome/pro-duotone-svg-icons': 6.1.1
+      '@fortawesome/pro-solid-svg-icons': 6.1.1
       '@fortawesome/react-fontawesome': 0.2.0
       '@graphql-codegen/cli': 2.1.1
       '@graphql-codegen/typescript': 2.2.0
@@ -106,6 +108,7 @@ importers:
       snarkdown: 2.0.0
       typescript: 4.7.4
       webpack: 5.73.0
+      zod: 3.18.0
     dependencies:
       '@chakra-ui/icons': 1.1.7_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react': 1.8.8_64f869eddedbf7a995b2ffda3c62e350
@@ -114,7 +117,9 @@ importers:
       '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
       '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
       '@fortawesome/fontawesome-svg-core': 6.1.1
+      '@fortawesome/free-solid-svg-icons': 6.1.1
       '@fortawesome/pro-duotone-svg-icons': 6.1.1
+      '@fortawesome/pro-solid-svg-icons': 6.1.1
       '@fortawesome/react-fontawesome': 0.2.0_6909f5698ccb6b468185370814560628
       '@ifixit/app': link:../packages/app
       '@ifixit/auth-sdk': link:../packages/auth-sdk
@@ -151,6 +156,7 @@ importers:
       react-query: 3.34.19_react-dom@17.0.2+react@17.0.2
       sharp: 0.30.7
       snarkdown: 2.0.0
+      zod: 3.18.0
     devDependencies:
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.18.6_@babel+core@7.17.9
@@ -3403,8 +3409,24 @@ packages:
       '@fortawesome/fontawesome-common-types': 6.1.1
     dev: false
 
+  /@fortawesome/free-solid-svg-icons/6.1.1:
+    resolution: {integrity: sha512-0/5exxavOhI/D4Ovm2r3vxNojGZioPwmFrKg0ZUH69Q68uFhFPs6+dhAToh6VEQBntxPRYPuT5Cg1tpNa9JUPg==, tarball: '@fortawesome/free-solid-svg-icons/-/6.1.1/free-solid-svg-icons-6.1.1.tgz'}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 6.1.1
+    dev: false
+
   /@fortawesome/pro-duotone-svg-icons/6.1.1:
     resolution: {integrity: sha512-BA9hKuVK50NvUNl3V1NmKhyJGXN3QrmGdZ0AvZjGRj73zWa6vgGewl8/PSdqTLP3uWZZZRrIfYqFvnHweTfQ+Q==, tarball: '@fortawesome/pro-duotone-svg-icons/-/6.1.1/pro-duotone-svg-icons-6.1.1.tgz'}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 6.1.1
+    dev: false
+
+  /@fortawesome/pro-solid-svg-icons/6.1.1:
+    resolution: {integrity: sha512-BF1vuvQlFNRy38EZAxaXuReQ73z9VrXaRmVy+MFnLFpHZa5yH3M68iZHl04/5uThUPbrXG7VsIRoICc5HjD0Iw==, tarball: '@fortawesome/pro-solid-svg-icons/-/6.1.1/pro-solid-svg-icons-6.1.1.tgz'}
     engines: {node: '>=6'}
     requiresBuild: true
     dependencies:
@@ -13857,3 +13879,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod/3.18.0:
+    resolution: {integrity: sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==}
+    dev: false


### PR DESCRIPTION
closes #655 

~~deploy_block 🛑 Blocked by #650~~

Adds replacements guides section:

<img width="812" alt="Screenshot 2022-08-26 at 17 36 41" src="https://user-images.githubusercontent.com/4640135/186941610-5fbef4db-852b-4a25-b026-185e4edd48e9.png">

## QA

1. Visit Vercel preview
2. Go to [/Products/iphone-11-pro-screen](https://react-commerce-git-add-replacement-guides-ifixit.vercel.app/Products/iphone-11-pro-screen)
3. Verify that you can see the replacement guides