### PR TITLE
Add Ability to Ignore Cache (Maybe)

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -161,24 +161,21 @@ export function InstantSearchProvider({
                // Item Type is the slug on device pages, not in the query.
                delete filterCopy['facet_tags.Item Type'];
             }
+            const customQueryParams = new URLSearchParams(location.search);
             const queryString = qsModule.stringify(
-               { ...routeState, filter: filterCopy },
+               {
+                  ...routeState,
+                  filter: filterCopy,
+                  _vercel_no_cache:
+                     customQueryParams.get('_vercel_no_cache') || undefined,
+               },
                {
                   addQueryPrefix: true,
                   arrayFormat: 'indices',
                }
             );
 
-            let customQueries = '';
-            const customQueryParams = new URLSearchParams(location.search);
-            if (customQueryParams.has('_vercel_no_cache')) {
-               customQueries =
-                  (queryString ? '&' : '?') +
-                  '_vercel_no_cache=' +
-                  customQueryParams.get('_vercel_no_cache');
-            }
-
-            return `${baseUrl}${path}${queryString}${customQueries}`;
+            return `${baseUrl}${path}${queryString}`;
          },
          parseURL({ qsModule, location }) {
             const pathParts = location.pathname

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -169,7 +169,13 @@ export function InstantSearchProvider({
                }
             );
 
-            return `${baseUrl}${path}${queryString}`;
+            let customQueries = '';
+            const customQueryParams = new URLSearchParams(location.search);
+            if (customQueryParams.has('disableCacheGets')) {
+               customQueries = (queryString ? '&' : '?') + 'disableCacheGets';
+            }
+
+            return `${baseUrl}${path}${queryString}${customQueries}`;
          },
          parseURL({ qsModule, location }) {
             const pathParts = location.pathname

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -171,8 +171,11 @@ export function InstantSearchProvider({
 
             let customQueries = '';
             const customQueryParams = new URLSearchParams(location.search);
-            if (customQueryParams.has('disableCacheGets')) {
-               customQueries = (queryString ? '&' : '?') + 'disableCacheGets';
+            if (customQueryParams.has('_vercel_no_cache')) {
+               customQueries =
+                  (queryString ? '&' : '?') +
+                  '_vercel_no_cache=' +
+                  customQueryParams.get('_vercel_no_cache');
             }
 
             return `${baseUrl}${path}${queryString}${customQueries}`;

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -16,3 +16,7 @@ export function cache<T>(
    cacheStore.set(key, result, { ttl: ttl * 1000 });
    return result;
 }
+
+export function clearCache(): void {
+   cacheStore.clear();
+}

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -55,7 +55,7 @@ export const getProductListServerSideProps = ({
    productListType,
 }: GetProductListServerSidePropsOptions): GetServerSideProps<ProductListTemplateProps> => {
    return async (context) => {
-      if ('disableCacheGets' in context.query) {
+      if (context.query._vercel_no_cache) {
          context.res.setHeader(
             'Cache-Control',
             'no-store, no-cache, must-revalidate'

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -56,7 +56,7 @@ export const getProductListServerSideProps = ({
    productListType,
 }: GetProductListServerSidePropsOptions): GetServerSideProps<ProductListTemplateProps> => {
    return async (context) => {
-      if (context.query._vercel_no_cache) {
+      if (context.query._vercel_no_cache === '1') {
          context.res.setHeader(
             'Cache-Control',
             'no-store, no-cache, must-revalidate, stale-if-error=0'

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -55,10 +55,17 @@ export const getProductListServerSideProps = ({
    productListType,
 }: GetProductListServerSidePropsOptions): GetServerSideProps<ProductListTemplateProps> => {
    return async (context) => {
-      context.res.setHeader(
-         'Cache-Control',
-         'public, s-maxage=10, stale-while-revalidate=600'
-      );
+      if ('disableCacheGets' in context.query) {
+         context.res.setHeader(
+            'Cache-Control',
+            'no-store, no-cache, must-revalidate'
+         );
+      } else {
+         context.res.setHeader(
+            'Cache-Control',
+            'public, s-maxage=10, stale-while-revalidate=600'
+         );
+      }
 
       const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
       const layoutProps: Promise<DefaultLayoutProps> =

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -59,7 +59,7 @@ export const getProductListServerSideProps = ({
       if (context.query._vercel_no_cache) {
          context.res.setHeader(
             'Cache-Control',
-            'no-store, no-cache, must-revalidate'
+            'no-store, no-cache, must-revalidate, stale-if-error=0'
          );
          clearCache();
       } else {

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -17,6 +17,7 @@ import {
    DefaultLayoutProps,
    WithLayoutProps,
 } from '@layouts/default';
+import { clearCache } from '@lib/cache';
 import {
    findProductList,
    ProductList,
@@ -60,6 +61,7 @@ export const getProductListServerSideProps = ({
             'Cache-Control',
             'no-store, no-cache, must-revalidate'
          );
+         clearCache();
       } else {
          context.res.setHeader(
             'Cache-Control',


### PR DESCRIPTION
## Overview

This pull pertains to Vercel and `react-commerce`, and doesn't directly handle any Cloudfront related caching. Hopefully they respect `cache-control` headers.

Allow the `_vercel_no_cache=1` to disable use of the [vercel cache ](https://vercel.com/docs/concepts/edge-network/caching#cacheable-responses)for that request. Also makes it so that response has `cache-control` [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) that should indicate to the browser to no cache. Also clears the `react-commerce` cache. 

## QA 
its pretty easy to check if vercel is ignoring its caches. You can go the `react-commerce-prod` [instance](https://vercel.com/ifixit/react-commerce-prod/8FoSXqTSmrgn43XKwDF8nb3xne3m/functions) of this branch's functions, verify that going to a page like `/Parts/iPhone` has cache misses like `Cache miss for 'storeList': 52ms` on the first call, but subsequent should not miss. Then if you add `_vercel_no_cache=1` as a parameter then it will always miss the caches. 
You should make sure that the `_vercel_no_cache` parameter works as intended, stays in the url and doesn't break. NOTE: I **now** have this set so it does need be set to `1` to work, any other string shouldnt work.

Also make sure that the prod's headers for `cache-control` are changed to `'no-store, no-cache, must-revalidate'` when you have a `_vercel_no_cache=1`.

I'm not sure how to test the cache on the `react-commerce` side honestly. I'm not sure how to create a scenario where the cache is wrong. Strapi seemed to update the data fine when messed with. 

Closes #548 until further notice