### PR TITLE
Redirect featured product links

### DIFF
--- a/frontend/helpers/product-helpers.ts
+++ b/frontend/helpers/product-helpers.ts
@@ -1,0 +1,12 @@
+import { IFIXIT_ORIGIN } from '@config/env';
+
+export function getProductPath(handle: string) {
+   switch (handle) {
+      case 'pro-tech-toolkit':
+         return `${IFIXIT_ORIGIN}/Store/Tools/Pro-Tech-Toolkit/IF145-307`;
+      case 'manta-driver-kit-112-bit-driver-kit':
+         return `${IFIXIT_ORIGIN}/Store/Tools/Manta-Driver-Kit--112-Bit-Driver-Kit/IF145-392`;
+      default:
+         return `/products/${handle}`;
+   }
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -88,6 +88,16 @@ const moduleExports = {
             destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/sitemap/marketing.xml`,
             permanent: true,
          },
+         {
+            source: '/products/pro-tech-toolkit',
+            destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/Store/Tools/Pro-Tech-Toolkit/IF145-307`,
+            permanent: false,
+         },
+         {
+            source: '/products/manta-driver-kit-112-bit-driver-kit',
+            destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/Store/Tools/Manta-Driver-Kit--112-Bit-Driver-Kit/IF145-392`,
+            permanent: false,
+         },
       ];
    },
    images: {

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -16,6 +16,7 @@ import {
    ProductCardTitle,
 } from '@components/common';
 import { flags } from '@config/flags';
+import { getProductPath } from '@helpers/product-helpers';
 import { useAppContext } from '@ifixit/app';
 import { ProductSearchHit } from '@models/product-list';
 import * as React from 'react';
@@ -110,7 +111,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
                <LinkOverlay
                   href={
                      flags.PRODUCT_PAGE_ENABLED
-                        ? `/products/${product.handle}`
+                        ? getProductPath(product.handle)
                         : `${appContext.ifixitOrigin}${product.url}`
                   }
                >

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -21,6 +21,7 @@ import { useAppContext } from '@ifixit/app';
 import { ProductSearchHit } from '@models/product-list';
 import * as React from 'react';
 import { useProductSearchHitPricing } from './useProductSearchHitPricing';
+import { getProductPath } from '@helpers/product-helpers';
 
 export type ProductListProps = React.PropsWithChildren<unknown>;
 
@@ -249,7 +250,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                      <LinkOverlay
                         href={
                            flags.PRODUCT_PAGE_ENABLED
-                              ? `/products/${product.handle}`
+                              ? getProductPath(product.handle)
                               : `${appContext.ifixitOrigin}${product.url}`
                         }
                      >

--- a/frontend/templates/product/sections/FeaturedProductsSection/index.tsx
+++ b/frontend/templates/product/sections/FeaturedProductsSection/index.tsx
@@ -11,6 +11,7 @@ import {
    Text,
 } from '@chakra-ui/react';
 import { ProductRating } from '@components/common';
+import { getProductPath } from '@helpers/product-helpers';
 import {
    computeDiscountPercentage,
    isLifetimeWarranty,
@@ -133,7 +134,7 @@ function ProductGridItem({
       >
          <Box flexGrow={1}>
             <CardImage src={imageSrc} alt={title} />
-            <NextLink href={`/products/${handle}`} passHref>
+            <NextLink href={getProductPath(handle)} passHref>
                <LinkOverlay
                   id={productHeadingId}
                   mt="3"


### PR DESCRIPTION
Attempts to visit featured products will redirect to our ifixit featured product pages.

When we link to featured products in Next.js, we link directly to ifixit featured product pages.

## QA

Confirm that the above features do what we intend them to do. (we link to featured products on collection pages)

CC @sterlinghirsh

Closes #806
