### PR TITLE
Have Single Select Refinement UI Change Look Smoother

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -3,15 +3,13 @@ import { faSort } from '@fortawesome/pro-solid-svg-icons';
 import { stylizeDeviceItemType } from '@helpers/product-list-helpers';
 import { FaIcon } from '@ifixit/icons';
 import { ProductList, ProductListType } from '@models/product-list';
-import {
-   RefinementListItem,
-   RefinementListRenderState,
-} from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
+import { RefinementListRenderState } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 import NextLink from 'next/link';
 import React from 'react';
 import {
    useCurrentRefinements,
    UseRefinementListProps,
+   useInstantSearch,
 } from 'react-instantsearch-hooks-web';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { useSortBy } from './useSortBy';
@@ -79,6 +77,7 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
    onClose,
 }: SingleSelectItemProps) {
    const { createURL } = useCurrentRefinements();
+   const { setIndexUiState } = useInstantSearch();
    const shouldBeLink =
       attribute === 'facet_tags.Item Type' &&
       productListType === ProductListType.DeviceParts;
@@ -90,6 +89,21 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
          as={shouldBeLink ? 'a' : 'button'}
          onClick={(event) => {
             event.preventDefault();
+            setIndexUiState((prevUiState) => {
+               const refinementList = {
+                  ...prevUiState.refinementList,
+                  [attribute]: [item.value],
+               };
+               if (
+                  item.value === prevUiState?.refinementList?.[attribute]?.[0]
+               ) {
+                  delete refinementList[attribute];
+               }
+               return {
+                  ...prevUiState,
+                  refinementList: refinementList,
+               };
+            });
             onClose?.();
          }}
          _hover={{

--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -32,19 +32,6 @@ export function RefinementSingleSelect({
          sortBy: useSortBy(otherProps),
       });
 
-   const onClickSingleSelect = React.useCallback(
-      (newSelected: RefinementListItem) => {
-         refine(newSelected.value);
-
-         const oldSelected: RefinementListItem | undefined = items.find(
-            (item) => item.isRefined
-         );
-         if (oldSelected && oldSelected !== newSelected) {
-            refine(oldSelected.value);
-         }
-      },
-      [items, refine]
-   );
    return (
       <Box>
          <VStack align="stretch" spacing="1" role="listbox">
@@ -56,7 +43,6 @@ export function RefinementSingleSelect({
                      attribute={otherProps.attribute}
                      productListType={productList.type}
                      onClose={onClose}
-                     onClick={onClickSingleSelect}
                   />
                );
             })}
@@ -84,7 +70,6 @@ type SingleSelectItemProps = {
    attribute: string;
    productListType: ProductListType;
    onClose?: () => void;
-   onClick?: (newSelected: RefinementListItem) => void;
 };
 
 const SingleSelectItem = React.memo(function SingleSelectItem({
@@ -92,7 +77,6 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
    attribute,
    productListType,
    onClose,
-   onClick,
 }: SingleSelectItemProps) {
    const { createURL } = useCurrentRefinements();
    const shouldBeLink =
@@ -106,7 +90,6 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
          as={shouldBeLink ? 'a' : 'button'}
          onClick={(event) => {
             event.preventDefault();
-            onClick && onClick(item);
             onClose?.();
          }}
          _hover={{


### PR DESCRIPTION
## Overview

Basically a reopening of #617 now that the `instant-search` update is working on vercel.

When we used to swap single select refinements we would sometimes have the no-refinements selection blip on the screen for a half second (see the issue #526 for an example). This pr should solve that problem by updating the full Index UI State at once (including the refinements) and not clearing out the refinements and then setting them which was why we would have a slight blip of wrong results.

## CR
Is there a more efficient way to organize the data for the IndexUIState than what I have?

## QA
Make sure that pages don't have the blip of wrong results when switching single select refinements (note that even on master this blip disappears on switching if youve already switched between the two refinements on a page load. it must be caching the refinement results in the browser). Make sure that refinements are working as intended. Also make sure that performance isn't down the toilet.

Closes #526