### PR TITLE
Add service value proposition section

### DIFF
--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -19,6 +19,7 @@ import { useSelectedVariant } from './hooks/useSelectedVariant';
 import { ProductSection } from './sections/ProductSection';
 import { ReviewsSection } from './sections/ReviewsSection';
 import { ReplacementGuidesSection } from './sections/ReplacementGuidesSection';
+import { ServiceValuePropositionSection } from './sections/ServiceValuePropositionSection';
 
 export type ProductTemplateProps = WithProvidersProps<
    WithLayoutProps<{
@@ -49,6 +50,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = ({
                onVariantChange={setSelectedVariantId}
             />
             <ReplacementGuidesSection product={product} />
+            <ServiceValuePropositionSection />
             <ReviewsSection
                product={product}
                selectedVariant={selectedVariant}

--- a/frontend/templates/product/sections/ReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ReviewsSection/index.tsx
@@ -73,7 +73,7 @@ export function ReviewsSection({
    }
 
    return (
-      <Box bg="white" py="16" mt="16" fontSize="sm">
+      <Box bg="white" py="16" fontSize="sm">
          <PageContentWrapper>
             <Heading
                as="h2"

--- a/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
+++ b/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
@@ -1,0 +1,113 @@
+import {
+   Box,
+   forwardRef,
+   Heading,
+   Icon,
+   IconProps,
+   Stack,
+   Text,
+   useTheme,
+   VStack,
+} from '@chakra-ui/react';
+import React from 'react';
+import {
+   FontAwesomeIcon,
+   FontAwesomeIconProps,
+} from '@fortawesome/react-fontawesome';
+import {
+   faBoxCircleCheck,
+   faRocket,
+   faShieldCheck,
+} from '@fortawesome/pro-duotone-svg-icons';
+
+export type ServiceValuePropositionSectionProps = {};
+
+export function ServiceValuePropositionSection() {
+   return (
+      <>
+         <Heading as="h2" srOnly>
+            Service value proposition
+         </Heading>
+         <Stack
+            direction={{
+               base: 'column',
+               md: 'row',
+            }}
+            bg="blue.50"
+            align={{
+               base: 'center',
+               md: 'flex-start',
+            }}
+            justify="center"
+            borderTopWidth="1px"
+            borderBottomWidth="1px"
+            borderColor="blue.100"
+            fontSize="xs"
+            spacing={{
+               base: 8,
+               md: 20,
+            }}
+            mt="16"
+            py="16"
+            px="6"
+         >
+            <ValueProposition>
+               <ValuePropositionIcon icon={faBoxCircleCheck} />
+               <Title>Satified or 100% refunded</Title>
+               <Description>
+                  Our parts quality consistently sets the industry standard.
+               </Description>
+            </ValueProposition>
+            <ValueProposition>
+               <ValuePropositionIcon icon={faShieldCheck} />
+               <Title>Secure payment</Title>
+               <Description>Encrypted checkout through Shopify.</Description>
+            </ValueProposition>
+            <ValueProposition>
+               <ValuePropositionIcon icon={faRocket} />
+               <Title>Express shipping</Title>
+               <Description>
+                  Shipped same-day if you order before 5PM.
+               </Description>
+            </ValueProposition>
+         </Stack>
+      </>
+   );
+}
+
+const ValuePropositionIcon = ({ icon, ...props }: FontAwesomeIconProps) => {
+   const theme = useTheme();
+   return (
+      <FontAwesomeIcon
+         icon={icon}
+         color={theme.colors.brand[500]}
+         style={{ width: '32px', height: '32px' }}
+         {...props}
+      />
+   );
+};
+
+function ValueProposition({ children }: React.PropsWithChildren<{}>) {
+   return (
+      <VStack
+         direction="column"
+         textAlign="center"
+         spacing="2"
+         w={{ base: 'unset', md: '200px' }}
+      >
+         {children}
+      </VStack>
+   );
+}
+
+function Title({ children }: React.PropsWithChildren<{}>) {
+   return (
+      <Text fontWeight="bold" fontSize="md">
+         {children}
+      </Text>
+   );
+}
+
+function Description({ children }: React.PropsWithChildren<{}>) {
+   return <Text fontSize="md">{children}</Text>;
+}


### PR DESCRIPTION
close #667 

This PR adds the service value proposition section
The section is already using the new icons and is already responsive

<img width="845" alt="Screenshot 2022-08-31 at 21 47 26" src="https://user-images.githubusercontent.com/7805759/187768976-aeeaae08-4efb-43b4-83bc-976b8482cd0e.png">


## QA

1. Open Vercel preview
2. Go to [/Products/iphone-11-screen](https://react-commerce-git-add-service-value-proposition-section-ifixit.vercel.app/Products/iphone-11-screen)
3. Verify that the section is present and responsive
