### PR TITLE
Use variant description in product page

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6446,6 +6446,7 @@ export type FindProductQuery = {
                name: string;
                value: string;
             }>;
+            description?: { __typename?: 'Metafield'; value: string } | null;
             kitContents?: { __typename?: 'Metafield'; value: string } | null;
             note?: { __typename?: 'Metafield'; value: string } | null;
             disclaimer?: { __typename?: 'Metafield'; value: string } | null;
@@ -6687,6 +6688,9 @@ export const FindProductDocument = `
         }
         selectedOptions {
           name
+          value
+        }
+        description: metafield(namespace: "ifixit", key: "description") {
           value
         }
         kitContents: metafield(namespace: "ifixit", key: "kit_contents") {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -102,6 +102,9 @@ query findProduct($handle: String) {
                name
                value
             }
+            description: metafield(namespace: "ifixit", key: "description") {
+               value
+            }
             kitContents: metafield(namespace: "ifixit", key: "kit_contents") {
                value
             }

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -107,6 +107,7 @@ function getVariants(shopifyProduct: ShopifyApiProduct) {
          ),
          isDiscounted,
          discountPercentage,
+         description: variant.description?.value ?? null,
          kitContents: variant.kitContents?.value ?? null,
          note: variant.note?.value ?? null,
          disclaimer: variant.disclaimer?.value ?? null,

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -192,24 +192,10 @@ export function ProductSection({
                      <CustomAccordionButton>Description</CustomAccordionButton>
                      <CustomAccordionPanel>
                         <VStack>
-                           <Box
-                              dangerouslySetInnerHTML={{
-                                 __html: product.descriptionHtml,
-                              }}
-                              fontSize="sm"
-                              sx={{
-                                 ul: {
-                                    my: 3,
-                                    pl: 5,
-                                 },
-                                 p: {
-                                    mb: 3,
-                                    _last: {
-                                       mb: 0,
-                                    },
-                                 },
-                              }}
-                           />
+                           <VariantDescription>
+                              {selectedVariant.description ??
+                                 product.descriptionHtml}
+                           </VariantDescription>
                            {selectedVariant.note && (
                               <Alert
                                  status="info"
@@ -489,5 +475,38 @@ function VariantWarranty({ variant, ...other }: VariantWarrantyProps) {
          )}
          <Box>{variant.warranty}</Box>
       </HStack>
+   );
+}
+
+type VariantDescriptionProps = {
+   children: string;
+};
+
+function VariantDescription({ children }: VariantDescriptionProps) {
+   return (
+      <Box
+         dangerouslySetInnerHTML={{
+            __html: children,
+         }}
+         fontSize="sm"
+         sx={{
+            ul: {
+               my: 3,
+               pl: 5,
+            },
+            p: {
+               mb: 3,
+               _last: {
+                  mb: 0,
+               },
+            },
+            a: {
+               color: 'brand.500',
+            },
+            'a:hover': {
+               textDecoration: 'underline',
+            },
+         }}
+      />
    );
 }


### PR DESCRIPTION
closes #889 

## QA

1. Open [Vercel preview](https://react-commerce-git-use-product-page-variant-description-ifixit.vercel.app/products/p5-pentalobe-screwdriver-retina-macbook-pro-and-air)
2. Verify that the variant description is being used