### PR TITLE
Links to Guides on Product Pages now open in a new tab

### DIFF
--- a/frontend/templates/product/sections/ReplacementGuidesSection/index.tsx
+++ b/frontend/templates/product/sections/ReplacementGuidesSection/index.tsx
@@ -135,6 +135,7 @@ export function ReplacementGuidesSection({
                            <Text
                               as="a"
                               href={guide.guide_url}
+                              target="_blank"
                               fontWeight="bold"
                               fontSize="sm"
                               lineHeight="short"


### PR DESCRIPTION
## Overview

We want our customers to be able to view the guides that products are involved in without navigating them completely away from the store. So this opens the guide in a new tab for them.

## QA

Does clicking on the links for `Replacement Guides` now open them up in a new tab?
Recommend using `/Products/iphone-11-pro-screen`

Connects: #732

Analogous to https://github.com/iFixit/ifixit/pull/44987