### PR TITLE
Value Proposition: hide iFixit's for drop-shipped items

### DIFF
--- a/frontend/templates/product/hooks/useInternationalBuyBox.tsx
+++ b/frontend/templates/product/hooks/useInternationalBuyBox.tsx
@@ -15,7 +15,7 @@ export function useInternationalBuyBox(product: Product) {
       null,
       7 // expire in days
    );
-   const [selectedVariant] = useSelectedVariant(product);
+   const selectedVariant = useSelectedVariant();
    const buyBox = useQuery(
       buyBoxKey(String(product.productcode)),
       () => {

--- a/frontend/templates/product/hooks/useSelectedVariant.ts
+++ b/frontend/templates/product/hooks/useSelectedVariant.ts
@@ -1,7 +1,7 @@
 import { invariant } from '@ifixit/helpers';
 import { Product, ProductVariant } from '@models/product';
 import { useRouter } from 'next/router';
-import React from 'react';
+import { useCallback } from 'react';
 
 type SetVariantIdFn = (variantId: string) => void;
 
@@ -25,7 +25,7 @@ export function useSelectedVariant(
       `Something went wrong, variant with id "${currentVariantId}" not found`
    );
 
-   const setVariantId = React.useCallback<SetVariantIdFn>(
+   const setVariantId = useCallback<SetVariantIdFn>(
       (variantId) => {
          const { variant, ...newQuery } = router.query;
          if (variantId !== defaultVariantId) {

--- a/frontend/templates/product/hooks/useSelectedVariant.ts
+++ b/frontend/templates/product/hooks/useSelectedVariant.ts
@@ -1,11 +1,22 @@
 import { invariant } from '@ifixit/helpers';
 import { Product, ProductVariant } from '@models/product';
 import { useRouter } from 'next/router';
-import { useCallback } from 'react';
+import {
+   useCallback,
+   createContext,
+   useContext,
+   PropsWithChildren,
+} from 'react';
 
 type SetVariantIdFn = (variantId: string) => void;
 
-export function useSelectedVariant(
+const SelectedVariantContext = createContext<ProductVariant | undefined>(
+   undefined
+);
+
+export const SelectedVariantProvider = SelectedVariantContext.Provider;
+
+export function useSelectedVariantFromUrl(
    product: Product
 ): [ProductVariant, SetVariantIdFn] {
    const router = useRouter();
@@ -43,6 +54,14 @@ export function useSelectedVariant(
    );
 
    return [variant, setVariantId];
+}
+
+export function useSelectedVariant(): ProductVariant {
+   const contextValue = useContext(SelectedVariantContext);
+   if (!contextValue) {
+      throw new Error('Component must be inside SelectedVariantProvider');
+   }
+   return contextValue;
 }
 
 function useDefaultVariantId(product: Product): string {

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -68,7 +68,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                onVariantChange={setSelectedVariantId}
             />
             <ReplacementGuidesSection product={product} />
-            <ServiceValuePropositionSection />
+            <ServiceValuePropositionSection variant={selectedVariant} />
             {isProductForSale && (
                <CrossSellSection
                   key={selectedVariant.id}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -72,7 +72,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                onVariantChange={setSelectedVariantId}
             />
             <ReplacementGuidesSection product={product} />
-            <ServiceValuePropositionSection variant={selectedVariant} />
+            <ServiceValuePropositionSection />
             {isProductForSale && (
                <CrossSellSection
                   key={selectedVariant.id}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -19,7 +19,10 @@ import {
    ProductTemplateProps,
    useProductTemplateProps,
 } from './hooks/useProductTemplateProps';
-import { useSelectedVariant } from './hooks/useSelectedVariant';
+import {
+   SelectedVariantProvider,
+   useSelectedVariantFromUrl,
+} from './hooks/useSelectedVariant';
 import { MetaTags } from './MetaTags';
 import { CompatibilitySection } from './sections/CompatibilitySection';
 import { CrossSellSection } from './sections/CrossSellSection';
@@ -32,7 +35,8 @@ import { ServiceValuePropositionSection } from './sections/ServiceValuePropositi
 
 export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    const { product } = useProductTemplateProps();
-   const [selectedVariant, setSelectedVariantId] = useSelectedVariant(product);
+   const [selectedVariant, setSelectedVariantId] =
+      useSelectedVariantFromUrl(product);
 
    const isProductForSale = useIsProductForSale(product);
 
@@ -54,7 +58,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    }, []);
 
    return (
-      <React.Fragment key={product.handle}>
+      <SelectedVariantProvider value={selectedVariant} key={product.handle}>
          <MetaTags product={product} selectedVariant={selectedVariant} />
          {product.breadcrumbs != null && (
             <SecondaryNavigation>
@@ -87,7 +91,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
             <FeaturedProductsSection product={product} />
             <LifetimeWarrantySection variant={selectedVariant} />
          </Box>
-      </React.Fragment>
+      </SelectedVariantProvider>
    );
 };
 

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -167,7 +167,7 @@ export function ProductSection({
                   <NotForSaleAlert mt="4" />
                )}
                {isForSale && (
-                  <BuyBoxPropositionSection variant={selectedVariant} />
+                  <BuyBoxPropositionSection />
                )}
                <Accordion defaultIndex={[0, 1]} allowMultiple mt="10">
                   <AccordionItem>

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -159,7 +159,9 @@ export function ProductSection({
                ) : (
                   <NotForSaleAlert mt="4" />
                )}
-               {isForSale && <BuyBoxPropositionSection />}
+               {isForSale && (
+                  <BuyBoxPropositionSection variant={selectedVariant} />
+               )}
                <Accordion defaultIndex={[0, 1]} allowMultiple mt="10">
                   <AccordionItem>
                      <CustomAccordionButton>Description</CustomAccordionButton>

--- a/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
+++ b/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
@@ -13,22 +13,10 @@ import {
    faShieldCheck,
 } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon, FaIconProps } from '@ifixit/icons';
+import { useSelectedVariant } from '../../hooks/useSelectedVariant';
 
-export type ServiceValuePropositionSectionProps = {
-   variant: ProductVariant;
-};
-
-export function ServiceValuePropositionSection({
-   variant,
-}: ServiceValuePropositionSectionProps) {
-   if (isDropshipped(variant)) {
-      return null;
-   } else {
-      return <ServiceValuePropositionSectioniFixit />;
-   }
-}
-
-function ServiceValuePropositionSectioniFixit() {
+export function ServiceValuePropositionSection() {
+   const variant = useSelectedVariant();
    return (
       <>
          <Heading as="h2" srOnly>
@@ -72,31 +60,20 @@ function ServiceValuePropositionSectioniFixit() {
                   backed by industry-leading guarantees.
                </Text>
             </ValueProposition>
-            <ValueProposition>
-               <ValuePropositionIcon icon={faRocketDuo} />
-               <Text fontWeight="bold">Fast shipping</Text>
-               <Text>Same day shipping if ordered by 1PM Pacific.</Text>
-            </ValueProposition>
+            {!isDropshipped(variant) && (
+               <ValueProposition>
+                  <ValuePropositionIcon icon={faRocketDuo} />
+                  <Text fontWeight="bold">Fast shipping</Text>
+                  <Text>Same day shipping if ordered by 1PM Pacific.</Text>
+               </ValueProposition>
+            )}
          </Stack>
       </>
    );
 }
 
-export type BuyBoxPropositionSectionProps = {
-   variant: ProductVariant;
-};
-
-export function BuyBoxPropositionSection({
-   variant,
-}: BuyBoxPropositionSectionProps) {
-   if (isDropshipped(variant)) {
-      return null;
-   } else {
-      return <BuyBoxPropositionSectioniFixit />;
-   }
-}
-
-export function BuyBoxPropositionSectioniFixit() {
+export function BuyBoxPropositionSection() {
+   const variant = useSelectedVariant();
    return (
       <div>
          <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
@@ -126,17 +103,19 @@ export function BuyBoxPropositionSectioniFixit() {
                   backed by industry-leading guarantees.
                </div>
             </ListItem>
-            <ListItem display="flex" alignItems="center">
-               <ListIcon
-                  as={FaIcon}
-                  h="4"
-                  w="5"
-                  mr="1.5"
-                  color="brand.500"
-                  icon={faRocket}
-               />
-               Same day shipping if ordered by 1PM Pacific.
-            </ListItem>
+            {!isDropshipped(variant) && (
+               <ListItem display="flex" alignItems="center">
+                  <ListIcon
+                     as={FaIcon}
+                     h="4"
+                     w="5"
+                     mr="1.5"
+                     color="brand.500"
+                     icon={faRocket}
+                  />
+                  Same day shipping if ordered by 1PM Pacific.
+               </ListItem>
+            )}
          </List>
       </div>
    );

--- a/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
+++ b/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
@@ -1,3 +1,4 @@
+import { ProductVariant } from '@models/product';
 import { Heading, Stack, Text, VStack } from '@chakra-ui/react';
 import React from 'react';
 import { List, ListIcon, ListItem } from '@chakra-ui/react';
@@ -13,9 +14,21 @@ import {
 } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon, FaIconProps } from '@ifixit/icons';
 
-export type ServiceValuePropositionSectionProps = {};
+export type ServiceValuePropositionSectionProps = {
+   variant: ProductVariant;
+};
 
-export function ServiceValuePropositionSection() {
+export function ServiceValuePropositionSection({
+   variant,
+}: ServiceValuePropositionSectionProps) {
+   if (isDropshipped(variant)) {
+      return null;
+   } else {
+      return <ServiceValuePropositionSectioniFixit />;
+   }
+}
+
+function ServiceValuePropositionSectioniFixit() {
    return (
       <>
          <Heading as="h2" srOnly>
@@ -69,7 +82,21 @@ export function ServiceValuePropositionSection() {
    );
 }
 
-export function BuyBoxPropositionSection() {
+export type BuyBoxPropositionSectionProps = {
+   variant: ProductVariant;
+};
+
+export function BuyBoxPropositionSection({
+   variant,
+}: BuyBoxPropositionSectionProps) {
+   if (isDropshipped(variant)) {
+      return null;
+   } else {
+      return <BuyBoxPropositionSectioniFixit />;
+   }
+}
+
+export function BuyBoxPropositionSectioniFixit() {
    return (
       <div>
          <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
@@ -130,3 +157,8 @@ function ValueProposition({ children }: React.PropsWithChildren<{}>) {
 const ValuePropositionIcon = ({ icon, ...props }: FaIconProps) => {
    return <FaIcon icon={icon} h="8" color="brand.500" {...props} />;
 };
+
+function isDropshipped(variant: ProductVariant) {
+   const restrictions = variant.shippingRestrictions;
+   return restrictions && restrictions.includes('fulfilled_via_dropshipping');
+}


### PR DESCRIPTION
We don't want to say all the "lifetime warranty" stuff for products that are dropshipped and thus not actually guaranteed / warrantied by us.

Note: I'd rather have this conditional on variant.fulfillmentService, but that info is literally not availble from the graphQL api. We set that value at the same time and from the same source as this meatfield, so they *will* stay in sync.

QA: View a product page who's `shopify_fulfillment_us` Akeneo attribute is not null. The "value proposition" sections should both be missing

Closes iFixit/ifixit#45298