### PR TITLE
Product List Items: Fix decimal display

### DIFF
--- a/frontend/components/common/ProductCard.tsx
+++ b/frontend/components/common/ProductCard.tsx
@@ -130,14 +130,19 @@ export const ProductCardSoldOutBadge = (props: BadgeProps) => {
 
 export type ProductCardDiscountBadgeProps = BadgeProps & {
    percentage: number;
+   isProPrice: boolean;
 };
 
 export const ProductCardDiscountBadge = ({
    percentage,
+   isProPrice,
    ...badgeProps
 }: ProductCardDiscountBadgeProps) => {
    return (
-      <ProductCardBadge {...badgeProps} colorScheme="red">
+      <ProductCardBadge
+         {...badgeProps}
+         colorScheme={isProPrice ? 'orange' : 'red'}
+      >
          {percentage}% Off
       </ProductCardBadge>
    );

--- a/frontend/components/common/ProductCard.tsx
+++ b/frontend/components/common/ProductCard.tsx
@@ -88,55 +88,6 @@ export const ProductCardRating = ({
    );
 };
 
-export type ProductCardPricingProps = StackProps & {
-   price: number;
-   compareAtPrice?: number;
-   currency: string;
-};
-
-export const ProductCardPricing = ({
-   price,
-   compareAtPrice,
-   currency,
-   ...stackProps
-}: ProductCardPricingProps) => {
-   const isDiscounted = compareAtPrice != null && compareAtPrice > price;
-   if (price == null) {
-      return null;
-   }
-   return (
-      <HStack
-         w="full"
-         flexGrow={1}
-         align="flex-end"
-         justify="flex-end"
-         spacing="2"
-         {...stackProps}
-      >
-         {isDiscounted && (
-            <Text
-               lineHeight="1em"
-               textDecoration="line-through"
-               color="gray.400"
-               data-testid="product-price"
-            >
-               {currency}
-               {compareAtPrice}
-            </Text>
-         )}
-         <Text
-            color={isDiscounted ? 'red.700' : 'inherit'}
-            fontWeight="bold"
-            fontSize="xl"
-            lineHeight="1em"
-         >
-            {currency}
-            {price}
-         </Text>
-      </HStack>
-   );
-};
-
 export const ProductCardBadgeList = (props: StackProps) => {
    return (
       <HStack

--- a/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
@@ -207,6 +207,7 @@ function ProductListItem({ product }: ProductListItemProps) {
                      compareAtPrice={compareAtPrice}
                      proPricesByTier={proPricesByTier}
                      showDiscountLabel={false}
+                     direction="column"
                      alignSelf="flex-end"
                   />
                </HStack>

--- a/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
@@ -24,7 +24,7 @@ import { Card } from '@components/ui';
 import { computeProductListAlgoliaFilterPreset } from '@helpers/product-list-helpers';
 import { useAppContext } from '@ifixit/app';
 import { FeaturedProductList, ProductSearchHit } from '@models/product-list';
-import { IfixitImage, ProductVariantPrice } from '@ifixit/ui';
+import { IfixitImage, ProductVariantPrice, useUserPrice } from '@ifixit/ui';
 import NextLink from 'next/link';
 import { Configure, Index, useHits } from 'react-instantsearch-hooks-web';
 import { computeDiscountPercentage } from '@ifixit/helpers';
@@ -169,6 +169,12 @@ function ProductListItem({ product }: ProductListItemProps) {
       useProductSearchHitPricing(product);
    const isSoldOut = product.quantity_available <= 0;
 
+   const { isProPrice } = useUserPrice({
+      price,
+      compareAtPrice,
+      proPricesByTier,
+   });
+
    return (
       <LinkBox
          as="article"
@@ -190,7 +196,10 @@ function ProductListItem({ product }: ProductListItemProps) {
                   <ProductCardSoldOutBadge />
                ) : (
                   isDiscounted && (
-                     <ProductCardDiscountBadge percentage={percentage} />
+                     <ProductCardDiscountBadge
+                        percentage={percentage}
+                        isProPrice={isProPrice}
+                     />
                   )
                )}
             </ProductCardBadgeList>

--- a/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
@@ -3,6 +3,7 @@ import {
    Button,
    Flex,
    Heading,
+   HStack,
    LinkBox,
    LinkOverlay,
    SimpleGrid,
@@ -15,7 +16,6 @@ import {
    ProductCardBody,
    ProductCardDiscountBadge,
    ProductCardImage,
-   ProductCardPricing,
    ProductCardRating,
    ProductCardSoldOutBadge,
    ProductCardTitle,
@@ -24,11 +24,12 @@ import { Card } from '@components/ui';
 import { computeProductListAlgoliaFilterPreset } from '@helpers/product-list-helpers';
 import { useAppContext } from '@ifixit/app';
 import { FeaturedProductList, ProductSearchHit } from '@models/product-list';
-import { IfixitImage } from '@ifixit/ui';
+import { IfixitImage, ProductVariantPrice } from '@ifixit/ui';
 import NextLink from 'next/link';
 import { Configure, Index, useHits } from 'react-instantsearch-hooks-web';
 import { computeDiscountPercentage } from '@ifixit/helpers';
 import { productListPath } from '@helpers/path-helpers';
+import { useProductSearchHitPricing } from './FilterableProductsSection/useProductSearchHitPricing';
 
 export interface FeaturedProductListSectionProps {
    productList: FeaturedProductList;
@@ -164,17 +165,8 @@ interface ProductListItemProps {
 
 function ProductListItem({ product }: ProductListItemProps) {
    const appContext = useAppContext();
-   const isDiscounted =
-      product.compare_at_price != null &&
-      product.compare_at_price > product.price_float;
-
-   const percentage = isDiscounted
-      ? computeDiscountPercentage(
-           product.price_float * 100,
-           product.compare_at_price! * 100
-        )
-      : 0;
-
+   const { price, compareAtPrice, isDiscounted, percentage, proPricesByTier } =
+      useProductSearchHitPricing(product);
    const isSoldOut = product.quantity_available <= 0;
 
    return (
@@ -209,11 +201,15 @@ function ProductListItem({ product }: ProductListItemProps) {
                   </ProductCardTitle>
                </LinkOverlay>
                <ProductCardRating rating={product.rating} count={102} />
-               <ProductCardPricing
-                  currency="$"
-                  price={product.price_float}
-                  compareAtPrice={product.compare_at_price}
-               />
+               <HStack w="full" flexGrow={1} justify="flex-end" spacing="2">
+                  <ProductVariantPrice
+                     price={price}
+                     compareAtPrice={compareAtPrice}
+                     proPricesByTier={proPricesByTier}
+                     showDiscountLabel={false}
+                     alignSelf="flex-end"
+                  />
+               </HStack>
             </ProductCardBody>
          </ProductCard>
       </LinkBox>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -131,6 +131,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
                      compareAtPrice={compareAtPrice}
                      proPricesByTier={proPricesByTier}
                      showDiscountLabel={false}
+                     direction="row-reverse"
                      alignSelf="flex-end"
                   />
                </HStack>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -17,7 +17,7 @@ import {
 import { flags } from '@config/flags';
 import { getProductPath } from '@helpers/product-helpers';
 import { useAppContext } from '@ifixit/app';
-import { ProductVariantPrice } from '@ifixit/ui';
+import { ProductVariantPrice, useUserPrice } from '@ifixit/ui';
 import { ProductSearchHit } from '@models/product-list';
 import * as React from 'react';
 import { useProductSearchHitPricing } from './useProductSearchHitPricing';
@@ -75,6 +75,12 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
    const showLifetimeWarrantyBadge = product.lifetime_warranty;
    const showOemPartnershipBadge = product.oem_partnership;
 
+   const { isProPrice } = useUserPrice({
+      price,
+      compareAtPrice,
+      proPricesByTier,
+   });
+
    return (
       <LinkBox as="article" display="block" w="full" role="group">
          <ProductCard h="full">
@@ -97,7 +103,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
                   </ProductCardBadge>
                )}
                {showDiscountBadge && (
-                  <ProductCardBadge colorScheme="red">
+                  <ProductCardBadge colorScheme={isProPrice ? 'orange' : 'red'}>
                      {percentage}% Off
                   </ProductCardBadge>
                )}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -1,6 +1,7 @@
 import {
    Badge,
    BadgeProps,
+   HStack,
    LinkBox,
    LinkOverlay,
    SimpleGrid,
@@ -9,15 +10,14 @@ import {
    ProductCard,
    ProductCardBadgeList,
    ProductCardBody,
-   ProductCardDiscountBadge,
    ProductCardImage,
-   ProductCardPricing,
    ProductCardRating,
    ProductCardTitle,
 } from '@components/common';
 import { flags } from '@config/flags';
 import { getProductPath } from '@helpers/product-helpers';
 import { useAppContext } from '@ifixit/app';
+import { ProductVariantPrice } from '@ifixit/ui';
 import { ProductSearchHit } from '@models/product-list';
 import * as React from 'react';
 import { useProductSearchHitPricing } from './useProductSearchHitPricing';
@@ -67,7 +67,7 @@ export interface ProductGridItemProps {
 export function ProductGridItem({ product }: ProductGridItemProps) {
    const appContext = useAppContext();
 
-   const { price, compareAtPrice, isDiscounted, percentage } =
+   const { price, compareAtPrice, isDiscounted, percentage, proPricesByTier } =
       useProductSearchHitPricing(product);
 
    const showProBadge = product.is_pro > 0;
@@ -125,11 +125,15 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
                      count={product.rating_count}
                   />
                )}
-               <ProductCardPricing
-                  currency="$"
-                  price={price}
-                  compareAtPrice={compareAtPrice}
-               />
+               <HStack w="full" flexGrow={1} justify="flex-end" spacing="2">
+                  <ProductVariantPrice
+                     price={price}
+                     compareAtPrice={compareAtPrice}
+                     proPricesByTier={proPricesByTier}
+                     showDiscountLabel={false}
+                     alignSelf="flex-end"
+                  />
+               </HStack>
             </ProductCardBody>
          </ProductCard>
       </LinkBox>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -213,6 +213,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                            compareAtPrice={compareAtPrice}
                            proPricesByTier={proPricesByTier}
                            showDiscountLabel={false}
+                           direction="column"
                         />
                      </VStack>
                   )}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -14,7 +14,7 @@ import {
    Text,
    VStack,
 } from '@chakra-ui/react';
-import { IfixitImage, ProductVariantPrice } from '@ifixit/ui';
+import { IfixitImage, ProductVariantPrice, useUserPrice } from '@ifixit/ui';
 import { Rating } from '@components/ui';
 import { flags } from '@config/flags';
 import { useAppContext } from '@ifixit/app';
@@ -63,6 +63,12 @@ export function ProductListItem({ product }: ProductListItemProps) {
       showDiscountBadge ||
       showLifetimeWarrantyBadge ||
       showOemPartnershipBadge;
+
+   const { isProPrice } = useUserPrice({
+      price,
+      compareAtPrice,
+      proPricesByTier,
+   });
 
    return (
       <LinkBox as="article" aria-labelledby={productHeadingId} role="group">
@@ -172,7 +178,9 @@ export function ProductListItem({ product }: ProductListItemProps) {
                            </ProductListItemBadge>
                         )}
                         {showDiscountBadge && (
-                           <ProductListItemBadge colorScheme="red">
+                           <ProductListItemBadge
+                              colorScheme={isProPrice ? 'orange' : 'red'}
+                           >
                               {percentage}% Off
                            </ProductListItemBadge>
                         )}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -14,7 +14,7 @@ import {
    Text,
    VStack,
 } from '@chakra-ui/react';
-import { IfixitImage } from '@ifixit/ui';
+import { IfixitImage, ProductVariantPrice } from '@ifixit/ui';
 import { Rating } from '@components/ui';
 import { flags } from '@config/flags';
 import { useAppContext } from '@ifixit/app';
@@ -47,7 +47,7 @@ export interface ProductListItemProps {
 export function ProductListItem({ product }: ProductListItemProps) {
    const appContext = useAppContext();
 
-   const { price, compareAtPrice, isDiscounted, percentage } =
+   const { price, compareAtPrice, isDiscounted, percentage, proPricesByTier } =
       useProductSearchHitPricing(product);
 
    const productHeadingId = `product-heading-${product.handle}`;
@@ -208,25 +208,12 @@ export function ProductListItem({ product }: ProductListItemProps) {
                            lg: 0,
                         }}
                      >
-                        <Text
-                           color={isDiscounted ? 'red.700' : 'inherit'}
-                           fontWeight="bold"
-                           fontSize="xl"
-                           lineHeight="1em"
-                           data-testid="product-price"
-                        >
-                           ${price}
-                        </Text>
-                        {isDiscounted && (
-                           <Text
-                              lineHeight="1em"
-                              textDecoration="line-through"
-                              color="gray.400"
-                              data-testid="product-compared-at-price"
-                           >
-                              ${compareAtPrice}
-                           </Text>
-                        )}
+                        <ProductVariantPrice
+                           price={price}
+                           compareAtPrice={compareAtPrice}
+                           proPricesByTier={proPricesByTier}
+                           showDiscountLabel={false}
+                        />
                      </VStack>
                   )}
                   <Stack

--- a/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
@@ -31,11 +31,12 @@ export function useProductSearchHitPricing(
 
    const price = proTierPrice ?? product.price_float;
    const compareAtPrice = product.compare_at_price ?? product.price_float;
-   const isDiscounted = compareAtPrice > price;
 
-   const percentage = isDiscounted
-      ? computeDiscountPercentage(price * 100, compareAtPrice * 100)
-      : 0;
+   const percentage = computeDiscountPercentage(
+      price * 100,
+      compareAtPrice * 100
+   );
+   const isDiscounted = percentage > 0;
 
    const proPricesByTier =
       product.price_tiers && !isEmpty(product.price_tiers)

--- a/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
@@ -29,10 +29,10 @@ export function useProductSearchHitPricing(
 
    const price = proTierPrice ?? product.price_float;
    const compareAtPrice = product.compare_at_price ?? product.price_float;
-   const isDiscounted = compareAtPrice != null && compareAtPrice > price;
+   const isDiscounted = compareAtPrice > price;
 
    const percentage = isDiscounted
-      ? computeDiscountPercentage(price * 100, compareAtPrice! * 100)
+      ? computeDiscountPercentage(price * 100, compareAtPrice * 100)
       : 0;
 
    return {

--- a/frontend/test/jest/tests/ProductListItem.test.tsx
+++ b/frontend/test/jest/tests/ProductListItem.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { ProductListItem } from '@templates/product-list/sections/FilterableProductsSection/ProductList';
 import * as ProductSearch from '@templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing';
+import * as UserPrice from '@ifixit/ui/commerce/hooks/useUserPrice';
 import { mockProduct } from 'test/jest/__mocks__/mockProduct';
 
 jest.mock('@ifixit/app');
@@ -13,6 +14,11 @@ describe('ProductListItem', () => {
          compareAtPrice: { amount: 5, currencyCode: 'usd' },
          isDiscounted: 5,
          percentage: 5,
+      });
+      // @ts-ignore: Assigning to a read-only property
+      UserPrice.useUserPrice = jest.fn().mockReturnValue({
+         price: { amount: 5, currencyCode: 'usd' },
+         compareAtPrice: { amount: 5, currencyCode: 'usd' },
       });
    });
 

--- a/frontend/test/jest/tests/ProductListItem.test.tsx
+++ b/frontend/test/jest/tests/ProductListItem.test.tsx
@@ -9,8 +9,8 @@ describe('ProductListItem', () => {
    beforeEach(() => {
       // @ts-ignore
       ProductSearch.useProductSearchHitPricing = jest.fn().mockReturnValue({
-         price: 5,
-         compareAtPrice: 5,
+         price: { amount: 5, currencyCode: 'usd' },
+         compareAtPrice: { amount: 5, currencyCode: 'usd' },
          isDiscounted: 5,
          percentage: 5,
       });

--- a/frontend/test/jest/tests/__snapshots__/ProductListItem.test.tsx.snap
+++ b/frontend/test/jest/tests/__snapshots__/ProductListItem.test.tsx.snap
@@ -168,18 +168,16 @@ exports[`ProductListItem renders and matches the snapshot 1`] = `
           <div
             class="chakra-stack css-1wwkyaq"
           >
-            <p
-              class="chakra-text css-12jr671"
-              data-testid="product-price"
+            <div
+              class="css-14apnby"
             >
-              $5
-            </p>
-            <p
-              class="chakra-text css-m9wb1i"
-              data-testid="product-compared-at-price"
-            >
-              $5
-            </p>
+              <p
+                class="chakra-text css-1bsyxr8"
+                data-testid="product-price"
+              >
+                $5.00
+              </p>
+            </div>
           </div>
           <div
             class="chakra-stack css-1dz9rto"

--- a/packages/ui/commerce/ProductPrice.tsx
+++ b/packages/ui/commerce/ProductPrice.tsx
@@ -28,7 +28,7 @@ export type ProductVariantPriceProps = Omit<BoxProps, 'children'> & {
    showDiscountLabel?: boolean;
    formatDiscountLabel?: (discountPercentage: number) => string;
    size?: 'large' | 'medium' | 'small';
-   direction?: 'row' | 'column' | 'column-reverse';
+   direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
 };
 
 export const ProductVariantPrice = forwardRef<ProductVariantPriceProps, 'div'>(
@@ -94,7 +94,7 @@ type ProductPriceProps = {
    showProBadge?: boolean;
    size?: 'large' | 'medium' | 'small';
    colorScheme?: ThemeTypings['colorSchemes'];
-   direction?: 'row' | 'column' | 'column-reverse';
+   direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
 };
 
 const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
@@ -116,6 +116,7 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
       const priceFontSize =
          size === 'large' ? 'xl' : size === 'medium' ? 'md' : 'sm';
       const compareAtPriceFontSize = size === 'large' ? 'md' : 'sm';
+      const isRow = direction === 'row' || direction === 'row-reverse';
 
       return (
          <Box
@@ -123,17 +124,17 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
             display="flex"
             flexDir={direction}
             alignSelf="flex-start"
-            alignItems={direction === 'row' ? 'center' : 'flex-end'}
+            alignItems={isRow ? 'center' : 'flex-end'}
             {...other}
          >
             <Text
-               mr={direction === 'row' ? 1 : 0}
+               mr={isRow ? 1 : 0}
                fontSize={priceFontSize}
                fontWeight="semibold"
                color={isDiscounted ? `${colorScheme}.600` : 'gray.900'}
                data-testid="product-price"
             >
-               {showProBadge && direction !== 'row' && (
+               {showProBadge && !isRow && (
                   <FaIcon
                      icon={faRectanglePro}
                      h="4"
@@ -146,14 +147,14 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
             {isDiscounted && (
                <>
                   <Text
-                     mr={direction === 'row' ? '10px' : 0}
+                     mr={isRow ? '10px' : 0}
                      fontSize={compareAtPriceFontSize}
                      color="gray.500"
                      textDecor="line-through"
                   >
                      {formattedCompareAtPrice}
                   </Text>
-                  {isDiscounted && showDiscountLabel && direction === 'row' && (
+                  {isDiscounted && showDiscountLabel && isRow && (
                      <IconBadge
                         icon={showProBadge ? faRectanglePro : undefined}
                         colorScheme={colorScheme}

--- a/packages/ui/commerce/ProductPrice.tsx
+++ b/packages/ui/commerce/ProductPrice.tsx
@@ -131,6 +131,7 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
                fontSize={priceFontSize}
                fontWeight="semibold"
                color={isDiscounted ? `${colorScheme}.600` : 'gray.900'}
+               data-testid="product-price"
             >
                {showProBadge && direction !== 'row' && (
                   <FaIcon


### PR DESCRIPTION
Reuses the `ProductPrice` component in our collections to consistently render product prices. Fixes a bug where trailing zeros weren't rendered in discounted prices.

## QA

Visit collection pages with and without discounts, and make sure prices are rendered correctly and the UI looks ok.

Also do this as a pro user.

Closes #886
