### PR TITLE
Small Styling Changes for the Buy Box.

### DIFF
--- a/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
@@ -255,7 +255,13 @@ function InventoryMessage({
    const remaining = Math.max(0, quantityAvailable - quantityAddedToCart);
 
    return (
-      <Flex color="red.600" py="0" fontSize="sm" align="center">
+      <Flex
+         color="red.600"
+         mt="2.5"
+         fontSize="sm"
+         align="center"
+         justify="center"
+      >
          <FaIcon
             icon={faCircleExclamation}
             display="block"

--- a/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
+++ b/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
@@ -2,11 +2,15 @@ import { Heading, Stack, Text, VStack } from '@chakra-ui/react';
 import React from 'react';
 import { List, ListIcon, ListItem } from '@chakra-ui/react';
 import {
+   faBoxCircleCheck as faBoxCircleCheckDuo,
+   faRocket as faRocketDuo,
+   faShieldCheck as faShieldCheckDuo,
+} from '@fortawesome/pro-duotone-svg-icons';
+import {
    faBadgeDollar,
-   faBoxCircleCheck,
    faRocket,
    faShieldCheck,
-} from '@fortawesome/pro-duotone-svg-icons';
+} from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon, FaIconProps } from '@ifixit/icons';
 
 export type ServiceValuePropositionSectionProps = {};
@@ -40,7 +44,7 @@ export function ServiceValuePropositionSection() {
             px={{ base: 5, sm: 6 }}
          >
             <ValueProposition>
-               <ValuePropositionIcon icon={faBoxCircleCheck} />
+               <ValuePropositionIcon icon={faBoxCircleCheckDuo} />
                <Text fontWeight="bold">Purchase with purpose</Text>
                <Text>
                   Repair makes a global impact, reduces e-waste, and saves you
@@ -48,7 +52,7 @@ export function ServiceValuePropositionSection() {
                </Text>
             </ValueProposition>
             <ValueProposition>
-               <ValuePropositionIcon icon={faShieldCheck} />
+               <ValuePropositionIcon icon={faShieldCheckDuo} />
                <Text fontWeight="bold">Repair with confidence</Text>
                <Text>
                   All our products meet rigorous quality standards and are
@@ -56,7 +60,7 @@ export function ServiceValuePropositionSection() {
                </Text>
             </ValueProposition>
             <ValueProposition>
-               <ValuePropositionIcon icon={faRocket} />
+               <ValuePropositionIcon icon={faRocketDuo} />
                <Text fontWeight="bold">Fast shipping</Text>
                <Text>Same day shipping if ordered by 1PM Pacific.</Text>
             </ValueProposition>


### PR DESCRIPTION
## Overview
Pictures in here are the examples from our figma mock up.
In this pull we address the spacing for the limited products. It should look like 

We also change the icons in the buy box to be solid colors again. Ignore the line dividing the two sections.
![Screenshot from 2022-10-27 15-32-17](https://user-images.githubusercontent.com/109113415/198410461-cecb7a94-9d78-4375-b57f-f35678de67ad.png)

## QA
Make sure the buy box looks right and that the Value proposition at the bottom looks right too.
![Screenshot from 2022-10-27 15-32-36](https://user-images.githubusercontent.com/109113415/198410480-3279b030-b2b3-49d9-b7aa-c4f44c640726.png)
Note the text will be different in the mock ups than on the site and that is fine. Just make sure everything else visually hasn't broken.

Connects: #923