### PR TITLE
Only append suffix to default titles

### DIFF
--- a/frontend/templates/product-list/MetaTags.tsx
+++ b/frontend/templates/product-list/MetaTags.tsx
@@ -30,11 +30,11 @@ export function MetaTags({ productList }: MetaTagsProps) {
    const isFiltered = currentRefinements.items.length > 0 && !isItemTypeFilter;
    const itemType = useDevicePartsItemType(productList);
    let title =
-      productList.metaTitle || getProductListTitle(productList, itemType);
+      productList.metaTitle ||
+      getProductListTitle(productList, itemType) + ' | iFixit';
    if (!isFiltered && page > 1) {
       title += ` - Page ${page}`;
    }
-   title += ' | iFixit';
    const itemTypeHandle = itemType
       ? `/${encodeURIComponent(stylizeDeviceItemType(itemType))}`
       : '';


### PR DESCRIPTION
Only append " | iFixit" to the titles of pages that don't have a custom title set in Strapi.

To give Strapi admin users full control over the title, we will use the custom title exactly as it exists on Strapi.

## QA

All product list pages should have ` | iFixit` appended to the title, unless there is a custom `meta title` set in Strapi. If that's the case, the meta title in Strapi is used as is. There should never be a case where it is double appended (like www.ifixit.com/Parts is right now).

Closes #735
