### PR TITLE
Sentry: don't report 404s

### DIFF
--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -16,7 +16,12 @@ export const sentryFetch: typeof fetch = async (resource, options) => {
    };
    return fetch(resource, options)
       .then((response) => {
-         if (!shouldIgnoreUserAgent && response.status >= 500) {
+         if (
+            !shouldIgnoreUserAgent &&
+            response.status >= 400 &&
+            response.status !== 401 &&
+            response.status !== 404
+         ) {
             const msg = `fetch() HTTP error: ${response.status} ${response.statusText}`;
             Sentry.captureException(new Error(msg), (scope) => {
                scope.setContext('request', context);

--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -18,8 +18,7 @@ export const sentryFetch: typeof fetch = async (resource, options) => {
       .then((response) => {
          if (
             !shouldIgnoreUserAgent &&
-            response.status >= 400 &&
-            response.status !== 401
+            response.status >= 500
          ) {
             const msg = `fetch() HTTP error: ${response.status} ${response.statusText}`;
             Sentry.captureException(new Error(msg), (scope) => {

--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -16,10 +16,7 @@ export const sentryFetch: typeof fetch = async (resource, options) => {
    };
    return fetch(resource, options)
       .then((response) => {
-         if (
-            !shouldIgnoreUserAgent &&
-            response.status >= 500
-         ) {
+         if (!shouldIgnoreUserAgent && response.status >= 500) {
             const msg = `fetch() HTTP error: ${response.status} ${response.statusText}`;
             Sentry.captureException(new Error(msg), (scope) => {
                scope.setContext('request', context);


### PR DESCRIPTION
If someone visits `/Parts/made-up-device-name` and this API 404s, let's not bother reporting this to Sentry.

Previously we were curious if this would help us find bugs (linking to pages that don't exist). But mostly we just get botspam that's just munging our urls to see what happens.

I've looked at the last 20 or 30 and found many variants on the same thing (Random edits to urls, urls for devices that don't exist, messe up punction in the urls, ...). None of the errors made me think we were at fault, so let's stop being hassled.

qa_req 0 Because of low blast-radius

Closes #632