### PR TITLE
feat: middleware to no-index non ifixit.com pages

### DIFF
--- a/frontend/config/constants.ts
+++ b/frontend/config/constants.ts
@@ -1,4 +1,3 @@
 export const PRODUCT_LIST_PAGE_PARAM = 'p';
 export const PRODUCT_LIST_QUERY_PARAM = 'q';
 export const DEFAULT_ANIMATION_DURATION_MS = 300;
-export const PROD_HOSTNAME = 'www.ifixit.com';

--- a/frontend/config/constants.ts
+++ b/frontend/config/constants.ts
@@ -1,3 +1,4 @@
 export const PRODUCT_LIST_PAGE_PARAM = 'p';
 export const PRODUCT_LIST_QUERY_PARAM = 'q';
 export const DEFAULT_ANIMATION_DURATION_MS = 300;
+export const PROD_HOSTNAME = 'www.ifixit.com';

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,11 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { PROD_HOSTNAME } from '@config/constants';
 
 export function middleware(request: NextRequest) {
-   const init =
-      request.nextUrl.hostname === PROD_HOSTNAME
-         ? { headers: [['X-Robots-Tag', 'noindex, nofollow']] }
-         : undefined;
-   return NextResponse.next(init);
+   return NextResponse.next();
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { PROD_HOSTNAME } from '@config/constants';
+
+export function middleware(request: NextRequest) {
+   const init =
+      request.nextUrl.hostname === PROD_HOSTNAME
+         ? { headers: [['X-Robots-Tag', 'noindex, nofollow']] }
+         : undefined;
+   return NextResponse.next(init);
+}


### PR DESCRIPTION
We only want to index ifixit.com urls, not vercel.app urls. This will no-index all pages that are not hosted on ifixit.com.
