### PR TITLE
README: Add troubleshooting steps for missing test store in strapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,13 @@ pyenv install 2.7.18
 pyenv global 2.7.18
 echo 'PATH=$(pyenv root)/shims:$PATH' >> ~/.zshrc
 ```
+
+With the latest changes, we might run into a situation where the local strapi does not have the ifixit test store in it. In order to fix this add the folowing to `backend/.env`
+
+```
+STRAPI_ADMIN_ENABLE_ADDONS_DANGEROUS_ACTIONS=true
+```
+
+With a recent version of main, go to your local strapi at http://localhost:1337/admin/plugins/addons and hit `Reset Seed` with the domain set to `main.govinor.com`.
+
+If this page does not appear, then delete `backend/.cache` and `backend/dist` and re-start the dev server.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,6 @@ With the latest changes, we might run into a situation where the local strapi do
 STRAPI_ADMIN_ENABLE_ADDONS_DANGEROUS_ACTIONS=true
 ```
 
-With a recent version of main, go to your local strapi at http://localhost:1337/admin/plugins/addons and hit `Reset Seed` with the domain set to `main.govinor.com`.
+With the latest version of main, go to your local strapi at http://localhost:1337/admin/plugins/addons and hit `Reset Seed` with the domain set to `main.govinor.com`.
 
 If this page does not appear, then delete `backend/.cache` and `backend/dist` and re-start the dev server.


### PR DESCRIPTION
After running into the situation where my strapi did not have the ifixit test store, these were the steps I followed to fix it. In doing so, I also ran into the situation where the desired addons page did not appear on my localhost:1337 for strapi. I then had to delete the `.cache` and `dist` under `backend` and restart the dev server to finally be able to get my development environment back up and running

qa_req 0

CC: @sterlinghirsh @masonmcelvain @dhmacs 