### PR TITLE
Show no selector for variants with one option

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -46,20 +46,10 @@ export function ProductOptions({
                   <HStack>
                      <Text fontWeight="bold" color="gray.800">
                         {option.name}
+                        {selectorType === SelectorType.SINGLE &&
+                           `: ${option.values[0]}`}
                      </Text>
                   </HStack>
-                  {selectorType === SelectorType.SINGLE && (
-                     <Box
-                        bg="white"
-                        borderWidth={1}
-                        borderColor="gray.200"
-                        borderRadius="md"
-                        px="4"
-                        py="1.5"
-                     >
-                        {option.values[0]}
-                     </Box>
-                  )}
                   {selectorType === SelectorType.SELECT && (
                      <Select
                         bg="white"


### PR DESCRIPTION
We would prefer not to show a component that looks like a dropdown/button when there is only one option associated with a variant.

## QA

Make sure products with only one option per variant axis just display text for that axis (as opposed to a dropdown or radio buttons).

CC @sterlinghirsh 

Closes #793