### PR TITLE
Prop 65 Warning polish

### DIFF
--- a/frontend/templates/product/sections/ProductSection/Prop65Warning.tsx
+++ b/frontend/templates/product/sections/ProductSection/Prop65Warning.tsx
@@ -74,8 +74,12 @@ export function Prop65Warning({ type, chemicals }: Prop65WarningProps) {
                   </Text>
                   <Text mt="2">
                      For more information, go to{' '}
-                     <Link href="www.P65Warnings.ca.gov" color="brand.500">
-                        www.P65Warnings.ca.gov
+                     <Link
+                        href="https://www.p65warnings.ca.gov"
+                        isExternal
+                        color="brand.500"
+                     >
+                        www.P65warnings.ca.gov
                      </Link>
                   </Text>
                </PopoverBody>

--- a/frontend/templates/product/sections/ProductSection/Prop65Warning.tsx
+++ b/frontend/templates/product/sections/ProductSection/Prop65Warning.tsx
@@ -30,7 +30,7 @@ export function Prop65Warning({ type, chemicals }: Prop65WarningProps) {
       sm: 'bottom',
    });
    return (
-      <Flex align="center" position="relative">
+      <Flex align="center" position="relative" gap="1">
          <Text>California Residents: Prop 65 WARNING</Text>
          <Popover placement={placement}>
             <PopoverTrigger>


### PR DESCRIPTION
- fix(prop65): make warning link external
- fix(ui): prevent overlapping elements

## QA

Click the prop 65 external link on the product page, and make sure it opens in a new tab.

After closing the popup, make sure the accessibility highlight ring doesn't overlap with any text.

Closes #893
