### PR TITLE
Sync product variant selection with url

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -16,7 +16,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
    return (
       <ServerSidePropsProvider props={pageProps}>
          <AppProviders {...pageProps.appProps}>
-            <NextNProgress />
+            <NextNProgress showOnShallow={false} />
             {getLayout(<Component {...pageProps} />, pageProps)}
          </AppProviders>
       </ServerSidePropsProvider>

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -23,8 +23,7 @@ import { ServiceValuePropositionSection } from './sections/ServiceValuePropositi
 
 export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    const { product } = useProductTemplateProps();
-   const { selectedVariant, setSelectedVariantId } =
-      useSelectedVariant(product);
+   const [selectedVariant, setSelectedVariantId] = useSelectedVariant(product);
 
    return (
       <>


### PR DESCRIPTION
closes #707 

## QA

1. Visit Vercel preview
2. Open a [product page](https://react-commerce-g76xpq4uq-ifixit.vercel.app/Products/repair-business-toolkit)
3. Select a different variant and verify that the url updates accordingly
4. Reload the page and verify that the variant is selected according to the `variant` param