### PR TITLE
Enable product page in production

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -4,7 +4,7 @@ import { setSentryPageContext } from '@ifixit/sentry';
 import * as Sentry from '@sentry/nextjs';
 import { PROD_USER_AGENT } from '@config/constants';
 
-export function serverSidePropsWrapper<T>(
+export function serverSidePropsWrapper<T extends { [key: string]: any }>(
    getServerSidePropsInternal: GetServerSideProps<T>
 ): GetServerSideProps<T> {
    return async (context) => {

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -63,13 +63,10 @@ ProductTemplate.getLayout = function getLayout(page, pageProps) {
 export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
    async (context) => {
       noindexDevDomains(context);
+      // @TODO: Remove this before the page goes live
+      context.res.setHeader('X-Robots-Tag', 'noindex, nofollow');
       const { handle } = context.params || {};
       invariant(typeof handle === 'string', 'handle param is missing');
-      if (!flags.PRODUCT_PAGE_ENABLED) {
-         return {
-            notFound: true,
-         };
-      }
       const layoutProps = await getLayoutServerSideProps();
       const product = await findProduct(
          {


### PR DESCRIPTION
closes #770 

## QA

1. Visit [react-commerce-prod preview](https://react-commerce-prod-git-enable-product-page-in-pr-a1546e-ifixit.vercel.app/products/macbook-pro-14-2021-a2442-and-16-2021-a2485-antenna-cable-bracket)
2. Verify that the product page is visible
3. Verify that the product page is not indexable (`x-robots-tag` header set to `noindex, nofollow`
4. Go to product lists (e.g. [`/Parts`](https://react-commerce-prod-git-enable-product-page-in-pr-a1546e-ifixit.vercel.app/Parts)) and verify that products links still point to the legacy us product page