### PR TITLE
Log findProductList Failures With More Context

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -1,11 +1,20 @@
 import { GetServerSideProps } from 'next';
 import { logAsync } from '@ifixit/helpers';
 import { setSentryPageContext } from '@ifixit/sentry';
+import * as Sentry from '@sentry/nextjs';
 
 export function serverSidePropsWrapper<T>(
    getServerSidePropsInternal: GetServerSideProps<T>
 ): GetServerSideProps<T> {
    return async (context) => {
+      Sentry.setContext("Extra Info", {
+         headers: context?.req.headers,
+         url: context?.req.url,
+         method: context?.req.method,
+         locale: context?.locale,
+         ...context?.params,
+         ...context?.query,
+       });
       return logAsync('getServerSideProps', () =>
          getServerSidePropsInternal(context)
       ).catch((err) => {


### PR DESCRIPTION
## Overview

We've had some errors like [this](https://sentry.io/organizations/ifixit/issues/3504489498/events/d9719aa880c2447abada45d57cdcf3fe/?project=6469069) where there seems to be some sort of link that is not encoded correctly. To investigate this more lets try to get the request/response context with the error for sentry.


## QA
Check if bad devices (so like `/Parts/badItemHere`) reports to sentry with a `Extra Info` json.

Connects #632