### PR TITLE
Improve product page gallery alt tags

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6400,6 +6400,7 @@ export type FindProductQuery = {
          nodes: Array<{
             __typename?: 'ProductVariant';
             id: string;
+            title: string;
             sku?: Maybe<string>;
             quantityAvailable?: Maybe<number>;
             image?: Maybe<{
@@ -6636,6 +6637,7 @@ export const FindProductDocument = `
     variants(first: 100) {
       nodes {
         id
+        title
         sku
         quantityAvailable
         image {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -64,6 +64,7 @@ query findProduct($handle: String) {
       variants(first: 100) {
          nodes {
             id
+            title
             sku
             quantityAvailable
             image {

--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -210,14 +210,7 @@ function ProductOptionImage({ image }: ProductOptionImageProps) {
          : null;
 
    if (ratio == null) {
-      return (
-         <Img
-            h="16"
-            src={image.url}
-            alt={image.altText ?? ''}
-            objectFit="contain"
-         />
-      );
+      return <Img h="16" src={image.url} alt="" objectFit="contain" />;
    }
    return (
       <Box h="16" position="relative" overflow="hidden" mb="1">
@@ -227,7 +220,7 @@ function ProductOptionImage({ image }: ProductOptionImageProps) {
             maxW="full"
             mx="auto"
             src={image.url}
-            alt={image.altText ?? ''}
+            alt=""
             objectFit="contain"
          />
       </Box>

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -83,7 +83,7 @@ export function ProductSection({
             >
                <ProductGallery
                   product={product}
-                  selectedVariantId={selectedVariant.id}
+                  selectedVariant={selectedVariant}
                   selectedImageId={selectedImageId}
                   showThumbnails
                   enableZoom
@@ -130,7 +130,7 @@ export function ProductSection({
                <Flex display={{ base: 'flex', md: 'none' }} w="full" pt="6">
                   <ProductGallery
                      product={product}
-                     selectedVariantId={selectedVariant.id}
+                     selectedVariant={selectedVariant}
                      selectedImageId={selectedImageId}
                      onChangeImage={setSelectedImageId}
                   />


### PR DESCRIPTION
closes #823 

## QA

1. Visit [Vercel preview](https://react-commerce-git-fix-product-page-gallery-alt-texts-ifixit.vercel.app/products/galaxy-a51-screen)
2. Verify that product gallery images have alt tags set to the product title, or product title + product variant title