### PR TITLE
Make repair guides boxes all clickable

### DIFF
--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -297,7 +297,10 @@ const ReplacementGuideMetafieldItemSchema = z.object({
    title: z.string(),
    guide_url: z.string(),
    image_url: z.string().optional().nullable(),
-   summary: z.string().optional().nullable(),
+   summary: z.preprocess(
+      (val) => (typeof val === 'string' ? val : null),
+      z.string().optional().nullable()
+   ),
    difficulty: z.string().optional().nullable(),
    time_required: z.string().optional().nullable(),
 });

--- a/frontend/templates/product/sections/ReplacementGuidesSection/index.tsx
+++ b/frontend/templates/product/sections/ReplacementGuidesSection/index.tsx
@@ -4,6 +4,8 @@ import {
    Flex,
    forwardRef,
    Heading,
+   LinkBox,
+   LinkOverlay,
    ListItem,
    SimpleGrid,
    TagProps,
@@ -80,7 +82,10 @@ function ReplacementGuideCard({ guide }: ReplacementGuideCardProps) {
    const hasBadges =
       isPresent(guide.difficulty) || isPresent(guide.time_required);
    return (
-      <Flex
+      <LinkBox
+         as="article"
+         display="flex"
+         overflow="hidden"
          minH={{
             base: 'auto',
             md: '150px',
@@ -89,6 +94,7 @@ function ReplacementGuideCard({ guide }: ReplacementGuideCardProps) {
          borderColor="gray.300"
          borderWidth="1px"
          borderRadius="md"
+         role="group"
       >
          {guide.image_url && (
             <>
@@ -144,8 +150,7 @@ function ReplacementGuideCard({ guide }: ReplacementGuideCardProps) {
             </>
          )}
          <Box px="3" py="3" overflow="hidden">
-            <Text
-               as="a"
+            <LinkOverlay
                href={guide.guide_url}
                target="_blank"
                fontWeight="bold"
@@ -153,9 +158,12 @@ function ReplacementGuideCard({ guide }: ReplacementGuideCardProps) {
                lineHeight="short"
                noOfLines={3}
                flexShrink={0}
+               _groupHover={{
+                  color: 'brand.500',
+               }}
             >
                {guide.title}
-            </Text>
+            </LinkOverlay>
             {isPresent(guide.summary) && (
                <Text
                   fontSize="sm"
@@ -194,7 +202,7 @@ function ReplacementGuideCard({ guide }: ReplacementGuideCardProps) {
                </UnorderedList>
             )}
          </Box>
-      </Flex>
+      </LinkBox>
    );
 }
 


### PR DESCRIPTION
closes #862 

## QA

1. Open [Vercel preview](https://react-commerce-git-make-repair-guides-boxes-all-c-522826-ifixit.vercel.app/products/iphone-7-plus-screen)
2. Verify that the entire repair guide box is clickable