### PR TITLE
Proposal active image always first

### DIFF
--- a/frontend/templates/product/hooks/useSwiper.ts
+++ b/frontend/templates/product/hooks/useSwiper.ts
@@ -22,7 +22,7 @@ export function useSwiper({
    const [mainSwiper, setMainSwiper] = React.useState<Swiper | null>(null);
    const [thumbsSwiper, setThumbsSwiper] = React.useState<Swiper | null>(null);
    const slideChangeCallbackRef = React.useRef<(swiper: Swiper) => void>();
-   const slideChangeTransitionStartCallbackRef =
+   const slideNextTransitionStartCallbackRef =
       React.useRef<(swiper: Swiper) => void>();
 
    const [{ realIndex, isBeginning, isEnd }, setNavigationConfig] =
@@ -38,7 +38,7 @@ export function useSwiper({
          setNavigationConfig({ realIndex, isBeginning, isEnd });
          onSlideChange?.(swiper.realIndex);
       };
-      const slideChangeTransitionStartCallback = (swiper: Swiper) => {
+      const slideNextTransitionStartCallback = (swiper: Swiper) => {
          const { realIndex } = swiper;
          if (thumbsSwiper && realIndex > thumbsSwiper.realIndex) {
             thumbsSwiper?.slideTo(realIndex);
@@ -47,20 +47,20 @@ export function useSwiper({
       if (slideChangeCallbackRef.current) {
          mainSwiper?.off('slideChange', slideChangeCallbackRef.current);
       }
-      if (slideChangeTransitionStartCallbackRef.current) {
+      if (slideNextTransitionStartCallbackRef.current) {
          mainSwiper?.off(
-            'slideChangeTransitionStart',
-            slideChangeTransitionStartCallbackRef.current
+            'slideNextTransitionStart',
+            slideNextTransitionStartCallbackRef.current
          );
       }
       mainSwiper?.on('slideChange', slideChangeCallback);
       slideChangeCallbackRef.current = slideChangeCallback;
       mainSwiper?.on(
-         'slideChangeTransitionStart',
-         slideChangeTransitionStartCallback
+         'slideNextTransitionStart',
+         slideNextTransitionStartCallback
       );
-      slideChangeTransitionStartCallbackRef.current =
-         slideChangeTransitionStartCallback;
+      slideNextTransitionStartCallbackRef.current =
+         slideNextTransitionStartCallback;
    }, [mainSwiper, thumbsSwiper, onSlideChange]);
 
    React.useEffect(() => {

--- a/frontend/templates/product/hooks/useSwiper.ts
+++ b/frontend/templates/product/hooks/useSwiper.ts
@@ -24,6 +24,8 @@ export function useSwiper({
    const slideChangeCallbackRef = React.useRef<(swiper: Swiper) => void>();
    const slideNextTransitionStartCallbackRef =
       React.useRef<(swiper: Swiper) => void>();
+   const slidePrevTransitionStartCallbackRef =
+      React.useRef<(swiper: Swiper) => void>();
 
    const [{ realIndex, isBeginning, isEnd }, setNavigationConfig] =
       React.useState({
@@ -40,8 +42,14 @@ export function useSwiper({
       };
       const slideNextTransitionStartCallback = (swiper: Swiper) => {
          const { realIndex } = swiper;
-         if (thumbsSwiper && realIndex > thumbsSwiper.realIndex) {
-            thumbsSwiper?.slideTo(realIndex);
+         if (thumbsSwiper && realIndex > thumbsSwiper.realIndex + 1) {
+            thumbsSwiper?.slideTo(realIndex - 1);
+         }
+      };
+      const slidePrevTransitionStartCallback = (swiper: Swiper) => {
+         const { realIndex } = swiper;
+         if (thumbsSwiper && realIndex < thumbsSwiper.realIndex + 1) {
+            thumbsSwiper?.slideTo(realIndex - 1);
          }
       };
       if (slideChangeCallbackRef.current) {
@@ -53,6 +61,12 @@ export function useSwiper({
             slideNextTransitionStartCallbackRef.current
          );
       }
+      if (slidePrevTransitionStartCallbackRef.current) {
+         mainSwiper?.off(
+            'slidePrevTransitionStart',
+            slidePrevTransitionStartCallbackRef.current
+         );
+      }
       mainSwiper?.on('slideChange', slideChangeCallback);
       slideChangeCallbackRef.current = slideChangeCallback;
       mainSwiper?.on(
@@ -60,6 +74,12 @@ export function useSwiper({
          slideNextTransitionStartCallback
       );
       slideNextTransitionStartCallbackRef.current =
+         slideNextTransitionStartCallback;
+      mainSwiper?.on(
+         'slidePrevTransitionStart',
+         slidePrevTransitionStartCallback
+      );
+      slidePrevTransitionStartCallbackRef.current =
          slideNextTransitionStartCallback;
    }, [mainSwiper, thumbsSwiper, onSlideChange]);
 

--- a/frontend/templates/product/hooks/useSwiper.ts
+++ b/frontend/templates/product/hooks/useSwiper.ts
@@ -36,8 +36,6 @@ export function useSwiper({
          isEnd: false,
       });
 
-   console.log({ realIndex, snapIndex, isBeginning, isEnd });
-
    React.useEffect(() => {
       if (!showThumbnails) {
          setThumbsSwiper(null);
@@ -46,7 +44,6 @@ export function useSwiper({
 
    React.useEffect(() => {
       if (mainSwiper && !mainSwiper.destroyed && slideIndex != null) {
-         console.log('!DESTROYED');
          mainSwiper.slideTo(slideIndex);
          setNavigationConfig((navigationConfig) => ({
             ...navigationConfig,

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -49,6 +49,7 @@ export function ProductGallery({
       thumbsSwiper,
       setThumbsSwiper,
       realIndex,
+      snapIndex,
       isBeginning,
       isEnd,
    } = useSwiper({
@@ -147,12 +148,12 @@ export function ProductGallery({
                   zIndex="10"
                   pointerEvents="none"
                   opacity={
-                     realIndex > 1 && variantImages.length > THUMBNAILS_COUNT
+                     snapIndex > 0 && variantImages.length > THUMBNAILS_COUNT
                         ? 1
                         : 0
                   }
                   transition="all 300ms"
-               ></Box>
+               />
                <Box
                   position="absolute"
                   bgGradient="linear(to-r, transparent, blueGray.50)"
@@ -164,12 +165,12 @@ export function ProductGallery({
                   zIndex="10"
                   pointerEvents="none"
                   opacity={
-                     variantImages.length - realIndex >= THUMBNAILS_COUNT
+                     variantImages.length - snapIndex - 1 >= THUMBNAILS_COUNT
                         ? 1
                         : 0
                   }
                   transition="all 300ms"
-               ></Box>
+               />
             </Box>
          )}
       </Box>

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -131,7 +131,7 @@ export function ProductGallery({
                </ReactSwiper>
                <Box
                   position="absolute"
-                  bgGradient="linear(to-l, transparent, white)"
+                  bgGradient="linear(to-l, transparent, blueGray.50)"
                   w="25%"
                   h="full"
                   top="0"
@@ -144,7 +144,7 @@ export function ProductGallery({
                ></Box>
                <Box
                   position="absolute"
-                  bgGradient="linear(to-r, transparent, white)"
+                  bgGradient="linear(to-r, transparent, blueGray.50)"
                   w="25%"
                   h="full"
                   top="0"

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -105,6 +105,7 @@ export function ProductGallery({
                onSwiper={setThumbsSwiper}
                modules={[Navigation, Thumbs]}
                watchSlidesProgress
+               threshold={5}
                slidesPerView={6}
                spaceBetween={12}
                style={{

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -16,26 +16,22 @@ import { Swiper as ReactSwiper, SwiperSlide } from 'swiper/react';
 export type ProductGalleryProps = {
    product: Product;
    selectedVariant: ProductVariant;
-   selectedImageId?: string | null;
    showThumbnails?: boolean;
    enableZoom?: boolean;
    onChangeImage?: (imageId: string) => void;
 };
 
+const THUMBNAILS_COUNT = 6;
+const THUMBNAILS_SPACE_BETWEEN = 12;
+
 export function ProductGallery({
    product,
    selectedVariant,
-   selectedImageId,
    showThumbnails,
    enableZoom,
    onChangeImage,
 }: ProductGalleryProps) {
    const variantImages = useVariantImages(product, selectedVariant.id);
-   const selectedImageIndex = useCurrentImageIndex(
-      variantImages,
-      selectedImageId
-   );
-
    const onSlideChange = React.useCallback(
       (slideIndex) => onChangeImage?.(variantImages[slideIndex].id!),
       [onChangeImage, variantImages]
@@ -50,7 +46,6 @@ export function ProductGallery({
       isBeginning,
       isEnd,
    } = useSwiper({
-      slideIndex: selectedImageIndex,
       totalSlides: variantImages.length,
       showThumbnails: variantImages.length > 1,
       onSlideChange,
@@ -101,35 +96,68 @@ export function ProductGallery({
          )}
 
          {showThumbnails && variantImages.length > 1 && (
-            <ReactSwiper
-               onSwiper={setThumbsSwiper}
-               modules={[Navigation, Thumbs]}
-               watchSlidesProgress
-               threshold={5}
-               slidesPerView={6}
-               spaceBetween={12}
-               style={{
-                  width: '100%',
-                  marginTop: '12px',
-               }}
-            >
-               {variantImages.map((variantImage, index) => {
-                  return (
-                     <SwiperSlide
-                        key={variantImage.id}
-                        style={{
-                           maxWidth: 'calc((100% - 60px) / 6)',
-                           marginRight: '12px',
-                        }}
-                     >
-                        <ImageThumbnail
-                           image={variantImage}
-                           active={realIndex === index}
-                        />
-                     </SwiperSlide>
-                  );
-               })}
-            </ReactSwiper>
+            <Box position="relative">
+               <ReactSwiper
+                  onSwiper={setThumbsSwiper}
+                  modules={[Navigation, Thumbs]}
+                  watchSlidesProgress
+                  threshold={5}
+                  slidesPerView={THUMBNAILS_COUNT}
+                  spaceBetween={THUMBNAILS_SPACE_BETWEEN}
+                  style={{
+                     width: '100%',
+                     marginTop: '12px',
+                  }}
+               >
+                  {variantImages.map((variantImage, index) => {
+                     return (
+                        <SwiperSlide
+                           key={variantImage.id}
+                           style={{
+                              maxWidth: `calc((100% - ${
+                                 THUMBNAILS_SPACE_BETWEEN *
+                                 (THUMBNAILS_COUNT - 1)
+                              }px) / ${THUMBNAILS_COUNT})`,
+                              marginRight: `${THUMBNAILS_SPACE_BETWEEN}px`,
+                           }}
+                        >
+                           <ImageThumbnail
+                              image={variantImage}
+                              active={realIndex === index}
+                           />
+                        </SwiperSlide>
+                     );
+                  })}
+               </ReactSwiper>
+               <Box
+                  position="absolute"
+                  bgGradient="linear(to-l, transparent, white)"
+                  w="25%"
+                  h="full"
+                  top="0"
+                  bottom="0"
+                  left="0"
+                  zIndex="10"
+                  pointerEvents="none"
+                  opacity={realIndex > 0 ? 1 : 0}
+                  transition="all 300ms"
+               ></Box>
+               <Box
+                  position="absolute"
+                  bgGradient="linear(to-r, transparent, white)"
+                  w="25%"
+                  h="full"
+                  top="0"
+                  bottom="0"
+                  right="0"
+                  zIndex="10"
+                  pointerEvents="none"
+                  opacity={
+                     variantImages.length - realIndex > THUMBNAILS_COUNT ? 1 : 0
+                  }
+                  transition="all 300ms"
+               ></Box>
+            </Box>
          )}
       </Box>
    );
@@ -144,21 +172,6 @@ function useVariantImages(product: Product, variantId: string) {
          return linkedVariant == null || linkedVariant.id === variantId;
       });
    }, [product, variantId]);
-}
-
-function useCurrentImageIndex(
-   variantImages: ProductImage[],
-   selectedImageId?: string | null
-) {
-   const currentImageId = React.useMemo(() => {
-      return selectedImageId ?? variantImages[0]?.id;
-   }, [selectedImageId, variantImages]);
-
-   const currentImageIndex = React.useMemo(() => {
-      return variantImages.findIndex((image) => image.id === currentImageId)!;
-   }, [variantImages, currentImageId]);
-
-   return currentImageIndex;
 }
 
 type CustomNavigationType = {

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -139,7 +139,11 @@ export function ProductGallery({
                   left="0"
                   zIndex="10"
                   pointerEvents="none"
-                  opacity={realIndex > 0 ? 1 : 0}
+                  opacity={
+                     realIndex > 1 && variantImages.length > THUMBNAILS_COUNT
+                        ? 1
+                        : 0
+                  }
                   transition="all 300ms"
                ></Box>
                <Box
@@ -153,7 +157,9 @@ export function ProductGallery({
                   zIndex="10"
                   pointerEvents="none"
                   opacity={
-                     variantImages.length - realIndex > THUMBNAILS_COUNT ? 1 : 0
+                     variantImages.length - realIndex >= THUMBNAILS_COUNT
+                        ? 1
+                        : 0
                   }
                   transition="all 300ms"
                ></Box>

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -16,6 +16,7 @@ import { Swiper as ReactSwiper, SwiperSlide } from 'swiper/react';
 export type ProductGalleryProps = {
    product: Product;
    selectedVariant: ProductVariant;
+   selectedImageId?: string | null;
    showThumbnails?: boolean;
    enableZoom?: boolean;
    onChangeImage?: (imageId: string) => void;
@@ -27,11 +28,16 @@ const THUMBNAILS_SPACE_BETWEEN = 12;
 export function ProductGallery({
    product,
    selectedVariant,
+   selectedImageId,
    showThumbnails,
    enableZoom,
    onChangeImage,
 }: ProductGalleryProps) {
    const variantImages = useVariantImages(product, selectedVariant.id);
+   const selectedImageIndex = useCurrentImageIndex(
+      variantImages,
+      selectedImageId
+   );
    const onSlideChange = React.useCallback(
       (slideIndex) => onChangeImage?.(variantImages[slideIndex].id!),
       [onChangeImage, variantImages]
@@ -46,6 +52,7 @@ export function ProductGallery({
       isBeginning,
       isEnd,
    } = useSwiper({
+      slideIndex: selectedImageIndex,
       totalSlides: variantImages.length,
       showThumbnails: variantImages.length > 1,
       onSlideChange,
@@ -178,6 +185,24 @@ function useVariantImages(product: Product, variantId: string) {
          return linkedVariant == null || linkedVariant.id === variantId;
       });
    }, [product, variantId]);
+}
+
+function useCurrentImageIndex(
+   variantImages: ProductImage[],
+   selectedImageId?: string | null
+) {
+   const currentImageId = React.useMemo(() => {
+      return selectedImageId ?? variantImages[0]?.id;
+   }, [selectedImageId, variantImages]);
+
+   const currentImageIndex = React.useMemo(() => {
+      const index = variantImages.findIndex(
+         (image) => image.id === currentImageId
+      );
+      return index >= 0 ? index : 0;
+   }, [variantImages, currentImageId]);
+
+   return currentImageIndex;
 }
 
 type CustomNavigationType = {

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -33,13 +33,13 @@ import { Product, ProductVariant } from '@models/product';
 import { useIsProductForSale } from '@templates/product/hooks/useIsProductForSale';
 import NextLink from 'next/link';
 import * as React from 'react';
+import { BuyBoxPropositionSection } from '../ServiceValuePropositionSection';
 import { AddToCart, isVariantWithSku } from './AddToCart';
 import { GenuinePartBanner } from './GenuinePartBanner';
 import { ProductGallery } from './ProductGallery';
 import { ProductOptions } from './ProductOptions';
 import { ProductRating } from './ProductRating';
 import { Prop65Warning } from './Prop65Warning';
-import { BuyBoxPropositionSection } from '../ServiceValuePropositionSection';
 import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
 import { InternationalBuyBox } from './InternationalBuyBox';
 
@@ -56,6 +56,17 @@ export function ProductSection({
    onVariantChange,
    internationalBuyBox,
 }: ProductSectionProps) {
+   const [selectedImageId, setSelectedImageId] = React.useState<string | null>(
+      null
+   );
+
+   const handleVariantChange = React.useCallback(
+      (variantId: string) => {
+         onVariantChange(variantId);
+         setSelectedImageId(null);
+      },
+      [onVariantChange]
+   );
    const isForSale = useIsProductForSale(product);
 
    const compatibilityDrawerModelsTruncate = 4;
@@ -85,8 +96,10 @@ export function ProductSection({
                <ProductGallery
                   product={product}
                   selectedVariant={selectedVariant}
+                  selectedImageId={selectedImageId}
                   showThumbnails
                   enableZoom
+                  onChangeImage={setSelectedImageId}
                />
                <Box
                   id="zoom-container"
@@ -131,13 +144,15 @@ export function ProductSection({
                   <ProductGallery
                      product={product}
                      selectedVariant={selectedVariant}
+                     selectedImageId={selectedImageId}
+                     onChangeImage={setSelectedImageId}
                   />
                </Flex>
 
                <ProductOptions
                   product={product}
                   selected={selectedVariant.id}
-                  onChange={onVariantChange}
+                  onChange={handleVariantChange}
                />
                {isForSale ? (
                   isVariantWithSku(selectedVariant) &&

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -56,21 +56,6 @@ export function ProductSection({
    onVariantChange,
    internationalBuyBox,
 }: ProductSectionProps) {
-   const [selectedImageId, setSelectedImageId] = React.useState(
-      selectedVariant.image?.id
-   );
-
-   const handleVariantChange = React.useCallback(
-      (variantId: string) => {
-         onVariantChange(variantId);
-         const variant = product.variants.find(
-            (variant) => variant.id === variantId
-         )!;
-         setSelectedImageId(variant.image?.id);
-      },
-      [product.variants, onVariantChange]
-   );
-
    const isForSale = useIsProductForSale(product);
 
    const compatibilityDrawerModelsTruncate = 4;
@@ -100,10 +85,8 @@ export function ProductSection({
                <ProductGallery
                   product={product}
                   selectedVariant={selectedVariant}
-                  selectedImageId={selectedImageId}
                   showThumbnails
                   enableZoom
-                  onChangeImage={setSelectedImageId}
                />
                <Box
                   id="zoom-container"
@@ -148,15 +131,13 @@ export function ProductSection({
                   <ProductGallery
                      product={product}
                      selectedVariant={selectedVariant}
-                     selectedImageId={selectedImageId}
-                     onChangeImage={setSelectedImageId}
                   />
                </Flex>
 
                <ProductOptions
                   product={product}
                   selected={selectedVariant.id}
-                  onChange={handleVariantChange}
+                  onChange={onVariantChange}
                />
                {isForSale ? (
                   isVariantWithSku(selectedVariant) &&


### PR DESCRIPTION
closes #861 

As proposed in [comment](https://github.com/ifixit/react-commerce/issues/861#issuecomment-1289278944) this PR helps the user in understanding that there are more thumbnails available.

### QA

1. Visit [Vercel preview](https://react-commerce-git-improvements-on-product-galler-0c72c4-ifixit.vercel.app/products/fix-the-world-t-shirt)
2. Verify that the currently active image is always positioned as the leftmost visible in the thumbnails carousel
3. Only exception is when the carousel cannot scroll anymore to the right