### PR TITLE
Analytics: Track more events

### DIFF
--- a/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
@@ -26,8 +26,10 @@ import { useAppContext } from '@ifixit/app';
 import { FeaturedProductList, ProductSearchHit } from '@models/product-list';
 import { IfixitImage } from '@ifixit/ui';
 import NextLink from 'next/link';
+import * as React from 'react';
 import { Configure, Index, useHits } from 'react-instantsearch-hooks-web';
 import { computeDiscountPercentage } from '@ifixit/helpers';
+import { trackInMatomoAndGA } from '@ifixit/analytics';
 
 export interface FeaturedProductListSectionProps {
    productList: FeaturedProductList;
@@ -175,6 +177,12 @@ function ProductListItem({ product }: ProductListItemProps) {
       : 0;
 
    const isSoldOut = product.quantity_available <= 0;
+   const onClick = React.useCallback(() => {
+      trackInMatomoAndGA({
+         eventCategory: 'Featured Products - Product Page',
+         eventAction: `Featured on Product Page - ${product.sku}`,
+      });
+   }, [product.sku]);
 
    return (
       <LinkBox
@@ -202,7 +210,10 @@ function ProductListItem({ product }: ProductListItemProps) {
                )}
             </ProductCardBadgeList>
             <ProductCardBody>
-               <LinkOverlay href={`${appContext.ifixitOrigin}${product.url}`}>
+               <LinkOverlay
+                  href={`${appContext.ifixitOrigin}${product.url}`}
+                  onClick={onClick}
+               >
                   <ProductCardTitle _groupHover={{ color: 'brand.500' }}>
                      {product.title}
                   </ProductCardTitle>

--- a/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
@@ -26,11 +26,9 @@ import { useAppContext } from '@ifixit/app';
 import { FeaturedProductList, ProductSearchHit } from '@models/product-list';
 import { IfixitImage } from '@ifixit/ui';
 import NextLink from 'next/link';
-import * as React from 'react';
 import { Configure, Index, useHits } from 'react-instantsearch-hooks-web';
 import { computeDiscountPercentage } from '@ifixit/helpers';
 import { productListPath } from '@helpers/path-helpers';
-import { trackInMatomoAndGA } from '@ifixit/analytics';
 
 export interface FeaturedProductListSectionProps {
    productList: FeaturedProductList;
@@ -178,12 +176,6 @@ function ProductListItem({ product }: ProductListItemProps) {
       : 0;
 
    const isSoldOut = product.quantity_available <= 0;
-   const onClick = React.useCallback(() => {
-      trackInMatomoAndGA({
-         eventCategory: 'Featured Products - Product Page',
-         eventAction: `Featured on Product Page - ${product.sku}`,
-      });
-   }, [product.sku]);
 
    return (
       <LinkBox
@@ -211,10 +203,7 @@ function ProductListItem({ product }: ProductListItemProps) {
                )}
             </ProductCardBadgeList>
             <ProductCardBody>
-               <LinkOverlay
-                  href={`${appContext.ifixitOrigin}${product.url}`}
-                  onClick={onClick}
-               >
+               <LinkOverlay href={`${appContext.ifixitOrigin}${product.url}`}>
                   <ProductCardTitle _groupHover={{ color: 'brand.500' }}>
                      {product.title}
                   </ProductCardTitle>

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -40,7 +40,7 @@ export function CrossSellSection({
    product,
    selectedVariant,
 }: CrossSellSectionProps) {
-   const addToCart = useAddToCart();
+   const addToCart = useAddToCart('Frequently Bought Together');
    const getUserPrice = useGetUserPrice();
    const { onOpen } = useCartDrawer();
 

--- a/frontend/templates/product/sections/FeaturedProductsSection/index.tsx
+++ b/frontend/templates/product/sections/FeaturedProductsSection/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { ProductRating } from '@components/common';
 import { getProductPath } from '@helpers/product-helpers';
+import { trackInMatomoAndGA } from '@ifixit/analytics';
 import {
    computeDiscountPercentage,
    isLifetimeWarranty,
@@ -26,6 +27,7 @@ import {
 import { Product } from '@models/product';
 import { ImagePlaceholder } from '@templates/product/components/ImagePlaceholder';
 import NextLink from 'next/link';
+import * as React from 'react';
 
 export type FeaturedProductsSectionProps = {
    product: Product;
@@ -114,6 +116,12 @@ function ProductGridItem({
       typeof warranty === 'string' && isLifetimeWarranty(warranty);
 
    const productHeadingId = `product-heading-${handle}`;
+   const onClick = React.useCallback(() => {
+      trackInMatomoAndGA({
+         eventCategory: 'Featured Products - Product Page',
+         eventAction: `Featured on Product Page - ${handle}`,
+      });
+   }, [handle]);
 
    return (
       <LinkBox
@@ -137,6 +145,7 @@ function ProductGridItem({
             <NextLink href={getProductPath(handle)} passHref>
                <LinkOverlay
                   id={productHeadingId}
+                  onClick={onClick}
                   mt="3"
                   display="inline-block"
                   fontSize="md"

--- a/packages/analytics/google/index.tsx
+++ b/packages/analytics/google/index.tsx
@@ -51,30 +51,25 @@ export function trackGoogleAddToCart(addToCartInput: AddToCartInput) {
    }
    if (addToCartInput.type === 'bundle') {
       addToCartInput.bundle.items.forEach((item) =>
-         trackAddItemToCart(item, ga)
+         trackAddProductData(item, ga)
       );
    } else if (addToCartInput.type === 'product') {
-      trackAddItemToCart(addToCartInput.product, ga);
+      trackAddProductData(addToCartInput.product, ga);
    }
+   ga('ifixit.ec:setAction', 'add');
 }
 
-function trackAddItemToCart(item: CartLineItem, ga: GAType) {
-   const { category, optionid, productcode } = parseItemcode(item.itemcode);
+function trackAddProductData(item: CartLineItem, ga: GAType) {
+   const { category } = parseItemcode(item.itemcode);
    const addProductData: GAProductType & { quantity: number } = {
       id: item.itemcode,
       name: item.name,
       variant: item.internalDisplayName,
-      category: category,
+      category,
       price: moneyToNumber(item.price).toFixed(2),
       quantity: item.quantity,
    };
-
    ga('ifixit.ec:addProduct', addProductData);
-   ga('ifixit.ec:setAction', 'add');
-   gaSendEvent({
-      category: 'Add to Cart',
-      action: `Add to Cart - ${productcode}-${optionid}`,
-   });
 }
 
 export function gaSendEvent(event: GATrackEvent) {

--- a/packages/analytics/google/index.tsx
+++ b/packages/analytics/google/index.tsx
@@ -71,13 +71,13 @@ function trackAddItemToCart(item: CartLineItem, ga: GAType) {
 
    ga('ifixit.ec:addProduct', addProductData);
    ga('ifixit.ec:setAction', 'add');
-   sendEvent({
+   gaSendEvent({
       category: 'Add to Cart',
       action: `Add to Cart - ${productcode}-${optionid}`,
    });
 }
 
-function sendEvent(event: GATrackEvent) {
+export function gaSendEvent(event: GATrackEvent) {
    const ga = useGa();
    if (!ga) {
       return;

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -33,10 +33,10 @@ export function trackAddToCart(
    trackGoogleAddToCart(addToCartInput);
    if (addToCartInput.type === 'bundle') {
       addToCartInput.bundle.items.forEach((item) =>
-         trackAddItemToCartEvent(item)
+         trackAddItemToCartEvent(item, message)
       );
    } else if (addToCartInput.type === 'product') {
-      trackAddItemToCartEvent(addToCartInput.product);
+      trackAddItemToCartEvent(addToCartInput.product, message);
    }
 }
 

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -26,7 +26,8 @@ export const trackInMatomoAndGA = (trackData: TrackEventMatomo) => {
 
 export function trackAddToCart(
    cart: CartLineItem[],
-   addToCartInput: AddToCartInput
+   addToCartInput: AddToCartInput,
+   message?: string
 ) {
    trackMatomoCartChange(cart);
    trackGoogleAddToCart(addToCartInput);
@@ -39,12 +40,13 @@ export function trackAddToCart(
    }
 }
 
-function trackAddItemToCartEvent(item: CartLineItem) {
+function trackAddItemToCartEvent(item: CartLineItem, message?: string) {
+   const actionPrefix = message ? `${message} - ` : '';
    const actionSuffix = item.internalDisplayName
       ? ` - ${item.internalDisplayName}`
       : '';
    trackInMatomoAndGA({
       eventCategory: 'Add to Cart',
-      eventAction: `${item.itemcode}${actionSuffix}`,
+      eventAction: `${actionPrefix}${item.itemcode}${actionSuffix}`,
    });
 }

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -1,2 +1,23 @@
+import { gaSendEvent } from './google';
+import { TrackEventMatomo, trackInMatomo } from './matomo/track-event';
+
 export * from './google';
 export * from './matomo';
+
+/**
+ * @param trackData trackData.eventName will default to the page path if not provided
+ */
+export const trackInMatomoAndGA = (trackData: TrackEventMatomo) => {
+   const eventName =
+      trackData.eventName ||
+      `${window.location.origin}${window.location.pathname}`;
+   trackInMatomo({
+      ...trackData,
+      eventName,
+   });
+   gaSendEvent({
+      category: trackData.eventCategory,
+      action: trackData.eventAction,
+      name: eventName,
+   });
+};

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -10,6 +10,9 @@ export * from './matomo';
  * @param trackData trackData.eventName will default to the page path if not provided
  */
 export const trackInMatomoAndGA = (trackData: TrackEventMatomo) => {
+   if (typeof window === 'undefined') {
+      return;
+   }
    const eventName =
       trackData.eventName ||
       `${window.location.origin}${window.location.pathname}`;
@@ -29,24 +32,19 @@ export function trackAddToCart(
    addToCartInput: AddToCartInput,
    message?: string
 ) {
+   if (typeof window === 'undefined') {
+      return;
+   }
    trackMatomoCartChange(cart);
    trackGoogleAddToCart(addToCartInput);
-   if (addToCartInput.type === 'bundle') {
-      addToCartInput.bundle.items.forEach((item) =>
-         trackAddItemToCartEvent(item, message)
-      );
-   } else if (addToCartInput.type === 'product') {
-      trackAddItemToCartEvent(addToCartInput.product, message);
-   }
-}
-
-function trackAddItemToCartEvent(item: CartLineItem, message?: string) {
    const actionPrefix = message ? `${message} - ` : '';
-   const actionSuffix = item.internalDisplayName
-      ? ` - ${item.internalDisplayName}`
-      : '';
+   const itemcodes =
+      addToCartInput.type === 'product'
+         ? addToCartInput.product.itemcode
+         : addToCartInput.bundle.items.map((item) => item.itemcode).join(', ');
    trackInMatomoAndGA({
       eventCategory: 'Add to Cart',
-      eventAction: `${actionPrefix}${item.itemcode}${actionSuffix}`,
+      eventAction: `${actionPrefix}${itemcodes}`,
+      eventName: `${window.location.origin}${window.location.pathname}`,
    });
 }

--- a/packages/analytics/matomo/index.tsx
+++ b/packages/analytics/matomo/index.tsx
@@ -1,12 +1,6 @@
 import { CartLineItem } from '@ifixit/cart-sdk';
 import { Money, sumMoney } from '@ifixit/helpers';
-
-function usePaq(): any[] | undefined {
-   if (typeof window === 'undefined') {
-      return undefined;
-   }
-   return (window as any)._paq;
-}
+import { usePaq } from './usePaq';
 
 /**
  * @see https://developer.matomo.org/api-reference/tracking-javascript

--- a/packages/analytics/matomo/track-event.ts
+++ b/packages/analytics/matomo/track-event.ts
@@ -1,0 +1,65 @@
+import { usePaq } from './usePaq';
+
+/**
+ * @see https://matomo.org/docs/event-tracking/
+ * @see https://developer.matomo.org/api-reference/tracking-javascript
+ */
+export type TrackEventMatomo = {
+   /**
+    * Describes the type of events you want to track.
+    * For example, Link Clicks, Videos, Outbound Links, and Form Events.
+    */
+   eventCategory: string;
+   /**
+    * The specific action that is taken.
+    * For example, with a Video category, you might have a Play, Pause and Complete action.
+    */
+   eventAction: string;
+   /**
+    * Usually the title of the element that is being interacted with, to aid with analysis.
+    * For example, it could be the name of a Video that was played or the specific
+    * form that is being submitted.
+    */
+   eventName?: string;
+   /**
+    * A numeric value and is often added dynamically. It could be the cost of a
+    * product that is added to a cart, or the completion percentage of a video.
+    */
+   eventValue?: number;
+};
+
+/**
+ * @see https://matomo.org/docs/event-tracking/
+ * @see https://developer.matomo.org/api-reference/tracking-javascript
+ * @example
+ * const TrackingBrochureDownloads = {
+ *   EventCategory: 'Downloads',
+ *   EventAction: 'PDF Brochure Download',
+ *   EventName: 'MyBrochure'
+ * }
+ * @example
+ * const TrackingUserReviews = {
+ *   EventCategory: 'Reviews'
+ *   EventAction: 'Published Matomo Review'
+ *   EventValue: 10
+ * }
+ */
+export const trackInMatomo = (trackData: TrackEventMatomo) => {
+   const _paq = usePaq();
+   if (!_paq) {
+      return;
+   }
+   const dataWithEventName = {
+      ...trackData,
+      eventName:
+         trackData.eventName ||
+         `${window.location.origin}${window.location.pathname}`,
+   };
+   _paq.push([
+      'trackEvent',
+      dataWithEventName.eventCategory,
+      dataWithEventName.eventAction,
+      dataWithEventName.eventName,
+      dataWithEventName.eventValue,
+   ]);
+};

--- a/packages/analytics/matomo/usePaq.ts
+++ b/packages/analytics/matomo/usePaq.ts
@@ -1,0 +1,6 @@
+export function usePaq(): any[] | undefined {
+   if (typeof window === 'undefined') {
+      return undefined;
+   }
+   return (window as any)._paq;
+}

--- a/packages/cart-sdk/hooks/use-add-to-cart.ts
+++ b/packages/cart-sdk/hooks/use-add-to-cart.ts
@@ -1,4 +1,4 @@
-import { trackGoogleAddToCart, trackMatomoCartChange } from '@ifixit/analytics';
+import { trackAddToCart } from '@ifixit/analytics';
 import { assertNever, getProductVariantSku } from '@ifixit/helpers';
 import { useIFixitApiClient } from '@ifixit/ifixit-api-client';
 import { useMutation, useQueryClient } from 'react-query';
@@ -98,8 +98,7 @@ export function useAddToCart() {
          },
          onSuccess: (data, variables) => {
             const cart = client.getQueryData<Cart>(cartKeys.cart);
-            trackMatomoCartChange(cart?.lineItems ?? []);
-            trackGoogleAddToCart(variables);
+            trackAddToCart(cart?.lineItems ?? [], variables);
          },
          onSettled: () => {
             window.onbeforeunload = () => undefined;

--- a/packages/cart-sdk/hooks/use-add-to-cart.ts
+++ b/packages/cart-sdk/hooks/use-add-to-cart.ts
@@ -23,7 +23,7 @@ type AddBundleToCartInput = {
 /**
  * Update line item quantity.
  */
-export function useAddToCart() {
+export function useAddToCart(analyticsMessage?: string) {
    const client = useQueryClient();
    const iFixitApiClient = useIFixitApiClient();
    const mutation = useMutation(
@@ -98,7 +98,7 @@ export function useAddToCart() {
          },
          onSuccess: (data, variables) => {
             const cart = client.getQueryData<Cart>(cartKeys.cart);
-            trackAddToCart(cart?.lineItems ?? [], variables);
+            trackAddToCart(cart?.lineItems ?? [], variables, analyticsMessage);
          },
          onSettled: () => {
             window.onbeforeunload = () => undefined;

--- a/packages/cart-sdk/hooks/use-checkout.ts
+++ b/packages/cart-sdk/hooks/use-checkout.ts
@@ -1,3 +1,4 @@
+import { trackInMatomoAndGA } from '@ifixit/analytics';
 import { useAppContext } from '@ifixit/app';
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { assertNever, isError } from '@ifixit/helpers';
@@ -49,6 +50,10 @@ export function useCheckout(): UseCheckout {
                } else {
                   url = await standardCheckout();
                }
+               trackInMatomoAndGA({
+                  eventCategory: 'Mini Cart',
+                  eventAction: 'Btn "Check Out" - Click',
+               });
                window.location.href = url;
             } catch (error) {
                if (isError(error)) {

--- a/packages/footer/components/Legal.tsx
+++ b/packages/footer/components/Legal.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
    Box,
    BoxProps,
@@ -8,6 +7,7 @@ import {
    Stack,
    StackProps,
 } from '@chakra-ui/react';
+import { useTrackedOnClick } from '../hooks/useTrackedOnClick';
 
 export const FooterLegalSection = forwardRef<StackProps, 'div'>(
    ({ children, ...otherProps }, ref) => {
@@ -81,10 +81,12 @@ export const FooterLegalLinkList = forwardRef<StackProps, 'div'>(
 );
 
 export const FooterLegalLink = forwardRef<LinkProps, 'a'>((props, ref) => {
+   const trackedOnClick = useTrackedOnClick(props);
    return (
       <Link
          ref={ref}
          as="a"
+         onClick={trackedOnClick}
          align="center"
          color="gray.400"
          transition="color 300ms"

--- a/packages/footer/components/Navigation.tsx
+++ b/packages/footer/components/Navigation.tsx
@@ -11,6 +11,7 @@ import {
    SimpleGrid,
    SimpleGridProps,
 } from '@chakra-ui/react';
+import { useTrackedOnClick } from '../hooks/useTrackedOnClick';
 
 export const FooterNavigationSection = forwardRef<SimpleGridProps, 'div'>(
    (props, ref) => {
@@ -75,10 +76,12 @@ type FooterNavigationLinkProps = BoxProps & {
 
 export const FooterNavigationLink = forwardRef<FooterNavigationLinkProps, 'a'>(
    ({ icon, children, ...otherProps }, ref) => {
+      const trackedOnClick = useTrackedOnClick(otherProps);
       return (
          <Box
             ref={ref}
             as="a"
+            onClick={trackedOnClick}
             cursor="pointer"
             transition="all 400ms"
             _hover={{

--- a/packages/footer/components/Partners.tsx
+++ b/packages/footer/components/Partners.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps, forwardRef, SimpleGrid } from '@chakra-ui/react';
+import { useTrackedOnClick } from '../hooks/useTrackedOnClick';
 
 export const FooterPartners = forwardRef<BoxProps, 'div'>(
    ({ children, ...otherProps }, ref) => {
@@ -26,10 +27,12 @@ export const FooterPartners = forwardRef<BoxProps, 'div'>(
 
 export const FooterPartnerLink = forwardRef<BoxProps, 'a'>(
    ({ children, ...otherProps }, ref) => {
+      const trackedOnClick = useTrackedOnClick(otherProps);
       return (
          <Box
             ref={ref}
             as="a"
+            onClick={trackedOnClick}
             bg="gray.800"
             opacity="0.5"
             h="48px"

--- a/packages/footer/components/Shared.tsx
+++ b/packages/footer/components/Shared.tsx
@@ -9,7 +9,8 @@ import {
    StackProps,
    Text,
 } from '@chakra-ui/react';
-import React from 'react';
+import { trackInMatomoAndGA } from '@ifixit/analytics';
+import * as React from 'react';
 import { PageContentWrapper } from './PageContentWrapper';
 
 export const Footer = forwardRef<FlexProps, 'footer'>(
@@ -34,7 +35,18 @@ type FooterLinkProps = StackProps & {
 };
 
 export const FooterLink = forwardRef<FooterLinkProps, 'a'>(
-   ({ fontSize = 'sm', href, children, icon, ...otherProps }, ref) => {
+   ({ fontSize = 'sm', href, children, icon, onClick, ...otherProps }, ref) => {
+      const trackedOnClick: React.MouseEventHandler<HTMLDivElement> =
+         React.useCallback(
+            (e) => {
+               onClick?.(e);
+               trackInMatomoAndGA({
+                  eventCategory: 'Footer',
+                  eventAction: `Link Click - ${href}`,
+               });
+            },
+            [href, onClick]
+         );
       return (
          <HStack
             ref={ref}
@@ -45,6 +57,7 @@ export const FooterLink = forwardRef<FooterLinkProps, 'a'>(
             _visited={{ color: 'gray.300' }}
             _hover={{ color: 'white', textDecoration: 'none' }}
             href={href}
+            onClick={trackedOnClick}
             {...otherProps}
          >
             <Text

--- a/packages/footer/components/Shared.tsx
+++ b/packages/footer/components/Shared.tsx
@@ -9,8 +9,7 @@ import {
    StackProps,
    Text,
 } from '@chakra-ui/react';
-import { trackInMatomoAndGA } from '@ifixit/analytics';
-import * as React from 'react';
+import { useTrackedOnClick } from '../hooks/useTrackedOnClick';
 import { PageContentWrapper } from './PageContentWrapper';
 
 export const Footer = forwardRef<FlexProps, 'footer'>(
@@ -36,17 +35,7 @@ type FooterLinkProps = StackProps & {
 
 export const FooterLink = forwardRef<FooterLinkProps, 'a'>(
    ({ fontSize = 'sm', href, children, icon, onClick, ...otherProps }, ref) => {
-      const trackedOnClick: React.MouseEventHandler<HTMLDivElement> =
-         React.useCallback(
-            (e) => {
-               onClick?.(e);
-               trackInMatomoAndGA({
-                  eventCategory: 'Footer',
-                  eventAction: `Link Click - ${href}`,
-               });
-            },
-            [href, onClick]
-         );
+      const trackedOnClick = useTrackedOnClick({ href, onClick });
       return (
          <HStack
             ref={ref}

--- a/packages/footer/hooks/useTrackedOnClick.tsx
+++ b/packages/footer/hooks/useTrackedOnClick.tsx
@@ -1,0 +1,24 @@
+import { trackInMatomoAndGA } from '@ifixit/analytics';
+import * as React from 'react';
+
+type UseFooterLinkTrackingProps<T> = {
+   href?: string;
+   onClick?: React.MouseEventHandler<T>;
+};
+
+export function useTrackedOnClick<T>({
+   href,
+   onClick,
+}: UseFooterLinkTrackingProps<T>) {
+   const trackedOnClick: React.MouseEventHandler<T> = React.useCallback(
+      (e) => {
+         trackInMatomoAndGA({
+            eventCategory: 'Footer',
+            eventAction: `Link Click - ${href}`,
+         });
+         onClick?.(e);
+      },
+      [href, onClick]
+   );
+   return trackedOnClick;
+}

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -9,6 +9,9 @@
       "build": "",
       "type-check": "tsc --pretty --noEmit"
    },
+   "dependencies": {
+      "@ifixit/analytics": "workspace:*"
+   },
    "peerDependencies": {
       "@chakra-ui/react": ">= 1.8.3 < 2",
       "@core-ds/primitives": ">2.4",

--- a/packages/newsletter-sdk/index.tsx
+++ b/packages/newsletter-sdk/index.tsx
@@ -44,7 +44,7 @@ export function useSubscribeToNewsletter(): [Subscription, SubscribeFn] {
             }));
             trackInMatomoAndGA({
                eventCategory: 'Newsletter',
-               eventAction: `Subscribe Form - Submit`,
+               eventAction: 'Subscribe Form - Submit',
             });
          } catch (error) {
             let message: string;

--- a/packages/newsletter-sdk/index.tsx
+++ b/packages/newsletter-sdk/index.tsx
@@ -1,3 +1,4 @@
+import { trackInMatomoAndGA } from '@ifixit/analytics';
 import { useAppContext } from '@ifixit/app';
 import { isError } from '@ifixit/helpers';
 import { sentryFetch } from '@ifixit/sentry';
@@ -41,6 +42,10 @@ export function useSubscribeToNewsletter(): [Subscription, SubscribeFn] {
                status: SubscriptionStatus.Subscribed,
                error: undefined,
             }));
+            trackInMatomoAndGA({
+               eventCategory: 'Newsletter',
+               eventAction: `Subscribe Form - Submit`,
+            });
          } catch (error) {
             let message: string;
             if (isError(error)) {

--- a/packages/newsletter-sdk/package.json
+++ b/packages/newsletter-sdk/package.json
@@ -5,6 +5,7 @@
    "types": "./index.tsx",
    "license": "MIT",
    "dependencies": {
+      "@ifixit/analytics": "workspace:*",
       "@ifixit/app": "workspace:*",
       "@ifixit/helpers": "workspace:*",
       "@ifixit/sentry": "workspace:*"

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -45,7 +45,7 @@ import { useCartDrawer } from './hooks/useCartDrawer';
 
 export function CartDrawer() {
    const appContext = useAppContext();
-   const { isOpen, onOpen, onClose } = useCartDrawer();
+   const { isOpen, onOpen, onClose, onViewCart } = useCartDrawer();
    const isMounted = useIsMounted();
    const cart = useCart();
    const checkout = useCheckout();
@@ -240,7 +240,7 @@ export function CartDrawer() {
                                  as="a"
                                  href={`${appContext.ifixitOrigin}/cart/view`}
                                  variant="outline"
-                                 onClick={onClose}
+                                 onClick={onViewCart}
                               >
                                  View cart
                               </Button>

--- a/packages/ui/cart/drawer/hooks/useCartDrawer.tsx
+++ b/packages/ui/cart/drawer/hooks/useCartDrawer.tsx
@@ -1,4 +1,5 @@
 import { useDisclosure } from '@chakra-ui/react';
+import { trackInMatomoAndGA } from '@ifixit/analytics';
 import * as React from 'react';
 
 export type CartDrawerContext = ReturnType<typeof useDisclosure> & {};
@@ -25,5 +26,12 @@ export function useCartDrawer() {
    if (context === null) {
       throw new Error('useCartDrawer must be used within a CartDrawerProvider');
    }
-   return context;
+   const onViewCart = React.useCallback(() => {
+      trackInMatomoAndGA({
+         eventCategory: 'Mini Cart',
+         eventAction: 'Btn "View Cart" - Click',
+      });
+      context.onClose();
+   }, [context.onClose]);
+   return { ...context, onViewCart };
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
       "type-check": "tsc --pretty --noEmit"
    },
    "dependencies": {
+      "@ifixit/analytics": "workspace:*",
       "@ifixit/app": "workspace:*",
       "@ifixit/cart-sdk": "workspace:*",
       "@ifixit/icons": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,7 @@ importers:
 
   packages/newsletter-sdk:
     specifiers:
+      '@ifixit/analytics': workspace:*
       '@ifixit/app': workspace:*
       '@ifixit/helpers': workspace:*
       '@ifixit/sentry': workspace:*
@@ -377,6 +378,7 @@ importers:
       '@types/react-dom': 17.0.11
       typescript: 4.5.3
     dependencies:
+      '@ifixit/analytics': link:../analytics
       '@ifixit/app': link:../app
       '@ifixit/helpers': link:../helpers
       '@ifixit/sentry': link:../sentry

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,7 @@ importers:
       '@babel/core': '>=7.0.0 <8.0.0'
       '@emotion/react': '>=11.0.0 <12.0.0'
       '@emotion/styled': '>=11.0.0 <12.0.0'
+      '@ifixit/analytics': workspace:*
       '@ifixit/tsconfig': workspace:*
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
@@ -297,6 +298,8 @@ importers:
       react-icons: 4.2.0
       regenerator-runtime: '*'
       typescript: 4.5.3
+    dependencies:
+      '@ifixit/analytics': link:../analytics
     devDependencies:
       '@babel/core': 7.18.6
       '@emotion/react': 11.7.1_yse24c3tnaw3czhkbk3q2k7woy

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,6 +430,7 @@ importers:
       '@babel/core': '>=7.0.0 <8.0.0'
       '@emotion/react': '>=11.0.0 <12.0.0'
       '@emotion/styled': '>=11.0.0 <12.0.0'
+      '@ifixit/analytics': workspace:*
       '@ifixit/app': workspace:*
       '@ifixit/auth-sdk': workspace:*
       '@ifixit/cart-sdk': workspace:*
@@ -446,6 +447,7 @@ importers:
       regenerator-runtime: '*'
       typescript: 4.5.3
     dependencies:
+      '@ifixit/analytics': link:../analytics
       '@ifixit/app': link:../app
       '@ifixit/auth-sdk': link:../auth-sdk
       '@ifixit/cart-sdk': link:../cart-sdk


### PR DESCRIPTION
This tracks more events in Matomo/GA across Next.js, making it more similar to what we already do for iFixit/ifixit pages.

## CR

Our iFixit/ifixit event tracking implementation: https://github.com/iFixit/ifixit/blob/323d77c499fc79b1088e453da3a17442a3a4369c/carpenter-frontend/Shared/Analytics/CombinedGAMatomo.ts#L29

Search for usages of this function in iFixit/ifixit to find the analogs to the usages here.

## QA

Check for each of the types of events in the parent issue. The wording might not be exactly the same, but make sure we're at least getting the relevant information for each type of event.

You'll need the [google tag manager legacy extension](https://chrome.google.com/webstore/detail/tag-assistant-legacy-by-g/kejbdjndbnbjgmefkgdddjlbokphdefk?hl=en) to QA this.

Click "Record", refresh the page, perform some actions, click "Stop recording", then view the report to see the events.

CC @erinemay

Closes #855
