### PR TITLE
Drop product list `path` field

### DIFF
--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -234,16 +234,13 @@ function createProductListAncestors(
    const type = getProductListType(attributes.type);
 
    return ancestors.concat({
+      deviceTitle: attributes.deviceTitle ?? null,
       title: getProductListTitle({
          title: attributes.title,
          type,
       }),
+      type: getProductListType(attributes.type),
       handle: attributes.handle,
-      path: productListPath({
-         type,
-         handle: attributes.handle,
-         deviceTitle: attributes.deviceTitle ?? null,
-      }),
    });
 }
 
@@ -368,12 +365,8 @@ function createProductListSection(
                   return {
                      handle: productList.handle,
                      title: productList.title,
+                     type: getProductListType(productList.type),
                      deviceTitle: productList.deviceTitle ?? null,
-                     path: productListPath({
-                        handle: productList.handle,
-                        deviceTitle: productList.deviceTitle ?? null,
-                        type: getProductListType(productList.type),
-                     }),
                      description: productList.description,
                      image:
                         image == null

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -276,11 +276,6 @@ function createProductListChild({ deviceWiki }: CreateProductListChildOptions) {
          type,
          deviceTitle: attributes.deviceTitle || null,
          handle: attributes.handle,
-         path: productListPath({
-            type,
-            handle: attributes.handle,
-            deviceTitle: attributes.deviceTitle ?? null,
-         }),
          image:
             imageAttributes == null
                ? deviceWiki && attributes.deviceTitle

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -338,12 +338,8 @@ function createProductListSection(
             productList: {
                handle: productList.handle,
                title: productList.title,
+               type: getProductListType(productList.type),
                deviceTitle: productList.deviceTitle ?? null,
-               path: productListPath({
-                  handle: productList.handle,
-                  deviceTitle: productList.deviceTitle ?? null,
-                  type: getProductListType(productList.type),
-               }),
                description: productList.description,
                image:
                   image == null

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -81,19 +81,12 @@ export async function findProductList(
    );
    const productListType = getProductListType(productList?.type);
 
-   const path = productListPath({
-      type: productListType,
-      handle: handle,
-      deviceTitle: deviceTitle,
-   });
-
    const ancestors = createProductListAncestors(parents);
 
    const baseProductList: BaseProductList = {
       title: title,
       handle: handle,
       deviceTitle: deviceTitle,
-      path,
       tagline: productList?.tagline ?? null,
       description: description,
       metaDescription: productList?.metaDescription ?? null,

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -152,7 +152,7 @@ export interface FeaturedProductList {
    };
    handle: string;
    title: string;
-   path: string;
+   type: ProductListType;
    deviceTitle: string | null;
    description: string;
    image: ProductListImage | null;

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -54,7 +54,6 @@ export interface BaseProductList {
    title: string;
    handle: string;
    deviceTitle: string | null;
-   path: string;
    tagline: string | null;
    description: string;
    metaDescription: string | null;

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -92,9 +92,10 @@ interface MarketingProductList extends BaseProductList {
 }
 
 export interface ProductListAncestor {
+   deviceTitle: string | null;
    title: string;
+   type: ProductListType;
    handle: string;
-   path: string;
 }
 
 export interface ProductListChild {
@@ -169,7 +170,7 @@ export interface ProductListProductListSetSection {
 export interface ProductListPreview {
    handle: string;
    title: string;
-   path: string;
+   type: ProductListType;
    deviceTitle: string | null;
    description: string;
    image: ProductListImage | null;

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -102,7 +102,6 @@ export interface ProductListChild {
    title: string;
    deviceTitle: string | null;
    handle: string;
-   path: string;
    image: ProductListImage | null;
    sortPriority: number | null;
    type: ProductListType;

--- a/frontend/templates/page/sections/BrowseSection.tsx
+++ b/frontend/templates/page/sections/BrowseSection.tsx
@@ -147,11 +147,7 @@ function FeaturedCategories({ categories }: FeaturedCategoriesProps) {
                   }}
                >
                   <NextLink
-                     href={productListPath({
-                        deviceTitle: category.deviceTitle,
-                        handle: category.handle,
-                        type: category.type,
-                     })}
+                     href={productListPath(category)}
                      passHref
                   >
                      <ProductListCard

--- a/frontend/templates/page/sections/BrowseSection.tsx
+++ b/frontend/templates/page/sections/BrowseSection.tsx
@@ -146,10 +146,7 @@ function FeaturedCategories({ categories }: FeaturedCategoriesProps) {
                      lg: isBigger ? 6 : 3,
                   }}
                >
-                  <NextLink
-                     href={productListPath(category)}
-                     passHref
-                  >
+                  <NextLink href={productListPath(category)} passHref>
                      <ProductListCard
                         as="a"
                         variant={isBigger ? 'medium' : 'small'}

--- a/frontend/templates/product-list/MetaTags.tsx
+++ b/frontend/templates/product-list/MetaTags.tsx
@@ -1,4 +1,5 @@
 import { PRODUCT_LIST_PAGE_PARAM } from '@config/constants';
+import { productListPath } from '@helpers/path-helpers';
 import {
    getProductListTitle,
    stylizeDeviceItemType,
@@ -38,9 +39,9 @@ export function MetaTags({ productList }: MetaTagsProps) {
    const itemTypeHandle = itemType
       ? `/${encodeURIComponent(stylizeDeviceItemType(itemType))}`
       : '';
-   const canonicalUrl = `${appContext.ifixitOrigin}${
-      productList.path
-   }${itemTypeHandle}${page > 1 ? `?${PRODUCT_LIST_PAGE_PARAM}=${page}` : ''}`;
+   const canonicalUrl = `${appContext.ifixitOrigin}${productListPath(
+      productList
+   )}${itemTypeHandle}${page > 1 ? `?${PRODUCT_LIST_PAGE_PARAM}=${page}` : ''}`;
    const imageUrl = productList.image?.url;
    const productListExemptions =
       noIndexExemptions[productList.deviceTitle ?? ''];

--- a/frontend/templates/product-list/ProductListBreadcrumb.tsx
+++ b/frontend/templates/product-list/ProductListBreadcrumb.tsx
@@ -81,7 +81,7 @@ export function ProductListBreadcrumb({
                   lg: 'inline-flex',
                }}
             >
-               <NextLink href={ancestor.path} passHref>
+               <NextLink href={productListPath(ancestor)} passHref>
                   <BreadcrumbLink
                      color="gray.500"
                      whiteSpace="nowrap"
@@ -115,7 +115,7 @@ export function ProductListBreadcrumb({
                      {reverseAncestorList.map((ancestor) => (
                         <NextLink
                            key={ancestor.handle}
-                           href={ancestor.path}
+                           href={productListPath(ancestor)}
                            passHref
                         >
                            <MenuItem as="a">{ancestor.title}</MenuItem>
@@ -139,15 +139,12 @@ function appendDeviceAncestor(
    productList: ProductList
 ) {
    return ancestors.concat({
+      deviceTitle: productList.deviceTitle,
       title: getProductListTitle({
          title: productList.title,
          type: productList.type,
       }),
+      type: productList.type,
       handle: productList.handle,
-      path: productListPath({
-         type: productList.type,
-         handle: productList.handle,
-         deviceTitle: productList.deviceTitle ?? null,
-      }),
    });
 }

--- a/frontend/templates/product-list/ProductListBreadcrumb.tsx
+++ b/frontend/templates/product-list/ProductListBreadcrumb.tsx
@@ -139,7 +139,7 @@ function appendDeviceAncestor(
    productList: ProductList
 ) {
    return ancestors.concat({
-      deviceTitle: productList.deviceTitle,
+      deviceTitle: productList.deviceTitle ?? null,
       title: getProductListTitle({
          title: productList.title,
          type: productList.type,

--- a/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
@@ -28,6 +28,7 @@ import { IfixitImage } from '@ifixit/ui';
 import NextLink from 'next/link';
 import { Configure, Index, useHits } from 'react-instantsearch-hooks-web';
 import { computeDiscountPercentage } from '@ifixit/helpers';
+import { productListPath } from '@helpers/path-helpers';
 
 export interface FeaturedProductListSectionProps {
    productList: FeaturedProductList;
@@ -110,7 +111,7 @@ export function FeaturedProductListSection({
                      <Text color="white" noOfLines={2}>
                         {productList.description}
                      </Text>
-                     <NextLink href={productList.path} passHref>
+                     <NextLink href={productListPath(productList)} passHref>
                         <Button
                            as="a"
                            variant="outline"

--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '@chakra-ui/react';
 import { Card } from '@components/ui';
 import { IFIXIT_ORIGIN } from '@config/env';
+import { productListPath } from '@helpers/path-helpers';
 import { getProductListTitle } from '@helpers/product-list-helpers';
 import { cypressReplace, cypressWindowLog } from '@helpers/test-helpers';
 import { useLocalPreference } from '@ifixit/ui';
@@ -253,7 +254,7 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
                   This collection does not have products.
                </Text>
                {parentCategory && (
-                  <Link href={parentCategory.path}>
+                  <Link href={productListPath(productList)}>
                      Return to {parentCategory.title}
                   </Link>
                )}

--- a/frontend/templates/product-list/sections/ProductListSetSection.tsx
+++ b/frontend/templates/product-list/sections/ProductListSetSection.tsx
@@ -11,6 +11,7 @@ import { ProductListPreview } from '@models/product-list';
 import { IfixitImage } from '@ifixit/ui';
 import NextLink from 'next/link';
 import * as React from 'react';
+import { productListPath } from '@helpers/path-helpers';
 
 export type ProductListSetSectionProps = {
    title: string;
@@ -83,7 +84,7 @@ const ProductListLink = ({ productList }: ProductListLinkProps) => {
                </Flex>
             )}
             <Divider orientation="vertical" />
-            <NextLink href={productList.path} passHref>
+            <NextLink href={productListPath(productList)} passHref>
                <LinkOverlay
                   px="3"
                   py="2"


### PR DESCRIPTION
Followup from this discussion. https://github.com/iFixit/react-commerce/pull/857#discussion_r1003497990

The idea is to centralize how we link to resources, so that whenever the routing logic changes it doesn't need to be changed in several place, just in the path helper.

## QA

Verify that product list links across the app still work. Some examples:

- [x] product list children links
- [x] product list ancestor links (ie breadcrumbs)
- [x] featured product list links

CC @dhmacs
