### PR TITLE
Footer: minor styling updates

### DIFF
--- a/packages/footer/components/Shared.tsx
+++ b/packages/footer/components/Shared.tsx
@@ -47,7 +47,12 @@ export const FooterLink = forwardRef<FooterLinkProps, 'a'>(
             href={href}
             {...otherProps}
          >
-            <Text fontSize={fontSize} lineHeight="1em" fontWeight="semibold" color="gray.300">
+            <Text
+               fontSize={fontSize}
+               lineHeight="1em"
+               fontWeight="semibold"
+               color="gray.300"
+            >
                {children}
             </Text>
             {icon && <Icon as={icon} boxSize="8" filter="opacity(0.5)" />}

--- a/packages/footer/components/Shared.tsx
+++ b/packages/footer/components/Shared.tsx
@@ -47,7 +47,7 @@ export const FooterLink = forwardRef<FooterLinkProps, 'a'>(
             href={href}
             {...otherProps}
          >
-            <Text fontSize={fontSize} lineHeight="1em" fontWeight="semibold">
+            <Text fontSize={fontSize} lineHeight="1em" fontWeight="semibold" color="gray.300">
                {children}
             </Text>
             {icon && <Icon as={icon} boxSize="8" filter="opacity(0.5)" />}

--- a/packages/footer/homepage-kpis/index.tsx
+++ b/packages/footer/homepage-kpis/index.tsx
@@ -32,6 +32,7 @@ export function StatsSection({ data: { stats } }: StatsSectionProps) {
          bg="blue.50"
          borderWidth={1}
          borderColor="blue.100"
+         mb={-10}
       >
          <PageContentWrapper>
             <SimpleGrid


### PR DESCRIPTION
We have some more minor changes to be made to the footer for iFixit/ifixit.

First, we added a margin on top of the footer to separate it from the content on the page. We want the KPI banner to be flush with the footer, however. So let's add a negative margin to remove the gap.

Second, we had some pages with a different default text color. To make sure we have the same color text on every page, let's be explicit about the colors.

qa_req 0