### PR TITLE
Reset cross sell section state on variant change

### DIFF
--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -64,6 +64,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
             <ReplacementGuidesSection product={product} />
             <ServiceValuePropositionSection />
             <CrossSellSection
+               key={selectedVariant.id}
                product={product}
                selectedVariant={selectedVariant}
             />


### PR DESCRIPTION
closes #860 

## QA

1. Open [Vercel preview](https://react-commerce-git-reset-cross-sell-section-state-86e57f-ifixit.vercel.app/products/iphone-se-2020-replacement-battery)
2. Verify that issue described by #860 is fixed