### PR TITLE
Ignore Typeerror: Network Request Failed In Sentry

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -21,5 +21,8 @@ Sentry.init({
          'next.runtime': 'client',
       },
    },
-   ignoreErrors: ['TypeError: NetworkError when attempting to fetch resource.'],
+   ignoreErrors: [
+      'TypeError: NetworkError when attempting to fetch resource.',
+      'TypeError: Network request failed',
+   ],
 });


### PR DESCRIPTION
## Overview

These ` Typeerror: Network Request Failed` seem hard to reproduce and not overly harmful. Lets ignore them from sentry logs so they don't take up room on Sentry.

## QA
I don't think this needs qa since we don't know how to reproduce the error specifically. qa_req 0;

Connects: iFixit/ifixit#42336 