### PR TITLE
Handing enable (enabled2) metafield

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6435,6 +6435,7 @@ export type FindProductQuery = {
             warning?: Maybe<{ __typename?: 'Metafield'; value: string }>;
             specifications?: Maybe<{ __typename?: 'Metafield'; value: string }>;
             warranty?: Maybe<{ __typename?: 'Metafield'; value: string }>;
+            enabled?: Maybe<{ __typename?: 'Metafield'; value: string }>;
             disableWhenOOS?: Maybe<{ __typename?: 'Metafield'; value: string }>;
             crossSell?: Maybe<{
                __typename?: 'Metafield';
@@ -6671,6 +6672,9 @@ export const FindProductDocument = `
           value
         }
         warranty: metafield(namespace: "ifixit", key: "warranty") {
+          value
+        }
+        enabled: metafield(namespace: "ifixit", key: "enabled2") {
           value
         }
         disableWhenOOS: metafield(namespace: "ifixit", key: "disable_when_oos") {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -112,6 +112,9 @@ query findProduct($handle: String) {
             warranty: metafield(namespace: "ifixit", key: "warranty") {
                value
             }
+            enabled: metafield(namespace: "ifixit", key: "enabled2") {
+               value
+            }
             disableWhenOOS: metafield(
                namespace: "ifixit"
                key: "disable_when_oos"


### PR DESCRIPTION
closes #784 

This PR adds handling of the `enabled` metafield (formally `enabled2`)
We assumed all active variant have the `enabled2` metafield set to true by default and that only disabled variants have falsey values in it.

### QA

1. Visit the Vercel preview
2. Try to disable explicitly some product variants via the `enabled2` metafield
3. Verify that the interface is working as expected locking or even hiding disabled product options if no active variants include them at all
