### PR TITLE
Fix layout shift in gallery thumbnails

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -139,6 +139,7 @@ export function ProductGallery({
                         key={variantImage.id}
                         style={{
                            maxWidth: 'calc((100% - 60px) / 6)',
+                           marginRight: '12px',
                         }}
                      >
                         <ImageThumbnail

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -135,7 +135,12 @@ export function ProductGallery({
             >
                {variantImages.map((variantImage, index) => {
                   return (
-                     <SwiperSlide key={variantImage.id}>
+                     <SwiperSlide
+                        key={variantImage.id}
+                        style={{
+                           maxWidth: 'calc((100% - 60px) / 6)',
+                        }}
+                     >
                         <ImageThumbnail
                            image={variantImage}
                            active={realIndex === index}


### PR DESCRIPTION
closes #762 

The problem seems to be due to the fact that before js kicks in, thumbnails are rendered with a width equal to 100% of the column width. I've inserted some css to resize images to the same scale that will be enforced as soon as js kicks in.

### QA

1. Visit Vercel preview
2. No thumbnail induced shift should be visible