### PR TITLE
Product Page: use high level key prop

### DIFF
--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -48,7 +48,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    }, []);
 
    return (
-      <>
+      <React.Fragment key={product.handle}>
          <MetaTags product={product} selectedVariant={selectedVariant} />
          {product.breadcrumbs != null && (
             <SecondaryNavigation>
@@ -76,7 +76,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
             <FeaturedProductsSection product={product} />
             <LifetimeWarrantySection variant={selectedVariant} />
          </Box>
-      </>
+      </React.Fragment>
    );
 };
 


### PR DESCRIPTION
There's some state on product pages. When you click a next-link and go to a different product page, we shouldn't be preserving any of that state. Previously, we were and we ran into bugs like: https://github.com/iFixit/react-commerce/issues/860

This should avoid an entire class of bugs like that.

CC @sterlinghirsh @federicobadini 