### PR TITLE
ProductPrice component

### DIFF
--- a/frontend/components/common/ProductPrice.tsx
+++ b/frontend/components/common/ProductPrice.tsx
@@ -1,0 +1,79 @@
+import { Box, Text, ThemeTypings, useTheme } from '@chakra-ui/react';
+import { IconBadge } from '@components/ui';
+import { faRectanglePro } from '@fortawesome/pro-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export type ProductPriceProps = {
+   formattedPrice: string;
+   formattedCompareAtPrice?: string | null;
+   isDiscounted: boolean;
+   discountLabel?: string;
+   showDiscountLabel?: boolean;
+   showProBadge?: boolean;
+   size?: 'large' | 'medium' | 'small';
+   colorScheme?: ThemeTypings['colorSchemes'];
+   direction?: 'row' | 'column' | 'column-reverse';
+};
+
+export function ProductPrice({
+   formattedPrice,
+   formattedCompareAtPrice,
+   isDiscounted,
+   discountLabel,
+   showDiscountLabel = true,
+   showProBadge = false,
+   size = 'large',
+   colorScheme = 'red',
+   direction = 'row',
+}: ProductPriceProps) {
+   const theme = useTheme();
+   const priceFontSize =
+      size === 'large' ? 'xl' : size === 'medium' ? 'md' : 'sm';
+   const compareAtPriceFontSize = size === 'large' ? 'md' : 'sm';
+
+   return (
+      <Box
+         display="flex"
+         flexDir={direction}
+         alignSelf="flex-start"
+         alignItems={direction === 'row' ? 'center' : 'flex-end'}
+      >
+         <Text
+            mr={direction === 'row' ? 1 : 0}
+            fontSize={priceFontSize}
+            fontWeight="semibold"
+            color={isDiscounted ? theme.colors[colorScheme][600] : 'gray.900'}
+         >
+            {showProBadge && direction !== 'row' && (
+               <FontAwesomeIcon
+                  icon={faRectanglePro}
+                  size="1x"
+                  color={theme.colors[colorScheme][500]}
+                  style={{ marginRight: '6px' }}
+               />
+            )}
+            {formattedPrice}
+         </Text>
+         {isDiscounted && (
+            <>
+               <Text
+                  mr={direction === 'row' ? '10px' : 0}
+                  fontSize={compareAtPriceFontSize}
+                  color="gray.500"
+                  textDecor="line-through"
+               >
+                  {formattedCompareAtPrice}
+               </Text>
+               {isDiscounted && showDiscountLabel && direction === 'row' && (
+                  <IconBadge
+                     icon={showProBadge ? faRectanglePro : undefined}
+                     colorScheme={colorScheme}
+                  >
+                     {discountLabel}
+                  </IconBadge>
+               )}
+            </>
+         )}
+      </Box>
+   );
+}

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -22,11 +22,12 @@ export async function findProduct(shop: ShopCredentials, handle: string) {
    const variants = response.product.variants.nodes.map((variant) => {
       const isDiscounted =
          variant.compareAtPriceV2 != null &&
-         variant.compareAtPriceV2.amount > variant.priceV2.amount;
+         parseFloat(variant.compareAtPriceV2.amount) >
+            parseFloat(variant.priceV2.amount);
       const discountPercentage = isDiscounted
          ? computeDiscountPercentage(
-              variant.priceV2.amount * 100,
-              variant.compareAtPriceV2!.amount * 100
+              parseFloat(variant.priceV2.amount) * 100,
+              parseFloat(variant.compareAtPriceV2!.amount) * 100
            )
          : 0;
 

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -1,5 +1,6 @@
 import { IFIXIT_ORIGIN } from '@config/env';
 import { filterNullableItems, invariant } from '@helpers/application-helpers';
+import { computeDiscountPercentage } from '@helpers/commerce-helpers';
 import { isRecord } from '@ifixit/helpers';
 import {
    ShopCredentials,
@@ -19,8 +20,20 @@ export async function findProduct(shop: ShopCredentials, handle: string) {
       return null;
    }
    const variants = response.product.variants.nodes.map((variant) => {
+      const isDiscounted =
+         variant.compareAtPriceV2 != null &&
+         variant.compareAtPriceV2.amount > variant.priceV2.amount;
+      const discountPercentage = isDiscounted
+         ? computeDiscountPercentage(
+              variant.priceV2.amount * 100,
+              variant.compareAtPriceV2!.amount * 100
+           )
+         : 0;
+
       return {
          ...variant,
+         isDiscounted,
+         discountPercentage,
          formattedPrice: formatPrice(variant.priceV2),
          formattedCompareAtPrice: variant.compareAtPriceV2
             ? formatPrice(variant.compareAtPriceV2)

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -44,6 +44,7 @@ import {
 import { ProductGallery } from './ProductGallery';
 import { ProductOptions } from './ProductOptions';
 import { ProductRating } from './ProductRating';
+import { ProductPrice } from '../../../../components/common/ProductPrice';
 
 export type ProductSectionProps = {
    product: Product;
@@ -106,8 +107,12 @@ export function ProductSection({
                )}
                <ProductTitle mb="2.5">{product.title}</ProductTitle>
                <ProductPrice
-                  price={selectedVariant.formattedPrice}
-                  compareAt={selectedVariant.formattedCompareAtPrice}
+                  formattedPrice={selectedVariant.formattedPrice}
+                  formattedCompareAtPrice={
+                     selectedVariant.formattedCompareAtPrice
+                  }
+                  isDiscounted={selectedVariant.isDiscounted}
+                  discountLabel={`${selectedVariant.discountPercentage}% OFF`}
                />
                <ProductRating product={product} />
                <ProductOptions
@@ -425,19 +430,6 @@ const ProductTitle = chakra(
       );
    }
 );
-
-type ProductPriceProps = {
-   price: string;
-   compareAt?: string | null;
-};
-
-function ProductPrice({ price, compareAt }: ProductPriceProps) {
-   return (
-      <Text fontWeight="bold" fontSize="xl">
-         {price}
-      </Text>
-   );
-}
 
 type CustomAccordionButtonProps = React.PropsWithChildren<{}>;
 


### PR DESCRIPTION
close #662 

This PR introduce a new ProductPrice component.

The product page heading will use the red color scheme in horizontal direction as per mockup:

<img width="725" alt="Screenshot 2022-08-30 at 17 54 13" src="https://user-images.githubusercontent.com/7805759/187781684-e1b34aca-ae95-421e-a6b5-2ae71401fb5c.png">

The component can however be configured to cover all the layouts visible in the mockup:

<img width="138" alt="Screenshot 2022-08-31 at 23 02 17" src="https://user-images.githubusercontent.com/7805759/187781522-a1d0d831-9f49-44ca-a487-def30e7fd1f2.png">

So, it may already cover most - if not all - the use cases that are being discussed [here](https://github.com/iFixit/react-commerce/issues/533). 


## QA
1. Open Vercel preview
2. Go to [here](https://react-commerce-git-enrich-price-component-ifixit.vercel.app/Products/macbook-air-13-late-2010-2017-replacement-battery) to see a discounted product
3. Go to [here](https://react-commerce-git-enrich-price-component-ifixit.vercel.app/Products/iphone-11-screen) to see a product without discount