### PR TITLE
Add store home page stats section

### DIFF
--- a/backend/src/api/page/content-types/page/schema.json
+++ b/backend/src/api/page/content-types/page/schema.json
@@ -42,7 +42,7 @@
             }
          },
          "type": "dynamiczone",
-         "components": ["page.hero", "page.browse"],
+         "components": ["page.hero", "page.browse", "page.stats"],
          "required": true
       }
    }

--- a/backend/src/components/page/stat-item.json
+++ b/backend/src/components/page/stat-item.json
@@ -1,0 +1,17 @@
+{
+   "collectionName": "components_page_stat_items",
+   "info": {
+      "displayName": "stat item"
+   },
+   "options": {},
+   "attributes": {
+      "label": {
+         "type": "string",
+         "required": true
+      },
+      "value": {
+         "type": "string",
+         "required": true
+      }
+   }
+}

--- a/backend/src/components/page/stats.json
+++ b/backend/src/components/page/stats.json
@@ -1,0 +1,17 @@
+{
+   "collectionName": "components_page_stats",
+   "info": {
+      "displayName": "stats",
+      "icon": "chart-line"
+   },
+   "options": {},
+   "attributes": {
+      "stats": {
+         "displayName": "stat item",
+         "type": "component",
+         "repeatable": true,
+         "component": "page.stat-item",
+         "required": true
+      }
+   }
+}

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -142,6 +142,33 @@ export type ComponentPageHero = {
    title?: Maybe<Scalars['String']>;
 };
 
