### PR TITLE
Use first variant as default variant

### DIFF
--- a/frontend/templates/product/hooks/useSelectedVariant.ts
+++ b/frontend/templates/product/hooks/useSelectedVariant.ts
@@ -46,11 +46,7 @@ export function useSelectedVariant(
 }
 
 function useDefaultVariantId(product: Product): string {
-   const variant =
-      product.variants.find(
-         (variant) => variant.quantityAvailable && variant.quantityAvailable > 0
-      ) ?? product.variants[0];
-   return variant.id;
+   return product.variants[0].id;
 }
 
 function useSearchParamVariantId(): string | null {


### PR DESCRIPTION
closes #881 

## QA

1. Open [Vercel preview](https://react-commerce-git-respect-akeneo-order-for-defau-c7d311-ifixit.vercel.app/products/macbook-12-retina-early-2015-2017-audio-board-flex-cable)
2. Verify that Akineo order by is respected as described by #881 