### PR TITLE
Handle disable_when_oos metafield

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6435,6 +6435,7 @@ export type FindProductQuery = {
             warning?: Maybe<{ __typename?: 'Metafield'; value: string }>;
             specifications?: Maybe<{ __typename?: 'Metafield'; value: string }>;
             warranty?: Maybe<{ __typename?: 'Metafield'; value: string }>;
+            disableWhenOOS?: Maybe<{ __typename?: 'Metafield'; value: string }>;
             crossSell?: Maybe<{
                __typename?: 'Metafield';
                references?: Maybe<{
@@ -6670,6 +6671,9 @@ export const FindProductDocument = `
           value
         }
         warranty: metafield(namespace: "ifixit", key: "warranty") {
+          value
+        }
+        disableWhenOOS: metafield(namespace: "ifixit", key: "disable_when_oos") {
           value
         }
         crossSell: metafield(namespace: "ifixit", key: "cross_sell_ref") {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -112,6 +112,12 @@ query findProduct($handle: String) {
             warranty: metafield(namespace: "ifixit", key: "warranty") {
                value
             }
+            disableWhenOOS: metafield(
+               namespace: "ifixit"
+               key: "disable_when_oos"
+            ) {
+               value
+            }
             crossSell: metafield(namespace: "ifixit", key: "cross_sell_ref") {
                references(first: 2) {
                   nodes {

--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -1,5 +1,7 @@
 import {
    Box,
+   Circle,
+   Flex,
    HStack,
    Image,
    Img,
@@ -8,8 +10,10 @@ import {
    Text,
    VStack,
 } from '@chakra-ui/react';
+import { faImageSlash } from '@fortawesome/pro-duotone-svg-icons';
 import type { Product } from '@models/product';
 import * as React from 'react';
+import { FaIcon } from '@ifixit/icons';
 
 export type ProductOptionsProps = {
    product: Product;
@@ -91,6 +95,7 @@ export function ProductOptions({
                            return (
                               <ProductOptionValue
                                  key={value}
+                                 disabled={variant == null}
                                  isActive={variant?.id === selected}
                                  label={value}
                                  image={variant?.image}
@@ -151,6 +156,7 @@ type ProductOptionProps = {
    label: string;
    image?: Image | null;
    isActive?: boolean;
+   disabled?: boolean;
    onClick?: () => void;
 };
 
@@ -166,6 +172,7 @@ function ProductOptionValue({
    label,
    image,
    isActive,
+   disabled,
    onClick,
 }: ProductOptionProps) {
    return (
@@ -174,13 +181,13 @@ function ProductOptionValue({
          borderWidth={isActive ? 2 : 1}
          borderColor={isActive ? 'brand.500' : 'gray.200'}
          borderRadius="md"
-         px={image == null ? 2 : 2.5}
-         py={image == null ? 1.5 : 2.5}
-         cursor="pointer"
+         px={2.5}
+         py={2.5}
+         cursor={disabled ? 'default' : 'pointer'}
          textAlign="center"
-         onClick={onClick}
+         onClick={disabled ? undefined : onClick}
       >
-         {image && <ProductOptionImage image={image} />}
+         <ProductOptionImage image={image} />
          <Text fontSize="13px" color="gray.800">
             {label}
          </Text>
@@ -189,10 +196,24 @@ function ProductOptionValue({
 }
 
 type ProductOptionImageProps = {
-   image: Image;
+   image?: Image | null;
 };
 
 function ProductOptionImage({ image }: ProductOptionImageProps) {
+   if (!image) {
+      return (
+         <Flex h="16" alignItems="center" justifyContent="center" mb="1">
+            <Circle bgColor="gray.200" size="14">
+               <FaIcon
+                  icon={faImageSlash}
+                  h="6"
+                  color="gray.400"
+                  transition="color 300ms"
+               />
+            </Circle>
+         </Flex>
+      );
+   }
    const ratio =
       image.width != null && image.height != null
          ? image.width / image.height

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -152,7 +152,7 @@ export function ProductSection({
                />
                <AddToCart product={product} selectedVariant={selectedVariant} />
                <div>
-                  <List spacing="2.5" fontSize="sm" mt="5">
+                  <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
                      <ListItem display="flex" alignItems="center">
                         <ListIcon
                            as={FaIcon}


### PR DESCRIPTION
closes #701 

This PR disable product variants that have `disable_when_oos = true` and `variant.availability <= 0`.
Such disabled variants are filtered out from the active variant set.
Moreover, product options that are not associated to any active variant are filtered out too, since hinting to the existence of those variants is not useful anymore.

To summarize:

- Variants with availabilities are always active
- Variants with zero availability and `disable_when_oos = false` show the `Notify me` banner
- Variants with zero availability and `disable_when_oos = true` will not be shown on the website. 
**If a product option is associated only to disabled variants or no variants at all, it will be hidden**

### QA

1. Visit Vercel preview (you can also take [this product](https://react-commerce-git-respect-disable-when-oos-ifixit.vercel.app/Products/iphone-11-screen) as a reference since it has variants with 0 availability and `disable_when_oos = true`
2. Try playing with variant availabilities and their associated `disable_when_oos` metafield
3. The summary above should always be valid

