### PR TITLE
Some More Legacy Redirect Fixes

### DIFF
--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -1,5 +1,6 @@
 import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
 import { invariant } from '@ifixit/helpers';
+import { stylizeDeviceItemType } from '@helpers/product-list-helpers';
 
 export type DeviceWiki = Record<string, any>;
 
@@ -7,7 +8,7 @@ export async function fetchDeviceWiki(
    client: IFixitAPIClient,
    deviceTitle: string
 ): Promise<DeviceWiki | null> {
-   const deviceHandle = encodeURIComponent(deviceTitle);
+   const deviceHandle = encodeURIComponent(stylizeDeviceItemType(deviceTitle));
    try {
       invariant(
          deviceHandle.length > 0,

--- a/frontend/next-config/helpers/redirects.js
+++ b/frontend/next-config/helpers/redirects.js
@@ -3,7 +3,7 @@ function escapeStringForRegex(str) {
 }
 
 // based on destylizeDeviceItemType() from product-list-helpers
-function destylizeURIComponent(uriComponent ) {
+function destylizeURIComponent(uriComponent) {
    return uriComponent.replace(/_+/g, ' ');
 }
 

--- a/frontend/next-config/helpers/redirects.js
+++ b/frontend/next-config/helpers/redirects.js
@@ -2,4 +2,9 @@ function escapeStringForRegex(str) {
    return str.replace(/[/(){}:*+?]/g, '\\$&');
 }
 
-module.exports = { escapeStringForRegex };
+// based on destylizeDeviceItemType() from product-list-helpers
+function destylizeURIComponent(uriComponent ) {
+   return uriComponent.replace(/_+/g, ' ');
+}
+
+module.exports = { escapeStringForRegex, destylizeURIComponent };

--- a/frontend/next-config/redirects/legacy-filter-slugs.json
+++ b/frontend/next-config/redirects/legacy-filter-slugs.json
@@ -38,6 +38,7 @@
       "Power_Jacks": "Ports",
       "Rubber_Feet": "Case_Components",
       "SD_Card": "Hard_Drives",
+      "SSD_Enclosures": "Hard_Drives",
       "SSD_Upgrade_Kits": "Hard_Drives",
       "SSDs": "Hard_Drives",
       "Straps": "Case_Components",

--- a/frontend/next-config/redirects/legacy-filter-slugs.json
+++ b/frontend/next-config/redirects/legacy-filter-slugs.json
@@ -45,6 +45,7 @@
       "Styluses": "Accessories",
       "Test_Cables": "Cables",
       "Timing_Control_Boards": "Boards",
+      "Upgrade_Kits": "Hard_Drives",
       "USB_Boards": "Boards",
       "Wi-Fi_Boards": "Wireless_Boards",
       "Wireless": "Wireless_Boards"

--- a/frontend/next-config/redirects/part-collections.js
+++ b/frontend/next-config/redirects/part-collections.js
@@ -1,12 +1,12 @@
-const { escapeStringForRegex } = require('../helpers/redirects');
+const { escapeStringForRegex, destylizeURIComponent } = require('../helpers/redirects');
 const legacyFilterSlugs = require('./legacy-filter-slugs.json');
 
-function mapPartItemTypes() {
+function getLegacyPartItemTypeRedirects() {
    const legacyTagToItemType = legacyFilterSlugs['tagToItemType'];
    // Redirect tags we've renamed to the new item type name
    const oldToNew = Object.entries(legacyTagToItemType).map(
       ([oldTag, itemType]) => ({
-         source: `/Parts/:device/${escapeStringForRegex(oldTag)}`,
+         source: `/Parts/:device/${getRegexForTag(oldTag)}`,
          destination: `/Parts/:device/${itemType}`,
          permanent: true,
       })
@@ -15,7 +15,7 @@ function mapPartItemTypes() {
    const legacyTagsWithNoItemType = legacyFilterSlugs['tagsWithNoItemType'];
    // Redirect tags we don't support anymore to the base product list page.
    const legacyToParent = legacyTagsWithNoItemType.map((oldTag) => ({
-      source: `/Parts/:device/${escapeStringForRegex(oldTag)}`,
+      source: `/Parts/:device/${getRegexForTag(oldTag)}`,
       destination: `/Parts/:device`,
       permanent: true,
    }));
@@ -23,4 +23,11 @@ function mapPartItemTypes() {
    return [...oldToNew, ...legacyToParent];
 }
 
-module.exports = { mapPartItemTypes };
+function getRegexForTag(oldTag) {
+   return `(${escapeStringForRegex(
+      encodeURIComponent(destylizeURIComponent(oldTag))
+   )}|${escapeStringForRegex(oldTag)})`;
+}
+
+
+module.exports = { getLegacyPartItemTypeRedirects };

--- a/frontend/next-config/redirects/part-collections.js
+++ b/frontend/next-config/redirects/part-collections.js
@@ -1,4 +1,7 @@
-const { escapeStringForRegex, destylizeURIComponent } = require('../helpers/redirects');
+const {
+   escapeStringForRegex,
+   destylizeURIComponent,
+} = require('../helpers/redirects');
 const legacyFilterSlugs = require('./legacy-filter-slugs.json');
 
 function getLegacyPartItemTypeRedirects() {
@@ -28,6 +31,5 @@ function getRegexForTag(oldTag) {
       encodeURIComponent(destylizeURIComponent(oldTag))
    )}|${escapeStringForRegex(oldTag)})`;
 }
-
 
 module.exports = { getLegacyPartItemTypeRedirects };

--- a/frontend/next-config/redirects/part-collections.js
+++ b/frontend/next-config/redirects/part-collections.js
@@ -27,9 +27,10 @@ function getLegacyPartItemTypeRedirects() {
 }
 
 function getRegexForTag(oldTag) {
-   return `(${escapeStringForRegex(
-      encodeURIComponent(destylizeURIComponent(oldTag))
-   )}|${escapeStringForRegex(oldTag)})`;
+   const encodedTag = encodeURIComponent(destylizeURIComponent(oldTag));
+   return encodedTag === oldTag
+      ? escapeStringForRegex(oldTag)
+      : `(${escapeStringForRegex(encodedTag)}|${escapeStringForRegex(oldTag)})`;
 }
 
 module.exports = { getLegacyPartItemTypeRedirects };

--- a/frontend/next-config/redirects/tool-collections.js
+++ b/frontend/next-config/redirects/tool-collections.js
@@ -1,10 +1,25 @@
 const { escapeStringForRegex } = require('../helpers/redirects');
 const legacyFilterSlugs = require('./legacy-filter-slugs.json');
 
-function getToolRedirects() {
+function getLegacyToolRedirects() {
+   const legacyToolRedirects = {
+      source: `/Tools/:slug(${getToolRedirectRegex()})`,
+      destination: `/Tools`,
+      permanent: true,
+   };
+   const legacyHakkoRedirect = {
+      source: `/Tools/Hakko`,
+      destination: `/Tools/Microsoldering`,
+      permanent: true,
+   };
+
+   return [legacyToolRedirects, legacyHakkoRedirect];
+}
+
+function getToolRedirectRegex() {
    return legacyFilterSlugs['toolLegacyRoutes']
       .map((route) => escapeStringForRegex(route))
       .join('|');
 }
 
-module.exports = { getToolRedirects };
+module.exports = { getLegacyToolRedirects };

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,5 @@
 const {
-   mapPartItemTypes,
+   getLegacyPartItemTypeRedirects,
 } = require('./next-config/redirects/part-collections');
 
 const withTM = require('next-transpile-modules')([
@@ -65,7 +65,7 @@ const moduleExports = {
    },
    async redirects() {
       return [
-         ...mapPartItemTypes(),
+         ...getLegacyPartItemTypeRedirects(),
          {
             source: `/Tools/:slug(${getToolRedirects()})`,
             destination: `/Tools`,

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,9 @@
 const {
    getLegacyPartItemTypeRedirects,
 } = require('./next-config/redirects/part-collections');
+const {
+   getLegacyToolRedirects,
+} = require('./next-config/redirects/tool-collections');
 
 const withTM = require('next-transpile-modules')([
    '@ifixit/app',
@@ -17,9 +20,6 @@ const withTM = require('next-transpile-modules')([
 ]);
 
 const { withSentryConfig } = require('@sentry/nextjs');
-const {
-   getToolRedirects,
-} = require('./next-config/redirects/tool-collections');
 
 const withBundleAnalyzer =
    process.env.ANALYZE === 'true'
@@ -66,16 +66,7 @@ const moduleExports = {
    async redirects() {
       return [
          ...getLegacyPartItemTypeRedirects(),
-         {
-            source: `/Tools/:slug(${getToolRedirects()})`,
-            destination: `/Tools`,
-            permanent: true,
-         },
-         {
-            source: `/Tools/Hakko`,
-            destination: `/Tools/Microsoldering`,
-            permanent: true,
-         },
+         ...getLegacyToolRedirects(),
          {
             source: '/Store/Guide/:guideid',
             destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/Guide/_/:guideid`,


### PR DESCRIPTION
## Overview

Basically #529 had comments floating around it in and there were some more complaints to address.
This PR

1. Handles incorrect item types where they have spaces instead of "_" so things like `Parts/iPhone_11/Adhesive%20Strips` will now correctly reroute to `/Adhesives`. This might seem like an unnecessary fix but we are already handling things like `iPhone%2011` correctly so at least this stays consistent.
2. Redirect both  `/SSD_Enclosures` and `/Upgrade_Kits` to  `/Hard_Drives`.
3. Reorganize the `tool-collections` redirect generation so its more analogous to the parts one.

## QA
It should be pretty easy to test 1.) and 2.) above. 
`/Parts/HTC_Vive/I%2FO%20Board` seems like a decent route to test with.

Connects: #529
