### PR TITLE
Device compatibility image aspect ratio

### DIFF
--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -12,7 +12,6 @@ export function CompatibleDevice({ device }: CompatibleDeviceProps) {
             src={device.imageUrl}
             alt={device.deviceName ?? ''}
             w="12"
-            h="12"
             mr="3"
             borderWidth="1px"
             borderStyle="solid"

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -329,6 +329,7 @@ export function ProductSection({
                                  <chakra.a
                                     role="group"
                                     display="flex"
+                                    alignItems="flex-start"
                                     transition="all 300m"
                                     mb="6px"
                                  >


### PR DESCRIPTION
closes #891 

### QA

1. Visit [Vercel preview](https://react-commerce-git-fix-device-compatibility-image-181e12-ifixit.vercel.app/products/2-tb-ssd-hybrid-3-5-hard-drive)
2. Verify that the image aspect ratio in compatibility sections is now correct