### PR TITLE
Sync product page quantity with cart

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -43,7 +43,7 @@ import { PageContentWrapper, ProductVariantPrice } from '@ifixit/ui';
 import { Product, ProductVariant } from '@models/product';
 import NextLink from 'next/link';
 import * as React from 'react';
-import { AddToCart } from './AddToCart';
+import { AddToCart, isVariantWithSku } from './AddToCart';
 import { ProductGallery } from './ProductGallery';
 import { ProductOptions } from './ProductOptions';
 import { ProductRating } from './ProductRating';
@@ -150,7 +150,12 @@ export function ProductSection({
                   selected={selectedVariant.id}
                   onChange={handleVariantChange}
                />
-               <AddToCart product={product} selectedVariant={selectedVariant} />
+               {isVariantWithSku(selectedVariant) && (
+                  <AddToCart
+                     product={product}
+                     selectedVariant={selectedVariant}
+                  />
+               )}
                <div>
                   <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
                      <ListItem display="flex" alignItems="center">

--- a/packages/cart-sdk/hooks/use-cart-line-item.ts
+++ b/packages/cart-sdk/hooks/use-cart-line-item.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+import { CartLineItem } from '../types';
+import { useCart } from './use-cart';
+
+type UseCartLineItem = {
+   data: CartLineItem | null;
+   isLoading: boolean;
+   isError: boolean;
+};
+
+export function useCartLineItem(itemcode: string): UseCartLineItem {
+   const cart = useCart();
+
+   const isLoading = cart.isLoading;
+   const isError = cart.isError;
+
+   const data = React.useMemo<CartLineItem | null>(() => {
+      return (
+         cart.data?.lineItems.find((item) => item.itemcode === itemcode) ?? null
+      );
+   }, [cart.data, itemcode]);
+
+   return { data, isLoading, isError };
+}

--- a/packages/cart-sdk/index.tsx
+++ b/packages/cart-sdk/index.tsx
@@ -4,5 +4,6 @@ export { useAddToCart } from './hooks/use-add-to-cart';
 export type { AddToCartInput } from './hooks/use-add-to-cart';
 export { useRemoveLineItem } from './hooks/use-remove-line-item';
 export { useCheckout } from './hooks/use-checkout';
+export { useCartLineItem } from './hooks/use-cart-line-item';
 export type { Cart, CartLineItem } from './types';
 export { CartError } from './utils';


### PR DESCRIPTION
closes #799 

Product page now uses inventory quantity from the cart if available.

## QA

1. Visit [Vercel preview](https://react-commerce-git-sync-product-page-quantity-with-cart-ifixit.vercel.app/products/repair-business-toolkit?variant=39333695422554)
2. Verify that whenever an item is added to the cart the product page quantity is updated

⚠️ The iFixit test store has not always up to date inventory quantities so, when you add a product to the cart the remaining quantity count could show a different count than the expected, because we're using the available quantity returned by the cart api. This shouldn't happen in production