### PR TITLE
International Stores: add buy box when appropriate

### DIFF
--- a/frontend/lib/ifixit-api/international-buy-box.ts
+++ b/frontend/lib/ifixit-api/international-buy-box.ts
@@ -1,0 +1,33 @@
+import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
+import { invariant } from '@ifixit/helpers';
+
+export type BuyBoxVariant = {
+   sku: string;
+   optionid: number;
+   productURL: string;
+   price: string;
+   currency: string;
+   avail: number;
+   salesChannel: string;
+   gaSku: string;
+};
+
+export type BuyBoxResponse = {
+   countryCode: string;
+   storeid: string;
+   storeName: string;
+   storeUrl: string;
+   salesChannel: string;
+   // Keyed by optionid
+   products: Record<string, BuyBoxVariant>;
+};
+
+export function getBuyBoxForProduct(
+   client: IFixitAPIClient,
+   productcode: string
+): Promise<BuyBoxResponse | null> {
+   // TODO pull country override from browser url
+   return client.get(
+      `internal/international_store_promotion/buybox?productcode=${productcode}`
+   );
+}

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -7,6 +7,7 @@ import {
    isRecord,
    Money,
    logAsync,
+   parseItemcode,
 } from '@ifixit/helpers';
 import {
    FindProductQuery,
@@ -69,6 +70,7 @@ export async function findProduct(shop: ShopCredentials, handle: string) {
       ...response.product,
       breadcrumbs,
       iFixitProductId,
+      productcode: parseItemcode(variantSku).productcode,
       images: activeImages,
       options,
       variants: activeVariants,
@@ -102,8 +104,11 @@ function getVariants(shopifyProduct: ShopifyApiProduct) {
               parseFloat(variant.compareAtPrice!.amount) * 100
            )
          : 0;
+      const { productcode, optionid } = parseItemcode(String(variant.sku));
       return {
          ...other,
+         productcode,
+         optionid,
          image: variant.image
             ? formatImage(variant.image, shopifyProduct)
             : null,

--- a/frontend/templates/product/hooks/useInternationalBuyBox.tsx
+++ b/frontend/templates/product/hooks/useInternationalBuyBox.tsx
@@ -1,0 +1,42 @@
+import { Product } from '@models/product';
+import { useQuery } from 'react-query';
+import { useState } from 'react';
+import { useIFixitApiClient } from '@ifixit/ifixit-api-client';
+import { useSelectedVariant } from './useSelectedVariant';
+import { getBuyBoxForProduct } from '@lib/ifixit-api/international-buy-box';
+import { useExpiringLocalPreference } from '@ifixit/ui';
+
+const buyBoxKey = (productcode: string) => ['buy-box-api', productcode];
+
+export function useInternationalBuyBox(product: Product) {
+   const apiClient = useIFixitApiClient();
+   const [dismissed, setDismissed] = useExpiringLocalPreference<boolean | null>(
+      'buy-box-this-store',
+      null,
+      7 // expire in days
+   );
+   const [selectedVariant] = useSelectedVariant(product);
+   const buyBox = useQuery(
+      buyBoxKey(String(product.productcode)),
+      () => {
+         if (!product.productcode) {
+            return null;
+         }
+         return getBuyBoxForProduct(apiClient, product.productcode);
+      },
+      {
+         staleTime: Infinity,
+      }
+   );
+
+   const variant =
+      buyBox.data?.products[String(selectedVariant.optionid)] || null;
+   if (dismissed || !variant || !buyBox.data) {
+      return null;
+   }
+   return {
+      store: buyBox.data,
+      selectedVariant: variant,
+      dismissBuyBox: () => setDismissed(true),
+   };
+}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -29,10 +29,12 @@ import { ProductSection } from './sections/ProductSection';
 import { ReplacementGuidesSection } from './sections/ReplacementGuidesSection';
 import { ReviewsSection } from './sections/ReviewsSection';
 import { ServiceValuePropositionSection } from './sections/ServiceValuePropositionSection';
+import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
 
 export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    const { product } = useProductTemplateProps();
    const [selectedVariant, setSelectedVariantId] = useSelectedVariant(product);
+   const internationalBuyBox = useInternationalBuyBox(product);
 
    const isProductForSale = useIsProductForSale(product);
 
@@ -66,10 +68,11 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                product={product}
                selectedVariant={selectedVariant}
                onVariantChange={setSelectedVariantId}
+               internationalBuyBox={internationalBuyBox}
             />
             <ReplacementGuidesSection product={product} />
             <ServiceValuePropositionSection />
-            {isProductForSale && (
+            {isProductForSale && !internationalBuyBox && (
                <CrossSellSection
                   key={selectedVariant.id}
                   product={product}

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -30,7 +30,6 @@ import {
 } from '@ifixit/ui';
 import { MoneyV2 } from '@lib/shopify-storefront-sdk';
 import { Product, ProductVariant } from '@models/product';
-import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
 import React from 'react';
 
 export type CrossSellSectionProps = {
@@ -45,7 +44,6 @@ export function CrossSellSection({
    const addToCart = useAddToCart('Frequently Bought Together');
    const getUserPrice = useGetUserPrice();
    const { onOpen } = useCartDrawer();
-   const internationalBuyBox = useInternationalBuyBox(product);
 
    const crossSellVariantsForSale =
       useCrossSellVariantsForSale(selectedVariant);
@@ -164,10 +162,6 @@ export function CrossSellSection({
    };
 
    if (crossSellVariantsForSale.length === 0) {
-      return null;
-   }
-
-   if (internationalBuyBox) {
       return null;
    }
 

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@ifixit/ui';
 import { MoneyV2 } from '@lib/shopify-storefront-sdk';
 import { Product, ProductVariant } from '@models/product';
+import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
 import React from 'react';
 
 export type CrossSellSectionProps = {
@@ -44,6 +45,7 @@ export function CrossSellSection({
    const addToCart = useAddToCart('Frequently Bought Together');
    const getUserPrice = useGetUserPrice();
    const { onOpen } = useCartDrawer();
+   const internationalBuyBox = useInternationalBuyBox(product);
 
    const crossSellVariantsForSale =
       useCrossSellVariantsForSale(selectedVariant);
@@ -162,6 +164,10 @@ export function CrossSellSection({
    };
 
    if (crossSellVariantsForSale.length === 0) {
+      return null;
+   }
+
+   if (internationalBuyBox) {
       return null;
    }
 

--- a/frontend/templates/product/sections/ProductSection/InternationalBuyBox.tsx
+++ b/frontend/templates/product/sections/ProductSection/InternationalBuyBox.tsx
@@ -1,0 +1,38 @@
+import { Button, Link, Box } from '@chakra-ui/react';
+import {
+   BuyBoxResponse,
+   BuyBoxVariant,
+} from '@lib/ifixit-api/international-buy-box';
+import { Flag, FlagCountryCode } from '@ifixit/icons';
+
+type InternationalBuyBoxProps = {
+   store: BuyBoxResponse;
+   selectedVariant: BuyBoxVariant;
+   dismissBuyBox: () => void;
+};
+
+export function InternationalBuyBox({
+   store,
+   selectedVariant,
+   dismissBuyBox,
+}: InternationalBuyBoxProps) {
+   return (
+      <Box textAlign="center">
+         <Button
+            mt={3}
+            variant="outline"
+            as="a"
+            w="full"
+            colorScheme="brand"
+            href={selectedVariant?.productURL}
+         >
+            <Flag mr={3} w={7} code={store.countryCode as FlagCountryCode} />{' '}
+            Buy from our Store in {store.storeName}
+         </Button>
+         <Box m={2}>or</Box>
+         <Link color="brand.600" fontSize="md" onClick={dismissBuyBox}>
+            Buy from our US Store
+         </Link>
+      </Box>
+   );
+}

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -52,12 +52,14 @@ export type ProductSectionProps = {
    product: Product;
    selectedVariant: ProductVariant;
    onVariantChange: (variantId: string) => void;
+   internationalBuyBox: ReturnType<typeof useInternationalBuyBox>;
 };
 
 export function ProductSection({
    product,
    selectedVariant,
    onVariantChange,
+   internationalBuyBox,
 }: ProductSectionProps) {
    const [selectedImageId, setSelectedImageId] = React.useState(
       selectedVariant.image?.id
@@ -75,8 +77,6 @@ export function ProductSection({
    );
 
    const isForSale = useIsProductForSale(product);
-
-   const internationalBuyBox = useInternationalBuyBox(product);
 
    return (
       <PageContentWrapper as="section">

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -45,6 +45,8 @@ import { ProductOptions } from './ProductOptions';
 import { ProductRating } from './ProductRating';
 import { Prop65Warning } from './Prop65Warning';
 import { BuyBoxPropositionSection } from '../ServiceValuePropositionSection';
+import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
+import { InternationalBuyBox } from './InternationalBuyBox';
 
 export type ProductSectionProps = {
    product: Product;
@@ -73,6 +75,8 @@ export function ProductSection({
    );
 
    const isForSale = useIsProductForSale(product);
+
+   const internationalBuyBox = useInternationalBuyBox(product);
 
    return (
       <PageContentWrapper as="section">
@@ -150,12 +154,15 @@ export function ProductSection({
                   onChange={handleVariantChange}
                />
                {isForSale ? (
-                  isVariantWithSku(selectedVariant) && (
+                  isVariantWithSku(selectedVariant) &&
+                  (internationalBuyBox ? (
+                     <InternationalBuyBox {...internationalBuyBox} />
+                  ) : (
                      <AddToCart
                         product={product}
                         selectedVariant={selectedVariant}
                      />
-                  )
+                  ))
                ) : (
                   <NotForSaleAlert mt="4" />
                )}

--- a/packages/ui/hooks/index.ts
+++ b/packages/ui/hooks/index.ts
@@ -136,7 +136,7 @@ export function useSSRBreakpointValue<Value>(
 export function useExpiringLocalPreference<Data = any>(
    key: string,
    defaultData: Data,
-   expireInDays: number,
+   expireInDays: number
 ): [Data, (data: Data) => void] {
    type ExpiringData = {
       value: Data;
@@ -150,7 +150,9 @@ export function useExpiringLocalPreference<Data = any>(
       if (serializedData != null) {
          try {
             const data = JSON.parse(serializedData) as ExpiringData;
-            const expiresAt = Number.isInteger(data?.expires) ? data.expires : 0;
+            const expiresAt = Number.isInteger(data?.expires)
+               ? data.expires
+               : 0;
             if (expiresAt && Date.now() < expiresAt) {
                setData(data?.value);
             } else {
@@ -164,7 +166,7 @@ export function useExpiringLocalPreference<Data = any>(
       setData(data);
       const expiringData = {
          value: data,
-         expires: Date.now() + (expireInDays * 1000 * 86400),
+         expires: Date.now() + expireInDays * 1000 * 86400,
       } as ExpiringData;
       const serializedData = JSON.stringify(expiringData);
       localStorage.setItem(key, serializedData);
@@ -172,7 +174,6 @@ export function useExpiringLocalPreference<Data = any>(
 
    return [data, setAndSave];
 }
-
 
 /**
  * A simple hook to store user preferences in local storage.

--- a/packages/ui/hooks/index.ts
+++ b/packages/ui/hooks/index.ts
@@ -131,6 +131,52 @@ export function useSSRBreakpointValue<Value>(
 /**
  * A simple hook to store user preferences in local storage.
  * @param key localStorage key
+ * @returns [value, setValue] tuple where `value` is the current value and `setValue` is a function to update it.
+ */
+export function useExpiringLocalPreference<Data = any>(
+   key: string,
+   defaultData: Data,
+   expireInDays: number,
+): [Data, (data: Data) => void] {
+   type ExpiringData = {
+      value: Data;
+      expires: number;
+   };
+
+   const [data, setData] = React.useState(defaultData);
+
+   React.useEffect(() => {
+      const serializedData = localStorage.getItem(key);
+      if (serializedData != null) {
+         try {
+            const data = JSON.parse(serializedData) as ExpiringData;
+            const expiresAt = Number.isInteger(data?.expires) ? data.expires : 0;
+            if (expiresAt && Date.now() < expiresAt) {
+               setData(data?.value);
+            } else {
+               localStorage.deleteIem(key);
+            }
+         } catch (error) {}
+      }
+   }, []);
+
+   const setAndSave = (data: Data) => {
+      setData(data);
+      const expiringData = {
+         value: data,
+         expires: Date.now() + (expireInDays * 1000 * 86400),
+      } as ExpiringData;
+      const serializedData = JSON.stringify(expiringData);
+      localStorage.setItem(key, serializedData);
+   };
+
+   return [data, setAndSave];
+}
+
+
+/**
+ * A simple hook to store user preferences in local storage.
+ * @param key localStorage key
  * @param defaultData
  * @returns [value, setValue] tuple where `value` is the current value and `setValue` is a function to update it.
  */


### PR DESCRIPTION
This should function the same as it did on the previous product page.

* Makes an API request to ifixit.com from the browser for the given
  product
* That responds with "user is geolocated in country X, here's info for a
  banner for each of the variants"
  * OR it responds with null
* We use a react component to render the "Buy from our X Store" banner
  for the currently selected variant
* Shows a "or buy from the US Store" link that will dismiss the buy box
  for 7 days
   * The previous product page used a 7-day cookie, so I kept it the
     same.

Note: The UI differs from the old product page bannerl slightly and we
can definitely tweak it, but I might do that in a follow-up pull unless
there are bugs.

Also, matomo events will be in a follow up pull.

QA:
* Set your preferred store via the store dropdown in the header
* Visit product pages on the US store for products that are available in your preferred store
* Assert you see the "buy box" instead of the Add To Cart button
* Assert that clicking the button takes you to the correct store
* Assert that clicking the bottom option "buy from US store" makes the buy box disappear and you shouldn't see it on further page reloads (should stay away for 7 days)

Connect #930