### PR TITLE
Make pro only products not for sale for non pro users

### DIFF
--- a/frontend/templates/product/hooks/useIsProductForSale.ts
+++ b/frontend/templates/product/hooks/useIsProductForSale.ts
@@ -1,0 +1,10 @@
+import { useAuthenticatedUser } from '@ifixit/auth-sdk';
+import { Product } from '@models/product';
+
+export function useIsProductForSale(product: Product): boolean {
+   const user = useAuthenticatedUser();
+   const isProOnlyProduct = product.tags.includes('Pro Only');
+   const isProUser = user.data?.is_pro ?? false;
+   const isForSale = !isProOnlyProduct || (isProOnlyProduct && isProUser);
+   return isForSale;
+}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -11,6 +11,7 @@ import { findProduct } from '@models/product';
 import { GetServerSideProps } from 'next';
 import * as React from 'react';
 import { SecondaryNavigation } from './components/SecondaryNavigation';
+import { useIsProductForSale } from './hooks/useIsProductForSale';
 import {
    ProductTemplateProps,
    useProductTemplateProps,
@@ -29,6 +30,8 @@ import { ServiceValuePropositionSection } from './sections/ServiceValuePropositi
 export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    const { product } = useProductTemplateProps();
    const [selectedVariant, setSelectedVariantId] = useSelectedVariant(product);
+
+   const isProductForSale = useIsProductForSale(product);
 
    React.useEffect(() => {
       trackMatomoEcommerceView({
@@ -63,15 +66,20 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
             />
             <ReplacementGuidesSection product={product} />
             <ServiceValuePropositionSection />
-            <CrossSellSection
-               key={selectedVariant.id}
-               product={product}
-               selectedVariant={selectedVariant}
-            />
-            <ReviewsSection
-               product={product}
-               selectedVariant={selectedVariant}
-            />
+            {isProductForSale && (
+               <CrossSellSection
+                  key={selectedVariant.id}
+                  product={product}
+                  selectedVariant={selectedVariant}
+               />
+            )}
+            {isProductForSale && (
+               <ReviewsSection
+                  product={product}
+                  selectedVariant={selectedVariant}
+               />
+            )}
+
             <CompatibilitySection compatibility={product.compatibility} />
             <FeaturedProductsSection product={product} />
             <LifetimeWarrantySection variant={selectedVariant} />

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -6,6 +6,7 @@ import {
    AccordionItem,
    AccordionPanel,
    Alert,
+   AlertProps,
    Box,
    chakra,
    Flex,
@@ -32,6 +33,7 @@ import { isLifetimeWarranty } from '@ifixit/helpers';
 import { FaIcon } from '@ifixit/icons';
 import { PageContentWrapper, ProductVariantPrice } from '@ifixit/ui';
 import { Product, ProductVariant } from '@models/product';
+import { useIsProductForSale } from '@templates/product/hooks/useIsProductForSale';
 import NextLink from 'next/link';
 import * as React from 'react';
 import { AddToCart, isVariantWithSku } from './AddToCart';
@@ -65,6 +67,8 @@ export function ProductSection({
       },
       [product.variants, onVariantChange]
    );
+
+   const isForSale = useIsProductForSale(product);
 
    return (
       <PageContentWrapper as="section">
@@ -102,7 +106,7 @@ export function ProductSection({
                   borderRadius="md"
                />
             </Flex>
-            <Flex
+            <Box
                w={{
                   base: 'full',
                   md: '320px',
@@ -112,7 +116,6 @@ export function ProductSection({
                   base: 0,
                   md: 5,
                }}
-               direction="column"
                fontSize="sm"
                position="relative"
             >
@@ -120,12 +123,14 @@ export function ProductSection({
                   <Text color="gray.500">Item # {selectedVariant.sku}</Text>
                )}
                <ProductTitle mb="2.5">{product.title}</ProductTitle>
-               <ProductVariantPrice
-                  price={selectedVariant.price}
-                  compareAtPrice={selectedVariant.compareAtPrice}
-                  proPricesByTier={selectedVariant.proPricesByTier}
-               />
-               <ProductRating product={product} />
+               {isForSale && (
+                  <ProductVariantPrice
+                     price={selectedVariant.price}
+                     compareAtPrice={selectedVariant.compareAtPrice}
+                     proPricesByTier={selectedVariant.proPricesByTier}
+                  />
+               )}
+               {isForSale && <ProductRating product={product} />}
                <Flex display={{ base: 'flex', md: 'none' }} w="full" pt="6">
                   <ProductGallery
                      product={product}
@@ -140,53 +145,17 @@ export function ProductSection({
                   selected={selectedVariant.id}
                   onChange={handleVariantChange}
                />
-               {isVariantWithSku(selectedVariant) && (
-                  <AddToCart
-                     product={product}
-                     selectedVariant={selectedVariant}
-                  />
+               {isForSale ? (
+                  isVariantWithSku(selectedVariant) && (
+                     <AddToCart
+                        product={product}
+                        selectedVariant={selectedVariant}
+                     />
+                  )
+               ) : (
+                  <NotForSaleAlert mt="4" />
                )}
-               <div>
-                  <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
-                     <ListItem display="flex" alignItems="center">
-                        <ListIcon
-                           as={FaIcon}
-                           h="4"
-                           w="5"
-                           mr="1.5"
-                           color="brand.500"
-                           icon={faBadgeDollar}
-                        />
-                        Satisfaction guaranteed or your money back
-                     </ListItem>
-                     <ListItem display="flex" alignItems="center">
-                        <ListIcon
-                           as={FaIcon}
-                           h="4"
-                           w="5"
-                           mr="1.5"
-                           color="brand.500"
-                           icon={faShieldCheck}
-                        />
-
-                        <div>
-                           If it doesn&apos;t meet our meticulous standards, we
-                           won&apos;t sell it. Period.
-                        </div>
-                     </ListItem>
-                     <ListItem display="flex" alignItems="center">
-                        <ListIcon
-                           as={FaIcon}
-                           h="4"
-                           w="5"
-                           mr="1.5"
-                           color="brand.500"
-                           icon={faRocket}
-                        />
-                        Same day shipping if ordered by 5PM
-                     </ListItem>
-                  </List>
-               </div>
+               {isForSale && <ValuePropositions />}
                <Accordion defaultIndex={[0, 1]} allowMultiple mt="10">
                   <AccordionItem>
                      <CustomAccordionButton>Description</CustomAccordionButton>
@@ -411,7 +380,7 @@ export function ProductSection({
                      />
                   )}
                </VStack>
-            </Flex>
+            </Box>
          </Flex>
       </PageContentWrapper>
    );
@@ -489,5 +458,90 @@ function VariantWarranty({ variant, ...other }: VariantWarrantyProps) {
          )}
          <Box>{variant.warranty}</Box>
       </HStack>
+   );
+}
+
+function NotForSaleAlert(props: AlertProps) {
+   return (
+      <Alert
+         status="warning"
+         borderWidth={1}
+         borderColor="orange.300"
+         borderRadius="md"
+         alignItems="flex-start"
+         {...props}
+      >
+         <FaIcon
+            icon={faCircleExclamation}
+            h="4"
+            mt="0.5"
+            mr="2.5"
+            color="orange.500"
+         />
+         <Box fontSize="sm">
+            <p>Product available for pro users only.</p>
+            <p>
+               Learn more about{' '}
+               <Link
+                  href="https://pro.ifixit.com"
+                  target="_blank"
+                  fontWeight="bold"
+                  textDecoration="underline"
+                  _hover={{
+                     color: 'orange.800',
+                  }}
+               >
+                  iFixit Pro
+               </Link>
+               .
+            </p>
+         </Box>
+      </Alert>
+   );
+}
+
+function ValuePropositions() {
+   return (
+      <div>
+         <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
+            <ListItem display="flex" alignItems="center">
+               <ListIcon
+                  as={FaIcon}
+                  h="4"
+                  w="5"
+                  mr="1.5"
+                  color="brand.500"
+                  icon={faBadgeDollar}
+               />
+               Satisfaction guaranteed or your money back
+            </ListItem>
+            <ListItem display="flex" alignItems="center">
+               <ListIcon
+                  as={FaIcon}
+                  h="4"
+                  w="5"
+                  mr="1.5"
+                  color="brand.500"
+                  icon={faShieldCheck}
+               />
+
+               <div>
+                  If it doesn&apos;t meet our meticulous standards, we
+                  won&apos;t sell it. Period.
+               </div>
+            </ListItem>
+            <ListItem display="flex" alignItems="center">
+               <ListIcon
+                  as={FaIcon}
+                  h="4"
+                  w="5"
+                  mr="1.5"
+                  color="brand.500"
+                  icon={faRocket}
+               />
+               Same day shipping if ordered by 5PM
+            </ListItem>
+         </List>
+      </div>
    );
 }


### PR DESCRIPTION
closes #897 

This PR shows a "not for sale" alert on pro only products when viewed by non pro users. We're hiding also non relevant sections, such as product reviews and cross sell.

## QA

1. Open [Vercel preview](https://react-commerce-git-make-pro-only-not-for-sale-ifixit.vercel.app/products/20-lb-steel-shot-bag)
2. Visit a pro-only product (e.g. https://react-commerce-git-make-pro-only-not-for-sale-ifixit.vercel.app/products/20-lb-steel-shot-bag) as an anonymous / not-pro user
3. Verify that the add to cart section is replaced by an alert
4. Login on cominor as a pro user
5. Visit the same pro-only product page an verify that you can add the product to cart

deploy_block 🛑  on a question:

- This PR identifies pro only products by looking for a "Pro Only" product tag. Is this correct?

cc @sterlinghirsh @erinemay 