### PR TITLE
Yeti Crawler: don't send failed requests to sentry

### DIFF
--- a/packages/cart-sdk/hooks/use-cart.ts
+++ b/packages/cart-sdk/hooks/use-cart.ts
@@ -4,16 +4,16 @@ import { useQuery } from 'react-query';
 import { Cart, CartAPIResponse } from '../types';
 import { cartKeys } from '../utils';
 
-const CART_NOT_AVAILABLE = 'cart is not available';
-
 /**
  * Get the cart from the API.
  */
 export function useCart() {
    const client = useIFixitApiClient();
    const query = useQuery(cartKeys.cart, async (): Promise<Cart | null> => {
-      const result = await client.get('store/user/cart');
-      invariant(isValidCartPayload(result), CART_NOT_AVAILABLE);
+      const result = (await client.get('store/user/cart')) || null;
+      if (!isValidCartPayload(result)) {
+         return null;
+      }
       return {
          ...result.cart,
          hasItemsInCart: result.cart.totalNumItems > 0,

--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -2,6 +2,9 @@ import * as Sentry from '@sentry/nextjs';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { GetServerSidePropsContext } from 'next';
 
+const shouldIgnoreUserAgent =
+   typeof window !== 'undefined' && /Yeti/.test(window.navigator.userAgent);
+
 export const sentryFetch: typeof fetch = async (resource, options) => {
    const context = {
       // Underscore sorts the resource first in Sentry's UI
@@ -13,7 +16,11 @@ export const sentryFetch: typeof fetch = async (resource, options) => {
    };
    return fetch(resource, options)
       .then((response) => {
-         if (response.status >= 400 && response.status !== 401) {
+         if (
+            !shouldIgnoreUserAgent &&
+            response.status >= 400 &&
+            response.status !== 401
+         ) {
             const msg = `fetch() HTTP error: ${response.status} ${response.statusText}`;
             Sentry.captureException(new Error(msg), (scope) => {
                scope.setContext('request', context);

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -118,10 +118,11 @@ export function CartDrawer() {
                               bg="gray.100"
                               color="gray.400"
                            >
-                              {cart.isLoading ?
-                                 (<Spinner size="xs" />) :
-                                 (cart.data?.totalNumItems ?? 0)
-                              }
+                              {cart.isLoading ? (
+                                 <Spinner size="xs" />
+                              ) : (
+                                 cart.data?.totalNumItems ?? 0
+                              )}
                            </Badge>
                         )}
                      </HStack>

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -118,9 +118,10 @@ export function CartDrawer() {
                               bg="gray.100"
                               color="gray.400"
                            >
-                              {cart.data?.totalNumItems ?? (
-                                 <Spinner size="xs" />
-                              )}
+                              {cart.isLoading ?
+                                 (<Spinner size="xs" />) :
+                                 (cart.data?.totalNumItems ?? 0)
+                              }
                            </Badge>
                         )}
                      </HStack>
@@ -165,7 +166,7 @@ export function CartDrawer() {
                      </ScaleFade>
                      <Collapse
                         animateOpacity
-                        in={cart.data != null && cart.data.totalNumItems === 0}
+                        in={cart.isFetched && !cart.data?.totalNumItems}
                      >
                         <VStack spacing="5" p="5">
                            <Circle size="72px" bg={theme.colors.brand[100]}>


### PR DESCRIPTION
Yeti bot / browser / crawler for some reason pretends that our cart api
returns a 403. So, on every page load (When it's indexing) the failed
cart API request results in a report to sentry. Let's ignore failed
requests if we're on the client side and if the browser is Yeti.

See commit messages for more

Closes #685

CC @sterlinghirsh @jarstelfox 