### PR TITLE
Add-to-cart: don't fail when there are no images

### DIFF
--- a/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
@@ -55,7 +55,7 @@ export function AddToCart({ product, selectedVariant }: AddToCartProps) {
             itemcode: selectedVariant.sku,
             shopifyVariantId: selectedVariant.id,
             quantity: 1,
-            imageSrc: selectedVariant.image?.url || product.images[0].url,
+            imageSrc: selectedVariant.image?.url || product.images[0]?.url,
             price: userPrice.price,
             compareAtPrice: userPrice.compareAtPrice,
          },


### PR DESCRIPTION
Had some products that were impossible to buy because of this.

I don't think there's an issue.