### PR TITLE
GH Actions: Skip `format` workflow for `main`

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,9 @@
 name: Format
 
-on: [push]
+on:
+   push:
+      branches-ignore:
+         - 'main'
 
 jobs:
    prettier:
@@ -28,9 +31,6 @@ jobs:
               fi
          - name: Fail if Dependabot
            if: steps.detect-diff.outputs.HAS_DIFF == 'true' && github.actor == 'dependabot[bot]'
-           run: exit 1
-         - name: Fail in production
-           if: steps.detect-diff.outputs.HAS_DIFF == 'true' && github.ref_name == 'main'
            run: exit 1
          - name: Commit changes
            if: steps.detect-diff.outputs.HAS_DIFF == 'true'

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -21,7 +21,5 @@ Sentry.init({
          'next.runtime': 'client',
       },
    },
-   ignoreErrors: [
-      'TypeError: NetworkError when attempting to fetch resource.'
-   ],
+   ignoreErrors: ['TypeError: NetworkError when attempting to fetch resource.'],
 });


### PR DESCRIPTION
The "Fail in production" step [failed](https://github.com/iFixit/react-commerce/runs/8120146230?check_suite_focus=true) even when there was no diff for some reason.

Let's use a more idiomatic pattern to skip workflows for the main branch.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-branches-and-tags

## QA
Same as #665

Connects #616
