### PR TITLE
Augment the number of fetched product images

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6668,7 +6668,7 @@ export const FindProductDocument = `
     featuredImage {
       id
     }
-    images(first: 20) {
+    images(first: 250) {
       nodes {
         id
         altText

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -57,7 +57,7 @@ query findProduct($handle: String) {
       featuredImage {
          id
       }
-      images(first: 20) {
+      images(first: 250) {
          nodes {
             id
             altText

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -280,8 +280,8 @@ export type ComponentStoreSocialMediaAccounts = {
    id: Scalars['ID'];
    instagram?: Maybe<Scalars['String']>;
    repairOrg?: Maybe<Scalars['String']>;
-   twitter?: Maybe<Scalars['String']>;
    tiktok?: Maybe<Scalars['String']>;
+   twitter?: Maybe<Scalars['String']>;
    youtube?: Maybe<Scalars['String']>;
 };
 
@@ -296,8 +296,8 @@ export type ComponentStoreSocialMediaAccountsFiltersInput = {
       Array<InputMaybe<ComponentStoreSocialMediaAccountsFiltersInput>>
    >;
    repairOrg?: InputMaybe<StringFilterInput>;
-   twitter?: InputMaybe<StringFilterInput>;
    tiktok?: InputMaybe<StringFilterInput>;
+   twitter?: InputMaybe<StringFilterInput>;
    youtube?: InputMaybe<StringFilterInput>;
 };
 
@@ -306,8 +306,8 @@ export type ComponentStoreSocialMediaAccountsInput = {
    id?: InputMaybe<Scalars['ID']>;
    instagram?: InputMaybe<Scalars['String']>;
    repairOrg?: InputMaybe<Scalars['String']>;
-   twitter?: InputMaybe<Scalars['String']>;
    tiktok?: InputMaybe<Scalars['String']>;
+   twitter?: InputMaybe<Scalars['String']>;
    youtube?: InputMaybe<Scalars['String']>;
 };
 


### PR DESCRIPTION
closes #956

There was a low limit on the maximum number of images to fetch per product (was set to 20).
I augmented it to the maximum possible for a single storefront api query.

### QA

1. Visit Vercel preview
2. Verify that all product variants do show their associated images