### PR TITLE
Always have a facet box of some sort

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/useFilteredRefinementList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useFilteredRefinementList.tsx
@@ -5,14 +5,15 @@ import {
 } from 'react-instantsearch-hooks-web';
 
 export function useFilteredRefinementList(props: UseRefinementListProps) {
+   const isPriceRange = props.attribute == 'price_range';
    const { items, ...rest } = useRefinementList({ ...props });
    const { results } = useHits();
    const hitsCount = results?.nbHits ?? 0;
    const isAnyRefined = items.some((item) => item.isRefined);
-
-   const filteredItems = isAnyRefined
-      ? items
-      : items.filter((item) => hitsCount !== item.count);
+   const filteredItems =
+      isAnyRefined || isPriceRange
+         ? items
+         : items.filter((item) => hitsCount !== item.count);
 
    return { ...rest, items: filteredItems };
 }


### PR DESCRIPTION
## Overview
It was decided that the blank facet accordion is not what we want to display, so this implements a change so the `price_range` facet should always have some item returned so the accordion is not empty. The data sorted by the facet is not useful, but this looks better and isn't too confusing IMO.

## QA
Pages like `/Parts/Panasonic_PT-DX610` should now not have an empty accordion. Any product list should only have the price range as a facet choice if there is not multiple facet ranges/options for the returned products.

Closes: #461