### PR TITLE
Vertical spacing among paragraphs in product description

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -207,6 +207,12 @@ export function ProductSection({
                                     my: 3,
                                     pl: 5,
                                  },
+                                 p: {
+                                    mb: 3,
+                                    _last: {
+                                       mb: 0,
+                                    },
+                                 },
                               }}
                            />
                            {selectedVariant.note && (


### PR DESCRIPTION
closes #731 

### QA

1. Visit Vercel preview
2. Verify that the new inter-paragraph spacing (12px) is present
3. Verify that last paragraph has no margin-bottom too