### PR TITLE
Add zoom to product gallery

### DIFF
--- a/frontend/components/common/AppProviders.tsx
+++ b/frontend/components/common/AppProviders.tsx
@@ -16,17 +16,6 @@ const customTheme = extendTheme({
       ...theme.zIndices,
       header: 2000,
    },
-   styles: {
-      ...theme.styles,
-      global: {
-         ...theme.styles?.global,
-         body: {
-            // @ts-ignore
-            ...theme.styles?.global?.body,
-            touchAction: 'pan-x pan-y',
-         },
-      },
-   },
 });
 
 const queryClient = new QueryClient();

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,7 +2,7 @@ import { AppProviders } from '@components/common';
 import { AppProps } from 'next/app';
 import * as React from 'react';
 import NextNProgress from 'nextjs-progressbar';
-import Head from 'next/head';
+
 // Improve FontAwesome integration with Next.js https://fontawesome.com/v5/docs/web/use-with/react#next-js
 import { config } from '@fortawesome/fontawesome-svg-core';
 import '@fortawesome/fontawesome-svg-core/styles.css';
@@ -15,18 +15,10 @@ type AppPropsWithLayout = AppProps & {
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
    const getLayout = Component.getLayout ?? ((page) => page);
    return (
-      <>
-         <Head>
-            <meta
-               name="viewport"
-               content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-            />
-         </Head>
-         <AppProviders {...pageProps.appProps}>
-            <NextNProgress />
-            {getLayout(<Component {...pageProps} />, pageProps)}
-         </AppProviders>
-      </>
+      <AppProviders {...pageProps.appProps}>
+         <NextNProgress />
+         {getLayout(<Component {...pageProps} />, pageProps)}
+      </AppProviders>
    );
 }
 

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -34,7 +34,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = ({
    return (
       <>
          {product.breadcrumbs != null && (
-            <SecondaryNavigation>
+            <SecondaryNavigation zIndex="10">
                <PageBreadcrumb items={product.breadcrumbs} />
             </SecondaryNavigation>
          )}

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -108,6 +108,8 @@ export function ProductSection({
                      lg: '400px',
                   }}
                   left={{ base: 'calc(100% + 20px)', lg: 'calc(100% + 40px)' }}
+                  boxShadow="md"
+                  borderRadius="md"
                />
             </Flex>
             <Flex

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -88,13 +88,26 @@ export function ProductSection({
                direction="column"
                flex="1"
                w="0"
+               zIndex="1"
             >
                <ProductGallery
                   product={product}
                   selectedVariantId={selectedVariant.id}
                   selectedImageId={selectedImageId}
                   showThumbnails
+                  enableZoom
                   onChangeImage={setSelectedImageId}
+               />
+               <Box
+                  id="zoom-container"
+                  position="absolute"
+                  top="0"
+                  w={{
+                     base: 'full',
+                     md: '320px',
+                     lg: '400px',
+                  }}
+                  left={{ base: 'calc(100% + 20px)', lg: 'calc(100% + 40px)' }}
                />
             </Flex>
             <Flex
@@ -109,6 +122,7 @@ export function ProductSection({
                }}
                direction="column"
                fontSize="sm"
+               position="relative"
             >
                {selectedVariant.sku && (
                   <Text color="gray.500">Item # {selectedVariant.sku}</Text>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,9 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
+
+patchedDependencies:
+  react-instantsearch-hooks-server@6.32.1:
+    hash: hiec5pcpgig2m3qcu64y3isqke
+    path: patches/react-instantsearch-hooks-server@6.32.1.patch
 
 importers:
 
@@ -111,17 +116,17 @@ importers:
       webpack: 5.73.0
       zod: 3.18.0
     dependencies:
-      '@chakra-ui/icons': 1.1.7_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/react': 1.8.8_64f869eddedbf7a995b2ffda3c62e350
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/icons': 1.1.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/react': 1.8.8_mt4gt3o63p32tfns77ndyyxdka
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@core-ds/primitives': 2.4.5
-      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
-      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
+      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
+      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
       '@fortawesome/fontawesome-svg-core': 6.1.1
       '@fortawesome/free-solid-svg-icons': 6.1.1
       '@fortawesome/pro-duotone-svg-icons': 6.1.1
       '@fortawesome/pro-solid-svg-icons': 6.1.1
-      '@fortawesome/react-fontawesome': 0.2.0_6909f5698ccb6b468185370814560628
+      '@fortawesome/react-fontawesome': 0.2.0_nee7k2mmznvunamfg4ebivqgfa
       '@ifixit/app': link:../packages/app
       '@ifixit/auth-sdk': link:../packages/auth-sdk
       '@ifixit/cart-sdk': link:../packages/cart-sdk
@@ -130,31 +135,31 @@ importers:
       '@ifixit/ifixit-api-client': link:../packages/ifixit-api-client
       '@ifixit/matomo': link:../packages/matomo
       '@ifixit/newsletter-sdk': link:../packages/newsletter-sdk
-      '@ifixit/react-components': 0.3.0_e06ff26ea119e6f824fe692a65c0245d
+      '@ifixit/react-components': 0.3.0_4bx7e3vbdhtpqjh6nevglqbelu
       '@ifixit/sentry': link:../packages/sentry
       '@ifixit/shopify-storefront-client': link:../packages/shopify-storefront-client
       '@ifixit/ui': link:../packages/ui
-      '@sentry/nextjs': 7.8.1_1804bc4cd2289158683ed56d818b1ba6
+      '@sentry/nextjs': 7.8.1_daclytgsfcivq2b62vwydcy3uy
       '@sentry/tracing': 7.8.1
       '@xstate/fsm': 1.6.1
-      '@xstate/react': 1.5.1_f169e3cfda7dafef3dc8895cf096fabe
+      '@xstate/react': 1.5.1_6fu6ht62pwx66poirfopbfx2xy
       algoliasearch: 4.13.1
       cookie: 0.5.0
       dayjs: 1.10.5
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       graphql: 15.5.3
       immer: 9.0.14
       lodash: 4.17.21
       lru-cache: 7.10.1
-      next: 12.2.3_f370f735164a03a12cea0cc89593cbee
+      next: 12.2.3_6nyponiwjib2clhkbtejle6l5y
       nextjs-progressbar: 0.0.14_next@12.2.3+react@17.0.2
       query-string: 7.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-icons: 4.2.0_react@17.0.2
-      react-instantsearch-hooks-server: 6.32.1_6414a94af4ca8152be5dd238e8125fea
-      react-instantsearch-hooks-web: 6.32.1_6414a94af4ca8152be5dd238e8125fea
-      react-query: 3.34.19_react-dom@17.0.2+react@17.0.2
+      react-instantsearch-hooks-server: 6.32.1_hiec5pcpgig2m3qcu64y3isqke_mqkkssxuzkavfps52i4oqes75i
+      react-instantsearch-hooks-web: 6.32.1_mqkkssxuzkavfps52i4oqes75i
+      react-query: 3.34.19_sfoxds7t5ydpegc3knd667wn6m
       sharp: 0.30.7
       snarkdown: 2.0.0
       swiper: 8.3.2
@@ -163,9 +168,9 @@ importers:
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.18.6_@babel+core@7.17.9
       '@babel/preset-typescript': 7.18.6_@babel+core@7.17.9
-      '@graphql-codegen/cli': 2.1.1_1a6b74b6878fa7649e5c268b9124b376
+      '@graphql-codegen/cli': 2.1.1_djvxjnuhr6twjhs4e2fzcjftoy
       '@graphql-codegen/typescript': 2.2.0_graphql@15.5.3
-      '@graphql-codegen/typescript-generic-sdk': 2.1.3_f0201549fa0e4b0451075550008a6e70
+      '@graphql-codegen/typescript-generic-sdk': 2.1.3_6aqbksp2bzfqiuihkviabctooa
       '@graphql-codegen/typescript-operations': 2.1.3_graphql@15.5.3
       '@ifixit/tsconfig': link:../packages/tsconfig
       '@next/bundle-analyzer': 12.1.6
@@ -173,8 +178,8 @@ importers:
       '@testing-library/cypress': 8.0.2_cypress@9.3.1
       '@testing-library/dom': 7.21.4
       '@testing-library/jest-dom': 5.16.1
-      '@testing-library/react': 12.1.2_react-dom@17.0.2+react@17.0.2
-      '@testing-library/user-event': 13.5.0_@testing-library+dom@7.21.4
+      '@testing-library/react': 12.1.2_sfoxds7t5ydpegc3knd667wn6m
+      '@testing-library/user-event': 13.5.0_zbypwrtvpjrvnfnw5wxfpjfsci
       '@types/cookie': 0.5.1
       '@types/jest': 27.4.0
       '@types/node': 14.14.25
@@ -182,20 +187,20 @@ importers:
       '@types/react-virtualized-auto-sizer': 1.0.1
       '@types/react-window': 1.8.4
       '@types/shopify-buy': 2.10.5
-      '@typescript-eslint/eslint-plugin': 4.14.2_288d3a3f3ecf8c05ee60c65203ff1947
-      '@typescript-eslint/parser': 4.14.2_eslint@7.23.0+typescript@4.7.4
+      '@typescript-eslint/eslint-plugin': 4.14.2_fcgtupz6z6gal3tayzjah7yzi4
+      '@typescript-eslint/parser': 4.14.2_p2gelkc4nklso6eukbqqqhjfvq
       babel-jest: 28.1.3_@babel+core@7.17.9
       concurrently: 6.2.1
       cypress: 9.3.1
       dotenv: 10.0.0
       eslint: 7.23.0
-      eslint-config-next: 11.0.1_d0009ae60621841c5e91d414a65cc25b
+      eslint-config-next: 11.0.1_2aajvzqgegcbyxur2qkkmxgclm
       eslint-config-prettier: 7.2.0_eslint@7.23.0
       eslint-plugin-cypress: 2.12.1_eslint@7.23.0
       eslint-plugin-react: 7.23.0_eslint@7.23.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.23.0
       graphql-tag: 2.12.6_graphql@15.5.3
-      graphqurl: 1.0.1_a980934185fd468574748ee888a28d09
+      graphqurl: 1.0.1_vgajgqmf7vdik5dur3uiriunbe
       identity-obj-proxy: 3.0.0
       jest: 28.1.2_@types+node@14.14.25
       jest-environment-jsdom: 28.1.2
@@ -341,7 +346,7 @@ importers:
     devDependencies:
       '@babel/core': 7.18.6
       '@ifixit/tsconfig': link:../tsconfig
-      next: 12.2.3_03eb8178f285321bf7d6b0dd6884cacb
+      next: 12.2.3_apvyc6hsquzbx56wwdowrbgkzm
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       typescript: 4.5.3
@@ -387,12 +392,12 @@ importers:
       '@ifixit/newsletter-sdk': link:../newsletter-sdk
     devDependencies:
       '@babel/core': 7.18.6
-      '@emotion/react': 11.7.1_c489ae0b73682db164ea0ab70d2bf676
-      '@emotion/styled': 11.6.0_03671950d44bd6e47081c166ddd189e0
+      '@emotion/react': 11.7.1_yse24c3tnaw3czhkbk3q2k7woy
+      '@emotion/styled': 11.6.0_antrsugujploi4ebyftn3umj4a
       '@ifixit/tsconfig': link:../tsconfig
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       typescript: 4.5.3
@@ -2291,7 +2296,7 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@chakra-ui/accordion/1.4.11_93f24f53bc1d92516efca71355c649dc:
+  /@chakra-ui/accordion/1.4.11_spze6u54dwjfc3x4u4jvlrsj3q:
     resolution: {integrity: sha512-d/gvSgGwcZaJXxXqGmecpAgko/tUYb5vR0E0B2/V/z9AVbS8ei//fbiO9+8Ouyl/K46oWHWYj5vt8iTadlZleg==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2300,24 +2305,24 @@ packages:
     dependencies:
       '@chakra-ui/descendant': 2.1.3_react@17.0.2
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
-      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/alert/1.3.7_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/alert/1.3.7_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-fFpJYBpHOIK/BX4BVl/xafYiDBUW+Bq/gUYDOo4iAiO4vHgxo74oa+yOwSRNlNjAgIX7pi2ridsYQALKyWyxxQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2327,36 +2332,36 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
     dev: false
 
-  /@chakra-ui/avatar/1.3.11_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/avatar/1.3.11_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-/eRRK48Er92/QWAfWhxsJIN0gZBBvk+ew4Hglo+pxt3/NDnfTF2yPE7ZN29Dl6daPNbyTOpoksMwaU2mZIqLgA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/image': 1.1.10_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/image': 1.1.10_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/breadcrumb/1.3.6_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/breadcrumb/1.3.6_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-iXxienBO6RUnJEcDvyDWyRt+mzPyl7/b6N8i0vrjGKGLpgtayJFvIdo33tFcvx6TCy7V9hiE3HTtZnNomWdR6A==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/button/1.5.10_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/button/1.5.10_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-IVEOrleI378CckAa3b3CTUHMPZRfpy6LPwn1Mx3sMpHEkDTKu8zJcjgEvCE8HYzNC1KbwBsa1PfTgk40ui6EtA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2364,26 +2369,26 @@ packages:
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/spinner': 1.2.6_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/spinner': 1.2.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/checkbox/1.7.1_93f24f53bc1d92516efca71355c649dc:
+  /@chakra-ui/checkbox/1.7.1_spze6u54dwjfc3x4u4jvlrsj3q:
     resolution: {integrity: sha512-9Io97yn8OrdaIynCj+3Z/neJV7lTT1MtcdYh3BKMd7WnoJDkRY/GlBM8zsdgC5Wvm+ZQ1M83t0YvRPKLLzusyA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       framer-motion: 3.x || 4.x || 5.x || 6.x
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
     dev: false
 
@@ -2397,14 +2402,14 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/close-button/1.2.7_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/close-button/1.2.7_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-cYTxfgrIlPU4IZm1sehZXxx/TNQBk9c3LBPvTpywEM8GVRGINh4YLq8WiMaPtO+TDNBnKoWS/jS4IHnR+abADw==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2420,13 +2425,13 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/control-box/1.1.6_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/control-box/1.1.6_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-EUcq5f854puG6ZA6wAWl4107OPl8+bj4MMHJCa48BB0qec0U8HCEtxQGnFwJmaYLalIAjMfHuY3OwO2A3Hi9hA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2441,13 +2446,13 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/css-reset/1.1.3_79c1490562c3c65ef55eb132a37e39b4:
+  /@chakra-ui/css-reset/1.1.3_phausblcypdf55k6wezkg7rzwq:
     resolution: {integrity: sha512-AgfrE7bRTJvNi/4zIfacI/kBHmHmHEIeQtHwCvk/0qM9V2gK1VM3ctYlnibf7BTh17F/UszweOGRb1lHSPfWjw==}
     peerDependencies:
       '@emotion/react': '>=10.0.35'
       react: '>=16.8.6'
     dependencies:
-      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
+      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
       react: 17.0.2
     dev: false
 
@@ -2460,7 +2465,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/editable/1.4.2_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/editable/1.4.2_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-a5zKghA/IvG7yNkmFl7Z9c2KSsf0FgyijsNPTg/4S5jxyz13QJtoTg40tdpyaxHHCT25y25iUcV4FYCj6Jd01w==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2468,33 +2473,33 @@ packages:
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/focus-lock/1.2.6_@types+react@17.0.1+react@17.0.2:
+  /@chakra-ui/focus-lock/1.2.6_wk7fohhuxwcjfgq2kdoh4ny7by:
     resolution: {integrity: sha512-ZJNE1oNdUM1aGWuCJ+bxFa/d3EwxzfMWzTKzSvKDK50GWoUQQ10xFTT9nY/yFpkcwhBvx1KavxKf44mIhIbSog==}
     peerDependencies:
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
-      react-focus-lock: 2.5.2_@types+react@17.0.1+react@17.0.2
+      react-focus-lock: 2.5.2_wk7fohhuxwcjfgq2kdoh4ny7by
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@chakra-ui/form-control/1.6.0_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/form-control/1.6.0_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-MtUE98aocP2QTgvyyJ/ABuG33mhT3Ox56phKreG3HzbUKByMwrbQSm1QcAgyYdqSZ9eKB2tXx+qgGNh+avAfDA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2511,63 +2516,63 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/icon/2.0.5_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/icon/2.0.5_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/icons/1.1.7_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/icons/1.1.7_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-YIHxey/B4M2PyFASlHXtAWFyW+tsAtGAChOJ8dsM2kpu1MbVUqm/6nMI1KIFd7Te5IWuNYA75rAHBdLI0Yu61A==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@types/react': 17.0.37
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/image/1.1.10_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/image/1.1.10_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-PJZmhQ/R1PgdMyCRjALfoyq1FNh/WzMAw70sliHLtLcb9hBXniwQZuckYfUshCkUoFBj/ow9d4byn9Culdpk7Q==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/input/1.4.6_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/input/1.4.6_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-Ljy/NbOhh9cNQxKTWQRsT4aQiXs2vVya+Cj5NpMAz08NFFjPZovsTawhI7m6ejT5Vsh76QYjh2rOLLI3fWqQQw==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/layout/1.8.0_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/layout/1.8.0_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-GJtEKez5AZu0XQTxI6a6jwA/hMDD36pP0HBxBOGuHP1hWCebDzMjraiMfWiP9w7hKERFE4j19kocHxIXyocfJA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2581,7 +2586,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/media-query/2.0.4_95e3ae800e8ec2b9db829252af6af6dc:
+  /@chakra-ui/media-query/2.0.4_sxr25aaor3bltw4csjjk62xw3q:
     resolution: {integrity: sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2589,13 +2594,13 @@ packages:
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/react-env': 1.1.6_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/menu/1.8.11_93f24f53bc1d92516efca71355c649dc:
+  /@chakra-ui/menu/1.8.11_spze6u54dwjfc3x4u4jvlrsj3q:
     resolution: {integrity: sha512-8K65xItPsdMvSfuGWYIGigOF/QMcy7+D48UIEO/Hu0u0ckd11/JXbpSIFPddH5fYedclJ18PGRohTne487OVjQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2607,14 +2612,14 @@ packages:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/popper': 2.4.3_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
-      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/modal/1.11.1_6dafe5f9078aa265899836c510d1cd9b:
+  /@chakra-ui/modal/1.11.1_nwx6l6ihrkrglcmyg3crbuontm:
     resolution: {integrity: sha512-B2BBDonHb04vbPLAWgko1JYBwgW8ZNSLyhTJK+rbrCsRSgazuLTcwq4hdyJqrYNWtaQEfSwpAXqJ7joMZdv59A==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2622,40 +2627,40 @@ packages:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
     dependencies:
-      '@chakra-ui/close-button': 1.2.7_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/focus-lock': 1.2.6_@types+react@17.0.1+react@17.0.2
+      '@chakra-ui/close-button': 1.2.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/focus-lock': 1.2.6_wk7fohhuxwcjfgq2kdoh4ny7by
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/portal': 1.3.10_react-dom@17.0.2+react@17.0.2
+      '@chakra-ui/portal': 1.3.10_sfoxds7t5ydpegc3knd667wn6m
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
-      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
       '@chakra-ui/utils': 1.10.4
       aria-hidden: 1.1.3
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-remove-scroll: 2.4.1_@types+react@17.0.1+react@17.0.2
+      react-remove-scroll: 2.4.1_wk7fohhuxwcjfgq2kdoh4ny7by
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@chakra-ui/number-input/1.4.7_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/number-input/1.4.7_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-LorGRZFMipom8vCUEbLi2s7bTHF2Fgiu766W0jTbzMje+8Z1ZoRQunH9OZWQnxnWQTUfUM2KBW8KwToYh1ojfQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/counter': 1.2.10_react@17.0.2
-      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/pin-input/1.7.10_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/pin-input/1.7.10_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-Uz5vFK+ZevQtdYHBkddSFCrY44bweXLanpSv9X/D0pWpdML09qfPiKX4ydGzfRoS2u4L8NUtN86IcvdOQLhHQg==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2664,25 +2669,25 @@ packages:
       '@chakra-ui/descendant': 2.1.3_react@17.0.2
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/popover/1.11.9_93f24f53bc1d92516efca71355c649dc:
+  /@chakra-ui/popover/1.11.9_spze6u54dwjfc3x4u4jvlrsj3q:
     resolution: {integrity: sha512-hJ1/Lwukox3ryTN7W1wnj+nE44utfLwQYvfUSdatt5dznnh8k0P6Wx7Hmjm1cYffRavBhqzwua/QZDWjJN9N0g==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       framer-motion: 3.x || 4.x || 5.x || 6.x
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/close-button': 1.2.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/close-button': 1.2.7_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/popper': 2.4.3_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
     dev: false
 
@@ -2696,7 +2701,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/portal/1.3.10_react-dom@17.0.2+react@17.0.2:
+  /@chakra-ui/portal/1.3.10_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-t2KQ6MXbyf1qFYxWw/bs//CnwD+Clq7mbsP1Y7g+THCz2FvlLlMj45BWocLB30NoNyA8WCS2zyMBszW2/qvDiA==}
     peerDependencies:
       react: '>=16.8.6'
@@ -2709,19 +2714,19 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@chakra-ui/progress/1.2.6_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/progress/1.2.6_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-thaHRIYTVktgV78vJMNwzfCX+ickhSpn2bun6FtGVUphFx4tjV+ggz+IGohm6AH2hapskoR1mQU2iNZb6BK0hQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/provider/1.7.14_c84e354a724f4213aa6539fdea9d08aa:
+  /@chakra-ui/provider/1.7.14_zbhdkstsj5bbhktfhh66vhiivi:
     resolution: {integrity: sha512-FCA33CZy/jFzExglKMioeri8sr9NtDTcNVPnx95ZJiA7WpfFo0xuZ6/fMC4DwIQPkJKbSIZBXYLZ3U10Ntylrw==}
     peerDependencies:
       '@emotion/react': ^11.0.0
@@ -2729,30 +2734,30 @@ packages:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
     dependencies:
-      '@chakra-ui/css-reset': 1.1.3_79c1490562c3c65ef55eb132a37e39b4
+      '@chakra-ui/css-reset': 1.1.3_phausblcypdf55k6wezkg7rzwq
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/portal': 1.3.10_react-dom@17.0.2+react@17.0.2
+      '@chakra-ui/portal': 1.3.10_sfoxds7t5ydpegc3knd667wn6m
       '@chakra-ui/react-env': 1.1.6_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
-      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
-      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
+      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
+      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@chakra-ui/radio/1.5.1_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/radio/1.5.1_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-zO5eShz+j68A7935jJ2q5u3brX/bjPEGh9Pj2+bnKbmC9Vva6jEzBSJsAx9n4WbkAzR3xDMGWsbpivFp8X1tJw==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
       react: 17.0.2
     dev: false
 
@@ -2783,7 +2788,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/react/1.8.8_64f869eddedbf7a995b2ffda3c62e350:
+  /@chakra-ui/react/1.8.8_mt4gt3o63p32tfns77ndyyxdka:
     resolution: {integrity: sha512-/XqL25J0i0h+usAXBngn/RTG2u1oQRzbhHe9tNHwFyNbx/izIADhQW/6ji06QU0KtaRIU77XvgSAyTtMJY1KmA==}
     peerDependencies:
       '@emotion/react': ^11.0.0
@@ -2792,75 +2797,75 @@ packages:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
     dependencies:
-      '@chakra-ui/accordion': 1.4.11_93f24f53bc1d92516efca71355c649dc
-      '@chakra-ui/alert': 1.3.7_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/avatar': 1.3.11_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/breadcrumb': 1.3.6_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/button': 1.5.10_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/checkbox': 1.7.1_93f24f53bc1d92516efca71355c649dc
-      '@chakra-ui/close-button': 1.2.7_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/control-box': 1.1.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/accordion': 1.4.11_spze6u54dwjfc3x4u4jvlrsj3q
+      '@chakra-ui/alert': 1.3.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/avatar': 1.3.11_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/breadcrumb': 1.3.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/button': 1.5.10_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/checkbox': 1.7.1_spze6u54dwjfc3x4u4jvlrsj3q
+      '@chakra-ui/close-button': 1.2.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/control-box': 1.1.6_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/counter': 1.2.10_react@17.0.2
-      '@chakra-ui/css-reset': 1.1.3_79c1490562c3c65ef55eb132a37e39b4
-      '@chakra-ui/editable': 1.4.2_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/css-reset': 1.1.3_phausblcypdf55k6wezkg7rzwq
+      '@chakra-ui/editable': 1.4.2_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/image': 1.1.10_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/input': 1.4.6_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/layout': 1.8.0_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/image': 1.1.10_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/input': 1.4.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/layout': 1.8.0_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/live-region': 1.1.6_react@17.0.2
-      '@chakra-ui/media-query': 2.0.4_95e3ae800e8ec2b9db829252af6af6dc
-      '@chakra-ui/menu': 1.8.11_93f24f53bc1d92516efca71355c649dc
-      '@chakra-ui/modal': 1.11.1_6dafe5f9078aa265899836c510d1cd9b
-      '@chakra-ui/number-input': 1.4.7_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/pin-input': 1.7.10_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/popover': 1.11.9_93f24f53bc1d92516efca71355c649dc
+      '@chakra-ui/media-query': 2.0.4_sxr25aaor3bltw4csjjk62xw3q
+      '@chakra-ui/menu': 1.8.11_spze6u54dwjfc3x4u4jvlrsj3q
+      '@chakra-ui/modal': 1.11.1_nwx6l6ihrkrglcmyg3crbuontm
+      '@chakra-ui/number-input': 1.4.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/pin-input': 1.7.10_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/popover': 1.11.9_spze6u54dwjfc3x4u4jvlrsj3q
       '@chakra-ui/popper': 2.4.3_react@17.0.2
-      '@chakra-ui/portal': 1.3.10_react-dom@17.0.2+react@17.0.2
-      '@chakra-ui/progress': 1.2.6_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/provider': 1.7.14_c84e354a724f4213aa6539fdea9d08aa
-      '@chakra-ui/radio': 1.5.1_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/portal': 1.3.10_sfoxds7t5ydpegc3knd667wn6m
+      '@chakra-ui/progress': 1.2.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/provider': 1.7.14_zbhdkstsj5bbhktfhh66vhiivi
+      '@chakra-ui/radio': 1.5.1_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/react-env': 1.1.6_react@17.0.2
-      '@chakra-ui/select': 1.2.11_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/skeleton': 1.2.14_d713f7ab5012ba0f57775c6ca1ede6c2
-      '@chakra-ui/slider': 1.5.11_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/spinner': 1.2.6_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/stat': 1.2.7_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/switch': 1.3.10_93f24f53bc1d92516efca71355c649dc
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
-      '@chakra-ui/table': 1.3.6_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/tabs': 1.6.10_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/tag': 1.2.7_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/textarea': 1.2.11_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/select': 1.2.11_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/skeleton': 1.2.14_24j7pk2qck5a6v3xlrwkd3pgyi
+      '@chakra-ui/slider': 1.5.11_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/spinner': 1.2.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/stat': 1.2.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/switch': 1.3.10_spze6u54dwjfc3x4u4jvlrsj3q
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/table': 1.3.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/tabs': 1.6.10_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/tag': 1.2.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/textarea': 1.2.11_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
-      '@chakra-ui/toast': 1.5.9_52a57b03b5c9e77bb025e741e8f26457
-      '@chakra-ui/tooltip': 1.5.1_52a57b03b5c9e77bb025e741e8f26457
-      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
+      '@chakra-ui/toast': 1.5.9_kksxwa5vzhtxxmbf45a6r4tek4
+      '@chakra-ui/tooltip': 1.5.1_kksxwa5vzhtxxmbf45a6r4tek4
+      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
-      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
-      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
+      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
+      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@chakra-ui/select/1.2.11_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/select/1.2.11_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-6Tis1+ZrRjQeWhQfziQn3ZdPphV5ccafpZOhiPdTcM2J1XcXOlII+9rHxvaW+jx7zQ5ly5o8kd7iXzalDgl5wA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/skeleton/1.2.14_d713f7ab5012ba0f57775c6ca1ede6c2:
+  /@chakra-ui/skeleton/1.2.14_24j7pk2qck5a6v3xlrwkd3pgyi:
     resolution: {integrity: sha512-R0v4DfQ2yjXCJf9SzhTmDb2PLx5//LxsRbjjgRa8qJCR4MZaGswPrekp4dP8YjY8aEYzuZbvHU12T3vqZBk2GA==}
     peerDependencies:
       '@chakra-ui/theme': '>=1.0.0'
@@ -2869,16 +2874,16 @@ packages:
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/media-query': 2.0.4_95e3ae800e8ec2b9db829252af6af6dc
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/media-query': 2.0.4_sxr25aaor3bltw4csjjk62xw3q
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
-      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
-      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
+      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
+      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/slider/1.5.11_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/slider/1.5.11_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-THkGU2BsA6XMosXcEVQkWVRftqUIAKCb+y4iEpR3C2ztqL7Fl/CbIGwyr5majhPhKc275rb8dfxwp8R0L0ZIiQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2886,33 +2891,33 @@ packages:
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/spinner/1.2.6_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/spinner/1.2.6_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-GoUCccN120fGRVgUtfuwcEjeoaxffB+XsgpxX7jhWloXf8b6lkqm68bsxX4Ybb2vGN1fANI98/45JmrnddZO/A==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/stat/1.2.7_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/stat/1.2.7_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-m76jumFW1N+mCG4ytrUz9Mh09nZtS4OQcADEvOslfdI5StwwuzasTA1tueaelPzdhBioMwFUWL05Fr1fXbPJ/Q==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
       react: 17.0.2
     dev: false
 
@@ -2923,21 +2928,21 @@ packages:
       csstype: 3.0.9
     dev: false
 
-  /@chakra-ui/switch/1.3.10_93f24f53bc1d92516efca71355c649dc:
+  /@chakra-ui/switch/1.3.10_spze6u54dwjfc3x4u4jvlrsj3q:
     resolution: {integrity: sha512-V6qDLY6oECCbPyu7alWWOAhSBI4+SAuT6XW/zEQbelkwuUOiGO1ax67rTXOmZ59A2AaV1gqQFxDh8AcbvwO5XQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       framer-motion: 3.x || 4.x || 5.x || 6.x
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/checkbox': 1.7.1_93f24f53bc1d92516efca71355c649dc
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/checkbox': 1.7.1_spze6u54dwjfc3x4u4jvlrsj3q
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/system/1.12.1_922a85da57e3646a57465b7970b0de85:
+  /@chakra-ui/system/1.12.1_sivilwsx4nsguv2gln4xbmg6qu:
     resolution: {integrity: sha512-Rp09/rMuPA3hF38OJxeQciGO9N0Ie1GxwHRAw1AFA/TY3fVyK9pNI5oN+J/1cAxq7v9yKdIr1YfnruJTI9xfEg==}
     peerDependencies:
       '@emotion/react': ^11.0.0
@@ -2948,24 +2953,24 @@ packages:
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
       '@chakra-ui/styled-system': 1.19.0
       '@chakra-ui/utils': 1.10.4
-      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
-      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
+      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
+      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
       react: 17.0.2
       react-fast-compare: 3.2.0
     dev: false
 
-  /@chakra-ui/table/1.3.6_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/table/1.3.6_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-7agZAgAeDFKviqStvixqnLAH54+setzhx67EztioZTr5Xu+6hQ4rotfJbu8L4i587pcbNg98kCEXEkidjw0XRQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/tabs/1.6.10_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/tabs/1.6.10_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-ClOOHT3Wnf3l9X4F2S6ysPsHMDgKSTgkXpB9Qe0odwpT49ZXNjSAYYaXzO16l+Eq/m2u1HzLkXVsL42HIeOiNQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2975,31 +2980,31 @@ packages:
       '@chakra-ui/descendant': 2.1.3_react@17.0.2
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/tag/1.2.7_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/tag/1.2.7_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-RKrKOol4i/CnpFfo3T9LMm1abaqM+5Bs0soQLbo1iJBbBACY09sWXrQYvveQ2GYzU/OrAUloHqqmKjyVGOlNtg==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/textarea/1.2.11_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/textarea/1.2.11_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-RDWbMyC87/AFRX98EnVum5eig/7hhcvS1BrqW5lvmTgrpr7KVr80Dfa8hUj58Iq37Z7AqZijDPkBn/zg7bPdIg==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -3009,7 +3014,7 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.6.0
       '@types/tinycolor2': 1.4.2
       tinycolor2: 1.4.2
@@ -3020,7 +3025,7 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       '@ctrl/tinycolor': 3.4.1
     dev: false
@@ -3031,12 +3036,12 @@ packages:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
       '@chakra-ui/anatomy': 1.3.0_@chakra-ui+system@1.12.1
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
     dev: false
 
-  /@chakra-ui/toast/1.5.9_52a57b03b5c9e77bb025e741e8f26457:
+  /@chakra-ui/toast/1.5.9_kksxwa5vzhtxxmbf45a6r4tek4:
     resolution: {integrity: sha512-rns04bGdMcG7Ijg45L+PfuEW4rCd0Ycraix4EJQhcl9RXI18G9sphmlp9feidhZAkI6Ukafq1YvyvkBfkKnIzQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -3044,20 +3049,20 @@ packages:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
     dependencies:
-      '@chakra-ui/alert': 1.3.7_ec02b824bed6ab9ca8725186341c5110
-      '@chakra-ui/close-button': 1.2.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/alert': 1.3.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/close-button': 1.2.7_5qblqjf622vzzkdskgddihcrca
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
-      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
+      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
       '@chakra-ui/utils': 1.10.4
-      '@reach/alert': 0.13.2_react-dom@17.0.2+react@17.0.2
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      '@reach/alert': 0.13.2_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@chakra-ui/tooltip/1.5.1_52a57b03b5c9e77bb025e741e8f26457:
+  /@chakra-ui/tooltip/1.5.1_kksxwa5vzhtxxmbf45a6r4tek4:
     resolution: {integrity: sha512-EUAlDdlCBt63VpEVtj/RkFjHQVN/xA9gEAumngQdi1Sp+OXPYCBM9GwSY0NwrM1RfKBnhPSH9wz7FwredJWeaw==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -3067,24 +3072,24 @@ packages:
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/popper': 2.4.3_react@17.0.2
-      '@chakra-ui/portal': 1.3.10_react-dom@17.0.2+react@17.0.2
+      '@chakra-ui/portal': 1.3.10_sfoxds7t5ydpegc3knd667wn6m
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@chakra-ui/transition/1.4.8_framer-motion@6.2.7+react@17.0.2:
+  /@chakra-ui/transition/1.4.8_3zozpsudfkjdetkprj634votgy:
     resolution: {integrity: sha512-5uc8LEuCH7+0h++wqAav/EktTHOjbLDSTXQlU9fzPIlNNgyf2eXrHVN2AGMGKiMR9Z4gS7umQjZ54r0w/mZ/Fw==}
     peerDependencies:
       framer-motion: 3.x || 4.x || 5.x || 6.x
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
     dev: false
 
@@ -3106,13 +3111,13 @@ packages:
       lodash.mergewith: 4.6.2
     dev: false
 
-  /@chakra-ui/visually-hidden/1.1.6_ec02b824bed6ab9ca8725186341c5110:
+  /@chakra-ui/visually-hidden/1.1.6_5qblqjf622vzzkdskgddihcrca:
     resolution: {integrity: sha512-Xzy5bA0UA+IyMgwJizQYSEdgz8cC/tHdmFB3CniXzmpKTSK8mJddeEBl+cGbXHBzxEUhH7xF1eaS41O+0ezWEQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -3248,7 +3253,7 @@ packages:
   /@emotion/memoize/0.7.5:
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
 
-  /@emotion/react/11.7.1_a003f5d44f346f6e89b1b61bd07839ac:
+  /@emotion/react/11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq:
     resolution: {integrity: sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3272,7 +3277,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@emotion/react/11.7.1_c489ae0b73682db164ea0ab70d2bf676:
+  /@emotion/react/11.7.1_yse24c3tnaw3czhkbk3q2k7woy:
     resolution: {integrity: sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3308,7 +3313,7 @@ packages:
   /@emotion/sheet/1.1.0:
     resolution: {integrity: sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==}
 
-  /@emotion/styled/11.6.0_03671950d44bd6e47081c166ddd189e0:
+  /@emotion/styled/11.6.0_antrsugujploi4ebyftn3umj4a:
     resolution: {integrity: sha512-mxVtVyIOTmCAkFbwIp+nCjTXJNgcz4VWkOYQro87jE2QBTydnkiYusMrRGFtzuruiGK4dDaNORk4gH049iiQuw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3325,14 +3330,14 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/babel-plugin': 11.9.2_@babel+core@7.18.6
       '@emotion/is-prop-valid': 1.1.2
-      '@emotion/react': 11.7.1_c489ae0b73682db164ea0ab70d2bf676
+      '@emotion/react': 11.7.1_yse24c3tnaw3czhkbk3q2k7woy
       '@emotion/serialize': 1.0.3
       '@emotion/utils': 1.1.0
       '@types/react': 17.0.37
       react: 17.0.2
     dev: true
 
-  /@emotion/styled/11.6.0_3d1b1cae8d2c82499801a9e1836cb431:
+  /@emotion/styled/11.6.0_hunrzlunfsbetgabvhqyg3fuge:
     resolution: {integrity: sha512-mxVtVyIOTmCAkFbwIp+nCjTXJNgcz4VWkOYQro87jE2QBTydnkiYusMrRGFtzuruiGK4dDaNORk4gH049iiQuw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3349,7 +3354,7 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/babel-plugin': 11.9.2_@babel+core@7.17.9
       '@emotion/is-prop-valid': 1.1.2
-      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
+      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
       '@emotion/serialize': 1.0.3
       '@emotion/utils': 1.1.0
       '@types/react': 17.0.1
@@ -3365,7 +3370,7 @@ packages:
   /@emotion/weak-memoize/0.2.5:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
 
-  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_cb132979841079273b6378d6412c7bb8:
+  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_zmjss6mecb4soo3dpdlecld3xa:
     resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -3435,7 +3440,7 @@ packages:
       '@fortawesome/fontawesome-common-types': 6.1.1
     dev: false
 
-  /@fortawesome/react-fontawesome/0.2.0_6909f5698ccb6b468185370814560628:
+  /@fortawesome/react-fontawesome/0.2.0_nee7k2mmznvunamfg4ebivqgfa:
     resolution: {integrity: sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==, tarball: '@fortawesome/react-fontawesome/-/0.2.0/react-fontawesome-0.2.0.tgz'}
     peerDependencies:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6
@@ -3446,7 +3451,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@graphql-codegen/cli/2.1.1_1a6b74b6878fa7649e5c268b9124b376:
+  /@graphql-codegen/cli/2.1.1_djvxjnuhr6twjhs4e2fzcjftoy:
     resolution: {integrity: sha512-burl5HdZeaAOhe3gx/3LBNxNyboqNHSDQLlZUazm1Gu8lUdVN1trtO3P5xF7MCBm4MFTjzaAXdPT7FoYvYaWMg==}
     hasBin: true
     peerDependencies:
@@ -3461,8 +3466,8 @@ packages:
       '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.5.3
       '@graphql-tools/json-file-loader': 7.3.11_graphql@15.5.3
       '@graphql-tools/load': 7.5.10_graphql@15.5.3
-      '@graphql-tools/prisma-loader': 7.1.14_aa5d5446fc28dad81dfbf7da577664bd
-      '@graphql-tools/url-loader': 7.9.15_aa5d5446fc28dad81dfbf7da577664bd
+      '@graphql-tools/prisma-loader': 7.1.14_vjovirx4fdnnqhp367nfo5texu
+      '@graphql-tools/url-loader': 7.9.15_vjovirx4fdnnqhp367nfo5texu
       '@graphql-tools/utils': 8.6.9_graphql@15.5.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -3476,7 +3481,7 @@ packages:
       glob: 7.2.0
       globby: 11.1.0
       graphql: 15.5.3
-      graphql-config: 4.3.0_1a6b74b6878fa7649e5c268b9124b376
+      graphql-config: 4.3.0_djvxjnuhr6twjhs4e2fzcjftoy
       inquirer: 7.3.3
       is-glob: 4.0.3
       json-to-pretty-yaml: 1.2.2
@@ -3530,7 +3535,7 @@ packages:
       tslib: 2.3.1
     dev: true
 
-  /@graphql-codegen/typescript-generic-sdk/2.1.3_f0201549fa0e4b0451075550008a6e70:
+  /@graphql-codegen/typescript-generic-sdk/2.1.3_6aqbksp2bzfqiuihkviabctooa:
     resolution: {integrity: sha512-8B0JWzIs6nPr1nKytech6Zq7lQqDlkVpIJHul7ji5QUS5dBjmFXg+vddG7dBcy350ntleKgq3imqZGSjWOZ1vw==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
@@ -3854,12 +3859,12 @@ packages:
       tslib: 2.3.1
     dev: true
 
-  /@graphql-tools/prisma-loader/7.1.14_aa5d5446fc28dad81dfbf7da577664bd:
+  /@graphql-tools/prisma-loader/7.1.14_vjovirx4fdnnqhp367nfo5texu:
     resolution: {integrity: sha512-eHYyw34EgXNxEf0xfpJ2O2RUMdVgGAq6UAanpTIgq5jBr8FWlBPfSADV/JpNDKdziNUGBl6Q3EoJXRisW/+UBA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-tools/url-loader': 7.9.15_aa5d5446fc28dad81dfbf7da577664bd
+      '@graphql-tools/url-loader': 7.9.15_vjovirx4fdnnqhp367nfo5texu
       '@graphql-tools/utils': 8.6.9_graphql@15.5.3
       '@types/js-yaml': 4.0.5
       '@types/json-stable-stringify': 1.0.34
@@ -3926,7 +3931,7 @@ packages:
       value-or-promise: 1.0.11
     dev: true
 
-  /@graphql-tools/url-loader/7.9.15_578f20af2243ea79433bdcda6cbc04eb:
+  /@graphql-tools/url-loader/7.9.15_k6hsblzcipvhsqz33tngzpae5m:
     resolution: {integrity: sha512-WwYtsy4nEUYPOKgrCjhOdLNebnbLS4Rqv++TRlV3Pd4Zi+qVNsEQVwlfVEQZK4qelEhWNqessZILu/jx5B6Vng==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -3954,7 +3959,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-tools/url-loader/7.9.15_aa5d5446fc28dad81dfbf7da577664bd:
+  /@graphql-tools/url-loader/7.9.15_vjovirx4fdnnqhp367nfo5texu:
     resolution: {integrity: sha512-WwYtsy4nEUYPOKgrCjhOdLNebnbLS4Rqv++TRlV3Pd4Zi+qVNsEQVwlfVEQZK4qelEhWNqessZILu/jx5B6Vng==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -4049,7 +4054,7 @@ packages:
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
     dev: true
 
-  /@ifixit/react-components/0.3.0_e06ff26ea119e6f824fe692a65c0245d:
+  /@ifixit/react-components/0.3.0_4bx7e3vbdhtpqjh6nevglqbelu:
     resolution: {integrity: sha512-+UrZXGiPLjtcsr7FiYhO/ZPSiP+aF3pzKeWHY0O8cQ1c/f0FdBRAJsmdJJPovccG6emnD+kc4y+ThWH9ietuGA==}
     peerDependencies:
       '@chakra-ui/react': '>=1.4.2'
@@ -4058,13 +4063,13 @@ packages:
       framer-motion: '>=4'
       react: '>=16'
     dependencies:
-      '@chakra-ui/react': 1.8.8_64f869eddedbf7a995b2ffda3c62e350
+      '@chakra-ui/react': 1.8.8_mt4gt3o63p32tfns77ndyyxdka
       '@chakra-ui/react-utils': 1.1.1_react@17.0.2
       '@chakra-ui/theme-tools': 1.1.5_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.6.0
-      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
-      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
-      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
+      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
+      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
+      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
     transitivePeerDependencies:
       - '@chakra-ui/system'
@@ -4600,21 +4605,21 @@ packages:
     resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
     dev: false
 
-  /@reach/alert/0.13.2_react-dom@17.0.2+react@17.0.2:
+  /@reach/alert/0.13.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-LDz83AXCrClyq/MWe+0vaZfHp1Ytqn+kgL5VxG7rirUvmluWaj/snxzfNPWn0Ma4K2YENmXXRC/iHt5X95SqIg==}
     peerDependencies:
       react: ^16.8.0 || 17.x
       react-dom: ^16.8.0 || 17.x
     dependencies:
-      '@reach/utils': 0.13.2_react-dom@17.0.2+react@17.0.2
-      '@reach/visually-hidden': 0.13.2_react-dom@17.0.2+react@17.0.2
+      '@reach/utils': 0.13.2_sfoxds7t5ydpegc3knd667wn6m
+      '@reach/visually-hidden': 0.13.2_sfoxds7t5ydpegc3knd667wn6m
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       tslib: 2.4.0
     dev: false
 
-  /@reach/utils/0.13.2_react-dom@17.0.2+react@17.0.2:
+  /@reach/utils/0.13.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==}
     peerDependencies:
       react: ^16.8.0 || 17.x
@@ -4627,7 +4632,7 @@ packages:
       warning: 4.0.3
     dev: false
 
-  /@reach/visually-hidden/0.13.2_react-dom@17.0.2+react@17.0.2:
+  /@reach/visually-hidden/0.13.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-sPZwNS0/duOuG0mYwE5DmgEAzW9VhgU3aIt1+mrfT/xiT9Cdncqke+kRBQgU708q/Ttm9tWsoHni03nn/SuPTQ==}
     peerDependencies:
       react: ^16.8.0 || 17.x
@@ -4718,7 +4723,7 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/nextjs/7.8.1_1804bc4cd2289158683ed56d818b1ba6:
+  /@sentry/nextjs/7.8.1_daclytgsfcivq2b62vwydcy3uy:
     resolution: {integrity: sha512-YpDSbWXx/r0yasm9PEtrhECdrl1QYHOWtuyOZShIpxHZ+YcNmAUXhYp75fmxs5UU3+KOYT4jpTnzAtfQg8hCEw==}
     engines: {node: '>=8'}
     peerDependencies:
@@ -4738,7 +4743,7 @@ packages:
       '@sentry/types': 7.8.1
       '@sentry/utils': 7.8.1
       '@sentry/webpack-plugin': 1.19.0
-      next: 12.2.3_f370f735164a03a12cea0cc89593cbee
+      next: 12.2.3_6nyponiwjib2clhkbtejle6l5y
       react: 17.0.2
       tslib: 1.14.1
       webpack: 5.73.0
@@ -4767,7 +4772,7 @@ packages:
       '@sentry/types': 7.8.1
       '@sentry/utils': 7.8.1
       '@sentry/webpack-plugin': 1.19.0
-      next: 12.2.3_03eb8178f285321bf7d6b0dd6884cacb
+      next: 12.2.3_apvyc6hsquzbx56wwdowrbgkzm
       react: 17.0.2
       tslib: 1.14.1
     transitivePeerDependencies:
@@ -5055,7 +5060,7 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/12.1.2_react-dom@17.0.2+react@17.0.2:
+  /@testing-library/react/12.1.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -5068,7 +5073,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@testing-library/user-event/13.5.0_@testing-library+dom@7.21.4:
+  /@testing-library/user-event/13.5.0_zbypwrtvpjrvnfnw5wxfpjfsci:
     resolution: {integrity: sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==}
     engines: {node: '>=10', npm: '>=6'}
     peerDependencies:
@@ -5365,7 +5370,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin/4.14.2_288d3a3f3ecf8c05ee60c65203ff1947:
+  /@typescript-eslint/eslint-plugin/4.14.2_fcgtupz6z6gal3tayzjah7yzi4:
     resolution: {integrity: sha512-uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5376,8 +5381,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.14.2_eslint@7.23.0+typescript@4.7.4
-      '@typescript-eslint/parser': 4.14.2_eslint@7.23.0+typescript@4.7.4
+      '@typescript-eslint/experimental-utils': 4.14.2_p2gelkc4nklso6eukbqqqhjfvq
+      '@typescript-eslint/parser': 4.14.2_p2gelkc4nklso6eukbqqqhjfvq
       '@typescript-eslint/scope-manager': 4.14.2
       debug: 4.3.4
       eslint: 7.23.0
@@ -5391,7 +5396,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.14.2_eslint@7.23.0+typescript@4.7.4:
+  /@typescript-eslint/experimental-utils/4.14.2_p2gelkc4nklso6eukbqqqhjfvq:
     resolution: {integrity: sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5409,7 +5414,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.14.2_eslint@7.23.0+typescript@4.7.4:
+  /@typescript-eslint/parser/4.14.2_p2gelkc4nklso6eukbqqqhjfvq:
     resolution: {integrity: sha512-ipqSP6EuUsMu3E10EZIApOJgWSpcNXeKZaFeNKQyzqxnQl8eQCbV+TSNsl+s2GViX2d18m1rq3CWgnpOxDPgHg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5429,7 +5434,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_eslint@7.23.0+typescript@4.7.4:
+  /@typescript-eslint/parser/4.33.0_p2gelkc4nklso6eukbqqqhjfvq:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5629,7 +5634,7 @@ packages:
     resolution: {integrity: sha512-xYKDNuPR36/fUK+jmhM+oauBmbdUAfuJKnDjg3/7NbN+Pj03TX7e94LXnzkwGgAR+U/HWoMqM5UPTuGIYfIx9g==}
     dev: false
 
-  /@xstate/react/1.5.1_f169e3cfda7dafef3dc8895cf096fabe:
+  /@xstate/react/1.5.1_6fu6ht62pwx66poirfopbfx2xy:
     resolution: {integrity: sha512-DJHDqDlZHus08X98uMJw4KR17FRWBXLHMQ02YRxx0DMm5VLn75VwGyt4tXdlNZHQWjyk++C5c9Ichq3PdmM3og==}
     peerDependencies:
       '@xstate/fsm': ^1.0.0
@@ -5643,7 +5648,7 @@ packages:
     dependencies:
       '@xstate/fsm': 1.6.1
       react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.2_@types+react@17.0.1+react@17.0.2
+      use-isomorphic-layout-effect: 1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by
       use-subscription: 1.7.0_react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -7601,7 +7606,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next/11.0.1_d0009ae60621841c5e91d414a65cc25b:
+  /eslint-config-next/11.0.1_2aajvzqgegcbyxur2qkkmxgclm:
     resolution: {integrity: sha512-yy63K4Bmy8amE6VMb26CZK6G99cfVX3JaMTvuvmq/LL8/b8vKHcauUZREBTAQ+2DrIvlH4YrFXrkQ1vpYDL9Eg==}
     peerDependencies:
       eslint: ^7.23.0
@@ -7613,15 +7618,15 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 11.0.1
       '@rushstack/eslint-patch': 1.1.3
-      '@typescript-eslint/parser': 4.33.0_eslint@7.23.0+typescript@4.7.4
+      '@typescript-eslint/parser': 4.33.0_p2gelkc4nklso6eukbqqqhjfvq
       eslint: 7.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_9e9136a51bbec2ec9eb0df3ecb969545
-      eslint-plugin-import: 2.26.0_0bf7c3773694fd3fa3bd29d96e1f942c
+      eslint-import-resolver-typescript: 2.7.1_t2itnji3x3bozhvq347mxfuviu
+      eslint-plugin-import: 2.26.0_bp34g5zwst6t7i55fhmw4h4ufq
       eslint-plugin-jsx-a11y: 6.5.1_eslint@7.23.0
       eslint-plugin-react: 7.29.4_eslint@7.23.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.23.0
-      next: 12.2.3_f370f735164a03a12cea0cc89593cbee
+      next: 12.2.3_6nyponiwjib2clhkbtejle6l5y
       typescript: 4.7.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -7646,7 +7651,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/2.7.1_9e9136a51bbec2ec9eb0df3ecb969545:
+  /eslint-import-resolver-typescript/2.7.1_t2itnji3x3bozhvq347mxfuviu:
     resolution: {integrity: sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7655,7 +7660,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 7.23.0
-      eslint-plugin-import: 2.26.0_0bf7c3773694fd3fa3bd29d96e1f942c
+      eslint-plugin-import: 2.26.0_bp34g5zwst6t7i55fhmw4h4ufq
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.0
@@ -7664,7 +7669,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3_15e5dd8f4f4e9f615dc6e6f95b78ecf1:
+  /eslint-module-utils/2.7.3_cxs53d2pj2pwcxog434vw6hm6e:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7682,10 +7687,10 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0_eslint@7.23.0+typescript@4.7.4
+      '@typescript-eslint/parser': 4.33.0_p2gelkc4nklso6eukbqqqhjfvq
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_9e9136a51bbec2ec9eb0df3ecb969545
+      eslint-import-resolver-typescript: 2.7.1_t2itnji3x3bozhvq347mxfuviu
       find-up: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -7700,7 +7705,7 @@ packages:
       globals: 11.12.0
     dev: true
 
-  /eslint-plugin-import/2.26.0_0bf7c3773694fd3fa3bd29d96e1f942c:
+  /eslint-plugin-import/2.26.0_bp34g5zwst6t7i55fhmw4h4ufq:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7710,14 +7715,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0_eslint@7.23.0+typescript@4.7.4
+      '@typescript-eslint/parser': 4.33.0_p2gelkc4nklso6eukbqqqhjfvq
       array-includes: 3.1.4
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3_15e5dd8f4f4e9f615dc6e6f95b78ecf1
+      eslint-module-utils: 2.7.3_cxs53d2pj2pwcxog434vw6hm6e
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -8289,7 +8294,7 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /framer-motion/6.2.7_react-dom@17.0.2+react@17.0.2:
+  /framer-motion/6.2.7_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-RExmZCFpJ3OCakoXmZz8iW8ZI5MoaHmVadydetvTSrNaKmZ7ZC/JDQpNyw1NoDG+fchRGP86lXoiTFSQuin+Cg==}
     peerDependencies:
       react: '>=16.8 || ^17.0.0 || ^18.0.0'
@@ -8551,22 +8556,22 @@ packages:
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
-  /graphql-config/4.3.0_1a6b74b6878fa7649e5c268b9124b376:
+  /graphql-config/4.3.0_454f5u3pmwpijct4gz7tgkql2a:
     resolution: {integrity: sha512-Uiu3X7+s5c056WyrvdZVz2vG1fhAipMlYmtiCU/4Z2mX79OXDr1SqIon2MprC/pExIWJfAQZCcjYDY76fPBUQg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_cb132979841079273b6378d6412c7bb8
-      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.5.3
-      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.5.3
-      '@graphql-tools/load': 7.5.10_graphql@15.5.3
-      '@graphql-tools/merge': 8.2.10_graphql@15.5.3
-      '@graphql-tools/url-loader': 7.9.15_aa5d5446fc28dad81dfbf7da577664bd
-      '@graphql-tools/utils': 8.6.9_graphql@15.5.3
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_zmjss6mecb4soo3dpdlecld3xa
+      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.4.0
+      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.4.0
+      '@graphql-tools/load': 7.5.10_graphql@15.4.0
+      '@graphql-tools/merge': 8.2.10_graphql@15.4.0
+      '@graphql-tools/url-loader': 7.9.15_k6hsblzcipvhsqz33tngzpae5m
+      '@graphql-tools/utils': 8.6.9_graphql@15.4.0
       cosmiconfig: 7.0.1
       cosmiconfig-toml-loader: 1.0.0
-      graphql: 15.5.3
+      graphql: 15.4.0
       minimatch: 4.2.1
       string-env-interpolation: 1.0.1
     transitivePeerDependencies:
@@ -8577,22 +8582,22 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-config/4.3.0_e7785ed36f659e848a7c367f332a0bd0:
+  /graphql-config/4.3.0_djvxjnuhr6twjhs4e2fzcjftoy:
     resolution: {integrity: sha512-Uiu3X7+s5c056WyrvdZVz2vG1fhAipMlYmtiCU/4Z2mX79OXDr1SqIon2MprC/pExIWJfAQZCcjYDY76fPBUQg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_cb132979841079273b6378d6412c7bb8
-      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.4.0
-      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.4.0
-      '@graphql-tools/load': 7.5.10_graphql@15.4.0
-      '@graphql-tools/merge': 8.2.10_graphql@15.4.0
-      '@graphql-tools/url-loader': 7.9.15_578f20af2243ea79433bdcda6cbc04eb
-      '@graphql-tools/utils': 8.6.9_graphql@15.4.0
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_zmjss6mecb4soo3dpdlecld3xa
+      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.5.3
+      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.5.3
+      '@graphql-tools/load': 7.5.10_graphql@15.5.3
+      '@graphql-tools/merge': 8.2.10_graphql@15.5.3
+      '@graphql-tools/url-loader': 7.9.15_vjovirx4fdnnqhp367nfo5texu
+      '@graphql-tools/utils': 8.6.9_graphql@15.5.3
       cosmiconfig: 7.0.1
       cosmiconfig-toml-loader: 1.0.0
-      graphql: 15.4.0
+      graphql: 15.5.3
       minimatch: 4.2.1
       string-env-interpolation: 1.0.1
     transitivePeerDependencies:
@@ -8621,16 +8626,16 @@ packages:
       graphql: 15.5.3
     dev: true
 
-  /graphql-language-service-interface/2.10.2_e7785ed36f659e848a7c367f332a0bd0:
+  /graphql-language-service-interface/2.10.2_454f5u3pmwpijct4gz7tgkql2a:
     resolution: {integrity: sha512-RKIEBPhRMWdXY3fxRs99XysTDnEgAvNbu8ov/5iOlnkZsWQNzitjtd0O0l1CutQOQt3iXoHde7w8uhCnKL4tcg==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       graphql: 15.4.0
-      graphql-config: 4.3.0_e7785ed36f659e848a7c367f332a0bd0
-      graphql-language-service-parser: 1.10.4_e7785ed36f659e848a7c367f332a0bd0
-      graphql-language-service-types: 1.8.7_e7785ed36f659e848a7c367f332a0bd0
-      graphql-language-service-utils: 2.7.1_e7785ed36f659e848a7c367f332a0bd0
+      graphql-config: 4.3.0_454f5u3pmwpijct4gz7tgkql2a
+      graphql-language-service-parser: 1.10.4_454f5u3pmwpijct4gz7tgkql2a
+      graphql-language-service-types: 1.8.7_454f5u3pmwpijct4gz7tgkql2a
+      graphql-language-service-utils: 2.7.1_454f5u3pmwpijct4gz7tgkql2a
       vscode-languageserver-types: 3.17.2
     transitivePeerDependencies:
       - '@types/node'
@@ -8640,13 +8645,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-language-service-parser/1.10.4_e7785ed36f659e848a7c367f332a0bd0:
+  /graphql-language-service-parser/1.10.4_454f5u3pmwpijct4gz7tgkql2a:
     resolution: {integrity: sha512-duDE+0aeKLFVrb9Kf28U84ZEHhHcvTjWIT6dJbIAQJWBaDoht0D4BK9EIhd94I3DtKRc1JCJb2+70y1lvP/hiA==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       graphql: 15.4.0
-      graphql-language-service-types: 1.8.7_e7785ed36f659e848a7c367f332a0bd0
+      graphql-language-service-types: 1.8.7_454f5u3pmwpijct4gz7tgkql2a
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -8655,13 +8660,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-language-service-types/1.8.7_e7785ed36f659e848a7c367f332a0bd0:
+  /graphql-language-service-types/1.8.7_454f5u3pmwpijct4gz7tgkql2a:
     resolution: {integrity: sha512-LP/Mx0nFBshYEyD0Ny6EVGfacJAGVx+qXtlJP4hLzUdBNOGimfDNtMVIdZANBXHXcM41MDgMHTnyEx2g6/Ttbw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       graphql: 15.4.0
-      graphql-config: 4.3.0_e7785ed36f659e848a7c367f332a0bd0
+      graphql-config: 4.3.0_454f5u3pmwpijct4gz7tgkql2a
       vscode-languageserver-types: 3.17.2
     transitivePeerDependencies:
       - '@types/node'
@@ -8671,13 +8676,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-language-service-utils/2.5.1_e7785ed36f659e848a7c367f332a0bd0:
+  /graphql-language-service-utils/2.5.1_454f5u3pmwpijct4gz7tgkql2a:
     resolution: {integrity: sha512-Lzz723cYrYlVN4WVzIyFGg3ogoe+QYAIBfdtDboiIILoy0FTmqbyC2TOErqbmWKqO4NK9xDA95cSRFbWiHYj0g==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
       graphql: 15.4.0
-      graphql-language-service-types: 1.8.7_e7785ed36f659e848a7c367f332a0bd0
+      graphql-language-service-types: 1.8.7_454f5u3pmwpijct4gz7tgkql2a
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@types/node'
@@ -8687,14 +8692,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-language-service-utils/2.7.1_e7785ed36f659e848a7c367f332a0bd0:
+  /graphql-language-service-utils/2.7.1_454f5u3pmwpijct4gz7tgkql2a:
     resolution: {integrity: sha512-Wci5MbrQj+6d7rfvbORrA9uDlfMysBWYaG49ST5TKylNaXYFf3ixFOa74iM1KtM9eidosUbI3E1JlWi0JaidJA==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       '@types/json-schema': 7.0.9
       graphql: 15.4.0
-      graphql-language-service-types: 1.8.7_e7785ed36f659e848a7c367f332a0bd0
+      graphql-language-service-types: 1.8.7_454f5u3pmwpijct4gz7tgkql2a
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@types/node'
@@ -8754,7 +8759,7 @@ packages:
     resolution: {integrity: sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==}
     engines: {node: '>= 10.x'}
 
-  /graphqurl/1.0.1_a980934185fd468574748ee888a28d09:
+  /graphqurl/1.0.1_vgajgqmf7vdik5dur3uiriunbe:
     resolution: {integrity: sha512-97Chda90OBIHCpH6iQHNYc9qTTADN0LOFbiMcRws3V5SottC/0yTDIQDgBzncZYVCkttyjAnT6YmVuNId7ymQA==}
     engines: {node: '>=8.0.0'}
     hasBin: true
@@ -8766,8 +8771,8 @@ packages:
       cli-ux: 4.9.3
       express: 4.16.3
       graphql: 15.4.0
-      graphql-language-service-interface: 2.10.2_e7785ed36f659e848a7c367f332a0bd0
-      graphql-language-service-utils: 2.5.1_e7785ed36f659e848a7c367f332a0bd0
+      graphql-language-service-interface: 2.10.2_454f5u3pmwpijct4gz7tgkql2a
+      graphql-language-service-utils: 2.5.1_454f5u3pmwpijct4gz7tgkql2a
       isomorphic-fetch: 3.0.0
       isomorphic-ws: 4.0.1_ws@7.4.2
       open: 7.3.1
@@ -10732,7 +10737,7 @@ packages:
       escalade: 3.1.1
     dev: true
 
-  /next/12.2.3_03eb8178f285321bf7d6b0dd6884cacb:
+  /next/12.2.3_6nyponiwjib2clhkbtejle6l5y:
     resolution: {integrity: sha512-TA0tmSA6Dk6S6kfvCNbF7CWYW8468gZUxr/3/30z4KvAQbXnl2ASYZElVe7q/hBW/1F1ee0tSBlHa4/sn+ZIBw==}
     engines: {node: '>=12.22.0'}
     hasBin: true
@@ -10756,7 +10761,7 @@ packages:
       postcss: 8.4.14
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      styled-jsx: 5.0.2_@babel+core@7.18.6+react@17.0.2
+      styled-jsx: 5.0.2_cun6ua7ys3vo4t2323flhwfg7m
       use-sync-external-store: 1.2.0_react@17.0.2
     optionalDependencies:
       '@next/swc-android-arm-eabi': 12.2.3
@@ -10776,7 +10781,7 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
-  /next/12.2.3_f370f735164a03a12cea0cc89593cbee:
+  /next/12.2.3_apvyc6hsquzbx56wwdowrbgkzm:
     resolution: {integrity: sha512-TA0tmSA6Dk6S6kfvCNbF7CWYW8468gZUxr/3/30z4KvAQbXnl2ASYZElVe7q/hBW/1F1ee0tSBlHa4/sn+ZIBw==}
     engines: {node: '>=12.22.0'}
     hasBin: true
@@ -10800,7 +10805,7 @@ packages:
       postcss: 8.4.14
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      styled-jsx: 5.0.2_@babel+core@7.17.9+react@17.0.2
+      styled-jsx: 5.0.2_on4pwhjuscz2cucak6hkhs726q
       use-sync-external-store: 1.2.0_react@17.0.2
     optionalDependencies:
       '@next/swc-android-arm-eabi': 12.2.3
@@ -10831,7 +10836,7 @@ packages:
       next: '>= 6.0.0'
       react: '>= 16.0.0'
     dependencies:
-      next: 12.2.3_f370f735164a03a12cea0cc89593cbee
+      next: 12.2.3_6nyponiwjib2clhkbtejle6l5y
       nprogress: 0.2.0
       prop-types: 15.8.1
       react: 17.0.2
@@ -11609,7 +11614,7 @@ packages:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
     dev: false
 
-  /react-focus-lock/2.5.2_@types+react@17.0.1+react@17.0.2:
+  /react-focus-lock/2.5.2_wk7fohhuxwcjfgq2kdoh4ny7by:
     resolution: {integrity: sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -11619,8 +11624,8 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
       react-clientside-effect: 1.2.5_react@17.0.2
-      use-callback-ref: 1.3.0_@types+react@17.0.1+react@17.0.2
-      use-sidecar: 1.1.2_@types+react@17.0.1+react@17.0.2
+      use-callback-ref: 1.3.0_wk7fohhuxwcjfgq2kdoh4ny7by
+      use-sidecar: 1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -11633,7 +11638,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-instantsearch-hooks-server/6.32.1_6414a94af4ca8152be5dd238e8125fea:
+  /react-instantsearch-hooks-server/6.32.1_hiec5pcpgig2m3qcu64y3isqke_mqkkssxuzkavfps52i4oqes75i:
     resolution: {integrity: sha512-B4lQO5WYFzof7mjl6YB1ri5sUEu0Aai4/mIzl7KXKPEUqpyfrbf5oJt+kKQYsvAjxAiTP2t7iv0QR4te6qouPw==}
     peerDependencies:
       algoliasearch: '>= 3.1 < 5'
@@ -11645,10 +11650,11 @@ packages:
       instantsearch.js: 4.44.0_algoliasearch@4.13.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-instantsearch-hooks: 6.32.1_b7c6bccee043686b2080156151f2feed
+      react-instantsearch-hooks: 6.32.1_w7dlztxainugwieacvqvd4x65u
     dev: false
+    patched: true
 
-  /react-instantsearch-hooks-web/6.32.1_6414a94af4ca8152be5dd238e8125fea:
+  /react-instantsearch-hooks-web/6.32.1_mqkkssxuzkavfps52i4oqes75i:
     resolution: {integrity: sha512-fyMg99MOblOouKqLoaFamBv142/3ZybZi4gYMKA2EdsACsu74mxB9qDZKMfdz2p5aP7RB+lFuOYLSPWiF/emmQ==}
     peerDependencies:
       algoliasearch: '>= 3.1 < 5'
@@ -11660,10 +11666,10 @@ packages:
       instantsearch.js: 4.44.0_algoliasearch@4.13.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-instantsearch-hooks: 6.32.1_b7c6bccee043686b2080156151f2feed
+      react-instantsearch-hooks: 6.32.1_w7dlztxainugwieacvqvd4x65u
     dev: false
 
-  /react-instantsearch-hooks/6.32.1_b7c6bccee043686b2080156151f2feed:
+  /react-instantsearch-hooks/6.32.1_w7dlztxainugwieacvqvd4x65u:
     resolution: {integrity: sha512-yKxxY7Ps2y/iuS1viOAkI3Rf8vQ7C+piEMZgXAnWNunY2mK3JfhMl/KsAyNYLdC5C8gGszhYpps+UmPvqZEa0Q==}
     peerDependencies:
       algoliasearch: '>= 3.1 < 5'
@@ -11688,7 +11694,7 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react-query/3.34.19_react-dom@17.0.2+react@17.0.2:
+  /react-query/3.34.19_sfoxds7t5ydpegc3knd667wn6m:
     resolution: {integrity: sha512-JO0Ymi58WKmvnhgg6bGIrYIeKb64KsKaPWo8JcGnmK2jJxAs2XmMBzlP75ZepSU7CHzcsWtIIyhMrLbX3pb/3w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -11707,7 +11713,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /react-remove-scroll-bar/2.3.0_@types+react@17.0.1+react@17.0.2:
+  /react-remove-scroll-bar/2.3.0_wk7fohhuxwcjfgq2kdoh4ny7by:
     resolution: {integrity: sha512-v2vf8kgrRph5FQeLVZjSOmM0g3ZiBxwMk98VXhsiJDSPeRDUaXJrzYDk2Hhoe6qLggrhWtAXJZVxUwXmRXa93g==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -11719,11 +11725,11 @@ packages:
     dependencies:
       '@types/react': 17.0.1
       react: 17.0.2
-      react-style-singleton: 2.2.0_@types+react@17.0.1+react@17.0.2
+      react-style-singleton: 2.2.0_wk7fohhuxwcjfgq2kdoh4ny7by
       tslib: 2.4.0
     dev: false
 
-  /react-remove-scroll/2.4.1_@types+react@17.0.1+react@17.0.2:
+  /react-remove-scroll/2.4.1_wk7fohhuxwcjfgq2kdoh4ny7by:
     resolution: {integrity: sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==}
     engines: {node: '>=8.5.0'}
     peerDependencies:
@@ -11735,14 +11741,14 @@ packages:
     dependencies:
       '@types/react': 17.0.1
       react: 17.0.2
-      react-remove-scroll-bar: 2.3.0_@types+react@17.0.1+react@17.0.2
-      react-style-singleton: 2.2.0_@types+react@17.0.1+react@17.0.2
+      react-remove-scroll-bar: 2.3.0_wk7fohhuxwcjfgq2kdoh4ny7by
+      react-style-singleton: 2.2.0_wk7fohhuxwcjfgq2kdoh4ny7by
       tslib: 1.14.1
-      use-callback-ref: 1.3.0_@types+react@17.0.1+react@17.0.2
-      use-sidecar: 1.1.2_@types+react@17.0.1+react@17.0.2
+      use-callback-ref: 1.3.0_wk7fohhuxwcjfgq2kdoh4ny7by
+      use-sidecar: 1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by
     dev: false
 
-  /react-style-singleton/2.2.0_@types+react@17.0.1+react@17.0.2:
+  /react-style-singleton/2.2.0_wk7fohhuxwcjfgq2kdoh4ny7by:
     resolution: {integrity: sha512-nK7mN92DMYZEu3cQcAhfwE48NpzO5RpxjG4okbSqRRbfal9Pk+fG2RdQXTMp+f6all1hB9LIJSt+j7dCYrU11g==}
     engines: {node: '>=10'}
     deprecated: wrong managing of dynamic styles
@@ -12653,7 +12659,7 @@ packages:
       hey-listen: 1.0.8
       tslib: 2.4.0
 
-  /styled-jsx/5.0.2_@babel+core@7.17.9+react@17.0.2:
+  /styled-jsx/5.0.2_cun6ua7ys3vo4t2323flhwfg7m:
     resolution: {integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -12669,7 +12675,7 @@ packages:
       '@babel/core': 7.17.9
       react: 17.0.2
 
-  /styled-jsx/5.0.2_@babel+core@7.18.6+react@17.0.2:
+  /styled-jsx/5.0.2_on4pwhjuscz2cucak6hkhs726q:
     resolution: {integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -13269,7 +13275,7 @@ packages:
       querystring: 0.2.0
     dev: true
 
-  /use-callback-ref/1.3.0_@types+react@17.0.1+react@17.0.2:
+  /use-callback-ref/1.3.0_wk7fohhuxwcjfgq2kdoh4ny7by:
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -13284,7 +13290,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /use-isomorphic-layout-effect/1.1.2_@types+react@17.0.1+react@17.0.2:
+  /use-isomorphic-layout-effect/1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -13297,7 +13303,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /use-sidecar/1.1.2_@types+react@17.0.1+react@17.0.2:
+  /use-sidecar/1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -13839,8 +13845,3 @@ packages:
   /zod/3.18.0:
     resolution: {integrity: sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==}
     dev: false
-
-patchedDependencies:
-  react-instantsearch-hooks-server@6.32.1:
-    hash: hiec5pcpgig2m3qcu64y3isqke
-    path: patches/react-instantsearch-hooks-server@6.32.1.patch

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,4 @@
-lockfileVersion: 5.4
-
-patchedDependencies:
-  react-instantsearch-hooks-server@6.32.1:
-    hash: hiec5pcpgig2m3qcu64y3isqke
-    path: patches/react-instantsearch-hooks-server@6.32.1.patch
+lockfileVersion: 5.3
 
 importers:
 
@@ -116,17 +111,17 @@ importers:
       webpack: 5.73.0
       zod: 3.18.0
     dependencies:
-      '@chakra-ui/icons': 1.1.7_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/react': 1.8.8_mt4gt3o63p32tfns77ndyyxdka
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/icons': 1.1.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/react': 1.8.8_64f869eddedbf7a995b2ffda3c62e350
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@core-ds/primitives': 2.4.5
-      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
-      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
+      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
+      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
       '@fortawesome/fontawesome-svg-core': 6.1.1
       '@fortawesome/free-solid-svg-icons': 6.1.1
       '@fortawesome/pro-duotone-svg-icons': 6.1.1
       '@fortawesome/pro-solid-svg-icons': 6.1.1
-      '@fortawesome/react-fontawesome': 0.2.0_nee7k2mmznvunamfg4ebivqgfa
+      '@fortawesome/react-fontawesome': 0.2.0_6909f5698ccb6b468185370814560628
       '@ifixit/app': link:../packages/app
       '@ifixit/auth-sdk': link:../packages/auth-sdk
       '@ifixit/cart-sdk': link:../packages/cart-sdk
@@ -135,31 +130,31 @@ importers:
       '@ifixit/ifixit-api-client': link:../packages/ifixit-api-client
       '@ifixit/matomo': link:../packages/matomo
       '@ifixit/newsletter-sdk': link:../packages/newsletter-sdk
-      '@ifixit/react-components': 0.3.0_4bx7e3vbdhtpqjh6nevglqbelu
+      '@ifixit/react-components': 0.3.0_e06ff26ea119e6f824fe692a65c0245d
       '@ifixit/sentry': link:../packages/sentry
       '@ifixit/shopify-storefront-client': link:../packages/shopify-storefront-client
       '@ifixit/ui': link:../packages/ui
-      '@sentry/nextjs': 7.8.1_daclytgsfcivq2b62vwydcy3uy
+      '@sentry/nextjs': 7.8.1_1804bc4cd2289158683ed56d818b1ba6
       '@sentry/tracing': 7.8.1
       '@xstate/fsm': 1.6.1
-      '@xstate/react': 1.5.1_6fu6ht62pwx66poirfopbfx2xy
+      '@xstate/react': 1.5.1_f169e3cfda7dafef3dc8895cf096fabe
       algoliasearch: 4.13.1
       cookie: 0.5.0
       dayjs: 1.10.5
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       graphql: 15.5.3
       immer: 9.0.14
       lodash: 4.17.21
       lru-cache: 7.10.1
-      next: 12.2.3_6nyponiwjib2clhkbtejle6l5y
+      next: 12.2.3_f370f735164a03a12cea0cc89593cbee
       nextjs-progressbar: 0.0.14_next@12.2.3+react@17.0.2
       query-string: 7.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-icons: 4.2.0_react@17.0.2
-      react-instantsearch-hooks-server: 6.32.1_hiec5pcpgig2m3qcu64y3isqke_mqkkssxuzkavfps52i4oqes75i
-      react-instantsearch-hooks-web: 6.32.1_mqkkssxuzkavfps52i4oqes75i
-      react-query: 3.34.19_sfoxds7t5ydpegc3knd667wn6m
+      react-instantsearch-hooks-server: 6.32.1_6414a94af4ca8152be5dd238e8125fea
+      react-instantsearch-hooks-web: 6.32.1_6414a94af4ca8152be5dd238e8125fea
+      react-query: 3.34.19_react-dom@17.0.2+react@17.0.2
       sharp: 0.30.7
       snarkdown: 2.0.0
       swiper: 8.3.2
@@ -168,9 +163,9 @@ importers:
       '@babel/core': 7.17.9
       '@babel/preset-env': 7.18.6_@babel+core@7.17.9
       '@babel/preset-typescript': 7.18.6_@babel+core@7.17.9
-      '@graphql-codegen/cli': 2.1.1_djvxjnuhr6twjhs4e2fzcjftoy
+      '@graphql-codegen/cli': 2.1.1_1a6b74b6878fa7649e5c268b9124b376
       '@graphql-codegen/typescript': 2.2.0_graphql@15.5.3
-      '@graphql-codegen/typescript-generic-sdk': 2.1.3_6aqbksp2bzfqiuihkviabctooa
+      '@graphql-codegen/typescript-generic-sdk': 2.1.3_f0201549fa0e4b0451075550008a6e70
       '@graphql-codegen/typescript-operations': 2.1.3_graphql@15.5.3
       '@ifixit/tsconfig': link:../packages/tsconfig
       '@next/bundle-analyzer': 12.1.6
@@ -178,8 +173,8 @@ importers:
       '@testing-library/cypress': 8.0.2_cypress@9.3.1
       '@testing-library/dom': 7.21.4
       '@testing-library/jest-dom': 5.16.1
-      '@testing-library/react': 12.1.2_sfoxds7t5ydpegc3knd667wn6m
-      '@testing-library/user-event': 13.5.0_zbypwrtvpjrvnfnw5wxfpjfsci
+      '@testing-library/react': 12.1.2_react-dom@17.0.2+react@17.0.2
+      '@testing-library/user-event': 13.5.0_@testing-library+dom@7.21.4
       '@types/cookie': 0.5.1
       '@types/jest': 27.4.0
       '@types/node': 14.14.25
@@ -187,20 +182,20 @@ importers:
       '@types/react-virtualized-auto-sizer': 1.0.1
       '@types/react-window': 1.8.4
       '@types/shopify-buy': 2.10.5
-      '@typescript-eslint/eslint-plugin': 4.14.2_fcgtupz6z6gal3tayzjah7yzi4
-      '@typescript-eslint/parser': 4.14.2_p2gelkc4nklso6eukbqqqhjfvq
+      '@typescript-eslint/eslint-plugin': 4.14.2_288d3a3f3ecf8c05ee60c65203ff1947
+      '@typescript-eslint/parser': 4.14.2_eslint@7.23.0+typescript@4.7.4
       babel-jest: 28.1.3_@babel+core@7.17.9
       concurrently: 6.2.1
       cypress: 9.3.1
       dotenv: 10.0.0
       eslint: 7.23.0
-      eslint-config-next: 11.0.1_2aajvzqgegcbyxur2qkkmxgclm
+      eslint-config-next: 11.0.1_d0009ae60621841c5e91d414a65cc25b
       eslint-config-prettier: 7.2.0_eslint@7.23.0
       eslint-plugin-cypress: 2.12.1_eslint@7.23.0
       eslint-plugin-react: 7.23.0_eslint@7.23.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.23.0
       graphql-tag: 2.12.6_graphql@15.5.3
-      graphqurl: 1.0.1_vgajgqmf7vdik5dur3uiriunbe
+      graphqurl: 1.0.1_a980934185fd468574748ee888a28d09
       identity-obj-proxy: 3.0.0
       jest: 28.1.2_@types+node@14.14.25
       jest-environment-jsdom: 28.1.2
@@ -346,7 +341,7 @@ importers:
     devDependencies:
       '@babel/core': 7.18.6
       '@ifixit/tsconfig': link:../tsconfig
-      next: 12.2.3_apvyc6hsquzbx56wwdowrbgkzm
+      next: 12.2.3_03eb8178f285321bf7d6b0dd6884cacb
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       typescript: 4.5.3
@@ -392,12 +387,12 @@ importers:
       '@ifixit/newsletter-sdk': link:../newsletter-sdk
     devDependencies:
       '@babel/core': 7.18.6
-      '@emotion/react': 11.7.1_yse24c3tnaw3czhkbk3q2k7woy
-      '@emotion/styled': 11.6.0_antrsugujploi4ebyftn3umj4a
+      '@emotion/react': 11.7.1_c489ae0b73682db164ea0ab70d2bf676
+      '@emotion/styled': 11.6.0_03671950d44bd6e47081c166ddd189e0
       '@ifixit/tsconfig': link:../tsconfig
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       typescript: 4.5.3
@@ -2296,7 +2291,7 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@chakra-ui/accordion/1.4.11_spze6u54dwjfc3x4u4jvlrsj3q:
+  /@chakra-ui/accordion/1.4.11_93f24f53bc1d92516efca71355c649dc:
     resolution: {integrity: sha512-d/gvSgGwcZaJXxXqGmecpAgko/tUYb5vR0E0B2/V/z9AVbS8ei//fbiO9+8Ouyl/K46oWHWYj5vt8iTadlZleg==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2305,24 +2300,24 @@ packages:
     dependencies:
       '@chakra-ui/descendant': 2.1.3_react@17.0.2
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
-      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/alert/1.3.7_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/alert/1.3.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-fFpJYBpHOIK/BX4BVl/xafYiDBUW+Bq/gUYDOo4iAiO4vHgxo74oa+yOwSRNlNjAgIX7pi2ridsYQALKyWyxxQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2332,36 +2327,36 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
     dev: false
 
-  /@chakra-ui/avatar/1.3.11_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/avatar/1.3.11_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-/eRRK48Er92/QWAfWhxsJIN0gZBBvk+ew4Hglo+pxt3/NDnfTF2yPE7ZN29Dl6daPNbyTOpoksMwaU2mZIqLgA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/image': 1.1.10_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/image': 1.1.10_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/breadcrumb/1.3.6_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/breadcrumb/1.3.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-iXxienBO6RUnJEcDvyDWyRt+mzPyl7/b6N8i0vrjGKGLpgtayJFvIdo33tFcvx6TCy7V9hiE3HTtZnNomWdR6A==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/button/1.5.10_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/button/1.5.10_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-IVEOrleI378CckAa3b3CTUHMPZRfpy6LPwn1Mx3sMpHEkDTKu8zJcjgEvCE8HYzNC1KbwBsa1PfTgk40ui6EtA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2369,26 +2364,26 @@ packages:
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/spinner': 1.2.6_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/spinner': 1.2.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/checkbox/1.7.1_spze6u54dwjfc3x4u4jvlrsj3q:
+  /@chakra-ui/checkbox/1.7.1_93f24f53bc1d92516efca71355c649dc:
     resolution: {integrity: sha512-9Io97yn8OrdaIynCj+3Z/neJV7lTT1MtcdYh3BKMd7WnoJDkRY/GlBM8zsdgC5Wvm+ZQ1M83t0YvRPKLLzusyA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       framer-motion: 3.x || 4.x || 5.x || 6.x
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2402,14 +2397,14 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/close-button/1.2.7_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/close-button/1.2.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-cYTxfgrIlPU4IZm1sehZXxx/TNQBk9c3LBPvTpywEM8GVRGINh4YLq8WiMaPtO+TDNBnKoWS/jS4IHnR+abADw==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2425,13 +2420,13 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/control-box/1.1.6_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/control-box/1.1.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-EUcq5f854puG6ZA6wAWl4107OPl8+bj4MMHJCa48BB0qec0U8HCEtxQGnFwJmaYLalIAjMfHuY3OwO2A3Hi9hA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2446,13 +2441,13 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/css-reset/1.1.3_phausblcypdf55k6wezkg7rzwq:
+  /@chakra-ui/css-reset/1.1.3_79c1490562c3c65ef55eb132a37e39b4:
     resolution: {integrity: sha512-AgfrE7bRTJvNi/4zIfacI/kBHmHmHEIeQtHwCvk/0qM9V2gK1VM3ctYlnibf7BTh17F/UszweOGRb1lHSPfWjw==}
     peerDependencies:
       '@emotion/react': '>=10.0.35'
       react: '>=16.8.6'
     dependencies:
-      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
+      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
       react: 17.0.2
     dev: false
 
@@ -2465,7 +2460,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/editable/1.4.2_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/editable/1.4.2_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-a5zKghA/IvG7yNkmFl7Z9c2KSsf0FgyijsNPTg/4S5jxyz13QJtoTg40tdpyaxHHCT25y25iUcV4FYCj6Jd01w==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2473,33 +2468,33 @@ packages:
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/focus-lock/1.2.6_wk7fohhuxwcjfgq2kdoh4ny7by:
+  /@chakra-ui/focus-lock/1.2.6_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-ZJNE1oNdUM1aGWuCJ+bxFa/d3EwxzfMWzTKzSvKDK50GWoUQQ10xFTT9nY/yFpkcwhBvx1KavxKf44mIhIbSog==}
     peerDependencies:
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
-      react-focus-lock: 2.5.2_wk7fohhuxwcjfgq2kdoh4ny7by
+      react-focus-lock: 2.5.2_@types+react@17.0.1+react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@chakra-ui/form-control/1.6.0_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/form-control/1.6.0_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-MtUE98aocP2QTgvyyJ/ABuG33mhT3Ox56phKreG3HzbUKByMwrbQSm1QcAgyYdqSZ9eKB2tXx+qgGNh+avAfDA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2516,63 +2511,63 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/icon/2.0.5_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/icon/2.0.5_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-ZrqRvCCIxGr4qFd/r1pmtd9tobRmv8KAxV7ygFoc/t4vOSKTcVIjhE12gsI3FzgvXM15ZFVwsxa1zodwgo5neQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/icons/1.1.7_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/icons/1.1.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-YIHxey/B4M2PyFASlHXtAWFyW+tsAtGAChOJ8dsM2kpu1MbVUqm/6nMI1KIFd7Te5IWuNYA75rAHBdLI0Yu61A==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@types/react': 17.0.37
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/image/1.1.10_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/image/1.1.10_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-PJZmhQ/R1PgdMyCRjALfoyq1FNh/WzMAw70sliHLtLcb9hBXniwQZuckYfUshCkUoFBj/ow9d4byn9Culdpk7Q==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/input/1.4.6_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/input/1.4.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-Ljy/NbOhh9cNQxKTWQRsT4aQiXs2vVya+Cj5NpMAz08NFFjPZovsTawhI7m6ejT5Vsh76QYjh2rOLLI3fWqQQw==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/layout/1.8.0_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/layout/1.8.0_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-GJtEKez5AZu0XQTxI6a6jwA/hMDD36pP0HBxBOGuHP1hWCebDzMjraiMfWiP9w7hKERFE4j19kocHxIXyocfJA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -2586,7 +2581,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/media-query/2.0.4_sxr25aaor3bltw4csjjk62xw3q:
+  /@chakra-ui/media-query/2.0.4_95e3ae800e8ec2b9db829252af6af6dc:
     resolution: {integrity: sha512-kn6g/L0IFFUHz2v4yiCsBnhg9jUeA7525Z+AWl+BPtvryi7i9J+AJ27y/QAge7vUGy4dwDeFyxOZTs2oZ9/BsA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2594,13 +2589,13 @@ packages:
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/react-env': 1.1.6_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/menu/1.8.11_spze6u54dwjfc3x4u4jvlrsj3q:
+  /@chakra-ui/menu/1.8.11_93f24f53bc1d92516efca71355c649dc:
     resolution: {integrity: sha512-8K65xItPsdMvSfuGWYIGigOF/QMcy7+D48UIEO/Hu0u0ckd11/JXbpSIFPddH5fYedclJ18PGRohTne487OVjQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2612,14 +2607,14 @@ packages:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/popper': 2.4.3_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
-      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/modal/1.11.1_nwx6l6ihrkrglcmyg3crbuontm:
+  /@chakra-ui/modal/1.11.1_6dafe5f9078aa265899836c510d1cd9b:
     resolution: {integrity: sha512-B2BBDonHb04vbPLAWgko1JYBwgW8ZNSLyhTJK+rbrCsRSgazuLTcwq4hdyJqrYNWtaQEfSwpAXqJ7joMZdv59A==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2627,40 +2622,40 @@ packages:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
     dependencies:
-      '@chakra-ui/close-button': 1.2.7_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/focus-lock': 1.2.6_wk7fohhuxwcjfgq2kdoh4ny7by
+      '@chakra-ui/close-button': 1.2.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/focus-lock': 1.2.6_@types+react@17.0.1+react@17.0.2
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/portal': 1.3.10_sfoxds7t5ydpegc3knd667wn6m
+      '@chakra-ui/portal': 1.3.10_react-dom@17.0.2+react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
-      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
       '@chakra-ui/utils': 1.10.4
       aria-hidden: 1.1.3
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-remove-scroll: 2.4.1_wk7fohhuxwcjfgq2kdoh4ny7by
+      react-remove-scroll: 2.4.1_@types+react@17.0.1+react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@chakra-ui/number-input/1.4.7_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/number-input/1.4.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-LorGRZFMipom8vCUEbLi2s7bTHF2Fgiu766W0jTbzMje+8Z1ZoRQunH9OZWQnxnWQTUfUM2KBW8KwToYh1ojfQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/counter': 1.2.10_react@17.0.2
-      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/pin-input/1.7.10_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/pin-input/1.7.10_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-Uz5vFK+ZevQtdYHBkddSFCrY44bweXLanpSv9X/D0pWpdML09qfPiKX4ydGzfRoS2u4L8NUtN86IcvdOQLhHQg==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2669,25 +2664,25 @@ packages:
       '@chakra-ui/descendant': 2.1.3_react@17.0.2
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/popover/1.11.9_spze6u54dwjfc3x4u4jvlrsj3q:
+  /@chakra-ui/popover/1.11.9_93f24f53bc1d92516efca71355c649dc:
     resolution: {integrity: sha512-hJ1/Lwukox3ryTN7W1wnj+nE44utfLwQYvfUSdatt5dznnh8k0P6Wx7Hmjm1cYffRavBhqzwua/QZDWjJN9N0g==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       framer-motion: 3.x || 4.x || 5.x || 6.x
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/close-button': 1.2.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/close-button': 1.2.7_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/popper': 2.4.3_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -2701,7 +2696,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/portal/1.3.10_sfoxds7t5ydpegc3knd667wn6m:
+  /@chakra-ui/portal/1.3.10_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-t2KQ6MXbyf1qFYxWw/bs//CnwD+Clq7mbsP1Y7g+THCz2FvlLlMj45BWocLB30NoNyA8WCS2zyMBszW2/qvDiA==}
     peerDependencies:
       react: '>=16.8.6'
@@ -2714,19 +2709,19 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@chakra-ui/progress/1.2.6_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/progress/1.2.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-thaHRIYTVktgV78vJMNwzfCX+ickhSpn2bun6FtGVUphFx4tjV+ggz+IGohm6AH2hapskoR1mQU2iNZb6BK0hQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/provider/1.7.14_zbhdkstsj5bbhktfhh66vhiivi:
+  /@chakra-ui/provider/1.7.14_c84e354a724f4213aa6539fdea9d08aa:
     resolution: {integrity: sha512-FCA33CZy/jFzExglKMioeri8sr9NtDTcNVPnx95ZJiA7WpfFo0xuZ6/fMC4DwIQPkJKbSIZBXYLZ3U10Ntylrw==}
     peerDependencies:
       '@emotion/react': ^11.0.0
@@ -2734,30 +2729,30 @@ packages:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
     dependencies:
-      '@chakra-ui/css-reset': 1.1.3_phausblcypdf55k6wezkg7rzwq
+      '@chakra-ui/css-reset': 1.1.3_79c1490562c3c65ef55eb132a37e39b4
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/portal': 1.3.10_sfoxds7t5ydpegc3knd667wn6m
+      '@chakra-ui/portal': 1.3.10_react-dom@17.0.2+react@17.0.2
       '@chakra-ui/react-env': 1.1.6_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
-      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
-      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
+      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
+      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@chakra-ui/radio/1.5.1_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/radio/1.5.1_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-zO5eShz+j68A7935jJ2q5u3brX/bjPEGh9Pj2+bnKbmC9Vva6jEzBSJsAx9n4WbkAzR3xDMGWsbpivFp8X1tJw==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
       react: 17.0.2
     dev: false
 
@@ -2788,7 +2783,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/react/1.8.8_mt4gt3o63p32tfns77ndyyxdka:
+  /@chakra-ui/react/1.8.8_64f869eddedbf7a995b2ffda3c62e350:
     resolution: {integrity: sha512-/XqL25J0i0h+usAXBngn/RTG2u1oQRzbhHe9tNHwFyNbx/izIADhQW/6ji06QU0KtaRIU77XvgSAyTtMJY1KmA==}
     peerDependencies:
       '@emotion/react': ^11.0.0
@@ -2797,75 +2792,75 @@ packages:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
     dependencies:
-      '@chakra-ui/accordion': 1.4.11_spze6u54dwjfc3x4u4jvlrsj3q
-      '@chakra-ui/alert': 1.3.7_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/avatar': 1.3.11_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/breadcrumb': 1.3.6_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/button': 1.5.10_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/checkbox': 1.7.1_spze6u54dwjfc3x4u4jvlrsj3q
-      '@chakra-ui/close-button': 1.2.7_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/control-box': 1.1.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/accordion': 1.4.11_93f24f53bc1d92516efca71355c649dc
+      '@chakra-ui/alert': 1.3.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/avatar': 1.3.11_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/breadcrumb': 1.3.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/button': 1.5.10_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/checkbox': 1.7.1_93f24f53bc1d92516efca71355c649dc
+      '@chakra-ui/close-button': 1.2.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/control-box': 1.1.6_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/counter': 1.2.10_react@17.0.2
-      '@chakra-ui/css-reset': 1.1.3_phausblcypdf55k6wezkg7rzwq
-      '@chakra-ui/editable': 1.4.2_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/css-reset': 1.1.3_79c1490562c3c65ef55eb132a37e39b4
+      '@chakra-ui/editable': 1.4.2_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/image': 1.1.10_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/input': 1.4.6_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/layout': 1.8.0_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/image': 1.1.10_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/input': 1.4.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/layout': 1.8.0_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/live-region': 1.1.6_react@17.0.2
-      '@chakra-ui/media-query': 2.0.4_sxr25aaor3bltw4csjjk62xw3q
-      '@chakra-ui/menu': 1.8.11_spze6u54dwjfc3x4u4jvlrsj3q
-      '@chakra-ui/modal': 1.11.1_nwx6l6ihrkrglcmyg3crbuontm
-      '@chakra-ui/number-input': 1.4.7_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/pin-input': 1.7.10_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/popover': 1.11.9_spze6u54dwjfc3x4u4jvlrsj3q
+      '@chakra-ui/media-query': 2.0.4_95e3ae800e8ec2b9db829252af6af6dc
+      '@chakra-ui/menu': 1.8.11_93f24f53bc1d92516efca71355c649dc
+      '@chakra-ui/modal': 1.11.1_6dafe5f9078aa265899836c510d1cd9b
+      '@chakra-ui/number-input': 1.4.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/pin-input': 1.7.10_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/popover': 1.11.9_93f24f53bc1d92516efca71355c649dc
       '@chakra-ui/popper': 2.4.3_react@17.0.2
-      '@chakra-ui/portal': 1.3.10_sfoxds7t5ydpegc3knd667wn6m
-      '@chakra-ui/progress': 1.2.6_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/provider': 1.7.14_zbhdkstsj5bbhktfhh66vhiivi
-      '@chakra-ui/radio': 1.5.1_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/portal': 1.3.10_react-dom@17.0.2+react@17.0.2
+      '@chakra-ui/progress': 1.2.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/provider': 1.7.14_c84e354a724f4213aa6539fdea9d08aa
+      '@chakra-ui/radio': 1.5.1_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/react-env': 1.1.6_react@17.0.2
-      '@chakra-ui/select': 1.2.11_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/skeleton': 1.2.14_24j7pk2qck5a6v3xlrwkd3pgyi
-      '@chakra-ui/slider': 1.5.11_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/spinner': 1.2.6_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/stat': 1.2.7_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/switch': 1.3.10_spze6u54dwjfc3x4u4jvlrsj3q
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
-      '@chakra-ui/table': 1.3.6_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/tabs': 1.6.10_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/tag': 1.2.7_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/textarea': 1.2.11_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/select': 1.2.11_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/skeleton': 1.2.14_d713f7ab5012ba0f57775c6ca1ede6c2
+      '@chakra-ui/slider': 1.5.11_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/spinner': 1.2.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/stat': 1.2.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/switch': 1.3.10_93f24f53bc1d92516efca71355c649dc
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
+      '@chakra-ui/table': 1.3.6_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/tabs': 1.6.10_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/tag': 1.2.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/textarea': 1.2.11_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
-      '@chakra-ui/toast': 1.5.9_kksxwa5vzhtxxmbf45a6r4tek4
-      '@chakra-ui/tooltip': 1.5.1_kksxwa5vzhtxxmbf45a6r4tek4
-      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
+      '@chakra-ui/toast': 1.5.9_52a57b03b5c9e77bb025e741e8f26457
+      '@chakra-ui/tooltip': 1.5.1_52a57b03b5c9e77bb025e741e8f26457
+      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
-      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
-      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
+      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
+      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
     dev: false
 
-  /@chakra-ui/select/1.2.11_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/select/1.2.11_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-6Tis1+ZrRjQeWhQfziQn3ZdPphV5ccafpZOhiPdTcM2J1XcXOlII+9rHxvaW+jx7zQ5ly5o8kd7iXzalDgl5wA==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/skeleton/1.2.14_24j7pk2qck5a6v3xlrwkd3pgyi:
+  /@chakra-ui/skeleton/1.2.14_d713f7ab5012ba0f57775c6ca1ede6c2:
     resolution: {integrity: sha512-R0v4DfQ2yjXCJf9SzhTmDb2PLx5//LxsRbjjgRa8qJCR4MZaGswPrekp4dP8YjY8aEYzuZbvHU12T3vqZBk2GA==}
     peerDependencies:
       '@chakra-ui/theme': '>=1.0.0'
@@ -2874,16 +2869,16 @@ packages:
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/media-query': 2.0.4_sxr25aaor3bltw4csjjk62xw3q
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/media-query': 2.0.4_95e3ae800e8ec2b9db829252af6af6dc
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
-      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
-      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
+      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
+      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/slider/1.5.11_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/slider/1.5.11_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-THkGU2BsA6XMosXcEVQkWVRftqUIAKCb+y4iEpR3C2ztqL7Fl/CbIGwyr5majhPhKc275rb8dfxwp8R0L0ZIiQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2891,33 +2886,33 @@ packages:
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/spinner/1.2.6_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/spinner/1.2.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-GoUCccN120fGRVgUtfuwcEjeoaxffB+XsgpxX7jhWloXf8b6lkqm68bsxX4Ybb2vGN1fANI98/45JmrnddZO/A==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/stat/1.2.7_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/stat/1.2.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-m76jumFW1N+mCG4ytrUz9Mh09nZtS4OQcADEvOslfdI5StwwuzasTA1tueaelPzdhBioMwFUWL05Fr1fXbPJ/Q==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
       react: 17.0.2
     dev: false
 
@@ -2928,21 +2923,21 @@ packages:
       csstype: 3.0.9
     dev: false
 
-  /@chakra-ui/switch/1.3.10_spze6u54dwjfc3x4u4jvlrsj3q:
+  /@chakra-ui/switch/1.3.10_93f24f53bc1d92516efca71355c649dc:
     resolution: {integrity: sha512-V6qDLY6oECCbPyu7alWWOAhSBI4+SAuT6XW/zEQbelkwuUOiGO1ax67rTXOmZ59A2AaV1gqQFxDh8AcbvwO5XQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       framer-motion: 3.x || 4.x || 5.x || 6.x
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/checkbox': 1.7.1_spze6u54dwjfc3x4u4jvlrsj3q
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/checkbox': 1.7.1_93f24f53bc1d92516efca71355c649dc
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/system/1.12.1_sivilwsx4nsguv2gln4xbmg6qu:
+  /@chakra-ui/system/1.12.1_922a85da57e3646a57465b7970b0de85:
     resolution: {integrity: sha512-Rp09/rMuPA3hF38OJxeQciGO9N0Ie1GxwHRAw1AFA/TY3fVyK9pNI5oN+J/1cAxq7v9yKdIr1YfnruJTI9xfEg==}
     peerDependencies:
       '@emotion/react': ^11.0.0
@@ -2953,24 +2948,24 @@ packages:
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
       '@chakra-ui/styled-system': 1.19.0
       '@chakra-ui/utils': 1.10.4
-      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
-      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
+      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
+      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
       react: 17.0.2
       react-fast-compare: 3.2.0
     dev: false
 
-  /@chakra-ui/table/1.3.6_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/table/1.3.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-7agZAgAeDFKviqStvixqnLAH54+setzhx67EztioZTr5Xu+6hQ4rotfJbu8L4i587pcbNg98kCEXEkidjw0XRQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/tabs/1.6.10_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/tabs/1.6.10_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-ClOOHT3Wnf3l9X4F2S6ysPsHMDgKSTgkXpB9Qe0odwpT49ZXNjSAYYaXzO16l+Eq/m2u1HzLkXVsL42HIeOiNQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -2980,31 +2975,31 @@ packages:
       '@chakra-ui/descendant': 2.1.3_react@17.0.2
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/tag/1.2.7_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/tag/1.2.7_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-RKrKOol4i/CnpFfo3T9LMm1abaqM+5Bs0soQLbo1iJBbBACY09sWXrQYvveQ2GYzU/OrAUloHqqmKjyVGOlNtg==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/icon': 2.0.5_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/icon': 2.0.5_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
 
-  /@chakra-ui/textarea/1.2.11_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/textarea/1.2.11_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-RDWbMyC87/AFRX98EnVum5eig/7hhcvS1BrqW5lvmTgrpr7KVr80Dfa8hUj58Iq37Z7AqZijDPkBn/zg7bPdIg==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/form-control': 1.6.0_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/form-control': 1.6.0_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -3014,7 +3009,7 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.6.0
       '@types/tinycolor2': 1.4.2
       tinycolor2: 1.4.2
@@ -3025,7 +3020,7 @@ packages:
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       '@ctrl/tinycolor': 3.4.1
     dev: false
@@ -3036,12 +3031,12 @@ packages:
       '@chakra-ui/system': '>=1.0.0'
     dependencies:
       '@chakra-ui/anatomy': 1.3.0_@chakra-ui+system@1.12.1
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/theme-tools': 1.3.6_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.10.4
     dev: false
 
-  /@chakra-ui/toast/1.5.9_kksxwa5vzhtxxmbf45a6r4tek4:
+  /@chakra-ui/toast/1.5.9_52a57b03b5c9e77bb025e741e8f26457:
     resolution: {integrity: sha512-rns04bGdMcG7Ijg45L+PfuEW4rCd0Ycraix4EJQhcl9RXI18G9sphmlp9feidhZAkI6Ukafq1YvyvkBfkKnIzQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -3049,20 +3044,20 @@ packages:
       react: '>=16.8.6'
       react-dom: '>=16.8.6'
     dependencies:
-      '@chakra-ui/alert': 1.3.7_5qblqjf622vzzkdskgddihcrca
-      '@chakra-ui/close-button': 1.2.7_5qblqjf622vzzkdskgddihcrca
+      '@chakra-ui/alert': 1.3.7_ec02b824bed6ab9ca8725186341c5110
+      '@chakra-ui/close-button': 1.2.7_ec02b824bed6ab9ca8725186341c5110
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/theme': 1.14.1_@chakra-ui+system@1.12.1
-      '@chakra-ui/transition': 1.4.8_3zozpsudfkjdetkprj634votgy
+      '@chakra-ui/transition': 1.4.8_framer-motion@6.2.7+react@17.0.2
       '@chakra-ui/utils': 1.10.4
-      '@reach/alert': 0.13.2_sfoxds7t5ydpegc3knd667wn6m
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      '@reach/alert': 0.13.2_react-dom@17.0.2+react@17.0.2
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@chakra-ui/tooltip/1.5.1_kksxwa5vzhtxxmbf45a6r4tek4:
+  /@chakra-ui/tooltip/1.5.1_52a57b03b5c9e77bb025e741e8f26457:
     resolution: {integrity: sha512-EUAlDdlCBt63VpEVtj/RkFjHQVN/xA9gEAumngQdi1Sp+OXPYCBM9GwSY0NwrM1RfKBnhPSH9wz7FwredJWeaw==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
@@ -3072,24 +3067,24 @@ packages:
     dependencies:
       '@chakra-ui/hooks': 1.9.1_react@17.0.2
       '@chakra-ui/popper': 2.4.3_react@17.0.2
-      '@chakra-ui/portal': 1.3.10_sfoxds7t5ydpegc3knd667wn6m
+      '@chakra-ui/portal': 1.3.10_react-dom@17.0.2+react@17.0.2
       '@chakra-ui/react-utils': 1.2.3_react@17.0.2
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
-      '@chakra-ui/visually-hidden': 1.1.6_5qblqjf622vzzkdskgddihcrca
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      '@chakra-ui/visually-hidden': 1.1.6_ec02b824bed6ab9ca8725186341c5110
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@chakra-ui/transition/1.4.8_3zozpsudfkjdetkprj634votgy:
+  /@chakra-ui/transition/1.4.8_framer-motion@6.2.7+react@17.0.2:
     resolution: {integrity: sha512-5uc8LEuCH7+0h++wqAav/EktTHOjbLDSTXQlU9fzPIlNNgyf2eXrHVN2AGMGKiMR9Z4gS7umQjZ54r0w/mZ/Fw==}
     peerDependencies:
       framer-motion: 3.x || 4.x || 5.x || 6.x
       react: '>=16.8.6'
     dependencies:
       '@chakra-ui/utils': 1.10.4
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
     dev: false
 
@@ -3111,13 +3106,13 @@ packages:
       lodash.mergewith: 4.6.2
     dev: false
 
-  /@chakra-ui/visually-hidden/1.1.6_5qblqjf622vzzkdskgddihcrca:
+  /@chakra-ui/visually-hidden/1.1.6_ec02b824bed6ab9ca8725186341c5110:
     resolution: {integrity: sha512-Xzy5bA0UA+IyMgwJizQYSEdgz8cC/tHdmFB3CniXzmpKTSK8mJddeEBl+cGbXHBzxEUhH7xF1eaS41O+0ezWEQ==}
     peerDependencies:
       '@chakra-ui/system': '>=1.0.0'
       react: '>=16.8.6'
     dependencies:
-      '@chakra-ui/system': 1.12.1_sivilwsx4nsguv2gln4xbmg6qu
+      '@chakra-ui/system': 1.12.1_922a85da57e3646a57465b7970b0de85
       '@chakra-ui/utils': 1.10.4
       react: 17.0.2
     dev: false
@@ -3253,7 +3248,7 @@ packages:
   /@emotion/memoize/0.7.5:
     resolution: {integrity: sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==}
 
-  /@emotion/react/11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq:
+  /@emotion/react/11.7.1_a003f5d44f346f6e89b1b61bd07839ac:
     resolution: {integrity: sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3277,7 +3272,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@emotion/react/11.7.1_yse24c3tnaw3czhkbk3q2k7woy:
+  /@emotion/react/11.7.1_c489ae0b73682db164ea0ab70d2bf676:
     resolution: {integrity: sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3313,7 +3308,7 @@ packages:
   /@emotion/sheet/1.1.0:
     resolution: {integrity: sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==}
 
-  /@emotion/styled/11.6.0_antrsugujploi4ebyftn3umj4a:
+  /@emotion/styled/11.6.0_03671950d44bd6e47081c166ddd189e0:
     resolution: {integrity: sha512-mxVtVyIOTmCAkFbwIp+nCjTXJNgcz4VWkOYQro87jE2QBTydnkiYusMrRGFtzuruiGK4dDaNORk4gH049iiQuw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3330,14 +3325,14 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/babel-plugin': 11.9.2_@babel+core@7.18.6
       '@emotion/is-prop-valid': 1.1.2
-      '@emotion/react': 11.7.1_yse24c3tnaw3czhkbk3q2k7woy
+      '@emotion/react': 11.7.1_c489ae0b73682db164ea0ab70d2bf676
       '@emotion/serialize': 1.0.3
       '@emotion/utils': 1.1.0
       '@types/react': 17.0.37
       react: 17.0.2
     dev: true
 
-  /@emotion/styled/11.6.0_hunrzlunfsbetgabvhqyg3fuge:
+  /@emotion/styled/11.6.0_3d1b1cae8d2c82499801a9e1836cb431:
     resolution: {integrity: sha512-mxVtVyIOTmCAkFbwIp+nCjTXJNgcz4VWkOYQro87jE2QBTydnkiYusMrRGFtzuruiGK4dDaNORk4gH049iiQuw==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3354,7 +3349,7 @@ packages:
       '@babel/runtime': 7.17.9
       '@emotion/babel-plugin': 11.9.2_@babel+core@7.17.9
       '@emotion/is-prop-valid': 1.1.2
-      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
+      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
       '@emotion/serialize': 1.0.3
       '@emotion/utils': 1.1.0
       '@types/react': 17.0.1
@@ -3370,7 +3365,7 @@ packages:
   /@emotion/weak-memoize/0.2.5:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
 
-  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_zmjss6mecb4soo3dpdlecld3xa:
+  /@endemolshinegroup/cosmiconfig-typescript-loader/3.0.2_cb132979841079273b6378d6412c7bb8:
     resolution: {integrity: sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -3440,7 +3435,7 @@ packages:
       '@fortawesome/fontawesome-common-types': 6.1.1
     dev: false
 
-  /@fortawesome/react-fontawesome/0.2.0_nee7k2mmznvunamfg4ebivqgfa:
+  /@fortawesome/react-fontawesome/0.2.0_6909f5698ccb6b468185370814560628:
     resolution: {integrity: sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==, tarball: '@fortawesome/react-fontawesome/-/0.2.0/react-fontawesome-0.2.0.tgz'}
     peerDependencies:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6
@@ -3451,7 +3446,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@graphql-codegen/cli/2.1.1_djvxjnuhr6twjhs4e2fzcjftoy:
+  /@graphql-codegen/cli/2.1.1_1a6b74b6878fa7649e5c268b9124b376:
     resolution: {integrity: sha512-burl5HdZeaAOhe3gx/3LBNxNyboqNHSDQLlZUazm1Gu8lUdVN1trtO3P5xF7MCBm4MFTjzaAXdPT7FoYvYaWMg==}
     hasBin: true
     peerDependencies:
@@ -3466,8 +3461,8 @@ packages:
       '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.5.3
       '@graphql-tools/json-file-loader': 7.3.11_graphql@15.5.3
       '@graphql-tools/load': 7.5.10_graphql@15.5.3
-      '@graphql-tools/prisma-loader': 7.1.14_vjovirx4fdnnqhp367nfo5texu
-      '@graphql-tools/url-loader': 7.9.15_vjovirx4fdnnqhp367nfo5texu
+      '@graphql-tools/prisma-loader': 7.1.14_aa5d5446fc28dad81dfbf7da577664bd
+      '@graphql-tools/url-loader': 7.9.15_aa5d5446fc28dad81dfbf7da577664bd
       '@graphql-tools/utils': 8.6.9_graphql@15.5.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -3481,7 +3476,7 @@ packages:
       glob: 7.2.0
       globby: 11.1.0
       graphql: 15.5.3
-      graphql-config: 4.3.0_djvxjnuhr6twjhs4e2fzcjftoy
+      graphql-config: 4.3.0_1a6b74b6878fa7649e5c268b9124b376
       inquirer: 7.3.3
       is-glob: 4.0.3
       json-to-pretty-yaml: 1.2.2
@@ -3535,7 +3530,7 @@ packages:
       tslib: 2.3.1
     dev: true
 
-  /@graphql-codegen/typescript-generic-sdk/2.1.3_6aqbksp2bzfqiuihkviabctooa:
+  /@graphql-codegen/typescript-generic-sdk/2.1.3_f0201549fa0e4b0451075550008a6e70:
     resolution: {integrity: sha512-8B0JWzIs6nPr1nKytech6Zq7lQqDlkVpIJHul7ji5QUS5dBjmFXg+vddG7dBcy350ntleKgq3imqZGSjWOZ1vw==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
@@ -3859,12 +3854,12 @@ packages:
       tslib: 2.3.1
     dev: true
 
-  /@graphql-tools/prisma-loader/7.1.14_vjovirx4fdnnqhp367nfo5texu:
+  /@graphql-tools/prisma-loader/7.1.14_aa5d5446fc28dad81dfbf7da577664bd:
     resolution: {integrity: sha512-eHYyw34EgXNxEf0xfpJ2O2RUMdVgGAq6UAanpTIgq5jBr8FWlBPfSADV/JpNDKdziNUGBl6Q3EoJXRisW/+UBA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-tools/url-loader': 7.9.15_vjovirx4fdnnqhp367nfo5texu
+      '@graphql-tools/url-loader': 7.9.15_aa5d5446fc28dad81dfbf7da577664bd
       '@graphql-tools/utils': 8.6.9_graphql@15.5.3
       '@types/js-yaml': 4.0.5
       '@types/json-stable-stringify': 1.0.34
@@ -3931,7 +3926,7 @@ packages:
       value-or-promise: 1.0.11
     dev: true
 
-  /@graphql-tools/url-loader/7.9.15_k6hsblzcipvhsqz33tngzpae5m:
+  /@graphql-tools/url-loader/7.9.15_578f20af2243ea79433bdcda6cbc04eb:
     resolution: {integrity: sha512-WwYtsy4nEUYPOKgrCjhOdLNebnbLS4Rqv++TRlV3Pd4Zi+qVNsEQVwlfVEQZK4qelEhWNqessZILu/jx5B6Vng==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -3959,7 +3954,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-tools/url-loader/7.9.15_vjovirx4fdnnqhp367nfo5texu:
+  /@graphql-tools/url-loader/7.9.15_aa5d5446fc28dad81dfbf7da577664bd:
     resolution: {integrity: sha512-WwYtsy4nEUYPOKgrCjhOdLNebnbLS4Rqv++TRlV3Pd4Zi+qVNsEQVwlfVEQZK4qelEhWNqessZILu/jx5B6Vng==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -4054,7 +4049,7 @@ packages:
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
     dev: true
 
-  /@ifixit/react-components/0.3.0_4bx7e3vbdhtpqjh6nevglqbelu:
+  /@ifixit/react-components/0.3.0_e06ff26ea119e6f824fe692a65c0245d:
     resolution: {integrity: sha512-+UrZXGiPLjtcsr7FiYhO/ZPSiP+aF3pzKeWHY0O8cQ1c/f0FdBRAJsmdJJPovccG6emnD+kc4y+ThWH9ietuGA==}
     peerDependencies:
       '@chakra-ui/react': '>=1.4.2'
@@ -4063,13 +4058,13 @@ packages:
       framer-motion: '>=4'
       react: '>=16'
     dependencies:
-      '@chakra-ui/react': 1.8.8_mt4gt3o63p32tfns77ndyyxdka
+      '@chakra-ui/react': 1.8.8_64f869eddedbf7a995b2ffda3c62e350
       '@chakra-ui/react-utils': 1.1.1_react@17.0.2
       '@chakra-ui/theme-tools': 1.1.5_@chakra-ui+system@1.12.1
       '@chakra-ui/utils': 1.6.0
-      '@emotion/react': 11.7.1_uab7lvcpgrxw5cnrwyn5a6bzvq
-      '@emotion/styled': 11.6.0_hunrzlunfsbetgabvhqyg3fuge
-      framer-motion: 6.2.7_sfoxds7t5ydpegc3knd667wn6m
+      '@emotion/react': 11.7.1_a003f5d44f346f6e89b1b61bd07839ac
+      '@emotion/styled': 11.6.0_3d1b1cae8d2c82499801a9e1836cb431
+      framer-motion: 6.2.7_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
     transitivePeerDependencies:
       - '@chakra-ui/system'
@@ -4605,21 +4600,21 @@ packages:
     resolution: {integrity: sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==}
     dev: false
 
-  /@reach/alert/0.13.2_sfoxds7t5ydpegc3knd667wn6m:
+  /@reach/alert/0.13.2_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-LDz83AXCrClyq/MWe+0vaZfHp1Ytqn+kgL5VxG7rirUvmluWaj/snxzfNPWn0Ma4K2YENmXXRC/iHt5X95SqIg==}
     peerDependencies:
       react: ^16.8.0 || 17.x
       react-dom: ^16.8.0 || 17.x
     dependencies:
-      '@reach/utils': 0.13.2_sfoxds7t5ydpegc3knd667wn6m
-      '@reach/visually-hidden': 0.13.2_sfoxds7t5ydpegc3knd667wn6m
+      '@reach/utils': 0.13.2_react-dom@17.0.2+react@17.0.2
+      '@reach/visually-hidden': 0.13.2_react-dom@17.0.2+react@17.0.2
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       tslib: 2.4.0
     dev: false
 
-  /@reach/utils/0.13.2_sfoxds7t5ydpegc3knd667wn6m:
+  /@reach/utils/0.13.2_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-3ir6cN60zvUrwjOJu7C6jec/samqAeyAB12ZADK+qjnmQPdzSYldrFWwDVV5H0WkhbYXR3uh+eImu13hCetNPQ==}
     peerDependencies:
       react: ^16.8.0 || 17.x
@@ -4632,7 +4627,7 @@ packages:
       warning: 4.0.3
     dev: false
 
-  /@reach/visually-hidden/0.13.2_sfoxds7t5ydpegc3knd667wn6m:
+  /@reach/visually-hidden/0.13.2_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-sPZwNS0/duOuG0mYwE5DmgEAzW9VhgU3aIt1+mrfT/xiT9Cdncqke+kRBQgU708q/Ttm9tWsoHni03nn/SuPTQ==}
     peerDependencies:
       react: ^16.8.0 || 17.x
@@ -4723,7 +4718,7 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@sentry/nextjs/7.8.1_daclytgsfcivq2b62vwydcy3uy:
+  /@sentry/nextjs/7.8.1_1804bc4cd2289158683ed56d818b1ba6:
     resolution: {integrity: sha512-YpDSbWXx/r0yasm9PEtrhECdrl1QYHOWtuyOZShIpxHZ+YcNmAUXhYp75fmxs5UU3+KOYT4jpTnzAtfQg8hCEw==}
     engines: {node: '>=8'}
     peerDependencies:
@@ -4743,7 +4738,7 @@ packages:
       '@sentry/types': 7.8.1
       '@sentry/utils': 7.8.1
       '@sentry/webpack-plugin': 1.19.0
-      next: 12.2.3_6nyponiwjib2clhkbtejle6l5y
+      next: 12.2.3_f370f735164a03a12cea0cc89593cbee
       react: 17.0.2
       tslib: 1.14.1
       webpack: 5.73.0
@@ -4772,7 +4767,7 @@ packages:
       '@sentry/types': 7.8.1
       '@sentry/utils': 7.8.1
       '@sentry/webpack-plugin': 1.19.0
-      next: 12.2.3_apvyc6hsquzbx56wwdowrbgkzm
+      next: 12.2.3_03eb8178f285321bf7d6b0dd6884cacb
       react: 17.0.2
       tslib: 1.14.1
     transitivePeerDependencies:
@@ -5060,7 +5055,7 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/12.1.2_sfoxds7t5ydpegc3knd667wn6m:
+  /@testing-library/react/12.1.2_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -5073,7 +5068,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: true
 
-  /@testing-library/user-event/13.5.0_zbypwrtvpjrvnfnw5wxfpjfsci:
+  /@testing-library/user-event/13.5.0_@testing-library+dom@7.21.4:
     resolution: {integrity: sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==}
     engines: {node: '>=10', npm: '>=6'}
     peerDependencies:
@@ -5370,7 +5365,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin/4.14.2_fcgtupz6z6gal3tayzjah7yzi4:
+  /@typescript-eslint/eslint-plugin/4.14.2_288d3a3f3ecf8c05ee60c65203ff1947:
     resolution: {integrity: sha512-uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5381,8 +5376,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.14.2_p2gelkc4nklso6eukbqqqhjfvq
-      '@typescript-eslint/parser': 4.14.2_p2gelkc4nklso6eukbqqqhjfvq
+      '@typescript-eslint/experimental-utils': 4.14.2_eslint@7.23.0+typescript@4.7.4
+      '@typescript-eslint/parser': 4.14.2_eslint@7.23.0+typescript@4.7.4
       '@typescript-eslint/scope-manager': 4.14.2
       debug: 4.3.4
       eslint: 7.23.0
@@ -5396,7 +5391,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.14.2_p2gelkc4nklso6eukbqqqhjfvq:
+  /@typescript-eslint/experimental-utils/4.14.2_eslint@7.23.0+typescript@4.7.4:
     resolution: {integrity: sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5414,7 +5409,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.14.2_p2gelkc4nklso6eukbqqqhjfvq:
+  /@typescript-eslint/parser/4.14.2_eslint@7.23.0+typescript@4.7.4:
     resolution: {integrity: sha512-ipqSP6EuUsMu3E10EZIApOJgWSpcNXeKZaFeNKQyzqxnQl8eQCbV+TSNsl+s2GViX2d18m1rq3CWgnpOxDPgHg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5434,7 +5429,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_p2gelkc4nklso6eukbqqqhjfvq:
+  /@typescript-eslint/parser/4.33.0_eslint@7.23.0+typescript@4.7.4:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5634,7 +5629,7 @@ packages:
     resolution: {integrity: sha512-xYKDNuPR36/fUK+jmhM+oauBmbdUAfuJKnDjg3/7NbN+Pj03TX7e94LXnzkwGgAR+U/HWoMqM5UPTuGIYfIx9g==}
     dev: false
 
-  /@xstate/react/1.5.1_6fu6ht62pwx66poirfopbfx2xy:
+  /@xstate/react/1.5.1_f169e3cfda7dafef3dc8895cf096fabe:
     resolution: {integrity: sha512-DJHDqDlZHus08X98uMJw4KR17FRWBXLHMQ02YRxx0DMm5VLn75VwGyt4tXdlNZHQWjyk++C5c9Ichq3PdmM3og==}
     peerDependencies:
       '@xstate/fsm': ^1.0.0
@@ -5648,7 +5643,7 @@ packages:
     dependencies:
       '@xstate/fsm': 1.6.1
       react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by
+      use-isomorphic-layout-effect: 1.1.2_@types+react@17.0.1+react@17.0.2
       use-subscription: 1.7.0_react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -7606,7 +7601,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next/11.0.1_2aajvzqgegcbyxur2qkkmxgclm:
+  /eslint-config-next/11.0.1_d0009ae60621841c5e91d414a65cc25b:
     resolution: {integrity: sha512-yy63K4Bmy8amE6VMb26CZK6G99cfVX3JaMTvuvmq/LL8/b8vKHcauUZREBTAQ+2DrIvlH4YrFXrkQ1vpYDL9Eg==}
     peerDependencies:
       eslint: ^7.23.0
@@ -7618,15 +7613,15 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 11.0.1
       '@rushstack/eslint-patch': 1.1.3
-      '@typescript-eslint/parser': 4.33.0_p2gelkc4nklso6eukbqqqhjfvq
+      '@typescript-eslint/parser': 4.33.0_eslint@7.23.0+typescript@4.7.4
       eslint: 7.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_t2itnji3x3bozhvq347mxfuviu
-      eslint-plugin-import: 2.26.0_bp34g5zwst6t7i55fhmw4h4ufq
+      eslint-import-resolver-typescript: 2.7.1_9e9136a51bbec2ec9eb0df3ecb969545
+      eslint-plugin-import: 2.26.0_0bf7c3773694fd3fa3bd29d96e1f942c
       eslint-plugin-jsx-a11y: 6.5.1_eslint@7.23.0
       eslint-plugin-react: 7.29.4_eslint@7.23.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.23.0
-      next: 12.2.3_6nyponiwjib2clhkbtejle6l5y
+      next: 12.2.3_f370f735164a03a12cea0cc89593cbee
       typescript: 4.7.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -7651,7 +7646,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/2.7.1_t2itnji3x3bozhvq347mxfuviu:
+  /eslint-import-resolver-typescript/2.7.1_9e9136a51bbec2ec9eb0df3ecb969545:
     resolution: {integrity: sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7660,7 +7655,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 7.23.0
-      eslint-plugin-import: 2.26.0_bp34g5zwst6t7i55fhmw4h4ufq
+      eslint-plugin-import: 2.26.0_0bf7c3773694fd3fa3bd29d96e1f942c
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.0
@@ -7669,7 +7664,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3_cxs53d2pj2pwcxog434vw6hm6e:
+  /eslint-module-utils/2.7.3_15e5dd8f4f4e9f615dc6e6f95b78ecf1:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7687,10 +7682,10 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0_p2gelkc4nklso6eukbqqqhjfvq
+      '@typescript-eslint/parser': 4.33.0_eslint@7.23.0+typescript@4.7.4
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_t2itnji3x3bozhvq347mxfuviu
+      eslint-import-resolver-typescript: 2.7.1_9e9136a51bbec2ec9eb0df3ecb969545
       find-up: 2.1.0
     transitivePeerDependencies:
       - supports-color
@@ -7705,7 +7700,7 @@ packages:
       globals: 11.12.0
     dev: true
 
-  /eslint-plugin-import/2.26.0_bp34g5zwst6t7i55fhmw4h4ufq:
+  /eslint-plugin-import/2.26.0_0bf7c3773694fd3fa3bd29d96e1f942c:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -7715,14 +7710,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 4.33.0_p2gelkc4nklso6eukbqqqhjfvq
+      '@typescript-eslint/parser': 4.33.0_eslint@7.23.0+typescript@4.7.4
       array-includes: 3.1.4
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3_cxs53d2pj2pwcxog434vw6hm6e
+      eslint-module-utils: 2.7.3_15e5dd8f4f4e9f615dc6e6f95b78ecf1
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -8294,7 +8289,7 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
-  /framer-motion/6.2.7_sfoxds7t5ydpegc3knd667wn6m:
+  /framer-motion/6.2.7_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-RExmZCFpJ3OCakoXmZz8iW8ZI5MoaHmVadydetvTSrNaKmZ7ZC/JDQpNyw1NoDG+fchRGP86lXoiTFSQuin+Cg==}
     peerDependencies:
       react: '>=16.8 || ^17.0.0 || ^18.0.0'
@@ -8556,22 +8551,22 @@ packages:
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
 
-  /graphql-config/4.3.0_454f5u3pmwpijct4gz7tgkql2a:
+  /graphql-config/4.3.0_1a6b74b6878fa7649e5c268b9124b376:
     resolution: {integrity: sha512-Uiu3X7+s5c056WyrvdZVz2vG1fhAipMlYmtiCU/4Z2mX79OXDr1SqIon2MprC/pExIWJfAQZCcjYDY76fPBUQg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_zmjss6mecb4soo3dpdlecld3xa
-      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.4.0
-      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.4.0
-      '@graphql-tools/load': 7.5.10_graphql@15.4.0
-      '@graphql-tools/merge': 8.2.10_graphql@15.4.0
-      '@graphql-tools/url-loader': 7.9.15_k6hsblzcipvhsqz33tngzpae5m
-      '@graphql-tools/utils': 8.6.9_graphql@15.4.0
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_cb132979841079273b6378d6412c7bb8
+      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.5.3
+      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.5.3
+      '@graphql-tools/load': 7.5.10_graphql@15.5.3
+      '@graphql-tools/merge': 8.2.10_graphql@15.5.3
+      '@graphql-tools/url-loader': 7.9.15_aa5d5446fc28dad81dfbf7da577664bd
+      '@graphql-tools/utils': 8.6.9_graphql@15.5.3
       cosmiconfig: 7.0.1
       cosmiconfig-toml-loader: 1.0.0
-      graphql: 15.4.0
+      graphql: 15.5.3
       minimatch: 4.2.1
       string-env-interpolation: 1.0.1
     transitivePeerDependencies:
@@ -8582,22 +8577,22 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-config/4.3.0_djvxjnuhr6twjhs4e2fzcjftoy:
+  /graphql-config/4.3.0_e7785ed36f659e848a7c367f332a0bd0:
     resolution: {integrity: sha512-Uiu3X7+s5c056WyrvdZVz2vG1fhAipMlYmtiCU/4Z2mX79OXDr1SqIon2MprC/pExIWJfAQZCcjYDY76fPBUQg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
       graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_zmjss6mecb4soo3dpdlecld3xa
-      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.5.3
-      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.5.3
-      '@graphql-tools/load': 7.5.10_graphql@15.5.3
-      '@graphql-tools/merge': 8.2.10_graphql@15.5.3
-      '@graphql-tools/url-loader': 7.9.15_vjovirx4fdnnqhp367nfo5texu
-      '@graphql-tools/utils': 8.6.9_graphql@15.5.3
+      '@endemolshinegroup/cosmiconfig-typescript-loader': 3.0.2_cb132979841079273b6378d6412c7bb8
+      '@graphql-tools/graphql-file-loader': 7.3.11_graphql@15.4.0
+      '@graphql-tools/json-file-loader': 7.3.11_graphql@15.4.0
+      '@graphql-tools/load': 7.5.10_graphql@15.4.0
+      '@graphql-tools/merge': 8.2.10_graphql@15.4.0
+      '@graphql-tools/url-loader': 7.9.15_578f20af2243ea79433bdcda6cbc04eb
+      '@graphql-tools/utils': 8.6.9_graphql@15.4.0
       cosmiconfig: 7.0.1
       cosmiconfig-toml-loader: 1.0.0
-      graphql: 15.5.3
+      graphql: 15.4.0
       minimatch: 4.2.1
       string-env-interpolation: 1.0.1
     transitivePeerDependencies:
@@ -8626,16 +8621,16 @@ packages:
       graphql: 15.5.3
     dev: true
 
-  /graphql-language-service-interface/2.10.2_454f5u3pmwpijct4gz7tgkql2a:
+  /graphql-language-service-interface/2.10.2_e7785ed36f659e848a7c367f332a0bd0:
     resolution: {integrity: sha512-RKIEBPhRMWdXY3fxRs99XysTDnEgAvNbu8ov/5iOlnkZsWQNzitjtd0O0l1CutQOQt3iXoHde7w8uhCnKL4tcg==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       graphql: 15.4.0
-      graphql-config: 4.3.0_454f5u3pmwpijct4gz7tgkql2a
-      graphql-language-service-parser: 1.10.4_454f5u3pmwpijct4gz7tgkql2a
-      graphql-language-service-types: 1.8.7_454f5u3pmwpijct4gz7tgkql2a
-      graphql-language-service-utils: 2.7.1_454f5u3pmwpijct4gz7tgkql2a
+      graphql-config: 4.3.0_e7785ed36f659e848a7c367f332a0bd0
+      graphql-language-service-parser: 1.10.4_e7785ed36f659e848a7c367f332a0bd0
+      graphql-language-service-types: 1.8.7_e7785ed36f659e848a7c367f332a0bd0
+      graphql-language-service-utils: 2.7.1_e7785ed36f659e848a7c367f332a0bd0
       vscode-languageserver-types: 3.17.2
     transitivePeerDependencies:
       - '@types/node'
@@ -8645,13 +8640,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-language-service-parser/1.10.4_454f5u3pmwpijct4gz7tgkql2a:
+  /graphql-language-service-parser/1.10.4_e7785ed36f659e848a7c367f332a0bd0:
     resolution: {integrity: sha512-duDE+0aeKLFVrb9Kf28U84ZEHhHcvTjWIT6dJbIAQJWBaDoht0D4BK9EIhd94I3DtKRc1JCJb2+70y1lvP/hiA==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       graphql: 15.4.0
-      graphql-language-service-types: 1.8.7_454f5u3pmwpijct4gz7tgkql2a
+      graphql-language-service-types: 1.8.7_e7785ed36f659e848a7c367f332a0bd0
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -8660,13 +8655,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-language-service-types/1.8.7_454f5u3pmwpijct4gz7tgkql2a:
+  /graphql-language-service-types/1.8.7_e7785ed36f659e848a7c367f332a0bd0:
     resolution: {integrity: sha512-LP/Mx0nFBshYEyD0Ny6EVGfacJAGVx+qXtlJP4hLzUdBNOGimfDNtMVIdZANBXHXcM41MDgMHTnyEx2g6/Ttbw==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       graphql: 15.4.0
-      graphql-config: 4.3.0_454f5u3pmwpijct4gz7tgkql2a
+      graphql-config: 4.3.0_e7785ed36f659e848a7c367f332a0bd0
       vscode-languageserver-types: 3.17.2
     transitivePeerDependencies:
       - '@types/node'
@@ -8676,13 +8671,13 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-language-service-utils/2.5.1_454f5u3pmwpijct4gz7tgkql2a:
+  /graphql-language-service-utils/2.5.1_e7785ed36f659e848a7c367f332a0bd0:
     resolution: {integrity: sha512-Lzz723cYrYlVN4WVzIyFGg3ogoe+QYAIBfdtDboiIILoy0FTmqbyC2TOErqbmWKqO4NK9xDA95cSRFbWiHYj0g==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
     dependencies:
       graphql: 15.4.0
-      graphql-language-service-types: 1.8.7_454f5u3pmwpijct4gz7tgkql2a
+      graphql-language-service-types: 1.8.7_e7785ed36f659e848a7c367f332a0bd0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@types/node'
@@ -8692,14 +8687,14 @@ packages:
       - utf-8-validate
     dev: true
 
-  /graphql-language-service-utils/2.7.1_454f5u3pmwpijct4gz7tgkql2a:
+  /graphql-language-service-utils/2.7.1_e7785ed36f659e848a7c367f332a0bd0:
     resolution: {integrity: sha512-Wci5MbrQj+6d7rfvbORrA9uDlfMysBWYaG49ST5TKylNaXYFf3ixFOa74iM1KtM9eidosUbI3E1JlWi0JaidJA==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
     dependencies:
       '@types/json-schema': 7.0.9
       graphql: 15.4.0
-      graphql-language-service-types: 1.8.7_454f5u3pmwpijct4gz7tgkql2a
+      graphql-language-service-types: 1.8.7_e7785ed36f659e848a7c367f332a0bd0
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@types/node'
@@ -8759,7 +8754,7 @@ packages:
     resolution: {integrity: sha512-sM+jXaO5KinTui6lbK/7b7H/Knj9BpjGxZ+Ki35v7YbUJxxdBCUqNM0h3CRVU1ZF9t5lNiBzvBCSYPvIwxPOQA==}
     engines: {node: '>= 10.x'}
 
-  /graphqurl/1.0.1_vgajgqmf7vdik5dur3uiriunbe:
+  /graphqurl/1.0.1_a980934185fd468574748ee888a28d09:
     resolution: {integrity: sha512-97Chda90OBIHCpH6iQHNYc9qTTADN0LOFbiMcRws3V5SottC/0yTDIQDgBzncZYVCkttyjAnT6YmVuNId7ymQA==}
     engines: {node: '>=8.0.0'}
     hasBin: true
@@ -8771,8 +8766,8 @@ packages:
       cli-ux: 4.9.3
       express: 4.16.3
       graphql: 15.4.0
-      graphql-language-service-interface: 2.10.2_454f5u3pmwpijct4gz7tgkql2a
-      graphql-language-service-utils: 2.5.1_454f5u3pmwpijct4gz7tgkql2a
+      graphql-language-service-interface: 2.10.2_e7785ed36f659e848a7c367f332a0bd0
+      graphql-language-service-utils: 2.5.1_e7785ed36f659e848a7c367f332a0bd0
       isomorphic-fetch: 3.0.0
       isomorphic-ws: 4.0.1_ws@7.4.2
       open: 7.3.1
@@ -10737,7 +10732,7 @@ packages:
       escalade: 3.1.1
     dev: true
 
-  /next/12.2.3_6nyponiwjib2clhkbtejle6l5y:
+  /next/12.2.3_03eb8178f285321bf7d6b0dd6884cacb:
     resolution: {integrity: sha512-TA0tmSA6Dk6S6kfvCNbF7CWYW8468gZUxr/3/30z4KvAQbXnl2ASYZElVe7q/hBW/1F1ee0tSBlHa4/sn+ZIBw==}
     engines: {node: '>=12.22.0'}
     hasBin: true
@@ -10761,7 +10756,7 @@ packages:
       postcss: 8.4.14
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      styled-jsx: 5.0.2_cun6ua7ys3vo4t2323flhwfg7m
+      styled-jsx: 5.0.2_@babel+core@7.18.6+react@17.0.2
       use-sync-external-store: 1.2.0_react@17.0.2
     optionalDependencies:
       '@next/swc-android-arm-eabi': 12.2.3
@@ -10781,7 +10776,7 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
-  /next/12.2.3_apvyc6hsquzbx56wwdowrbgkzm:
+  /next/12.2.3_f370f735164a03a12cea0cc89593cbee:
     resolution: {integrity: sha512-TA0tmSA6Dk6S6kfvCNbF7CWYW8468gZUxr/3/30z4KvAQbXnl2ASYZElVe7q/hBW/1F1ee0tSBlHa4/sn+ZIBw==}
     engines: {node: '>=12.22.0'}
     hasBin: true
@@ -10805,7 +10800,7 @@ packages:
       postcss: 8.4.14
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      styled-jsx: 5.0.2_on4pwhjuscz2cucak6hkhs726q
+      styled-jsx: 5.0.2_@babel+core@7.17.9+react@17.0.2
       use-sync-external-store: 1.2.0_react@17.0.2
     optionalDependencies:
       '@next/swc-android-arm-eabi': 12.2.3
@@ -10836,7 +10831,7 @@ packages:
       next: '>= 6.0.0'
       react: '>= 16.0.0'
     dependencies:
-      next: 12.2.3_6nyponiwjib2clhkbtejle6l5y
+      next: 12.2.3_f370f735164a03a12cea0cc89593cbee
       nprogress: 0.2.0
       prop-types: 15.8.1
       react: 17.0.2
@@ -11614,7 +11609,7 @@ packages:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}
     dev: false
 
-  /react-focus-lock/2.5.2_wk7fohhuxwcjfgq2kdoh4ny7by:
+  /react-focus-lock/2.5.2_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -11624,8 +11619,8 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
       react-clientside-effect: 1.2.5_react@17.0.2
-      use-callback-ref: 1.3.0_wk7fohhuxwcjfgq2kdoh4ny7by
-      use-sidecar: 1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by
+      use-callback-ref: 1.3.0_@types+react@17.0.1+react@17.0.2
+      use-sidecar: 1.1.2_@types+react@17.0.1+react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -11638,7 +11633,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-instantsearch-hooks-server/6.32.1_hiec5pcpgig2m3qcu64y3isqke_mqkkssxuzkavfps52i4oqes75i:
+  /react-instantsearch-hooks-server/6.32.1_6414a94af4ca8152be5dd238e8125fea:
     resolution: {integrity: sha512-B4lQO5WYFzof7mjl6YB1ri5sUEu0Aai4/mIzl7KXKPEUqpyfrbf5oJt+kKQYsvAjxAiTP2t7iv0QR4te6qouPw==}
     peerDependencies:
       algoliasearch: '>= 3.1 < 5'
@@ -11650,11 +11645,10 @@ packages:
       instantsearch.js: 4.44.0_algoliasearch@4.13.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-instantsearch-hooks: 6.32.1_w7dlztxainugwieacvqvd4x65u
+      react-instantsearch-hooks: 6.32.1_b7c6bccee043686b2080156151f2feed
     dev: false
-    patched: true
 
-  /react-instantsearch-hooks-web/6.32.1_mqkkssxuzkavfps52i4oqes75i:
+  /react-instantsearch-hooks-web/6.32.1_6414a94af4ca8152be5dd238e8125fea:
     resolution: {integrity: sha512-fyMg99MOblOouKqLoaFamBv142/3ZybZi4gYMKA2EdsACsu74mxB9qDZKMfdz2p5aP7RB+lFuOYLSPWiF/emmQ==}
     peerDependencies:
       algoliasearch: '>= 3.1 < 5'
@@ -11666,10 +11660,10 @@ packages:
       instantsearch.js: 4.44.0_algoliasearch@4.13.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-instantsearch-hooks: 6.32.1_w7dlztxainugwieacvqvd4x65u
+      react-instantsearch-hooks: 6.32.1_b7c6bccee043686b2080156151f2feed
     dev: false
 
-  /react-instantsearch-hooks/6.32.1_w7dlztxainugwieacvqvd4x65u:
+  /react-instantsearch-hooks/6.32.1_b7c6bccee043686b2080156151f2feed:
     resolution: {integrity: sha512-yKxxY7Ps2y/iuS1viOAkI3Rf8vQ7C+piEMZgXAnWNunY2mK3JfhMl/KsAyNYLdC5C8gGszhYpps+UmPvqZEa0Q==}
     peerDependencies:
       algoliasearch: '>= 3.1 < 5'
@@ -11694,7 +11688,7 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react-query/3.34.19_sfoxds7t5ydpegc3knd667wn6m:
+  /react-query/3.34.19_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-JO0Ymi58WKmvnhgg6bGIrYIeKb64KsKaPWo8JcGnmK2jJxAs2XmMBzlP75ZepSU7CHzcsWtIIyhMrLbX3pb/3w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -11713,7 +11707,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /react-remove-scroll-bar/2.3.0_wk7fohhuxwcjfgq2kdoh4ny7by:
+  /react-remove-scroll-bar/2.3.0_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-v2vf8kgrRph5FQeLVZjSOmM0g3ZiBxwMk98VXhsiJDSPeRDUaXJrzYDk2Hhoe6qLggrhWtAXJZVxUwXmRXa93g==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -11725,11 +11719,11 @@ packages:
     dependencies:
       '@types/react': 17.0.1
       react: 17.0.2
-      react-style-singleton: 2.2.0_wk7fohhuxwcjfgq2kdoh4ny7by
+      react-style-singleton: 2.2.0_@types+react@17.0.1+react@17.0.2
       tslib: 2.4.0
     dev: false
 
-  /react-remove-scroll/2.4.1_wk7fohhuxwcjfgq2kdoh4ny7by:
+  /react-remove-scroll/2.4.1_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-K7XZySEzOHMTq7dDwcHsZA6Y7/1uX5RsWhRXVYv8rdh+y9Qz2nMwl9RX/Mwnj/j7JstCGmxyfyC0zbVGXYh3mA==}
     engines: {node: '>=8.5.0'}
     peerDependencies:
@@ -11741,14 +11735,14 @@ packages:
     dependencies:
       '@types/react': 17.0.1
       react: 17.0.2
-      react-remove-scroll-bar: 2.3.0_wk7fohhuxwcjfgq2kdoh4ny7by
-      react-style-singleton: 2.2.0_wk7fohhuxwcjfgq2kdoh4ny7by
+      react-remove-scroll-bar: 2.3.0_@types+react@17.0.1+react@17.0.2
+      react-style-singleton: 2.2.0_@types+react@17.0.1+react@17.0.2
       tslib: 1.14.1
-      use-callback-ref: 1.3.0_wk7fohhuxwcjfgq2kdoh4ny7by
-      use-sidecar: 1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by
+      use-callback-ref: 1.3.0_@types+react@17.0.1+react@17.0.2
+      use-sidecar: 1.1.2_@types+react@17.0.1+react@17.0.2
     dev: false
 
-  /react-style-singleton/2.2.0_wk7fohhuxwcjfgq2kdoh4ny7by:
+  /react-style-singleton/2.2.0_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-nK7mN92DMYZEu3cQcAhfwE48NpzO5RpxjG4okbSqRRbfal9Pk+fG2RdQXTMp+f6all1hB9LIJSt+j7dCYrU11g==}
     engines: {node: '>=10'}
     deprecated: wrong managing of dynamic styles
@@ -12659,7 +12653,7 @@ packages:
       hey-listen: 1.0.8
       tslib: 2.4.0
 
-  /styled-jsx/5.0.2_cun6ua7ys3vo4t2323flhwfg7m:
+  /styled-jsx/5.0.2_@babel+core@7.17.9+react@17.0.2:
     resolution: {integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -12675,7 +12669,7 @@ packages:
       '@babel/core': 7.17.9
       react: 17.0.2
 
-  /styled-jsx/5.0.2_on4pwhjuscz2cucak6hkhs726q:
+  /styled-jsx/5.0.2_@babel+core@7.18.6+react@17.0.2:
     resolution: {integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -13275,7 +13269,7 @@ packages:
       querystring: 0.2.0
     dev: true
 
-  /use-callback-ref/1.3.0_wk7fohhuxwcjfgq2kdoh4ny7by:
+  /use-callback-ref/1.3.0_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -13290,7 +13284,7 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /use-isomorphic-layout-effect/1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by:
+  /use-isomorphic-layout-effect/1.1.2_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -13303,7 +13297,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /use-sidecar/1.1.2_wk7fohhuxwcjfgq2kdoh4ny7by:
+  /use-sidecar/1.1.2_@types+react@17.0.1+react@17.0.2:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -13845,3 +13839,8 @@ packages:
   /zod/3.18.0:
     resolution: {integrity: sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==}
     dev: false
+
+patchedDependencies:
+  react-instantsearch-hooks-server@6.32.1:
+    hash: hiec5pcpgig2m3qcu64y3isqke
+    path: patches/react-instantsearch-hooks-server@6.32.1.patch


### PR DESCRIPTION
closes #726 

This PR adds the side zoom functionality on product page.

<img width="1277" alt="Screenshot 2022-09-29 at 15 48 56" src="https://user-images.githubusercontent.com/7805759/193053234-0bfb60b4-c486-477f-ab66-e8bab6d02c66.png">

### Desktop/large screens 
Just hover with the mouse over any image in the gallery and a zoom side panel will appear.

### Mobile/small screens
We reverted #196 since now it is possible to handle pinch-zooming on modals - while still avoiding background scroll - exploiting the `allowPinchZoom ` flag of the [Chakra Modal component](https://chakra-ui.com/docs/components/modal/props).
So on mobile it is now possible to zoom on the gallery image by simply pinch zooming on the page.
Consider this as a base implementation for mobile. If then we want to add a more complex behaviour for mobile (click to fullscreen) we can discuss and integrate in a separate PR

### QA

1. Open Vercel preview
2. Verify that the zoom behaviour is working correctly on desktop
3. Verify that on mobile it is possible to pinch zoom