### PR TITLE
Ignore Firefox TypeError Network Errors in Sentry

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -21,4 +21,7 @@ Sentry.init({
          'next.runtime': 'client',
       },
    },
+   ignoreErrors: [
+      'TypeError: NetworkError when attempting to fetch resource.'
+   ],
 });


### PR DESCRIPTION
## Overview

Basically we are getting a bunch of errors `TypeError: NetworkError when attempting to fetch resource`, an error particular to Firefox, in Sentry. Looking into this, this error is very hard to reproduce and only happens occasionally. While unsure of the explanation, even when I did manage to reproduce the bug I didn't notice any functional differences. I suspect something like [this](https://bugzilla.mozilla.org/show_bug.cgi?id=1280189) is happening. With this in mind, and also that other people have [recommended](https://forum.sentry.io/t/typeerror-failed-to-fetch-reported-over-and-overe/8447) just having sentry ignore these errors, I think we shouldn't log them anymore with our sentry bandwidth. 

## QA
Its hard to reproduce, and there isn't much to check. I've checked my self and seen that this stops the error from getting to sentry, so i think qa_req 0.

Closes #630