### PR TITLE
Convert strapi product list filter to long text

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -71,7 +71,7 @@
                "localized": true
             }
          },
-         "type": "string"
+         "type": "text"
       },
       "tagline": {
          "pluginOptions": {

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -16,7 +16,8 @@ export function computeProductListAlgoliaFilterPreset<
    const conditions: string[] = [];
 
    if (filters && filters.length > 0) {
-      conditions.push(filters);
+      // Algolia can't handle newlines in the filter, so replace with space.
+      conditions.push(filters.replaceAll('\n', ' '));
    } else if (deviceTitle && deviceTitle.length > 0) {
       conditions.push(`device:${JSON.stringify(deviceTitle)}`);
    }


### PR DESCRIPTION
We weren't able to save > 255 chars. Now we can.

QA
==
Try saving more than 255 chars in a filter and make sure it works.

ON DEPLOY
==
Update Strapi

Closes #970