### PR TITLE
Cypress: Make tests faster and less flaky

### DIFF
--- a/frontend/test/cypress/integration/product-list/collections_view_button.cy.ts
+++ b/frontend/test/cypress/integration/product-list/collections_view_button.cy.ts
@@ -1,30 +1,27 @@
 describe('collection display', () => {
-   const user = cy;
    beforeEach(() => {
-      user.loadCollectionPageByPath('/Tools');
+      cy.loadCollectionPageByPath('/Tools');
    });
 
    it('should display grid view when selected', () => {
-      user.findByTestId('grid-view-button').click();
-      user.findByTestId('list-view-products').should('not.exist');
+      cy.findByTestId('grid-view-button').click();
+      cy.findByTestId('list-view-products').should('not.exist');
 
       // Make sure the display property equals to grid
-      user
-         .findByTestId('grid-view-products')
+      cy.findByTestId('grid-view-products')
          .invoke('css', 'display')
          .should('equal', 'grid');
    });
 
    it('should display list view when selected', () => {
       // First click on grid view button
-      user.findByTestId('grid-view-button').click();
+      cy.findByTestId('grid-view-button').click();
       // Then switch back to list view button
-      user.findByTestId('list-view-button').click();
-      user.findByTestId('grid-view-products').should('not.exist');
+      cy.findByTestId('list-view-button').click();
+      cy.findByTestId('grid-view-products').should('not.exist');
 
       // Make sure the display property equals to flex
-      user
-         .findByTestId('list-view-products')
+      cy.findByTestId('list-view-products')
          .invoke('css', 'display')
          .should('equal', 'flex');
    });

--- a/frontend/test/cypress/integration/product-list/filters.cy.ts
+++ b/frontend/test/cypress/integration/product-list/filters.cy.ts
@@ -1,31 +1,26 @@
 describe('product list filters', () => {
-   const user = cy;
    beforeEach(() => {
-      user.loadCollectionPageByPath('/Parts');
+      cy.loadCollectionPageByPath('/Parts');
    });
 
    it('should help user filter', () => {
-      user
-         .findAllByTestId(/collapsed-facet-accordion-item-.*/i)
+      cy.findAllByTestId(/collapsed-facet-accordion-item-.*/i)
          .first()
          .as('first-facet-accordion-item')
          .next()
          .as('second-facet-accordion-item');
 
-      user
-         .get('@first-facet-accordion-item')
+      cy.get('@first-facet-accordion-item')
          .invoke('attr', 'data-facet-name')
          .as('first-facet-name');
 
       // Click the first facet accordion item.
-      user
-         .get('@first-facet-accordion-item')
+      cy.get('@first-facet-accordion-item')
          .findByRole('button', { name: /expand/i, expanded: false })
          .click();
 
       // Click the first facet item
-      user
-         .get('@first-facet-accordion-item')
+      cy.get('@first-facet-accordion-item')
          .findAllByRole('option')
          .first()
          .click()
@@ -33,23 +28,22 @@ describe('product list filters', () => {
          .as('first-facet-option-value');
 
       // Wait for the search to be triggered and let the UI update.
-      user.wait('@search');
-      user.wait(2000);
+      cy.wait('@search');
+      cy.wait(2000);
 
-      user.get('@first-facet-option-value').then((refinementValue) => {
+      cy.get('@first-facet-option-value').then((refinementValue) => {
          const lowercaseRefinementValue: string = (
             refinementValue as any
          ).toLowerCase();
 
          // Check that the refinement value is in the current refinements.
-         user
-            .findAllByTestId(`current-refinement-${refinementValue}`)
-            .should('exist');
+         cy.findAllByTestId(`current-refinement-${refinementValue}`).should(
+            'exist'
+         );
 
          // Check that the refinement value is in the search results.
-         user.get('@first-facet-name').then((facetName) => {
-            user
-               .window()
+         cy.get('@first-facet-name').then((facetName) => {
+            cy.window()
                .its('filteredProducts')
                .each((product) => {
                   cy.wrap(product)
@@ -74,52 +68,47 @@ describe('product list filters', () => {
          });
       });
 
-      user
-         .get('@second-facet-accordion-item')
+      cy.get('@second-facet-accordion-item')
          .invoke('attr', 'data-facet-name')
          .as('second-facet-name');
 
       // Click the second facet accordion item.
-      user
-         .get('@second-facet-accordion-item')
+      cy.get('@second-facet-accordion-item')
          .findByRole('button', { name: /expand/i, expanded: false })
          .click();
 
       // Click the second facet item
-      user
-         .get('@second-facet-accordion-item')
+      cy.get('@second-facet-accordion-item')
          .findAllByRole('option')
          .first()
          .click()
          .invoke('attr', 'data-value')
          .as('second-facet-option-value');
 
-      user.get('@second-facet-option-value').then((refinementValue) => {
+      cy.get('@second-facet-option-value').then((refinementValue) => {
          // Check that the refinement value is in the current refinements.
-         user
-            .findAllByTestId(`current-refinement-${refinementValue}`)
-            .should('exist');
+         cy.findAllByTestId(`current-refinement-${refinementValue}`).should(
+            'exist'
+         );
       });
 
-      user
-         .findAllByTestId(/current-refinement-/i)
+      cy.findAllByTestId(/current-refinement-/i)
          .first()
          .invoke('attr', 'data-testid')
          .then((testId) => {
             // Remove the refinement
-            user
-               .findByTestId(testId!)
+            cy.findByTestId(testId!)
                .findByRole('button', { name: /remove/i })
                .click();
 
             // Check that the refinement is no longer in the current refinements.
-            user.findByTestId(testId!).should('not.exist');
+            cy.findByTestId(testId!).should('not.exist');
          });
 
       // Reset the filters
-      user.findByRole('button', { name: /clear all filters/i }).click();
+      cy.findByRole('button', { name: /clear all filters/i }).click();
       // Check that the current refinements are empty
-      user.findByTestId(/current-refinement-/i).should('not.exist');
+      cy.findByTestId(/current-refinement-/i).should('not.exist');
    });
 });
 

--- a/frontend/test/cypress/integration/product-list/filters.cy.ts
+++ b/frontend/test/cypress/integration/product-list/filters.cy.ts
@@ -29,7 +29,6 @@ describe('product list filters', () => {
 
       // Wait for the search to be triggered and let the UI update.
       cy.wait('@search');
-      cy.wait(2000);
 
       cy.get('@first-facet-option-value').then((refinementValue) => {
          const lowercaseRefinementValue: string = (

--- a/frontend/test/cypress/integration/product-list/newsletter_subscribe.cy.ts
+++ b/frontend/test/cypress/integration/product-list/newsletter_subscribe.cy.ts
@@ -1,46 +1,45 @@
 describe('subscribe to newsletter', () => {
-   const user = cy;
    beforeEach(() => {
-      user.loadCollectionPageByPath('/Parts');
+      cy.loadCollectionPageByPath('/Parts');
    });
 
    it('requires an email', () => {
-      user.findByTestId('footer-newsletter-form').within(() => {
-         user.findByText(/please insert a valid email/i).should('not.exist');
-         user.findByRole('button', { name: /subscribe|join/i }).click();
-         user.findByText(/please insert a valid email/i).should('be.visible');
+      cy.findByTestId('footer-newsletter-form').within(() => {
+         cy.findByText(/please insert a valid email/i).should('not.exist');
+         cy.findByRole('button', { name: /subscribe|join/i }).click();
+         cy.findByText(/please insert a valid email/i).should('be.visible');
       });
    });
 
    it('prevents invalid email', () => {
-      user.findByText(/please insert a valid email/i).should('not.exist');
-      user.findByLabelText(/enter your email/i).type('test@example');
-      user.findByRole('button', { name: /subscribe|join/i }).click();
-      user.findByText(/please insert a valid email/i).should('be.visible');
+      cy.findByText(/please insert a valid email/i).should('not.exist');
+      cy.findByLabelText(/enter your email/i).type('test@example');
+      cy.findByRole('button', { name: /subscribe|join/i }).click();
+      cy.findByText(/please insert a valid email/i).should('be.visible');
    });
 
    it('shows confirmation when email is subscribed', () => {
       cy.intercept('/api/2.0/cart/newsletter/subscribe', {
          statusCode: 200,
       });
-      user.findByLabelText(/enter your email/i).type('test@example.com');
-      user.findByRole('button', { name: /subscribe|join/i }).click();
-      user.findByText('Subscribed!').should('be.visible');
-      user
-         .findByTestId('footer-newsletter-subscribe-button')
-         .should('not.be.visible');
-      user.findByText(/please insert a valid email/i).should('not.exist');
+      cy.findByLabelText(/enter your email/i).type('test@example.com');
+      cy.findByRole('button', { name: /subscribe|join/i }).click();
+      cy.findByText('Subscribed!').should('be.visible');
+      cy.findByTestId('footer-newsletter-subscribe-button').should(
+         'not.be.visible'
+      );
+      cy.findByText(/please insert a valid email/i).should('not.exist');
    });
 
    it('shows an error when server request fails', () => {
       cy.intercept('/api/2.0/cart/newsletter/subscribe', {
          statusCode: 500,
       });
-      user.findByLabelText(/enter your email/i).type('test@example.com');
-      user.findByRole('button', { name: /subscribe|join/i }).click();
-      user
-         .findByText(/error trying to subscribe to newsletter/i)
-         .should('be.visible');
+      cy.findByLabelText(/enter your email/i).type('test@example.com');
+      cy.findByRole('button', { name: /subscribe|join/i }).click();
+      cy.findByText(/error trying to subscribe to newsletter/i).should(
+         'be.visible'
+      );
    });
 });
 

--- a/frontend/test/cypress/integration/product-list/parts_page_devices.cy.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_devices.cy.ts
@@ -1,19 +1,16 @@
 describe('parts page devices', () => {
-   const user = cy;
-
    beforeEach(() => {
-      user.loadCollectionPageByPath('/Parts');
+      cy.loadCollectionPageByPath('/Parts');
    });
 
    it('should navigate until the last device page', () => {
       assertVisibleFilterAndProducts();
       assertAvailableProducts();
 
-      user.get('body').then(($body) => {
+      cy.get('body').then(($body) => {
          const device = $body.find('a[href="/Parts/Mac"]');
          if (!device.is(':visible')) {
-            user
-               .get('button', { timeout: 10000 })
+            cy.get('button', { timeout: 10000 })
                .contains('Show more')
                .should('be.visible')
                .click();
@@ -21,10 +18,11 @@ describe('parts page devices', () => {
          device[0].click();
       });
 
-      user
-         .location('pathname', { timeout: 20000 })
-         .should('include', '/Parts/Mac');
-      user.get('h1').contains('Mac Parts').should('be.visible');
+      cy.location('pathname', { timeout: 20000 }).should(
+         'include',
+         '/Parts/Mac'
+      );
+      cy.get('h1').contains('Mac Parts').should('be.visible');
 
       navigateUntilLastDevice();
       assertVisibleFilterAndProducts();
@@ -32,17 +30,13 @@ describe('parts page devices', () => {
    });
 
    function assertVisibleFilterAndProducts() {
-      user.findByTestId('filterable-products-section').should('be.visible');
-      user
-         .findByTestId('facets-accordion')
-         .scrollIntoView()
-         .should('be.visible');
+      cy.findByTestId('filterable-products-section').should('be.visible');
+      cy.findByTestId('facets-accordion').scrollIntoView().should('be.visible');
    }
 
    // Makes sure there is at least 1 product available
    function assertAvailableProducts() {
-      user
-         .findByTestId('list-view-products')
+      cy.findByTestId('list-view-products')
          .children('article')
          .its('length')
          .should('be.gte', 1);
@@ -50,24 +44,23 @@ describe('parts page devices', () => {
 
    // Recursively navigate to the first device until no sub-devices are left
    function navigateUntilLastDevice() {
-      user.get('body').then(($body) => {
+      cy.get('body').then(($body) => {
          if ($body.find('[data-testid="product-list-devices"]').length <= 0)
             return false;
 
-         user
-            .findByTestId('product-list-devices')
+         cy.findByTestId('product-list-devices')
             .find('a')
             .first()
             .as('device')
             .click();
 
-         user
-            .get('@device')
+         cy.get('@device')
             .should('have.attr', 'href')
             .then((href) => {
-               user
-                  .location('pathname', { timeout: 20000 })
-                  .should('include', href);
+               cy.location('pathname', { timeout: 20000 }).should(
+                  'include',
+                  href
+               );
             });
          assertVisibleFilterAndProducts();
          navigateUntilLastDevice();

--- a/frontend/test/cypress/integration/product-list/parts_page_devices.cy.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_devices.cy.ts
@@ -10,18 +10,12 @@ describe('parts page devices', () => {
       cy.get('body').then(($body) => {
          const device = $body.find('a[href="/Parts/Mac"]');
          if (!device.is(':visible')) {
-            cy.get('button', { timeout: 10000 })
-               .contains('Show more')
-               .should('be.visible')
-               .click();
+            cy.get('button').contains('Show more').should('be.visible').click();
          }
          device[0].click();
       });
 
-      cy.location('pathname', { timeout: 20000 }).should(
-         'include',
-         '/Parts/Mac'
-      );
+      cy.location('pathname').should('include', '/Parts/Mac');
       cy.get('h1').contains('Mac Parts').should('be.visible');
 
       navigateUntilLastDevice();
@@ -57,10 +51,7 @@ describe('parts page devices', () => {
          cy.get('@device')
             .should('have.attr', 'href')
             .then((href) => {
-               cy.location('pathname', { timeout: 20000 }).should(
-                  'include',
-                  href
-               );
+               cy.location('pathname').should('include', href);
             });
          assertVisibleFilterAndProducts();
          navigateUntilLastDevice();

--- a/frontend/test/cypress/integration/product-list/parts_page_search.cy.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_search.cy.ts
@@ -15,7 +15,7 @@ describe('parts page search', () => {
       cy.wait('@search');
 
       // Check that url parameter contains ?q after searching
-      cy.location({ timeout: 2000 }).should((loc) => {
+      cy.location().should((loc) => {
          expect(loc.search).to.have.string('?q=iphone');
       });
 
@@ -37,7 +37,7 @@ describe('parts page search', () => {
       cy.wait('@search');
 
       // Check that url parameter contains ?q after searching
-      cy.location({ timeout: 2000 }).should((loc) => {
+      cy.location().should((loc) => {
          expect(loc.search).to.have.string('?q=');
       });
 

--- a/frontend/test/cypress/integration/product-list/parts_page_search.cy.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_search.cy.ts
@@ -1,55 +1,50 @@
 import { constants } from 'test/cypress/support/constants';
 
 describe('parts page search', () => {
-   const user = cy;
-
    beforeEach(() => {
-      user.loadCollectionPageByPath('/Parts');
+      cy.loadCollectionPageByPath('/Parts');
    });
 
    it('should show results when the search term exists', () => {
-      user
-         .findByTestId('collections-search-box')
+      cy.findByTestId('collections-search-box')
          .should('be.visible')
          .should('not.be.disabled')
          .type('iphone');
 
       // Wait for search result to be updated
-      user.wait('@search');
-      user.wait(2000);
+      cy.wait('@search');
+      cy.wait(2000);
 
       // Check that url parameter contains ?q after searching
-      user.location({ timeout: 2000 }).should((loc) => {
+      cy.location({ timeout: 2000 }).should((loc) => {
          expect(loc.search).to.have.string('?q=iphone');
       });
 
       // Assert that all products in the result contains word watch
-      user
-         .findByTestId('list-view-products')
+      cy.findByTestId('list-view-products')
          .children('article')
          .each((productListItem) => {
-            user.wrap(productListItem).contains('iphone', { matchCase: false });
+            cy.wrap(productListItem).contains('iphone', { matchCase: false });
          });
    });
 
    it("should show no results when search term doesn't exist", () => {
-      user
-         .findByTestId('collections-search-box')
+      cy.findByTestId('collections-search-box')
          .should('be.visible')
          .should('not.be.disabled')
          .type('asdasasdadasd');
 
       // Wait for search result to be updated
-      user.wait('@search');
+      cy.wait('@search');
 
       // Check that url parameter contains ?q after searching
-      user.location({ timeout: 2000 }).should((loc) => {
+      cy.location({ timeout: 2000 }).should((loc) => {
          expect(loc.search).to.have.string('?q=');
       });
 
-      user.findByTestId('list-view-products').should('not.exist');
-      user.contains(constants.NO_SEARCH_RESULTS);
-      user.contains(constants.NO_SEARCH_RESULT_DESC);
+      cy.findByTestId('list-view-products').should('not.exist');
+      cy.contains(constants.NO_SEARCH_RESULTS);
+      cy.contains(constants.NO_SEARCH_RESULT_DESC);
    });
 });
 

--- a/frontend/test/cypress/integration/product-list/parts_page_search.cy.ts
+++ b/frontend/test/cypress/integration/product-list/parts_page_search.cy.ts
@@ -13,7 +13,6 @@ describe('parts page search', () => {
 
       // Wait for search result to be updated
       cy.wait('@search');
-      cy.wait(2000);
 
       // Check that url parameter contains ?q after searching
       cy.location({ timeout: 2000 }).should((loc) => {

--- a/frontend/test/cypress/integration/product-list/parts_results_view.cy.ts
+++ b/frontend/test/cypress/integration/product-list/parts_results_view.cy.ts
@@ -1,34 +1,30 @@
 describe('parts page results view', () => {
-   const user = cy;
-
    beforeEach(() => {
-      user.loadCollectionPageByPath('/Parts');
+      cy.loadCollectionPageByPath('/Parts');
    });
 
    it('all products have a visible price', () => {
-      user
-         .findByTestId('list-view-products')
+      cy.findByTestId('list-view-products')
          .children('article')
          .each((productListItem) => {
-            user
-               .wrap(productListItem)
+            cy.wrap(productListItem)
                .findByTestId('product-price')
                .should('be.visible');
          });
    });
 
    it('product View button directs to the product page', () => {
-      user
-         .contains('.chakra-button', 'View')
+      cy.contains('.chakra-button', 'View')
          .parent()
          .then((link) => {
             // Find the first product View button and click
-            user.wrap(link).click();
+            cy.wrap(link).click();
 
             // Assert the current window url path is the same as button link
-            user
-               .location('pathname', { timeout: 10000 })
-               .should('equal', link.attr('href'));
+            cy.location('pathname', { timeout: 10000 }).should(
+               'equal',
+               link.attr('href')
+            );
          });
    });
 });

--- a/frontend/test/cypress/integration/product-list/parts_results_view.cy.ts
+++ b/frontend/test/cypress/integration/product-list/parts_results_view.cy.ts
@@ -21,10 +21,7 @@ describe('parts page results view', () => {
             cy.wrap(link).click();
 
             // Assert the current window url path is the same as button link
-            cy.location('pathname', { timeout: 10000 }).should(
-               'equal',
-               link.attr('href')
-            );
+            cy.location('pathname').should('equal', link.attr('href'));
          });
    });
 });

--- a/frontend/test/cypress/integration/product/add_to_cart.cy.ts
+++ b/frontend/test/cypress/integration/product/add_to_cart.cy.ts
@@ -3,68 +3,61 @@ describe('product page add to cart', () => {
       cy.loadProductPageByPath(
          '/products/spudger-retail-3-pack?variantid=39419992408154'
       );
-      cy.findByTestId('cart-drawer-open').click().wait(10);
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findByTestId('cart-drawer-open').click();
+      cy.findAllByTestId('cart-drawer-item-count')
          .should('exist')
          .invoke('text')
          .should('eq', '0');
       cy.findByTestId('cart-drawer-quantity').should('not.exist');
-      cy.findByTestId('cart-drawer-close').click().wait(10);
+      cy.findByTestId('cart-drawer-close').click();
       cy.findByTestId('cart-drawer-close').should('not.exist');
    });
 
    it('Clicking Add To Cart Adds Items To Cart', () => {
       const genArr = Array.from({ length: 5 }, (v, k) => k + 1);
       cy.wrap(genArr).each((index) => {
-         cy.findByTestId('product-add-to-cart-button').click().wait(10);
-         cy
-            .findAllByTestId('cart-drawer-quantity')
+         cy.findByTestId('product-add-to-cart-button').click();
+         cy.findAllByTestId('cart-drawer-quantity')
             .invoke('text')
             .then(parseInt)
             .should('eq', index);
-         cy.findByTestId('cart-drawer-close').click().wait(10);
+         cy.findByTestId('cart-drawer-close').click();
       });
 
-      cy.findByTestId('cart-drawer-open').click().wait(10);
+      cy.findByTestId('cart-drawer-open').click();
       cy.removeItemsFromCartAndCloseDrawer();
    });
 
    it('Clicking + and - Buttons Changes Item Quantity in Cart', () => {
-      cy.findByTestId('product-add-to-cart-button').click().wait(10);
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findByTestId('product-add-to-cart-button').click();
+      cy.findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
       const genArr = Array.from({ length: 5 }, (v, k) => k + 2);
       cy.wrap(genArr).each((index) => {
-         cy.findByTestId('cart-drawer-increase-quantity').click().wait(10);
-         cy
-            .findAllByTestId('cart-drawer-quantity')
+         cy.findByTestId('cart-drawer-increase-quantity').click();
+         cy.findAllByTestId('cart-drawer-quantity')
             .invoke('text')
             .then(parseInt)
             .should('eq', index);
       });
-      cy.findByTestId('cart-drawer-close').click().wait(10);
+      cy.findByTestId('cart-drawer-close').click();
 
-      cy.findByTestId('cart-drawer-open').click().wait(10);
+      cy.findByTestId('cart-drawer-open').click();
       const genArrRev = Array.from({ length: 5 }, (v, k) => k + 1).reverse();
       cy.wrap(genArrRev).each((index) => {
-         cy.findByTestId('cart-drawer-decrease-quantity').click().wait(10);
-         cy
-            .findAllByTestId('cart-drawer-quantity')
+         cy.findByTestId('cart-drawer-decrease-quantity').click();
+         cy.findAllByTestId('cart-drawer-quantity')
             .invoke('text')
             .then(parseInt)
             .should('eq', index);
       });
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
-      cy
-         .findAllByTestId('cart-drawer-quantity')
+      cy.findAllByTestId('cart-drawer-quantity')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
@@ -72,27 +65,20 @@ describe('product page add to cart', () => {
    });
 
    it('Item Can Be Added Again After Removing The Item', () => {
-      cy.findByTestId('product-add-to-cart-button').click().wait(10);
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findByTestId('product-add-to-cart-button').click();
+      cy.findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
-      cy
-         .findAllByTestId('cart-drawer-remove-item')
-         .wait(10)
-         .then((items) => items.trigger('click'))
-         .wait(10);
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findAllByTestId('cart-drawer-remove-item').click();
+      cy.findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 0);
       cy.findAllByTestId('cart-drawer-quantity').should('not.exist');
-      cy.findByTestId('cart-drawer-close').click().wait(10);
-      cy.findByTestId('product-add-to-cart-button').click().wait(10);
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findByTestId('cart-drawer-close').click();
+      cy.findByTestId('product-add-to-cart-button').click();
+      cy.findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
@@ -100,35 +86,28 @@ describe('product page add to cart', () => {
    });
 
    it('Back to Shopping Button Works', () => {
-      cy.findByTestId('cart-drawer-open').click().wait(10);
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findByTestId('cart-drawer-open').click();
+      cy.findAllByTestId('cart-drawer-item-count')
          .should('exist')
          .invoke('text')
          .should('eq', '0');
       cy.findAllByTestId('cart-drawer-quantity').should('not.exist');
-      cy.findByTestId('back-to-shopping').click().wait(10);
+      cy.findByTestId('back-to-shopping').click();
       cy.findAllByTestId('cart-drawer-item-count').should('not.exist');
 
-      cy.findByTestId('product-add-to-cart-button').click().wait(10);
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findByTestId('product-add-to-cart-button').click();
+      cy.findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
       cy.findByTestId('back-to-shopping').should('not.be.visible');
-      cy
-         .findAllByTestId('cart-drawer-remove-item')
-         .wait(10)
-         .then((items) => items.trigger('click'))
-         .wait(10);
-      cy
-         .findAllByTestId('cart-drawer-item-count')
+      cy.findAllByTestId('cart-drawer-remove-item').click();
+      cy.findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 0);
       cy.findByTestId('cart-drawer-quantity').should('not.exist');
-      cy.findByTestId('back-to-shopping').click().wait(10);
+      cy.findByTestId('back-to-shopping').click();
       cy.findAllByTestId('cart-drawer-item-count').should('not.exist');
       cy.findByTestId('cart-drawer-close').should('not.exist');
    });

--- a/frontend/test/cypress/integration/product/add_to_cart.cy.ts
+++ b/frontend/test/cypress/integration/product/add_to_cart.cy.ts
@@ -17,7 +17,7 @@ describe('product page add to cart', () => {
          cy.findByTestId('cart-drawer-close').click();
       }
       cy.findByTestId('cart-drawer-open').click();
-      removeItemFromCartAndCloseDrawer();
+      removeItemsFromCartAndCloseDrawer();
    });
 
    it('Clicking + and - Buttons Changes Item Quantity in Cart', () => {
@@ -36,7 +36,7 @@ describe('product page add to cart', () => {
       }
       cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
       cy.findAllByTestId('cart-drawer-quantity').should('have.text', 1);
-      removeItemFromCartAndCloseDrawer();
+      removeItemsFromCartAndCloseDrawer();
    });
 
    it('Item Can Be Added Again After Removing The Item', () => {
@@ -48,7 +48,7 @@ describe('product page add to cart', () => {
       cy.findByTestId('cart-drawer-close').click();
       cy.findByTestId('product-add-to-cart-button').click();
       cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
-      removeItemFromCartAndCloseDrawer();
+      removeItemsFromCartAndCloseDrawer();
    });
 
    it('Back to Shopping Button Works', () => {
@@ -70,7 +70,7 @@ describe('product page add to cart', () => {
    });
 });
 
-function removeItemFromCartAndCloseDrawer() {
+function removeItemsFromCartAndCloseDrawer() {
    cy.findAllByTestId('cart-drawer-remove-item').click();
    cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
    cy.findByTestId('cart-drawer-quantity').should('not.exist');

--- a/frontend/test/cypress/integration/product/add_to_cart.cy.ts
+++ b/frontend/test/cypress/integration/product/add_to_cart.cy.ts
@@ -1,138 +1,136 @@
 describe('product page add to cart', () => {
-   const user = cy;
-
    beforeEach(() => {
-      user.loadProductPageByPath(
+      cy.loadProductPageByPath(
          '/products/spudger-retail-3-pack?variantid=39419992408154'
       );
-      user.findByTestId('cart-drawer-open').click().wait(10);
-      user
+      cy.findByTestId('cart-drawer-open').click().wait(10);
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .should('exist')
          .invoke('text')
          .should('eq', '0');
-      user.findByTestId('cart-drawer-quantity').should('not.exist');
-      user.findByTestId('cart-drawer-close').click().wait(10);
-      user.findByTestId('cart-drawer-close').should('not.exist');
+      cy.findByTestId('cart-drawer-quantity').should('not.exist');
+      cy.findByTestId('cart-drawer-close').click().wait(10);
+      cy.findByTestId('cart-drawer-close').should('not.exist');
    });
 
    it('Clicking Add To Cart Adds Items To Cart', () => {
       var genArr = Array.from({ length: 5 }, (v, k) => k + 1);
-      user.wrap(genArr).each((index) => {
-         user.findByTestId('product-add-to-cart-button').click().wait(10);
-         user
+      cy.wrap(genArr).each((index) => {
+         cy.findByTestId('product-add-to-cart-button').click().wait(10);
+         cy
             .findAllByTestId('cart-drawer-quantity')
             .invoke('text')
             .then(parseInt)
             .should('eq', index);
-         user.findByTestId('cart-drawer-close').click().wait(10);
+         cy.findByTestId('cart-drawer-close').click().wait(10);
       });
 
-      user.findByTestId('cart-drawer-open').click().wait(10);
-      user.removeItemsFromCartAndCloseDrawer();
+      cy.findByTestId('cart-drawer-open').click().wait(10);
+      cy.removeItemsFromCartAndCloseDrawer();
    });
 
    it('Clicking + and - Buttons Changes Item Quantity in Cart', () => {
-      user.findByTestId('product-add-to-cart-button').click().wait(10);
-      user
+      cy.findByTestId('product-add-to-cart-button').click().wait(10);
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
       const genArr = Array.from({ length: 5 }, (v, k) => k + 2);
-      user.wrap(genArr).each((index) => {
-         user.findByTestId('cart-drawer-increase-quantity').click().wait(10);
-         user
+      cy.wrap(genArr).each((index) => {
+         cy.findByTestId('cart-drawer-increase-quantity').click().wait(10);
+         cy
             .findAllByTestId('cart-drawer-quantity')
             .invoke('text')
             .then(parseInt)
             .should('eq', index);
       });
-      user.findByTestId('cart-drawer-close').click().wait(10);
+      cy.findByTestId('cart-drawer-close').click().wait(10);
 
-      user.findByTestId('cart-drawer-open').click().wait(10);
+      cy.findByTestId('cart-drawer-open').click().wait(10);
       const genArrRev = Array.from({ length: 5 }, (v, k) => k + 1).reverse();
-      user.wrap(genArrRev).each((index) => {
-         user.findByTestId('cart-drawer-decrease-quantity').click().wait(10);
-         user
+      cy.wrap(genArrRev).each((index) => {
+         cy.findByTestId('cart-drawer-decrease-quantity').click().wait(10);
+         cy
             .findAllByTestId('cart-drawer-quantity')
             .invoke('text')
             .then(parseInt)
             .should('eq', index);
       });
-      user
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
-      user
+      cy
          .findAllByTestId('cart-drawer-quantity')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
-      user.removeItemsFromCartAndCloseDrawer();
+      cy.removeItemsFromCartAndCloseDrawer();
    });
 
    it('Item Can Be Added Again After Removing The Item', () => {
-      user.findByTestId('product-add-to-cart-button').click().wait(10);
-      user
+      cy.findByTestId('product-add-to-cart-button').click().wait(10);
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
-      user
+      cy
          .findAllByTestId('cart-drawer-remove-item')
          .wait(10)
          .then((items) => items.trigger('click'))
          .wait(10);
-      user
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 0);
-      user.findAllByTestId('cart-drawer-quantity').should('not.exist');
-      user.findByTestId('cart-drawer-close').click().wait(10);
-      user.findByTestId('product-add-to-cart-button').click().wait(10);
-      user
+      cy.findAllByTestId('cart-drawer-quantity').should('not.exist');
+      cy.findByTestId('cart-drawer-close').click().wait(10);
+      cy.findByTestId('product-add-to-cart-button').click().wait(10);
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
-      user.removeItemsFromCartAndCloseDrawer();
+      cy.removeItemsFromCartAndCloseDrawer();
    });
 
    it('Back to Shopping Button Works', () => {
-      user.findByTestId('cart-drawer-open').click().wait(10);
-      user
+      cy.findByTestId('cart-drawer-open').click().wait(10);
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .should('exist')
          .invoke('text')
          .should('eq', '0');
-      user.findAllByTestId('cart-drawer-quantity').should('not.exist');
-      user.findByTestId('back-to-shopping').click().wait(10);
-      user.findAllByTestId('cart-drawer-item-count').should('not.exist');
+      cy.findAllByTestId('cart-drawer-quantity').should('not.exist');
+      cy.findByTestId('back-to-shopping').click().wait(10);
+      cy.findAllByTestId('cart-drawer-item-count').should('not.exist');
 
-      user.findByTestId('product-add-to-cart-button').click().wait(10);
-      user
+      cy.findByTestId('product-add-to-cart-button').click().wait(10);
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 1);
-      user.findByTestId('back-to-shopping').should('not.be.visible');
-      user
+      cy.findByTestId('back-to-shopping').should('not.be.visible');
+      cy
          .findAllByTestId('cart-drawer-remove-item')
          .wait(10)
          .then((items) => items.trigger('click'))
          .wait(10);
-      user
+      cy
          .findAllByTestId('cart-drawer-item-count')
          .invoke('text')
          .then(parseInt)
          .should('eq', 0);
-      user.findByTestId('cart-drawer-quantity').should('not.exist');
-      user.findByTestId('back-to-shopping').click().wait(10);
-      user.findAllByTestId('cart-drawer-item-count').should('not.exist');
-      user.findByTestId('cart-drawer-close').should('not.exist');
+      cy.findByTestId('cart-drawer-quantity').should('not.exist');
+      cy.findByTestId('back-to-shopping').click().wait(10);
+      cy.findAllByTestId('cart-drawer-item-count').should('not.exist');
+      cy.findByTestId('cart-drawer-close').should('not.exist');
    });
 });
 

--- a/frontend/test/cypress/integration/product/add_to_cart.cy.ts
+++ b/frontend/test/cypress/integration/product/add_to_cart.cy.ts
@@ -4,108 +4,65 @@ describe('product page add to cart', () => {
          '/products/spudger-retail-3-pack?variantid=39419992408154'
       );
       cy.findByTestId('cart-drawer-open').click();
-      cy.findAllByTestId('cart-drawer-item-count')
-         .should('exist')
-         .invoke('text')
-         .should('eq', '0');
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
       cy.findByTestId('cart-drawer-quantity').should('not.exist');
       cy.findByTestId('cart-drawer-close').click();
       cy.findByTestId('cart-drawer-close').should('not.exist');
    });
 
    it('Clicking Add To Cart Adds Items To Cart', () => {
-      const genArr = Array.from({ length: 5 }, (v, k) => k + 1);
-      cy.wrap(genArr).each((index) => {
+      for (let i = 1; i <= 5; i++) {
          cy.findByTestId('product-add-to-cart-button').click();
-         cy.findAllByTestId('cart-drawer-quantity')
-            .invoke('text')
-            .then(parseInt)
-            .should('eq', index);
+         cy.findAllByTestId('cart-drawer-quantity').should('have.text', i);
          cy.findByTestId('cart-drawer-close').click();
-      });
-
+      }
       cy.findByTestId('cart-drawer-open').click();
       cy.removeItemsFromCartAndCloseDrawer();
    });
 
    it('Clicking + and - Buttons Changes Item Quantity in Cart', () => {
       cy.findByTestId('product-add-to-cart-button').click();
-      cy.findAllByTestId('cart-drawer-item-count')
-         .invoke('text')
-         .then(parseInt)
-         .should('eq', 1);
-      const genArr = Array.from({ length: 5 }, (v, k) => k + 2);
-      cy.wrap(genArr).each((index) => {
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
+      for (let i = 2; i <= 6; i++) {
          cy.findByTestId('cart-drawer-increase-quantity').click();
-         cy.findAllByTestId('cart-drawer-quantity')
-            .invoke('text')
-            .then(parseInt)
-            .should('eq', index);
-      });
+         cy.findAllByTestId('cart-drawer-quantity').should('have.text', i);
+      }
       cy.findByTestId('cart-drawer-close').click();
 
       cy.findByTestId('cart-drawer-open').click();
-      const genArrRev = Array.from({ length: 5 }, (v, k) => k + 1).reverse();
-      cy.wrap(genArrRev).each((index) => {
+      for (let i = 5; i >= 1; i--) {
          cy.findByTestId('cart-drawer-decrease-quantity').click();
-         cy.findAllByTestId('cart-drawer-quantity')
-            .invoke('text')
-            .then(parseInt)
-            .should('eq', index);
-      });
-      cy.findAllByTestId('cart-drawer-item-count')
-         .invoke('text')
-         .then(parseInt)
-         .should('eq', 1);
-      cy.findAllByTestId('cart-drawer-quantity')
-         .invoke('text')
-         .then(parseInt)
-         .should('eq', 1);
+         cy.findAllByTestId('cart-drawer-quantity').should('have.text', i);
+      }
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
+      cy.findAllByTestId('cart-drawer-quantity').should('have.text', 1);
       cy.removeItemsFromCartAndCloseDrawer();
    });
 
    it('Item Can Be Added Again After Removing The Item', () => {
       cy.findByTestId('product-add-to-cart-button').click();
-      cy.findAllByTestId('cart-drawer-item-count')
-         .invoke('text')
-         .then(parseInt)
-         .should('eq', 1);
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
       cy.findAllByTestId('cart-drawer-remove-item').click();
-      cy.findAllByTestId('cart-drawer-item-count')
-         .invoke('text')
-         .then(parseInt)
-         .should('eq', 0);
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
       cy.findAllByTestId('cart-drawer-quantity').should('not.exist');
       cy.findByTestId('cart-drawer-close').click();
       cy.findByTestId('product-add-to-cart-button').click();
-      cy.findAllByTestId('cart-drawer-item-count')
-         .invoke('text')
-         .then(parseInt)
-         .should('eq', 1);
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
       cy.removeItemsFromCartAndCloseDrawer();
    });
 
    it('Back to Shopping Button Works', () => {
       cy.findByTestId('cart-drawer-open').click();
-      cy.findAllByTestId('cart-drawer-item-count')
-         .should('exist')
-         .invoke('text')
-         .should('eq', '0');
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
       cy.findAllByTestId('cart-drawer-quantity').should('not.exist');
       cy.findByTestId('back-to-shopping').click();
       cy.findAllByTestId('cart-drawer-item-count').should('not.exist');
 
       cy.findByTestId('product-add-to-cart-button').click();
-      cy.findAllByTestId('cart-drawer-item-count')
-         .invoke('text')
-         .then(parseInt)
-         .should('eq', 1);
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
       cy.findByTestId('back-to-shopping').should('not.be.visible');
       cy.findAllByTestId('cart-drawer-remove-item').click();
-      cy.findAllByTestId('cart-drawer-item-count')
-         .invoke('text')
-         .then(parseInt)
-         .should('eq', 0);
+      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
       cy.findByTestId('cart-drawer-quantity').should('not.exist');
       cy.findByTestId('back-to-shopping').click();
       cy.findAllByTestId('cart-drawer-item-count').should('not.exist');

--- a/frontend/test/cypress/integration/product/add_to_cart.cy.ts
+++ b/frontend/test/cypress/integration/product/add_to_cart.cy.ts
@@ -17,7 +17,7 @@ describe('product page add to cart', () => {
          cy.findByTestId('cart-drawer-close').click();
       }
       cy.findByTestId('cart-drawer-open').click();
-      cy.removeItemsFromCartAndCloseDrawer();
+      removeItemFromCartAndCloseDrawer();
    });
 
    it('Clicking + and - Buttons Changes Item Quantity in Cart', () => {
@@ -36,7 +36,7 @@ describe('product page add to cart', () => {
       }
       cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
       cy.findAllByTestId('cart-drawer-quantity').should('have.text', 1);
-      cy.removeItemsFromCartAndCloseDrawer();
+      removeItemFromCartAndCloseDrawer();
    });
 
    it('Item Can Be Added Again After Removing The Item', () => {
@@ -48,7 +48,7 @@ describe('product page add to cart', () => {
       cy.findByTestId('cart-drawer-close').click();
       cy.findByTestId('product-add-to-cart-button').click();
       cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
-      cy.removeItemsFromCartAndCloseDrawer();
+      removeItemFromCartAndCloseDrawer();
    });
 
    it('Back to Shopping Button Works', () => {
@@ -69,5 +69,13 @@ describe('product page add to cart', () => {
       cy.findByTestId('cart-drawer-close').should('not.exist');
    });
 });
+
+function removeItemFromCartAndCloseDrawer() {
+   cy.findAllByTestId('cart-drawer-remove-item').click();
+   cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
+   cy.findByTestId('cart-drawer-quantity').should('not.exist');
+   cy.findByTestId('cart-drawer-close').click();
+   cy.findByTestId('cart-drawer-close').should('not.exist');
+}
 
 export {};

--- a/frontend/test/cypress/integration/product/add_to_cart.cy.ts
+++ b/frontend/test/cypress/integration/product/add_to_cart.cy.ts
@@ -15,7 +15,7 @@ describe('product page add to cart', () => {
    });
 
    it('Clicking Add To Cart Adds Items To Cart', () => {
-      var genArr = Array.from({ length: 5 }, (v, k) => k + 1);
+      const genArr = Array.from({ length: 5 }, (v, k) => k + 1);
       cy.wrap(genArr).each((index) => {
          cy.findByTestId('product-add-to-cart-button').click().wait(10);
          cy

--- a/frontend/test/cypress/integration/redirect.cy.ts
+++ b/frontend/test/cypress/integration/redirect.cy.ts
@@ -1,33 +1,31 @@
 describe('/parts page', () => {
-   const user = cy;
-
    it('redirects to correct sitemap', () => {
-      user
-         .request({ url: '/Parts/sitemap.xml', followRedirect: false })
-         .then((response) => {
+      cy.request({ url: '/Parts/sitemap.xml', followRedirect: false }).then(
+         (response) => {
             expect(response.status).to.eq(308);
             expect(response.headers.location).to.match(
                /\/sitemap\/parts\.xml$/
             );
-         });
+         }
+      );
 
-      user
-         .request({ url: '/Tools/sitemap.xml', followRedirect: false })
-         .then((response) => {
+      cy.request({ url: '/Tools/sitemap.xml', followRedirect: false }).then(
+         (response) => {
             expect(response.status).to.eq(308);
             expect(response.headers.location).to.match(
                /\/sitemap\/tools\.xml$/
             );
-         });
+         }
+      );
 
-      user
-         .request({ url: '/Shop/sitemap.xml', followRedirect: false })
-         .then((response) => {
+      cy.request({ url: '/Shop/sitemap.xml', followRedirect: false }).then(
+         (response) => {
             expect(response.status).to.eq(308);
             expect(response.headers.location).to.match(
                /\/sitemap\/marketing\.xml$/
             );
-         });
+         }
+      );
    });
 });
 

--- a/frontend/test/cypress/support/commands.ts
+++ b/frontend/test/cypress/support/commands.ts
@@ -21,22 +21,19 @@ Cypress.Commands.add(
 
 Cypress.Commands.add('loadCollectionPageByPath', (path: string) => {
    cy.intercept('/1/indexes/**').as('search');
-   // Here we stub the user api request so we don't depend on ifixit api
-   cy.intercept(
-      { method: 'GET', url: '/api/2.0/user' },
-      {
-         userid: 1,
-         algoliaApiKeyProduct: null,
-         username: 'john',
-         unique_username: 'john123',
-      }
-   ).as('user-api');
+   interceptLogin();
    cy.visit(path);
    cy.wait('@user-api');
    cy.window().its('userLoaded').should('be.true');
 });
 
 Cypress.Commands.add('loadProductPageByPath', (path: string) => {
+   interceptLogin();
+   cy.visit(path);
+   cy.wait('@user-api');
+});
+
+function interceptLogin() {
    cy.intercept(
       { method: 'GET', url: '/api/2.0/user' },
       {
@@ -46,6 +43,4 @@ Cypress.Commands.add('loadProductPageByPath', (path: string) => {
          unique_username: 'john123',
       }
    ).as('user-api');
-   cy.visit(path);
-   cy.wait('@user-api');
-});
+}

--- a/frontend/test/cypress/support/commands.ts
+++ b/frontend/test/cypress/support/commands.ts
@@ -49,11 +49,3 @@ Cypress.Commands.add('loadProductPageByPath', (path: string) => {
    cy.visit(path);
    cy.wait('@user-api');
 });
-
-Cypress.Commands.add('removeItemsFromCartAndCloseDrawer', () => {
-   cy.findAllByTestId('cart-drawer-remove-item').click();
-   cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
-   cy.findByTestId('cart-drawer-quantity').should('not.exist');
-   cy.findByTestId('cart-drawer-close').click();
-   cy.findByTestId('cart-drawer-close').should('not.exist');
-});

--- a/frontend/test/cypress/support/commands.ts
+++ b/frontend/test/cypress/support/commands.ts
@@ -51,15 +51,9 @@ Cypress.Commands.add('loadProductPageByPath', (path: string) => {
 });
 
 Cypress.Commands.add('removeItemsFromCartAndCloseDrawer', () => {
-   cy.findAllByTestId('cart-drawer-remove-item')
-      .wait(500)
-      .then((items) => items.trigger('click'))
-      .wait(500);
-   cy.findAllByTestId('cart-drawer-item-count')
-      .invoke('text')
-      .then(parseInt)
-      .should('eq', 0);
+   cy.findAllByTestId('cart-drawer-remove-item').click();
+   cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
    cy.findByTestId('cart-drawer-quantity').should('not.exist');
-   cy.findByTestId('cart-drawer-close').click().wait(500);
+   cy.findByTestId('cart-drawer-close').click();
    cy.findByTestId('cart-drawer-close').should('not.exist');
 });

--- a/frontend/test/cypress/support/cypress.config.ts
+++ b/frontend/test/cypress/support/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+   e2e: {
+      // https://docs.cypress.io/guides/references/configuration#e2e
+      experimentalSessionAndOrigin: true,
+   },
+});

--- a/frontend/test/cypress/support/index.d.ts
+++ b/frontend/test/cypress/support/index.d.ts
@@ -5,6 +5,5 @@ declare namespace Cypress {
       isWithinViewport(): Chainable<JQuery<HTMLElement>>;
       loadCollectionPageByPath(path: string): Chainable;
       loadProductPageByPath(path: string): Chainable;
-      removeItemsFromCartAndCloseDrawer(): Chainable;
    }
 }


### PR DESCRIPTION
I noticed the cart test was failing sometimes, and then rerunning it would cause it to pass.

Cypress's claim to fame is that it's less flaky than Selenium, so I used some best practices to hopefully make this test and others less flaky and faster.

## CR

The commits have documentation links in them.

qa_req 0 this only modifies tests
