### PR TITLE
Product option switch improvements

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -63,7 +63,7 @@ export function ProductOptions({
                            const variant = findVariant(
                               product,
                               selectedOptions,
-                              { [option.name]: value }
+                              { name: option.name, value }
                            );
                            return (
                               <option value={variant?.id} key={value}>
@@ -79,7 +79,7 @@ export function ProductOptions({
                            const variant = findVariant(
                               product,
                               selectedOptions,
-                              { [option.name]: value }
+                              { name: option.name, value }
                            );
                            return (
                               <ProductOptionValue
@@ -112,14 +112,18 @@ enum SelectorType {
 }
 
 type Option = Product['options'][0];
+type OptionValue = { name: string; value: string };
 
 function findVariant(
    product: Product,
    previousOptions: Record<string, string>,
-   optionsUpdate: Record<string, string>
+   optionUpdate: OptionValue
 ) {
    const { variants, options } = product;
-   const newOptions = { ...previousOptions, ...optionsUpdate };
+   const newOptions = {
+      ...previousOptions,
+      [optionUpdate.name]: optionUpdate.value,
+   };
 
    const exactMatch = variants.find((variant) => {
       return variant.selectedOptions.every((option) => {
@@ -132,15 +136,12 @@ function findVariant(
    }
 
    const productOptionsNames = options.map((option) => option.name);
-   const optionsUpdateNames = Object.keys(optionsUpdate);
 
    const variantsMatchingUpdate = variants.filter((variant) => {
-      return optionsUpdateNames.every((name) => {
-         const correspondingVariantOption = variant.selectedOptions.find(
-            (option) => option.name === name
-         );
-         return correspondingVariantOption?.value === optionsUpdate[name];
-      });
+      const matchingOption = variant.selectedOptions.find(
+         (option) => option.name === optionUpdate.name
+      );
+      return optionUpdate.value === matchingOption?.value;
    });
 
    const scoredVariantsMatchingUpdate = variantsMatchingUpdate
@@ -152,10 +153,10 @@ function findVariant(
                (option) => option.name === name
             );
             if (
-               !optionsUpdateNames.includes(name) &&
+               optionUpdate.name !== name &&
                previousOptions[name] !== variantOption?.value
             ) {
-               distance += 3 - i;
+               distance += productOptionsNames.length - i;
             }
          }
          return { variant, distance };


### PR DESCRIPTION
closes #788 

Allow to click on any variant option value. 
In case the chosen options combination has no corresponding variant, tweak it to match the nearest variant.

#### Note on how how the nearest variant is computed
In case there is no exact match for the currently selected options, we have to pick the nearest option set available.
In order to do so we have to compute a `distance-score`.

We take into account only variants that include the selection just performed by the user.
Among those variants we check how the other options changes wrt the previously selected values.

The first variant is generally considered the most important, the last is the least important.
So if we have to tweak the first variant value in order to find an existing variant we will add 3 to the distance score, 2 if we need to tweak the second variant and just 1 if we have to tweak the third and last variant.

The variant with the least distance score will be chosen

### QA

1. Visit the Vercel preview
2. Find a product that has some non-existing variant combination in its option matrix
3. Check that, whenever we try to chose a non-existing combination of options, the app tweak the selection to the nearest existing variant
