### PR TITLE
Make user menu display over breadcrumb bar

### DIFF
--- a/frontend/components/common/PageBreadcrumb.tsx
+++ b/frontend/components/common/PageBreadcrumb.tsx
@@ -140,7 +140,7 @@ function BreadcrumbMenu({ items }: BreadcrumbMenuProps) {
             size="xs"
             px="1.5"
          />
-         <MenuList>
+         <MenuList zIndex="dropdown">
             {items.map((ancestor, index) => (
                <NextLink key={index} href={ancestor.url} passHref>
                   <MenuItem fontSize="sm" as="a">

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@chakra-ui/react';
 import { PageBreadcrumb } from '@components/common';
-import { flags } from '@config/flags';
 import { noindexDevDomains } from '@helpers/next-helpers';
 import { invariant } from '@ifixit/helpers';
 import { trackMatomoEcommerceView } from '@ifixit/matomo';
@@ -40,7 +39,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    return (
       <>
          {product.breadcrumbs != null && (
-            <SecondaryNavigation zIndex="10">
+            <SecondaryNavigation>
                <PageBreadcrumb items={product.breadcrumbs} />
             </SecondaryNavigation>
          )}

--- a/frontend/templates/product/sections/ProductSection/Prop65Warning.tsx
+++ b/frontend/templates/product/sections/ProductSection/Prop65Warning.tsx
@@ -1,0 +1,86 @@
+import {
+   Flex,
+   IconButton,
+   Link,
+   PlacementWithLogical,
+   Popover,
+   PopoverArrow,
+   PopoverBody,
+   PopoverCloseButton,
+   PopoverContent,
+   PopoverHeader,
+   PopoverTrigger,
+   Text,
+   useBreakpointValue,
+} from '@chakra-ui/react';
+import {
+   faExclamationTriangle,
+   faInfoCircle,
+} from '@fortawesome/pro-solid-svg-icons';
+import { FaIcon } from '@ifixit/icons';
+
+export type Prop65WarningProps = {
+   type: string;
+   chemicals: string;
+};
+
+export function Prop65Warning({ type, chemicals }: Prop65WarningProps) {
+   const placement = useBreakpointValue<PlacementWithLogical>({
+      base: 'auto-end',
+      sm: 'bottom',
+   });
+   return (
+      <Flex align="center" position="relative">
+         <Text>California Residents: Prop 65 WARNING</Text>
+         <Popover placement={placement}>
+            <PopoverTrigger>
+               <IconButton
+                  variant="ghost"
+                  aria-label="read more about the warning"
+                  size="sm"
+                  icon={<FaIcon icon={faInfoCircle} h="4" color="brand.500" />}
+               >
+                  Trigger
+               </IconButton>
+            </PopoverTrigger>
+            <PopoverContent
+               maxW={{
+                  base: '260px',
+                  sm: 'unset',
+               }}
+               mx={{
+                  base: '5',
+                  md: '6',
+               }}
+            >
+               <PopoverArrow />
+               <PopoverCloseButton mt="0.5" />
+               <PopoverHeader textTransform="uppercase">
+                  <Flex align="center">
+                     <FaIcon
+                        icon={faExclamationTriangle}
+                        h="4"
+                        mr="2"
+                        color="yellow.500"
+                     />
+                     Warning
+                  </Flex>
+               </PopoverHeader>
+               <PopoverBody>
+                  <Text>
+                     This product can expose you to chemicals including{' '}
+                     {chemicals} which is known to the State of California to
+                     cause {type}.
+                  </Text>
+                  <Text mt="2">
+                     For more information, go to{' '}
+                     <Link href="www.P65Warnings.ca.gov" color="brand.500">
+                        www.P65Warnings.ca.gov
+                     </Link>
+                  </Text>
+               </PopoverBody>
+            </PopoverContent>
+         </Popover>
+      </Flex>
+   );
+}

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -12,18 +12,10 @@ import {
    Heading,
    HStack,
    Icon,
-   IconButton,
    Link,
    List,
    ListIcon,
    ListItem,
-   Popover,
-   PopoverArrow,
-   PopoverBody,
-   PopoverCloseButton,
-   PopoverContent,
-   PopoverHeader,
-   PopoverTrigger,
    Text,
    VStack,
 } from '@chakra-ui/react';
@@ -31,8 +23,6 @@ import { CompatibleDevice } from '@components/common';
 import {
    faBadgeDollar,
    faCircleExclamation,
-   faExclamationTriangle,
-   faInfoCircle,
    faRocket,
    faShieldCheck,
 } from '@fortawesome/pro-solid-svg-icons';
@@ -47,6 +37,7 @@ import { AddToCart, isVariantWithSku } from './AddToCart';
 import { ProductGallery } from './ProductGallery';
 import { ProductOptions } from './ProductOptions';
 import { ProductRating } from './ProductRating';
+import { Prop65Warning } from './Prop65Warning';
 
 export type ProductSectionProps = {
    product: Product;
@@ -425,59 +416,10 @@ export function ProductSection({
 
                <VStack mt="10" align="flex-start" spacing="4">
                   {product.prop65WarningType && product.prop65Chemicals && (
-                     <Flex align="center">
-                        <Text>California Residents: Prop 65 WARNING</Text>
-                        <Popover>
-                           <PopoverTrigger>
-                              <IconButton
-                                 variant="ghost"
-                                 aria-label="read more about the warning"
-                                 size="sm"
-                                 icon={
-                                    <FaIcon
-                                       icon={faInfoCircle}
-                                       h="4"
-                                       color="brand.500"
-                                    />
-                                 }
-                              >
-                                 Trigger
-                              </IconButton>
-                           </PopoverTrigger>
-                           <PopoverContent>
-                              <PopoverArrow />
-                              <PopoverCloseButton mt="0.5" />
-                              <PopoverHeader textTransform="uppercase">
-                                 <Flex align="center">
-                                    <FaIcon
-                                       icon={faExclamationTriangle}
-                                       h="4"
-                                       mr="2"
-                                       color="yellow.500"
-                                    />
-                                    Warning
-                                 </Flex>
-                              </PopoverHeader>
-                              <PopoverBody>
-                                 <Text>
-                                    This product can expose you to chemicals
-                                    including {product.prop65Chemicals} which is
-                                    known to the State of California to cause{' '}
-                                    {product.prop65WarningType}.
-                                 </Text>
-                                 <Text mt="2">
-                                    For more information, go to{' '}
-                                    <Link
-                                       href="www.P65Warnings.ca.gov"
-                                       color="brand.500"
-                                    >
-                                       www.P65Warnings.ca.gov
-                                    </Link>
-                                 </Text>
-                              </PopoverBody>
-                           </PopoverContent>
-                        </Popover>
-                     </Flex>
+                     <Prop65Warning
+                        type={product.prop65WarningType}
+                        chemicals={product.prop65Chemicals}
+                     />
                   )}
                   {product.productVideos && (
                      <Box


### PR DESCRIPTION
closes #834 

This PR fixes issue described by #834 and a tricky bug on small size devices happening due to prop 65 warning popover

## QA

1. Open [Vercel preview](https://react-commerce-git-fix-product-page-breadcrumb-ba-56c795-ifixit.vercel.app/products/samsung-galaxy-s21-ultra-usa-usb-c-charge-port-genuine)
2. Visit a [product page](https://react-commerce-git-fix-product-page-breadcrumb-ba-56c795-ifixit.vercel.app/products/samsung-galaxy-s21-ultra-usa-usb-c-charge-port-genuine)
3. Verify that the issue described by #834 is fixed