+export type ComponentPageStatItem = {
+   __typename?: 'ComponentPageStatItem';
+   id: Scalars['ID'];
+   label: Scalars['String'];
+   value: Scalars['String'];
+};
+
+export type ComponentPageStatItemFiltersInput = {
+   and?: InputMaybe<Array<InputMaybe<ComponentPageStatItemFiltersInput>>>;
+   label?: InputMaybe<StringFilterInput>;
+   not?: InputMaybe<ComponentPageStatItemFiltersInput>;
+   or?: InputMaybe<Array<InputMaybe<ComponentPageStatItemFiltersInput>>>;
+   value?: InputMaybe<StringFilterInput>;
+};
+
+export type ComponentPageStats = {
+   __typename?: 'ComponentPageStats';
+   id: Scalars['ID'];
+   stats: Array<Maybe<ComponentPageStatItem>>;
+};
+
+export type ComponentPageStatsStatsArgs = {
+   filters?: InputMaybe<ComponentPageStatItemFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
 export type ComponentProductListBanner = {
    __typename?: 'ComponentProductListBanner';
    callToActionLabel: Scalars['String'];
@@ -367,6 +394,8 @@ export type GenericMorph =
    | ComponentPageCallToAction
    | ComponentPageCategory
    | ComponentPageHero
+   | ComponentPageStatItem
+   | ComponentPageStats
    | ComponentProductListBanner
    | ComponentProductListFeaturedProductList
    | ComponentProductListLinkedProductListSet
@@ -914,6 +943,7 @@ export type PageRelationResponseCollection = {
 export type PageSectionsDynamicZone =
    | ComponentPageBrowse
    | ComponentPageHero
+   | ComponentPageStats
    | Error;
 
 export type Pagination = {
@@ -1769,6 +1799,16 @@ export type FindPageQuery = {
                           } | null;
                        } | null;
                     } | null;
+                 }
+               | {
+                    __typename: 'ComponentPageStats';
+                    id: string;
+                    stats: Array<{
+                       __typename?: 'ComponentPageStatItem';
+                       id: string;
+                       label: string;
+                       value: string;
+                    } | null>;
                  }
                | { __typename: 'Error' }
                | null
@@ -3021,6 +3061,14 @@ export const FindPageDocument = `
                   ...ProductListFields
                 }
               }
+            }
+          }
+          ... on ComponentPageStats {
+            id
+            stats {
+              id
+              label
+              value
             }
           }
         }

--- a/frontend/lib/strapi-sdk/operations/findPage.graphql
+++ b/frontend/lib/strapi-sdk/operations/findPage.graphql
@@ -41,6 +41,14 @@ query findPage(
                      }
                   }
                }
+               ... on ComponentPageStats {
+                  id
+                  stats {
+                     id
+                     label
+                     value
+                  }
+               }
             }
          }
       }

--- a/frontend/models/page.ts
+++ b/frontend/models/page.ts
@@ -70,6 +70,18 @@ export async function findPage({ path }: FindPageArgs) {
                   categories,
                };
             }
+            case 'ComponentPageStats': {
+               const stats = filterFalsyItems(section.stats).map(
+                  ({ id, label, value }) => {
+                     return { id, label, value };
+                  }
+               );
+               return {
+                  __typename: section.__typename,
+                  id: `${section.__typename}-${index}`,
+                  stats,
+               };
+            }
             case 'Error': {
                console.error('Failed to parse page section:', section);
                return null;

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -10,6 +10,7 @@ import {
 } from './hooks/usePageTemplateProps';
 import { BrowseSection } from './sections/BrowseSection';
 import { HeroSection } from './sections/HeroSection';
+import { StatsSection } from './sections/StatsSection';
 
 export const PageTemplate: NextPageWithLayout<PageTemplateProps> = () => {
    const { page } = usePageTemplateProps();
@@ -22,6 +23,9 @@ export const PageTemplate: NextPageWithLayout<PageTemplateProps> = () => {
                }
                case 'ComponentPageBrowse': {
                   return <BrowseSection key={section.id} data={section} />;
+               }
+               case 'ComponentPageStats': {
+                  return <StatsSection key={section.id} data={section} />;
                }
                default:
                   return assertNever(section);

--- a/frontend/templates/page/sections/StatsSection.tsx
+++ b/frontend/templates/page/sections/StatsSection.tsx
@@ -1,0 +1,76 @@
+import {
+   Box,
+   SimpleGrid,
+   Stat,
+   StatHelpText,
+   StatNumber,
+} from '@chakra-ui/react';
+import { PageContentWrapper } from '@ifixit/ui';
+import { GetSection } from '@models/page';
+
+export interface StatsSectionProps {
+   data: GetSection<'ComponentPageStats'>;
+}
+
+export function StatsSection({ data: { stats } }: StatsSectionProps) {
+   return (
+      <Box
+         as="section"
+         position="relative"
+         w="full"
+         bg="brand.100"
+         borderWidth={1}
+         borderColor="brand.200"
+         mb={-10}
+      >
+         <PageContentWrapper isResponsive>
+            <SimpleGrid
+               minChildWidth="200px"
+               spacing={{ base: 9, lg: 10 }}
+               py="12"
+            >
+               {stats.map((stat, index) => (
+                  <Stats key={index} value={stat.value} label={stat.label} />
+               ))}
+            </SimpleGrid>
+         </PageContentWrapper>
+      </Box>
+   );
+}
+
+interface StatsProps {
+   value: string;
+   label: string;
+}
+
+function Stats({ value, label }: StatsProps) {
+   const formattedValue = isNumber(value)
+      ? formatNumber(parseFloat(value))
+      : value;
+   return (
+      <Stat
+         sx={{
+            dl: {
+               display: 'flex',
+               flexDirection: 'column',
+               alignItems: 'center',
+            },
+         }}
+      >
+         <StatNumber color="brand.500" fontSize="4xl" m="0">
+            {formattedValue}
+         </StatNumber>
+         <StatHelpText color="brand.400" fontSize="md" m="0">
+            {label}
+         </StatHelpText>
+      </Stat>
+   );
+}
+
+function isNumber(value: string) {
+   return /^\d+$/.test(value);
+}
+
+function formatNumber(value: number) {
+   return new Intl.NumberFormat().format(value);
+}


### PR DESCRIPTION
closes #872 

## QA

1. Open [Vercel preview](https://react-commerce-git-add-store-home-page-stats-section-ifixit.vercel.app/store)
2. Verify that store home page stats section is implemented as specified in #872 

## Post merge

This PR adds a new content type so after having merged this we need to migrate the Strapi live server

cc @sterlinghirsh 