### PR TITLE
Sentry: stringify request body in reported error context

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -11,6 +11,7 @@ Sentry.init({
    dsn: SENTRY_DSN,
    integrations: [new BrowserTracing()],
    sampleRate: 1.0,
+   normalizeDepth: 5,
    tracesSampleRate: 0.005,
    // ...
    // Note: if you want to override the automatic release value, do not set a

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -9,6 +9,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN;
 Sentry.init({
    dsn: SENTRY_DSN,
    sampleRate: 1.0,
+   normalizeDepth: 5,
    // ...
    // Note: if you want to override the automatic release value, do not set a
    // `release` value here - use the environment variable `SENTRY_RELEASE`, so


### PR DESCRIPTION
Sentry only shows the top-level properties of json objects, if their values are nested json objects, you get "[Object]". This is pretty useless, so let's pretty print the request body

qa_req 0 //  low blast radius if it's incorrect.

Closes #815