### PR TITLE
Capitalize the section headers

### DIFF
--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -181,7 +181,7 @@ export function CrossSellSection({
                }}
                size="lg"
             >
-               Frequently bought together
+               Frequently Bought Together
             </Heading>
             <Flex
                justify="center"

--- a/frontend/templates/product/sections/FeaturedProductsSection/index.tsx
+++ b/frontend/templates/product/sections/FeaturedProductsSection/index.tsx
@@ -47,7 +47,7 @@ export function FeaturedProductsSection({
                textAlign="center"
                mb="12"
             >
-               Featured products
+               Featured Products
             </Heading>
          </PageContentWrapper>
          <SimpleGrid

--- a/frontend/templates/product/sections/ReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ReviewsSection/index.tsx
@@ -93,7 +93,7 @@ export function ReviewsSection({
                   md: 16,
                }}
             >
-               Customer reviews
+               Customer Reviews
             </Heading>
             {hasReview ? (
                <>


### PR DESCRIPTION
As mentioned in the issue, the following need to be capitalized.

Featured products -> Featured Products
Customer reviews -> Customer Reviews
Frequently bought together -> Frequently Bought Together

Closes #929 

CC: @erinemay 