### PR TITLE
Increase browse categories fetched count

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -3014,7 +3014,7 @@ export const FindPageDocument = `
             image {
               ...ImageFields
             }
-            categories {
+            categories(pagination: {limit: 100}) {
               id
               productList {
                 data {

--- a/frontend/lib/strapi-sdk/operations/findPage.graphql
+++ b/frontend/lib/strapi-sdk/operations/findPage.graphql
@@ -32,7 +32,7 @@ query findPage(
                   image {
                      ...ImageFields
                   }
-                  categories {
+                  categories(pagination: { limit: 100 }) {
                      id
                      productList {
                         data {


### PR DESCRIPTION
closes #272 

Part of #272 was already addressed in #857

## QA

1. Open [Vercel preview](https://react-commerce-git-improve-browse-section-categories-ifixit.vercel.app/store)
2. Verify that more than 10 categories are shown in the browse section (the limit has been set to 100)
3. Verify that the categories are sortable by changing the sort order in [Strapi](https://improve-browse-section-categories.govinor.com/admin/content-manager/collectionType/api::page.page/1?plugins[i18n][locale]=en)
    <img width="1136" alt="Screenshot 2022-10-25 at 15 38 37" src="https://user-images.githubusercontent.com/4640135/197788577-955532d4-1c29-48e0-ac61-e3a46f8169d1.png">
