### PR TITLE
Noindex when user agent does not match

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -29,7 +29,7 @@ export function serverSidePropsWrapper<T extends { [key: string]: any }>(
 }
 
 export function noindexDevDomains(context: GetServerSidePropsContext) {
-   if (context.req.headers['user-agent'] === PROD_USER_AGENT) {
+   if (context.req.headers['user-agent'] !== PROD_USER_AGENT) {
       context.res.setHeader('X-Robots-Tag', 'noindex, nofollow');
    }
 }


### PR DESCRIPTION
We tried to noindex when user agent was not "Amazon CloudFront", but we accidentally inverted the condition. This re-inverts the condition.

qa_req 0