### PR TITLE
Noindex products with "Pro Only" tag

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6308,6 +6308,7 @@ export type FindProductQuery = {
       title: string;
       handle: string;
       descriptionHtml: string;
+      tags: Array<string>;
       breadcrumbs?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       faqs?: Maybe<{ __typename?: 'Metafield'; value: string }>;
       prop65WarningType?: Maybe<{ __typename?: 'Metafield'; value: string }>;
@@ -6587,6 +6588,7 @@ export const FindProductDocument = `
     title
     handle
     descriptionHtml
+    tags
     breadcrumbs: metafield(namespace: "ifixit", key: "breadcrumbs") {
       value
     }

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -3,6 +3,7 @@ query findProduct($handle: String) {
       title
       handle
       descriptionHtml
+      tags
       breadcrumbs: metafield(namespace: "ifixit", key: "breadcrumbs") {
          value
       }

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -103,7 +103,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
          };
       }
 
-      const proOnly = product?.tags.find((tag: string) => tag === "Pro Only");
+      const proOnly = product?.tags.find((tag: string) => tag === 'Pro Only');
       if (proOnly) {
          context.res.setHeader('X-Robots-Tag', 'noindex, follow');
       } else {

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -86,8 +86,6 @@ ProductTemplate.getLayout = function getLayout(page, pageProps) {
 export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
    async (context) => {
       noindexDevDomains(context);
-      // @TODO: Remove this before the page goes live
-      context.res.setHeader('X-Robots-Tag', 'noindex, nofollow');
       const { handle } = context.params || {};
       invariant(typeof handle === 'string', 'handle param is missing');
       const layoutProps = await getLayoutServerSideProps();
@@ -98,11 +96,21 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
          },
          handle
       );
+
       if (product == null) {
          return {
             notFound: true,
          };
       }
+
+      const proOnly = product?.tags.find((tag: string) => tag === "Pro Only");
+      if (proOnly) {
+         context.res.setHeader('X-Robots-Tag', 'noindex, follow');
+      } else {
+         // @TODO: Remove this before the page goes live
+         context.res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+      }
+
       const pageProps: ProductTemplateProps = {
          layoutProps,
          appProps: {},


### PR DESCRIPTION
This is a redo of #847 since there were some extra changes in that commit.

QA
==
Check the a product without a "Pro Only" tag has header "X-Robots-Tag" = "noindex, nofollow", but one with a "Pro Only" tag has "noindex, follow".

Closes #825 