### PR TITLE
GH Actions: Update usage of set-output

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,9 +28,9 @@ jobs:
            id: detect-diff
            run: |
               if [ ! -z "$(git status --short)" ]; then
-                 echo "::set-output name=HAS_DIFF::true"
+                 echo "HAS_DIFF=true" >> $GITHUB_OUTPUT
               else
-                 echo "::set-output name=HAS_DIFF::false"
+                 echo "HAS_DIFF=false" >> $GITHUB_OUTPUT
               fi
          - name: Fail if Dependabot
            if: steps.detect-diff.outputs.HAS_DIFF == 'true' && github.actor == 'dependabot[bot]'


### PR DESCRIPTION
## Summary
Updates the usage of `set-output` in our current workflows, since it's getting deprecated.

## QA notes
1. git grep for `set-output` in the code and make sure there isn't any left.
2. Make sure the `format` workflow works fine. Check the logs, and see if there are any issues.  

Connects: https://github.com/iFixit/ifixit/issues/45080

