### PR TITLE
Improve error reporting for Shopify GraphQL SDK

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/index.ts
+++ b/frontend/lib/shopify-storefront-sdk/index.ts
@@ -1,6 +1,7 @@
 import { SHOPIFY_STOREFRONT_VERSION } from '@config/env';
 import { getSdk, Requester } from './generated/sdk';
 import * as Sentry from '@sentry/nextjs';
+import { z } from 'zod';
 export * from './generated/sdk';
 
 export type ShopCredentials = {
@@ -27,39 +28,67 @@ export function getShopifyStorefrontSdk(shop: ShopCredentials) {
             }),
          }
       );
-      let result: any;
-      try {
-         result = await response.json();
-      } catch (error) {
-         throw new Error(`Response is not a json: ${response.statusText}`);
-      }
-      if (response.ok) {
-         if (result?.data) {
-            return result.data;
-         }
-         throw new Error('Data not available in GraphQL response');
-      }
-      if (Array.isArray(result.errors)) {
-         console.error('GraphQL query failed with errors:');
-         result.errors.map((error: any) => {
-            const code = error.extensions?.code || 'UNKNOWN';
-            console.error(`\t[${code}]`, error.message);
+      const result = await getResult(response);
+      if (result.errors && result.errors.length > 0) {
+         let errorMessage = 'GraphQL query failed with errors: ';
+         const errorMessages = result.errors.map((error) => {
+            const code = error.extensions?.code ?? 'UNKNOWN';
+            return `[code: ${code}]: ${error.message}`;
          });
+         if (errorMessages.length > 1) {
+            errorMessage += errorMessages.join('\n\t - ');
+         } else {
+            errorMessage += errorMessages[0];
+         }
+         console.log(errorMessage);
          Sentry.withScope((scope) => {
             scope.setExtra('query', doc);
             scope.setExtra('variables', variables);
             scope.setExtra('errors', result.errors);
-            Sentry.captureException(
-               new Error(
-                  'Shopify Storefront SDK GraphQL query failed with errors'
-               )
-            );
+            Sentry.captureException(new Error(errorMessage));
          });
+         throw new Error(errorMessage);
       }
-      throw new Error(
-         `GraphQL query failed to execute: ${response.statusText}`
-      );
+      return result.data;
    };
 
    return getSdk(requester);
+}
+
+const GraphQLResultSchema = z.object({
+   data: z.any(),
+   errors: z
+      .array(
+         z.object({
+            message: z.string().optional().nullable(),
+            path: z.array(z.string()).optional().nullable(),
+            extensions: z
+               .object({
+                  code: z.string().optional().nullable(),
+               })
+               .optional()
+               .nullable(),
+         })
+      )
+      .optional()
+      .nullable(),
+});
+
+async function getResult(response: Response) {
+   if (!response.ok) {
+      throw new Error(
+         `GraphQL query failed to execute: ${response.statusText}`
+      );
+   }
+   let result: any;
+   try {
+      result = await response.json();
+      const parsedResult = GraphQLResultSchema.parse(result);
+      return parsedResult;
+   } catch (error) {
+      if (error instanceof z.ZodError) {
+         throw error;
+      }
+      throw new Error(`Response is not a json: ${response.statusText}`);
+   }
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -7,11 +7,11 @@ import NextNProgress from 'nextjs-progressbar';
 // Improve FontAwesome integration with Next.js https://fontawesome.com/v5/docs/web/use-with/react#next-js
 config.autoAddCss = false;
 
-type AppPropsWithLayout = AppProps & {
+type AppPropsWithLayout<P> = AppProps<P> & {
    Component: NextPageWithLayout;
 };
 
-function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+function MyApp({ Component, pageProps }: AppPropsWithLayout<any>) {
    const getLayout = Component.getLayout ?? ((page) => page);
    return (
       <ServerSidePropsProvider props={pageProps}>


### PR DESCRIPTION
closes #914 

This PR makes GraphQL call fail instead of silently return a successful result when there are GraphQL errors.
It also appropriately logs the error, as shown here:

<img width="1247" alt="Screenshot 2022-10-28 at 17 21 17" src="https://user-images.githubusercontent.com/4640135/198673810-5dbab11c-202e-4cc8-9fba-0427c76c9968.png">

## QA

I've set an invalid storefront token in Strapi:

<img width="1201" alt="Screenshot 2022-10-28 at 17 28 12" src="https://user-images.githubusercontent.com/4640135/198675295-4338ebb1-92d9-4b1a-b498-6f085770d9f4.png">


1. Open [Vercel preview](https://react-commerce-git-improve-product-page-error-reporting-ifixit.vercel.app/products/iphone-7-replacement-battery)
2. Verify that product page now returns 500 error

If you want to get rid of the error you just need to log into the branch Strapi instance and insert the same storefront access token used by https://main.govinor.com/admin

