### PR TITLE
Show shipping restriction when oos

### DIFF
--- a/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
@@ -8,6 +8,7 @@ import {
    PopoverBody,
    PopoverContent,
    PopoverTrigger,
+   StackProps,
    Text,
    VStack,
 } from '@chakra-ui/react';
@@ -77,7 +78,7 @@ export function AddToCart({ product, selectedVariant }: AddToCartProps) {
       inventory.maxToBeAdded != null && inventory.maxToBeAdded > 0;
 
    return (
-      <VStack mt="5" align="center">
+      <Box mt="5">
          {isSelectedVariantAvailable && (
             <>
                <Button
@@ -97,12 +98,22 @@ export function AddToCart({ product, selectedVariant }: AddToCartProps) {
                {selectedVariant.shippingRestrictions && (
                   <ShippingRestrictions
                      shippingRestrictions={selectedVariant.shippingRestrictions}
+                     mt="2.5"
                   />
                )}
             </>
          )}
          {!isSelectedVariantAvailable && selectedVariant.sku != null && (
-            <NotifyMeForm sku={selectedVariant.sku} />
+            <>
+               {selectedVariant.shippingRestrictions && (
+                  <ShippingRestrictions
+                     shippingRestrictions={selectedVariant.shippingRestrictions}
+                     mb="2.5"
+                     align="flex-start"
+                  />
+               )}
+               <NotifyMeForm sku={selectedVariant.sku} />
+            </>
          )}
          {!isSelectedVariantAvailable && selectedVariant.sku == null && (
             <Box
@@ -119,7 +130,7 @@ export function AddToCart({ product, selectedVariant }: AddToCartProps) {
                Sold out
             </Box>
          )}
-      </VStack>
+      </Box>
    );
 }
 
@@ -151,12 +162,13 @@ const shippingRestrictionsInfo: ShippingRestrictionsInfo = {
    },
 };
 
-type ShippingRestrictionsProps = {
+type ShippingRestrictionsProps = StackProps & {
    shippingRestrictions: string[];
 };
 
 function ShippingRestrictions({
    shippingRestrictions,
+   ...stackProps
 }: ShippingRestrictionsProps) {
    const restrictionKeysToShow: string[] = [];
    const primaryRestrictionKey = shippingRestrictions.find(
@@ -173,7 +185,7 @@ function ShippingRestrictions({
 
    if (restrictionKeysToShow.length > 0) {
       return (
-         <VStack mt="2.5" spacing="1">
+         <VStack spacing="1" {...stackProps}>
             {restrictionKeysToShow.map((restrictionKey) => {
                const shippingRestriction =
                   shippingRestrictionsInfo[restrictionKey];


### PR DESCRIPTION
closes #890 

<img width="447" alt="Screenshot 2022-10-27 at 16 00 58" src="https://user-images.githubusercontent.com/7805759/198306033-87c0f1b9-6ffa-4d3c-8b8c-cf1d902e9e25.png">

### QA
1. Visit Vercel preview
2. Check that products displaying shipping restrictions show them even when OOS