### PR TITLE
Change the ancestor label to `Store` if it is `Home`

### DIFF
--- a/frontend/components/common/PageBreadcrumb.tsx
+++ b/frontend/components/common/PageBreadcrumb.tsx
@@ -144,7 +144,7 @@ function BreadcrumbMenu({ items }: BreadcrumbMenuProps) {
             {items.map((ancestor, index) => (
                <NextLink key={index} href={ancestor.url} passHref>
                   <MenuItem fontSize="sm" as="a">
-                     {ancestor.label}
+                     {ancestor.label === 'Home' ? 'Store' : ancestor.label}
                   </MenuItem>
                </NextLink>
             ))}


### PR DESCRIPTION
This PR checks for when the label is Home and returns Store else we keep it what it was.

Closes #883 

CC: @erinemay @sterlinghirsh 