### PR TITLE
Product page: Show lowest price

### DIFF
--- a/packages/helpers/commerce-helpers.ts
+++ b/packages/helpers/commerce-helpers.ts
@@ -62,3 +62,7 @@ export function sumMoney(moneys: Money[]): Money {
       amount: amount.toFixed(2),
    };
 }
+
+export function lessThan(a: Money, b: Money): boolean {
+   return convertMoneyToCents(a) < convertMoneyToCents(b);
+}

--- a/packages/ui/commerce/ProductPrice.tsx
+++ b/packages/ui/commerce/ProductPrice.tsx
@@ -16,7 +16,6 @@ import {
    ThemeTypings,
 } from '@chakra-ui/react';
 import { faRectanglePro } from '@fortawesome/pro-solid-svg-icons';
-import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { computeDiscountPercentage, formatMoney, Money } from '@ifixit/helpers';
 import { FaIcon } from '@ifixit/icons';
 import { IconBadge } from '../misc';
@@ -47,13 +46,11 @@ export const ProductVariantPrice = forwardRef<ProductVariantPriceProps, 'div'>(
       },
       ref
    ) => {
-      const { data: user } = useAuthenticatedUser();
       const userPrice = useUserPrice({
          price,
          compareAtPrice,
          proPricesByTier,
       });
-      const isProUser = user?.is_pro ?? false;
       const discountPercentage =
          userPrice.compareAtPrice != null
             ? computeDiscountPercentage(
@@ -78,9 +75,9 @@ export const ProductVariantPrice = forwardRef<ProductVariantPriceProps, 'div'>(
                   : undefined
             }
             showDiscountLabel={showDiscountLabel}
-            showProBadge={isProUser && isDiscounted}
+            showProBadge={userPrice.isProPrice && isDiscounted}
             size={size}
-            colorScheme={isProUser ? 'orange' : 'red'}
+            colorScheme={userPrice.isProPrice ? 'orange' : 'red'}
             direction={direction}
             {...other}
          />

--- a/packages/ui/commerce/hooks/useUserPrice.tsx
+++ b/packages/ui/commerce/hooks/useUserPrice.tsx
@@ -11,7 +11,16 @@ type UseUserPriceProps = {
 type UseUserPriceResult = {
    price: Money;
    compareAtPrice?: Money | null;
+   isProPrice: boolean;
 };
+
+enum DiscountTier {
+   Employee = 'employee',
+   Pro1 = 'pro_1',
+   Pro2 = 'pro_2',
+   Pro3 = 'pro_3',
+   Pro4 = 'pro_4',
+}
 
 export function useUserPrice(props: UseUserPriceProps): UseUserPriceResult {
    const getUserPrice = useGetUserPrice();
@@ -32,15 +41,17 @@ export function useGetUserPrice() {
             discountTier != null && isProUser
                ? proPricesByTier?.[discountTier]
                : null;
-         if (proPrice == null) {
+         if (proPrice == null || price.amount < proPrice.amount) {
             return {
                price,
                compareAtPrice,
+               isProPrice: false,
             };
          }
          return {
             price: proPrice,
             compareAtPrice: compareAtPrice ?? price,
+            isProPrice: discountTier !== DiscountTier.Employee,
          };
       },
       [discountTier, isProUser]

--- a/packages/ui/commerce/hooks/useUserPrice.tsx
+++ b/packages/ui/commerce/hooks/useUserPrice.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';
-import { Money } from '@ifixit/helpers';
+import { lessThan, Money } from '@ifixit/helpers';
 
 type UseUserPriceProps = {
    price: Money;
@@ -41,7 +41,7 @@ export function useGetUserPrice() {
             discountTier != null && isProUser
                ? proPricesByTier?.[discountTier]
                : null;
-         if (proPrice == null || price.amount < proPrice.amount) {
+         if (proPrice == null || lessThan(price, proPrice)) {
             return {
                price,
                compareAtPrice,


### PR DESCRIPTION
This shows the lowest price available to a user on the product page.

If the discount is lower, that is shown and no pro badge is displayed.

~~If the user is a pro/employee and that price is lower, the pro price is shown. The pro badge also is shown, unless the user's discount tier is employee.~~

Each user has one and only one discount tier, determined in PHP. If their discount tier is 'pro_x', and the pro price is the lowest, the user will see the pro price and the pro badge. If their discount tier is 'employee', and the employee price is the lowest, they will see the employee price and the regular discount badge.

## QA

See the parent issues for the expected behavior.
Let's make sure to be pretty thoroughly here and test all the cases as an employee, regular user, and pro user:
- Discount is higher than pro price
- Discount is lower than pro price
- Discount with no special pro price
- No discount, but pro price
- No discount, no pro price

**Make sure we show users the price that they are going to receive when they check out.**

Pro pricing is set at the variant level in Akeneo. Set the us pro price for that tier, save and it should update the page immediately.
<details><summary>Akeneo</summary>

![image](https://user-images.githubusercontent.com/72166715/198695063-1485e79d-1dc4-4de7-af3e-348192e78c34.png)

</details>

Make a pro user by creating a test user and (as an admin) going to customer manager `https://www.cominor.com/Admin/CustomerManager?userid=<USERID>`. 
Click on the "No Discount" link, select a new pro tier (to the right of the page) and commit. That user is now a pro.
![image](https://user-images.githubusercontent.com/72166715/198695450-c0a74ee8-344a-4dab-ae14-b341b37ef6e1.png)
![image](https://user-images.githubusercontent.com/72166715/198695555-d35512c4-85c4-4b08-92ed-7520f2a7987a.png)


CC @erinemay 

Closes #937
Closes #938