### PR TITLE
Link reviews count to reviews section

### DIFF
--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -323,6 +323,7 @@ function CrossSellItem({
          _focus={{
             boxShadow: 'outline',
          }}
+         cursor="pointer"
       >
          <Flex
             direction={{

--- a/frontend/templates/product/sections/ProductSection/ProductRating.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductRating.tsx
@@ -1,4 +1,4 @@
-import { Box, HStack, Text } from '@chakra-ui/react';
+import { Box, HStack, Link, Text } from '@chakra-ui/react';
 import { Rating } from '@components/ui';
 import { shouldShowProductRating } from '@ifixit/helpers';
 import { Product } from '@models/product';
@@ -25,7 +25,10 @@ export function ProductRating({ product }: ProductRatingProps) {
          <Rating value={reviews.rating} />
          <Text color="gray.600">{reviews.rating}</Text>
          <Box w="1px" bg="gray.300"></Box>
-         <Text color="gray.600">{reviews.reviewsCount} reviews</Text>
+
+         <Link href="#reviews" color="gray.600">
+            {reviews.reviewsCount} reviews
+         </Link>
       </HStack>
    );
 }

--- a/frontend/templates/product/sections/ReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ReviewsSection/index.tsx
@@ -81,7 +81,13 @@ export function ReviewsSection({
    }
 
    return (
-      <Box bg="white" px={{ base: 5, sm: 0 }} py="16" fontSize="sm">
+      <Box
+         id="reviews"
+         bg="white"
+         px={{ base: 5, sm: 0 }}
+         py="16"
+         fontSize="sm"
+      >
          <PageContentWrapper>
             <Heading
                as="h2"

--- a/frontend/test/cypress/support/index.ts
+++ b/frontend/test/cypress/support/index.ts
@@ -18,3 +18,11 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.on('window:before:load', (win) => {
+   const htmlNode = win.document.querySelector('html');
+   if (htmlNode) {
+      // Cypress assertions on scroll break when the `scroll-behavior` css property is set to `smooth`.
+      htmlNode.style.scrollBehavior = 'inherit';
+   }
+});

--- a/packages/ui/theme/styles.ts
+++ b/packages/ui/theme/styles.ts
@@ -2,6 +2,9 @@ import { ThemeOverride } from '@chakra-ui/react';
 
 export const styles: ThemeOverride['styles'] = {
    global: {
+      html: {
+         scrollBehavior: 'smooth',
+      },
       body: {
          backgroundColor: 'blueGray.50',
       },


### PR DESCRIPTION
closes #727 

## QA

1. Visit Vercel preview
2. Go to a [product page](https://react-commerce-git-link-reviews-count-to-reviews-section-ifixit.vercel.app/Products/pro-tech-toolkit)
3. Click on the reviews count (under product title) and verify that the page scrolls to the reviews section