### PR TITLE
Mobile Productlist: Scroll on facet drawer close

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
@@ -146,9 +146,7 @@ export function FacetsDrawer({
                            attribute={facet}
                            isOpen={facet === currentFacet}
                            productList={productList}
-                           onClose={() => {
-                              setCurrentFacet(null);
-                           }}
+                           onClose={() => setCurrentFacet(null)}
                         />
                      );
                   })}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/Toolbar.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/Toolbar.tsx
@@ -15,6 +15,7 @@ import {
 } from '@chakra-ui/react';
 import { getProductListTitle } from '@helpers/product-list-helpers';
 import { ProductList } from '@models/product-list';
+import * as React from 'react';
 import { HiOutlineMenu, HiOutlineViewGrid } from 'react-icons/hi';
 import { useHits } from 'react-instantsearch-hooks-web';
 import { FacetsDrawer } from './FacetsDrawer';
@@ -36,6 +37,14 @@ export function Toolbar(props: ToolbarProps) {
    const drawer = useDisclosure({
       defaultIsOpen: false,
    });
+   const scrollRef = React.useRef<HTMLDivElement>(null);
+   const isFirstRender = React.useRef(true);
+   React.useEffect(() => {
+      if (!isFirstRender.current && !drawer.isOpen) {
+         scrollRef.current?.scrollIntoView();
+      }
+      isFirstRender.current = false;
+   }, [drawer.isOpen]);
    return (
       <>
          <FacetsDrawer
@@ -44,6 +53,7 @@ export function Toolbar(props: ToolbarProps) {
             productList={productList}
          />
          <Stack
+            ref={scrollRef}
             justify={{ md: 'space-between' }}
             align={{ base: 'stretch', md: 'center' }}
             direction={{ base: 'column', md: 'row' }}


### PR DESCRIPTION
When the facet drawer is closed on mobile, the view now scrolls so that the toolbar is at the top of the viewport.

## QA
- Preview /Parts on mobile.
- Click on "Filters" button.
- After closing the dialog, the view should have the number of results at the top of the screen. See the issue for a screenshot of the desired behavior.
- When the page first renders, nothing should be different (ie, there is no scroll effect).

CC @sumukhipandey

Closes #618
