### PR TITLE
Sentry: ignore malformed url errors

### DIFF
--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -18,4 +18,14 @@ Sentry.init({
          'next.runtime': 'server',
       },
    },
+   beforeSend(event, hint) {
+      const ex = hint.originalException;
+      if (ex && typeof ex == 'object' && ex.message) {
+         // Happens when receiving a bad url that fails to decode
+         if (ex.message.match(/URI malformed/)) {
+            return null;
+         }
+      }
+      return event;
+   },
 });


### PR DESCRIPTION
If a user submits a malformed url (with non-utf8 chars encoded), an error is thrown and was being reported to sentry.

I was never able to repro with a browser (nor with curl) but I can generate the error by just calling `decodeUriComponent('%80')`. This change effectively ignores these errors. In the past, we've gotten bursts of them as bots or vulnerability scanners peppered us with bad urls. As far as I could tell there wasn't an opportunity to stop these errors at the source because they happened deep in the next.js framework before middleware execution.

Closes #670