### PR TITLE
Add a flag to control the show all default value of product list children on large screen (backend changes)

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -177,6 +177,16 @@
             }
          },
          "type": "string"
+      },
+      "defaultShowAllChildrenOnLgSizes": {
+         "pluginOptions": {
+            "i18n": {
+               "localized": true
+            }
+         },
+         "type": "boolean",
+         "default": false,
+         "required": true
       }
    }
 }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -969,6 +969,7 @@ export type ProductList = {
    children?: Maybe<ProductListRelationResponseCollection>;
    childrenHeading?: Maybe<Scalars['String']>;
    createdAt?: Maybe<Scalars['DateTime']>;
+   defaultShowAllChildrenOnLgSizes: Scalars['Boolean'];
    description: Scalars['String'];
    deviceTitle?: Maybe<Scalars['String']>;
    excludeFromHierarchyDisplay: Scalars['Boolean'];
@@ -1027,6 +1028,7 @@ export type ProductListFiltersInput = {
    children?: InputMaybe<ProductListFiltersInput>;
    childrenHeading?: InputMaybe<StringFilterInput>;
    createdAt?: InputMaybe<DateTimeFilterInput>;
+   defaultShowAllChildrenOnLgSizes?: InputMaybe<BooleanFilterInput>;
    description?: InputMaybe<StringFilterInput>;
    deviceTitle?: InputMaybe<StringFilterInput>;
    excludeFromHierarchyDisplay?: InputMaybe<BooleanFilterInput>;
@@ -1053,6 +1055,7 @@ export type ProductListFiltersInput = {
 export type ProductListInput = {
    children?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
    childrenHeading?: InputMaybe<Scalars['String']>;
+   defaultShowAllChildrenOnLgSizes?: InputMaybe<Scalars['Boolean']>;
    description?: InputMaybe<Scalars['String']>;
    deviceTitle?: InputMaybe<Scalars['String']>;
    excludeFromHierarchyDisplay?: InputMaybe<Scalars['Boolean']>;


### PR DESCRIPTION
Strapi changes linked to #682 and #741 

This PR covers only the Strapi related changes and will be completed by #983 
The aim of the two PR combined is the following:

A new product list flag is now giving the possibility to show all product list children on large screen.
If enabled the list is not showing the `Show more` / `Show less` button on `> lg` screen sizes.
On smaller screen sized nothing should change.

Here is a preview of the `/Tools` page with the flag enabled:

<img width="1139" alt="Screenshot 2022-11-03 at 08 51 52" src="https://user-images.githubusercontent.com/7805759/199670800-8a20453e-c541-438a-90b7-642e655962de.png">

The same page on mobile is showing the `Show more` / `Show less` button as before:

<img width="539" alt="Screenshot 2022-11-03 at 09 03 54" src="https://user-images.githubusercontent.com/7805759/199672067-9414b278-afd5-49b4-8974-4d516b55de11.png">

This PR introduces only the flag into Strapi 

### QA

1. Visit Vercel preview
2. Verify that Strapi includes the new flag in the `productList` model