### PR TITLE
Truncate Device List In Compatibility Accordion 

### DIFF
--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -3,9 +3,16 @@ import { Product } from '@models/product';
 
 export type CompatibleDeviceProps = {
    device: NonNullable<Product['compatibility']>['devices'][number];
+   truncate?: number;
 };
 
-export function CompatibleDevice({ device }: CompatibleDeviceProps) {
+export function CompatibleDevice({
+   device,
+   truncate = 0,
+}: CompatibleDeviceProps) {
+   const variants = truncate
+      ? device.variants.slice(0, truncate)
+      : device.variants;
    return (
       <>
          <Img
@@ -32,7 +39,7 @@ export function CompatibleDevice({ device }: CompatibleDeviceProps) {
                {device.deviceName}
             </Text>
             <Flex mb="2px" flexDir="column">
-               {device.variants.map((variant) => (
+               {variants.map((variant) => (
                   <Text
                      key={variant}
                      lineHeight="short"

--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -1,4 +1,5 @@
-import { Flex, Img, Text } from '@chakra-ui/react';
+import { Flex, Img, Link, Text } from '@chakra-ui/react';
+import NextLink from 'next/link';
 import { Product } from '@models/product';
 
 export type CompatibleDeviceProps = {
@@ -10,9 +11,12 @@ export function CompatibleDevice({
    device,
    truncate = 0,
 }: CompatibleDeviceProps) {
-   const variants = truncate
-      ? device.variants.slice(0, truncate)
-      : device.variants;
+   let variants = device.variants;
+   let unlistedVariants = 0;
+   if (variants.length > truncate) {
+      variants = device.variants.slice(0, truncate - 1);
+      unlistedVariants = device.variants.length - variants.length;
+   }
    return (
       <>
          <Img
@@ -50,6 +54,11 @@ export function CompatibleDevice({
                   </Text>
                ))}
             </Flex>
+            {unlistedVariants !== 0 && (
+               <Text my="1px" lineHeight="short" fontSize="xs">
+                  And {unlistedVariants} other devices...
+               </Text>
+            )}
          </Flex>
       </>
    );

--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -13,7 +13,7 @@ export function CompatibleDevice({
 }: CompatibleDeviceProps) {
    let variants = device.variants;
    let unlistedVariants = 0;
-   if (variants.length > truncate) {
+   if (truncate > 0 && variants.length > truncate) {
       variants = device.variants.slice(0, truncate - 1);
       unlistedVariants = device.variants.length - variants.length;
    }

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -283,7 +283,10 @@ export function ProductSection({
                                     transition="all 300m"
                                     mb="6px"
                                  >
-                                    <CompatibleDevice device={device} />
+                                    <CompatibleDevice
+                                       device={device}
+                                       truncate={3}
+                                    />
                                  </chakra.a>
                               </NextLink>
                            ))}

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -285,7 +285,7 @@ export function ProductSection({
                                  >
                                     <CompatibleDevice
                                        device={device}
-                                       truncate={3}
+                                       truncate={4}
                                     />
                                  </chakra.a>
                               </NextLink>


### PR DESCRIPTION
## Overview
There are pages where theres a million devices under a compatible product list. This pull truncates that list so its only 3, and makes the page cleaner.

## QA
Does the page `/products/HP-Pavilion-G4-G6-and-G7-Fan` compatibility accordion now truncate into a readable form?
![Screenshot from 2022-10-27 17-09-53](https://user-images.githubusercontent.com/109113415/198420213-4f35e647-c61b-475f-8daa-00a3ee5a29e1.png)

Connects: #931