### PR TITLE
Use placeholder image for product options without specific images

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -14,7 +14,6 @@ import { faImageSlash } from '@fortawesome/pro-duotone-svg-icons';
 import type { Product } from '@models/product';
 import * as React from 'react';
 import { FaIcon } from '@ifixit/icons';
-import { invariant } from '@ifixit/helpers';
 
 export type ProductOptionsProps = {
    product: Product;
@@ -81,12 +80,16 @@ export function ProductOptions({
                               selectedOptions,
                               { name: option.name, value }
                            );
+                           const variantSpecificImage =
+                              variant?.image?.variantId === variant?.id
+                                 ? variant?.image
+                                 : undefined;
                            return (
                               <ProductOptionValue
                                  key={value}
                                  isActive={variant?.id === selected}
                                  label={value}
-                                 image={variant?.image}
+                                 image={variantSpecificImage}
                                  onClick={() => {
                                     if (variant) {
                                        onChange(variant.id);


### PR DESCRIPTION
closes #841 

### QA

1. Visit Vercel preview
2. Find a product that includes variants without associated images like [this](https://react-commerce-git-use-placeholder-for-product-op-965be3-ifixit.vercel.app/products/iphone-7-plus-screen?variant=39333810372698)
3. Verify that those variants are now showing image placeholder instead of generic product images