### PR TITLE
Add compatibility accordion panel + compatibility section

### DIFF
--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -19,7 +19,12 @@ export function CompatibleDevice({ device }: CompatibleDeviceProps) {
             borderColor="gray.300"
             borderRadius="4px"
          />
-         <Flex flexDir="column" alignSelf="center">
+         <Flex
+            minH="12"
+            flexDir="column"
+            alignSelf="flex-start"
+            justifyContent="center"
+         >
             <Text
                my="2px"
                fontWeight="medium"

--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -1,0 +1,45 @@
+import { Flex, Img, Text } from '@chakra-ui/react';
+import { Product } from '@models/product';
+
+export type CompatibleDeviceProps = {
+   device: NonNullable<Product['compatibility']>['devices'][number];
+};
+
+export function CompatibleDevice({ device }: CompatibleDeviceProps) {
+   return (
+      <>
+         <Img
+            src={device.imageUrl}
+            alt={device.deviceName ?? ''}
+            w="12"
+            h="12"
+            mr="3"
+            borderWidth="1px"
+            borderStyle="solid"
+            borderColor="gray.300"
+            borderRadius="4px"
+         />
+         <Flex flexDir="column" alignSelf="center">
+            <Text
+               my="2px"
+               fontWeight="medium"
+               _groupHover={{ color: 'brand.500' }}
+            >
+               {device.deviceName}
+            </Text>
+            <Flex mb="2px" flexDir="column">
+               {device.variants.map((variant) => (
+                  <Text
+                     key={variant}
+                     lineHeight="short"
+                     fontSize="xs"
+                     color="gray.600"
+                  >
+                     {variant}
+                  </Text>
+               ))}
+            </Flex>
+         </Flex>
+      </>
+   );
+}

--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6195,6 +6195,7 @@ export type FindProductQuery = {
       prop65Chemicals?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       productVideos?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       replacementGuides?: Maybe<{ __typename?: 'Metafield'; value: string }>;
+      compatibility?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       featuredImage?: Maybe<{ __typename?: 'Image'; id?: Maybe<string> }>;
       images: {
          __typename?: 'ImageConnection';
@@ -6273,6 +6274,9 @@ export const FindProductDocument = `
       value
     }
     replacementGuides: metafield(namespace: "ifixit", key: "replacement_guides") {
+      value
+    }
+    compatibility: metafield(namespace: "ifixit", key: "compatibility_json") {
       value
     }
     featuredImage {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -27,6 +27,9 @@ query findProduct($handle: String) {
       ) {
          value
       }
+      compatibility: metafield(namespace: "ifixit", key: "compatibility_json") {
+         value
+      }
       featuredImage {
          id
       }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -13,15 +13,11 @@ export type Scalars = {
    Boolean: boolean;
    Int: number;
    Float: number;
-   /** A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the `date-time` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar. */
    DateTime: any;
-   /** A string used to identify an i18n locale */
    I18NLocaleCode: any;
-   /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
    JSON: any;
    MenuItemsDynamicZoneInput: any;
    ProductListSectionsDynamicZoneInput: any;
-   /** The `Upload` scalar type represents a file upload. */
    Upload: any;
 };
 

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -20,6 +20,7 @@ import { ProductSection } from './sections/ProductSection';
 import { ReviewsSection } from './sections/ReviewsSection';
 import { ReplacementGuidesSection } from './sections/ReplacementGuidesSection';
 import { ServiceValuePropositionSection } from './sections/ServiceValuePropositionSection';
+import { CompatibilitySection } from './sections/CompatibilitySection';
 
 export type ProductTemplateProps = WithProvidersProps<
    WithLayoutProps<{
@@ -55,6 +56,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = ({
                product={product}
                selectedVariant={selectedVariant}
             />
+            <CompatibilitySection compatibility={product.compatibility} />
          </Box>
       </>
    );

--- a/frontend/templates/product/sections/CompatibilitySection/index.tsx
+++ b/frontend/templates/product/sections/CompatibilitySection/index.tsx
@@ -1,0 +1,61 @@
+import { Box, chakra, Heading, SimpleGrid } from '@chakra-ui/react';
+import { CompatibleDevice } from '@components/common/CompatibleDevice';
+
+import { PageContentWrapper } from '@ifixit/ui';
+import { Product } from '@models/product';
+import NextLink from 'next/link';
+
+export type CompatibilitySectionProps = {
+   compatibility: Product['compatibility'];
+};
+
+export function CompatibilitySection({
+   compatibility,
+}: CompatibilitySectionProps) {
+   return compatibility && compatibility.devices.length > 0 ? (
+      <Box id="compatibility" bg="gray.100" py="16" fontSize="sm">
+         <PageContentWrapper>
+            <Heading
+               as="h2"
+               fontFamily="Archivo Black"
+               color="gray.700"
+               textAlign="center"
+               mb="12"
+            >
+               Compatibility
+            </Heading>
+            <SimpleGrid
+               columns={{ base: 1, sm: 2, md: 3 }}
+               spacing={3}
+               margin={{ base: 5, sm: 0 }}
+            >
+               {compatibility?.devices.map((device, index) => (
+                  <NextLink key={index} href={device.deviceUrl} passHref>
+                     <chakra.a
+                        display="flex"
+                        p="3"
+                        bg="white"
+                        borderWidth="1px"
+                        borderStyle="solid"
+                        borderColor="gray.300"
+                        borderRadius="4px"
+                        transition="all 300ms"
+                        _hover={{
+                           boxShadow: 'md',
+                        }}
+                        alignItems="flex-start"
+                        gridColumnStart={
+                           compatibility.devices.length === 1
+                              ? { base: 1, md: 2 }
+                              : 'unset'
+                        }
+                     >
+                        <CompatibleDevice device={device} />
+                     </chakra.a>
+                  </NextLink>
+               ))}
+            </SimpleGrid>
+         </PageContentWrapper>
+      </Box>
+   ) : null;
+}

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -4,7 +4,6 @@ import {
    Button,
    Circle,
    Flex,
-   HStack,
    Img,
    Text,
    useTheme,
@@ -13,16 +12,16 @@ import {
 import { faArrowLeft, faArrowRight } from '@fortawesome/pro-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Product } from '@models/product';
+import { useSwiper } from '@templates/product/hooks/useSwiper';
 import * as React from 'react';
 import Swiper, { Navigation, Pagination, Thumbs } from 'swiper';
 import { Swiper as ReactSwiper, SwiperSlide } from 'swiper/react';
-import { useSwiper } from '@templates/product/hooks/useSwiper';
 
+import { faImage } from '@fortawesome/pro-duotone-svg-icons';
 import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import 'swiper/css/thumbs';
-import { faImage } from '@fortawesome/pro-duotone-svg-icons';
 
 export type ProductGalleryProps = {
    product: Product;

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -14,6 +14,7 @@ import {
    HStack,
    Icon,
    IconButton,
+   Img,
    Link,
    List,
    ListIcon,
@@ -31,6 +32,7 @@ import {
 import { useAppContext } from '@ifixit/app';
 import { PageContentWrapper } from '@ifixit/ui';
 import { Product, ProductVariant } from '@models/product';
+import NextLink from 'next/link';
 import * as React from 'react';
 import {
    FaExclamationTriangle,
@@ -39,11 +41,15 @@ import {
    FaShieldAlt,
    FaTruck,
 } from 'react-icons/fa';
+import { ProductPrice } from '../../../../components/common/ProductPrice';
 import { AddToCart } from './AddToCart';
 import { ProductGallery } from './ProductGallery';
 import { ProductOptions } from './ProductOptions';
 import { ProductRating } from './ProductRating';
-import { ProductPrice } from '../../../../components/common/ProductPrice';
+import {
+   CompatibleDevice,
+   CompatibleDeviceProps,
+} from '../../../../components/common/CompatibleDevice';
 
 export type ProductSectionProps = {
    product: Product;
@@ -257,6 +263,51 @@ export function ProductSection({
                   </AccordionItem>
 
                   <AccordionItem
+                     hidden={
+                        product.compatibility == null ||
+                        product.compatibility.devices.length <= 0
+                     }
+                  >
+                     <CustomAccordionButton>
+                        Compatibility
+                     </CustomAccordionButton>
+                     <CustomAccordionPanel>
+                        {product.compatibility?.devices
+                           .slice(0, 3)
+                           .map((device, index) => (
+                              <NextLink
+                                 key={index}
+                                 href={device.deviceUrl}
+                                 passHref
+                              >
+                                 <chakra.a
+                                    role="group"
+                                    display="flex"
+                                    transition="all 300m"
+                                    mb="6px"
+                                 >
+                                    <CompatibleDevice device={device} />
+                                 </chakra.a>
+                              </NextLink>
+                           ))}
+
+                        {product.compatibility &&
+                        product.compatibility.devices.length > 3 ? (
+                           <NextLink href="#compatibility" passHref>
+                              <Link
+                                 mt={3}
+                                 display="block"
+                                 fontWeight="medium"
+                                 color="brand.500"
+                              >
+                                 See all compatible devices
+                              </Link>
+                           </NextLink>
+                        ) : null}
+                     </CustomAccordionPanel>
+                  </AccordionItem>
+
+                  <AccordionItem
                      hidden={selectedVariant.specifications == null}
                   >
                      <CustomAccordionButton>
@@ -315,6 +366,7 @@ export function ProductSection({
                      </CustomAccordionPanel>
                   </AccordionItem>
                </Accordion>
+
                <VStack mt="10" align="flex-start" spacing="4">
                   {product.prop65WarningType && product.prop65Chemicals && (
                      <Flex align="center">

--- a/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
+++ b/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
@@ -1,24 +1,14 @@
-import {
-   Box,
-   forwardRef,
-   Heading,
-   Icon,
-   IconProps,
-   Stack,
-   Text,
-   useTheme,
-   VStack,
-} from '@chakra-ui/react';
-import React from 'react';
-import {
-   FontAwesomeIcon,
-   FontAwesomeIconProps,
-} from '@fortawesome/react-fontawesome';
+import { Heading, Stack, Text, useTheme, VStack } from '@chakra-ui/react';
 import {
    faBoxCircleCheck,
    faRocket,
    faShieldCheck,
 } from '@fortawesome/pro-duotone-svg-icons';
+import {
+   FontAwesomeIcon,
+   FontAwesomeIconProps,
+} from '@fortawesome/react-fontawesome';
+import React from 'react';
 
 export type ServiceValuePropositionSectionProps = {};
 
@@ -49,7 +39,7 @@ export function ServiceValuePropositionSection() {
             }}
             mt="16"
             py="16"
-            px="6"
+            px={{ base: 5, sm: 6 }}
          >
             <ValueProposition>
                <ValuePropositionIcon icon={faBoxCircleCheck} />

--- a/packages/ui/theme/components/alert.ts
+++ b/packages/ui/theme/components/alert.ts
@@ -4,7 +4,6 @@ const Alert: ComponentStyleConfig = {
    baseStyle: {},
    variants: {
       subtle: (props) => {
-         console.log('hey subtle');
          const schemeColors = props.theme.colors[props.colorScheme];
          return {
             container: {


### PR DESCRIPTION
closes #706 

This PR adds the compatibility accordion panel - just below the product variant selector - and the compatibility section in the lower part of the page.

The accordion panel shows the first 3 compatible devices at most. If there are more than 3 compatible devices it also show an anchor link that points to the compatibility section on the bottom of the page

The compatibility section always list all the possible compatible devices in a grid layout. 

Accordion panel:

<img width="374" alt="Screenshot 2022-09-20 at 11 38 08" src="https://user-images.githubusercontent.com/7805759/191224804-c36f75e0-2e47-49fe-842f-e306e7114922.png">

Section:

<img width="816" alt="Screenshot 2022-09-20 at 11 38 24" src="https://user-images.githubusercontent.com/7805759/191224853-37cc0f30-83a6-425a-bdae-70b70dccfe42.png">

## QA

1. Visit Vercel preview
2. Navigate to a [product with compatibilities](https://react-commerce-git-add-compatibility-panel-and-section-ifixit.vercel.app/Products/iphone-11-screen)
3. Verify that everything is like in the mockup
4. Check also products with a different number of compatible devices
