### PR TITLE
Improve product page breadcrumbs

### DIFF
--- a/frontend/components/common/PageBreadcrumb.tsx
+++ b/frontend/components/common/PageBreadcrumb.tsx
@@ -3,17 +3,17 @@ import {
    BreadcrumbItem,
    BreadcrumbLink,
    BreadcrumbProps,
-   Icon,
+   Flex,
    IconButton,
    Menu,
    MenuButton,
    MenuItem,
    MenuList,
-   Text,
+   useTheme,
 } from '@chakra-ui/react';
+import { faChevronRight, faEllipsis } from '@fortawesome/pro-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import NextLink from 'next/link';
-import * as React from 'react';
-import { HiChevronRight, HiDotsHorizontal } from 'react-icons/hi';
 
 export type PageBreadcrumbProps = BreadcrumbProps & {
    items: TBreadcrumbItem[];
@@ -24,109 +24,152 @@ export type TBreadcrumbItem = {
    url: string;
 };
 
+const MAX_VISIBLE_ITEMS = 3;
+
 export function PageBreadcrumb({ items, ...otherProps }: PageBreadcrumbProps) {
-   const ancestors = items.slice(0, -1);
-   const reverseAncestorList = [...ancestors].reverse();
-   const currentItem = items[items.length - 1];
+   const visibleAncestors = items.slice(-MAX_VISIBLE_ITEMS).slice(0, -1);
+   const desktopCollapsedItems = items.slice(0, -MAX_VISIBLE_ITEMS).reverse();
+   const mobileCollapsedItems = items.slice(0, -1).reverse();
 
    if (items.length === 0) {
       return null;
    }
 
+   const currentItem = items[items.length - 1];
+
    return (
       <Breadcrumb
          spacing={1}
-         separator={
-            <Icon
-               as={HiChevronRight}
-               display={{
-                  base: 'none',
-                  md: 'initial',
-               }}
-               color="gray.300"
-               mt="1"
-            />
-         }
-         fontSize="sm"
-         display="flex"
-         flexWrap="nowrap"
-         flexShrink={1}
-         minW="0"
-         maxW="full"
-         overflow="hidden"
-         pl="1"
-         ml="-2"
+         separator={<BreadcrumbIcon />}
+         py="3"
+         px={{
+            base: 4,
+            sm: 0,
+         }}
          sx={{
             '& > *': {
                display: 'flex',
+               flexWrap: 'nowrap',
             },
          }}
          {...otherProps}
       >
-         {ancestors.map((ancestor, index) => (
-            <BreadcrumbItem
-               key={index}
-               borderRadius="md"
-               display={{
-                  base: 'none',
-                  lg: 'inline-flex',
-               }}
-            >
-               <NextLink href={ancestor.url} passHref>
-                  <BreadcrumbLink
-                     color="gray.500"
-                     whiteSpace="nowrap"
-                     borderRadius="sm"
-                     px="1"
-                  >
-                     {ancestor.label}
-                  </BreadcrumbLink>
-               </NextLink>
-            </BreadcrumbItem>
-         ))}
-         {reverseAncestorList.length > 0 && (
+         {mobileCollapsedItems.length > 0 && (
             <BreadcrumbItem
                display={{
                   base: 'inline-flex',
                   lg: 'none',
                }}
             >
-               <Menu>
-                  <MenuButton
-                     as={IconButton}
-                     aria-label="Options"
-                     icon={<Icon as={HiDotsHorizontal} color="gray.400" />}
-                     variant="solid"
-                     bg="gray.200"
-                     size="xs"
-                     ml="1"
-                  />
-                  <MenuList>
-                     {reverseAncestorList.map((ancestor, index) => (
-                        <NextLink key={index} href={ancestor.url} passHref>
-                           <MenuItem as="a">{ancestor.label}</MenuItem>
-                        </NextLink>
-                     ))}
-                  </MenuList>
-               </Menu>
+               <BreadcrumbMenu items={mobileCollapsedItems} />
             </BreadcrumbItem>
          )}
+         {desktopCollapsedItems.length > 0 && (
+            <BreadcrumbItem
+               display={{
+                  base: 'none',
+                  lg: 'inline-flex',
+               }}
+            >
+               <BreadcrumbMenu items={desktopCollapsedItems} />
+            </BreadcrumbItem>
+         )}
+         {visibleAncestors.map((ancestor, index) => {
+            return (
+               <BreadcrumbItem
+                  key={index}
+                  borderRadius="md"
+                  display={{
+                     base: 'none',
+                     lg: 'inline-flex',
+                  }}
+               >
+                  <NextLink href={ancestor.url} passHref>
+                     <BreadcrumbLink
+                        color="gray.500"
+                        whiteSpace="nowrap"
+                        borderRadius="sm"
+                        px="1"
+                        maxW="300px"
+                        isTruncated
+                     >
+                        {ancestor.label}
+                     </BreadcrumbLink>
+                  </NextLink>
+               </BreadcrumbItem>
+            );
+         })}
          <BreadcrumbItem
+            borderRadius="md"
+            isLastChild
             isCurrentPage
-            display={{
-               base: 'none',
-               md: 'flex',
-            }}
+            overflow="hidden"
          >
-            <Text
+            <BreadcrumbLink
                color="black"
-               fontWeight="bold"
-               whiteSpace="nowrap"
                isTruncated
+               borderRadius="sm"
+               cursor="auto"
+               px="1"
+               _hover={{
+                  textDecoration: 'none',
+               }}
             >
                {currentItem.label}
-            </Text>
+            </BreadcrumbLink>
          </BreadcrumbItem>
       </Breadcrumb>
+   );
+}
+
+type BreadcrumbMenuProps = {
+   items: TBreadcrumbItem[];
+};
+
+function BreadcrumbMenu({ items }: BreadcrumbMenuProps) {
+   const theme = useTheme();
+   return (
+      <Menu>
+         <MenuButton
+            as={IconButton}
+            aria-label="Options"
+            icon={
+               <FontAwesomeIcon
+                  icon={faEllipsis}
+                  size="1x"
+                  color={theme.colors['gray'][500]}
+               />
+            }
+            variant="solid"
+            bg="gray.300"
+            size="xs"
+            px="1.5"
+         />
+         <MenuList>
+            {items.map((ancestor, index) => (
+               <NextLink key={index} href={ancestor.url} passHref>
+                  <MenuItem as="a">{ancestor.label}</MenuItem>
+               </NextLink>
+            ))}
+         </MenuList>
+      </Menu>
+   );
+}
+
+function BreadcrumbIcon() {
+   const theme = useTheme();
+   return (
+      <Flex>
+         <FontAwesomeIcon
+            icon={faChevronRight}
+            color={theme.colors['gray'][300]}
+            style={{
+               width: '10px',
+               height: '10px',
+               display: 'flex',
+               marginTop: '1px',
+            }}
+         />
+      </Flex>
    );
 }

--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6229,6 +6229,7 @@ export type FindProductQuery = {
       title: string;
       handle: string;
       descriptionHtml: string;
+      breadcrumbs?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       faqs?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       prop65WarningType?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       prop65Chemicals?: Maybe<{ __typename?: 'Metafield'; value: string }>;
@@ -6348,6 +6349,9 @@ export const FindProductDocument = `
     title
     handle
     descriptionHtml
+    breadcrumbs: metafield(namespace: "ifixit", key: "breadcrumbs") {
+      value
+    }
     faqs: metafield(namespace: "custom", key: "faq") {
       value
     }

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -3,6 +3,9 @@ query findProduct($handle: String) {
       title
       handle
       descriptionHtml
+      breadcrumbs: metafield(namespace: "ifixit", key: "breadcrumbs") {
+         value
+      }
       faqs: metafield(namespace: "custom", key: "faq") {
          value
       }

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -33,6 +33,7 @@ export async function findProduct(shop: ShopCredentials, handle: string) {
 
    return {
       ...response.product,
+      breadcrumbs: parseBreadcrumbs(response.product.breadcrumbs?.value),
       iFixitProductId,
       variants,
       images: response.product.images.nodes,
@@ -130,6 +131,29 @@ function parseFaqs(value: string | null | undefined) {
          };
       })
    );
+}
+
+type Breadcrumbs = z.infer<typeof BreadcrumbsSchema>;
+
+const BreadcrumbsSchema = z.array(
+   z.object({
+      label: z.string(),
+      url: z.string(),
+   })
+);
+
+function parseBreadcrumbs(
+   value: string | null | undefined
+): Breadcrumbs | null {
+   if (typeof value !== 'string') {
+      return null;
+   }
+   const json = JSON.parse(value);
+   const parsedValue = BreadcrumbsSchema.safeParse(json);
+   if (parsedValue.success) {
+      return parsedValue.data;
+   }
+   return null;
 }
 
 type ReplacementGuideMetafieldItem = z.infer<

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -30,10 +30,17 @@ export async function findProduct(shop: ShopCredentials, handle: string) {
       IFIXIT_ORIGIN,
       iFixitProductId
    );
+   let breadcrumbs = parseBreadcrumbsMetafieldValue(
+      response.product.breadcrumbs?.value
+   );
+   breadcrumbs = breadcrumbsWithCurrentProductPage(
+      breadcrumbs,
+      response.product.title
+   );
 
    return {
       ...response.product,
-      breadcrumbs: parseBreadcrumbs(response.product.breadcrumbs?.value),
+      breadcrumbs,
       iFixitProductId,
       variants,
       images: response.product.images.nodes,
@@ -142,7 +149,7 @@ const BreadcrumbsSchema = z.array(
    })
 );
 
-function parseBreadcrumbs(
+function parseBreadcrumbsMetafieldValue(
    value: string | null | undefined
 ): Breadcrumbs | null {
    if (typeof value !== 'string') {
@@ -154,6 +161,27 @@ function parseBreadcrumbs(
       return parsedValue.data;
    }
    return null;
+}
+
+function breadcrumbsWithCurrentProductPage(
+   breadcrumbs: Breadcrumbs | null,
+   productTitle: string
+) {
+   if (breadcrumbs == null) {
+      return null;
+   }
+   if (breadcrumbs.length > 0) {
+      const lastBreadcrumb = breadcrumbs[breadcrumbs.length - 1];
+      if (lastBreadcrumb.label.toLowerCase() !== productTitle.toLowerCase()) {
+         return breadcrumbs.concat([
+            {
+               label: productTitle,
+               url: '#',
+            },
+         ]);
+      }
+   }
+   return breadcrumbs;
 }
 
 type ReplacementGuideMetafieldItem = z.infer<

--- a/frontend/templates/product-list/ProductListBreadcrumb.tsx
+++ b/frontend/templates/product-list/ProductListBreadcrumb.tsx
@@ -3,14 +3,17 @@ import {
    BreadcrumbItem,
    BreadcrumbLink,
    BreadcrumbProps,
-   Icon,
+   Flex,
    IconButton,
    Menu,
    MenuButton,
    MenuItem,
    MenuList,
    Text,
+   useTheme,
 } from '@chakra-ui/react';
+import { faChevronRight, faEllipsis } from '@fortawesome/pro-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
    getProductListPath,
    getProductListTitle,
@@ -19,7 +22,6 @@ import { ProductList, ProductListType } from '@models/product-list';
 import { ProductListAncestor } from '@models/product-list/types';
 import NextLink from 'next/link';
 import * as React from 'react';
-import { HiChevronRight, HiDotsHorizontal } from 'react-icons/hi';
 import { useDevicePartsItemType } from './sections/FilterableProductsSection/useDevicePartsItemType';
 
 export type ProductListBreadcrumbProps = BreadcrumbProps & {
@@ -30,6 +32,7 @@ export function ProductListBreadcrumb({
    productList,
    ...otherProps
 }: ProductListBreadcrumbProps) {
+   const theme = useTheme();
    let { ancestors } = productList;
    const itemType = useDevicePartsItemType(productList);
 
@@ -46,7 +49,20 @@ export function ProductListBreadcrumb({
    return (
       <Breadcrumb
          spacing={1}
-         separator={<Icon as={HiChevronRight} color="gray.300" mt="1" />}
+         separator={
+            <Flex>
+               <FontAwesomeIcon
+                  icon={faChevronRight}
+                  color={theme.colors['gray'][300]}
+                  style={{
+                     width: '10px',
+                     height: '10px',
+                     display: 'flex',
+                     marginTop: '1px',
+                  }}
+               />
+            </Flex>
+         }
          fontSize="sm"
          display="flex"
          flexWrap="nowrap"
@@ -95,9 +111,15 @@ export function ProductListBreadcrumb({
                   <MenuButton
                      as={IconButton}
                      aria-label="Options"
-                     icon={<Icon as={HiDotsHorizontal} color="gray.400" />}
+                     icon={
+                        <FontAwesomeIcon
+                           icon={faEllipsis}
+                           size="1x"
+                           color={theme.colors['gray'][500]}
+                        />
+                     }
                      variant="solid"
-                     bg="gray.200"
+                     bg="gray.300"
                      size="xs"
                      ml="1"
                   />

--- a/frontend/templates/product/component/SecondaryNavigation.tsx
+++ b/frontend/templates/product/component/SecondaryNavigation.tsx
@@ -1,0 +1,21 @@
+import { Box, BoxProps } from '@chakra-ui/react';
+import { PageContentWrapper } from '@ifixit/ui';
+
+export function SecondaryNavigation({ children, ...other }: BoxProps) {
+   return (
+      <Box
+         bg={{
+            base: 'transparent',
+            lg: 'white',
+         }}
+         borderBottomWidth={{
+            base: 0,
+            lg: 'thin',
+         }}
+         borderColor="gray.300"
+         {...other}
+      >
+         <PageContentWrapper>{children}</PageContentWrapper>
+      </Box>
+   );
+}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -1,12 +1,7 @@
 import { Box } from '@chakra-ui/react';
-import {
-   PageBreadcrumb,
-   SecondaryNavbar,
-   WithProvidersProps,
-} from '@components/common';
+import { PageBreadcrumb, WithProvidersProps } from '@components/common';
 import { flags } from '@config/flags';
 import { invariant } from '@ifixit/helpers';
-import { PageContentWrapper } from '@ifixit/ui';
 import {
    DefaultLayout,
    getLayoutServerSideProps,
@@ -14,6 +9,7 @@ import {
 } from '@layouts/default';
 import { findProduct, Product } from '@models/product';
 import { GetServerSideProps } from 'next';
+import { SecondaryNavigation } from './component/SecondaryNavigation';
 import { useSelectedVariant } from './hooks/useSelectedVariant';
 import { CrossSellSection } from './sections/CrossSellSection';
 import { ProductSection } from './sections/ProductSection';
@@ -36,13 +32,11 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = ({
    return (
       <>
          {product.breadcrumbs != null && (
-            <SecondaryNavbar>
-               <PageContentWrapper>
-                  <PageBreadcrumb items={product.breadcrumbs} />
-               </PageContentWrapper>
-            </SecondaryNavbar>
+            <SecondaryNavigation>
+               <PageBreadcrumb items={product.breadcrumbs} />
+            </SecondaryNavigation>
          )}
-         <Box pt="10">
+         <Box pt="6">
             <ProductSection
                product={product}
                selectedVariant={selectedVariant}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -2,7 +2,6 @@ import { Box } from '@chakra-ui/react';
 import {
    PageBreadcrumb,
    SecondaryNavbar,
-   TBreadcrumbItem,
    WithProvidersProps,
 } from '@components/common';
 import { flags } from '@config/flags';
@@ -33,17 +32,16 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = ({
 }) => {
    const { selectedVariant, setSelectedVariantId } =
       useSelectedVariant(product);
-   const items: TBreadcrumbItem[] = [
-      { label: 'Parts', url: '/Parts' },
-      { label: product.title, url: `/Products/${product.handle}` },
-   ];
+
    return (
       <>
-         <SecondaryNavbar>
-            <PageContentWrapper>
-               <PageBreadcrumb items={items} />
-            </PageContentWrapper>
-         </SecondaryNavbar>
+         {product.breadcrumbs != null && (
+            <SecondaryNavbar>
+               <PageContentWrapper>
+                  <PageBreadcrumb items={product.breadcrumbs} />
+               </PageContentWrapper>
+            </SecondaryNavbar>
+         )}
          <Box pt="10">
             <ProductSection
                product={product}

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -100,7 +100,10 @@ export function ProductSection({
                   md: '320px',
                   lg: '400px',
                }}
-               pt="5"
+               pt={{
+                  base: 0,
+                  md: 5,
+               }}
                direction="column"
                fontSize="sm"
             >

--- a/frontend/templates/product/sections/ReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ReviewsSection/index.tsx
@@ -43,8 +43,6 @@ export function ReviewsSection({
 
    const reviewsData = reviewsQuery.data;
 
-   console.log('reviewsData', reviewsData);
-
    const totalReviewsCount = reviewsData?.count ?? 0;
 
    const reviewCountsByRating = React.useMemo(() => {


### PR DESCRIPTION
closes #716 

## Changelog

1. Connect with the `ifixit.breadcrumbs` metafield to display correct breadcrumbs
2. Improved UI and UX to address also edge cases (like very long titles)

## QA

1. Open Vercel preview
2. Visit some products (e.g. https://react-commerce-git-use-metafield-data-for-product-c0dc21-ifixit.vercel.app/Products/apple-watch-38-mm-series-2-replacement-battery )
3. Verify the breadcrumbs looks good, both [desktop](https://www.figma.com/file/jRG4EyQXRDMGfyLqut08KP/iFixit---Working-files?node-id=6737%3A90839) and [mobile](https://www.figma.com/file/jRG4EyQXRDMGfyLqut08KP/iFixit---Working-files?node-id=6737%3A90798). Please note that if there are more than 3 segments, we'll just show 3 and collapse the others into the menu button
