### PR TITLE
Noindex dev domains via middleware

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -1,8 +1,7 @@
-import { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import { GetServerSideProps } from 'next';
 import { logAsync } from '@ifixit/helpers';
 import { setSentryPageContext } from '@ifixit/sentry';
 import * as Sentry from '@sentry/nextjs';
-import { PROD_HOSTNAME } from '@config/constants';
 
 export function serverSidePropsWrapper<T>(
    getServerSidePropsInternal: GetServerSideProps<T>
@@ -23,13 +22,4 @@ export function serverSidePropsWrapper<T>(
          throw err;
       });
    };
-}
-
-export function noindexDevDomains(
-   url: string,
-   context: GetServerSidePropsContext
-) {
-   if (new URL(url).hostname !== PROD_HOSTNAME) {
-      context.res.setHeader('X-Robots-Tag', 'noindex, nofollow');
-   }
 }

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { PROD_HOSTNAME } from '@config/constants';
+
+export function middleware(request: NextRequest) {
+   const init =
+      request.nextUrl.hostname === PROD_HOSTNAME
+         ? undefined
+         : { headers: { 'X-Robots-Tag': 'noindex, nofollow' } };
+   return NextResponse.next(init);
+}

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -4,7 +4,6 @@ import {
    WithProvidersProps,
 } from '@components/common';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
-import { noindexDevDomains } from '@helpers/next-helpers';
 import {
    destylizeDeviceItemType,
    destylizeDeviceTitle as destylizeDeviceTitle,
@@ -70,9 +69,6 @@ export const getProductListServerSideProps = ({
             'public, s-maxage=10, stale-while-revalidate=600'
          );
       }
-
-      const url = urlFromContext(context);
-      noindexDevDomains(url, context);
 
       const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
       const layoutProps: Promise<DefaultLayoutProps> =
@@ -206,7 +202,7 @@ export const getProductListServerSideProps = ({
       const appProps: AppProvidersProps = {
          algolia: {
             indexName,
-            url,
+            url: urlFromContext(context),
             apiKey: productList.algolia.apiKey,
          },
       };

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -1,9 +1,7 @@
 import { Box } from '@chakra-ui/react';
 import { PageBreadcrumb } from '@components/common';
 import { flags } from '@config/flags';
-import { noindexDevDomains } from '@helpers/next-helpers';
 import { invariant } from '@ifixit/helpers';
-import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { DefaultLayout, getLayoutServerSideProps } from '@layouts/default';
 import { findProduct } from '@models/product';
 import { GetServerSideProps } from 'next';
@@ -69,8 +67,6 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
             notFound: true,
          };
       }
-
-      noindexDevDomains(urlFromContext(context), context);
 
       const layoutProps = await getLayoutServerSideProps();
       const product = await findProduct(


### PR DESCRIPTION
This is a simpler approach to noindexing dev domains. We couldn't use it before because it caused Cypress to fail the collection scroll test. Now that this passes tests we prefer to use it.

## QA

Make sure the previews are no-indexed. (see #734)