### PR TITLE
Metafields: render assembly_contents

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6454,6 +6454,10 @@ export type FindProductQuery = {
             }>;
             description?: { __typename?: 'Metafield'; value: string } | null;
             kitContents?: { __typename?: 'Metafield'; value: string } | null;
+            assemblyContents?: {
+               __typename?: 'Metafield';
+               value: string;
+            } | null;
             note?: { __typename?: 'Metafield'; value: string } | null;
             disclaimer?: { __typename?: 'Metafield'; value: string } | null;
             warning?: { __typename?: 'Metafield'; value: string } | null;
@@ -6714,6 +6718,9 @@ export const FindProductDocument = `
           value
         }
         kitContents: metafield(namespace: "ifixit", key: "kit_contents") {
+          value
+        }
+        assemblyContents: metafield(namespace: "ifixit", key: "assembly_contents") {
           value
         }
         note: metafield(namespace: "ifixit", key: "note") {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -108,6 +108,12 @@ query findProduct($handle: String) {
             kitContents: metafield(namespace: "ifixit", key: "kit_contents") {
                value
             }
+            assemblyContents: metafield(
+               namespace: "ifixit"
+               key: "assembly_contents"
+            ) {
+               value
+            }
             note: metafield(namespace: "ifixit", key: "note") {
                value
             }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -280,8 +280,8 @@ export type ComponentStoreSocialMediaAccounts = {
    id: Scalars['ID'];
    instagram?: Maybe<Scalars['String']>;
    repairOrg?: Maybe<Scalars['String']>;
-   twitter?: Maybe<Scalars['String']>;
    tiktok?: Maybe<Scalars['String']>;
+   twitter?: Maybe<Scalars['String']>;
    youtube?: Maybe<Scalars['String']>;
 };
 
@@ -296,8 +296,8 @@ export type ComponentStoreSocialMediaAccountsFiltersInput = {
       Array<InputMaybe<ComponentStoreSocialMediaAccountsFiltersInput>>
    >;
    repairOrg?: InputMaybe<StringFilterInput>;
-   twitter?: InputMaybe<StringFilterInput>;
    tiktok?: InputMaybe<StringFilterInput>;
+   twitter?: InputMaybe<StringFilterInput>;
    youtube?: InputMaybe<StringFilterInput>;
 };
 
@@ -306,8 +306,8 @@ export type ComponentStoreSocialMediaAccountsInput = {
    id?: InputMaybe<Scalars['ID']>;
    instagram?: InputMaybe<Scalars['String']>;
    repairOrg?: InputMaybe<Scalars['String']>;
-   twitter?: InputMaybe<Scalars['String']>;
    tiktok?: InputMaybe<Scalars['String']>;
+   twitter?: InputMaybe<Scalars['String']>;
    youtube?: InputMaybe<Scalars['String']>;
 };
 

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -120,6 +120,7 @@ function getVariants(shopifyProduct: ShopifyApiProduct) {
          discountPercentage,
          description: variant.description?.value ?? null,
          kitContents: variant.kitContents?.value ?? null,
+         assemblyContents: variant.assemblyContents?.value ?? null,
          note: variant.note?.value ?? null,
          disclaimer: variant.disclaimer?.value ?? null,
          warning: variant.warning?.value ?? null,

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -239,32 +239,7 @@ export function ProductSection({
                         </VStack>
                      </CustomAccordionPanel>
                   </AccordionItem>
-                  <AccordionItem hidden={selectedVariant.kitContents == null}>
-                     <CustomAccordionButton>Kit contents</CustomAccordionButton>
-                     <CustomAccordionPanel>
-                        <Box
-                           fontSize="sm"
-                           sx={{
-                              ul: {
-                                 listStyle: 'none',
-                              },
-                              li: {
-                                 borderTopWidth: '1px',
-                                 borderTopColor: 'gray.200',
-                                 py: 3,
-                                 '& ul': {
-                                    mt: 3,
-                                    ml: 5,
-                                 },
-                              },
-                           }}
-                           dangerouslySetInnerHTML={{
-                              __html: selectedVariant.kitContents ?? '',
-                           }}
-                        ></Box>
-                     </CustomAccordionPanel>
-                  </AccordionItem>
-
+                  <WikiHtmlAccordianItem title="Kit contents" contents={selectedVariant.kitContents}/>
                   <AccordionItem
                      hidden={
                         product.compatibility == null ||
@@ -548,5 +523,35 @@ function AlertText({ children, colorScheme }: AlertTextProps) {
             __html: children,
          }}
       />
+   );
+}
+
+function WikiHtmlAccordianItem({title, contents}: {title:string, contents:string|null}) {
+   return (
+      <AccordionItem hidden={contents == null}>
+         <CustomAccordionButton>{title}</CustomAccordionButton>
+         <CustomAccordionPanel>
+            <Box
+               fontSize="sm"
+               sx={{
+                  ul: {
+                     listStyle: 'none',
+                  },
+                  li: {
+                     borderTopWidth: '1px',
+                     borderTopColor: 'gray.200',
+                     py: 3,
+                     '& ul': {
+                        mt: 3,
+                        ml: 5,
+                     },
+                  },
+               }}
+               dangerouslySetInnerHTML={{
+                  __html: contents ?? ''
+               }}
+            ></Box>
+         </CustomAccordionPanel>
+      </AccordionItem>
    );
 }

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -240,6 +240,7 @@ export function ProductSection({
                      </CustomAccordionPanel>
                   </AccordionItem>
                   <WikiHtmlAccordianItem title="Kit contents" contents={selectedVariant.kitContents}/>
+                  <WikiHtmlAccordianItem title="Assembly contents" contents={selectedVariant.assemblyContents}/>
                   <AccordionItem
                      hidden={
                         product.compatibility == null ||

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -239,8 +239,14 @@ export function ProductSection({
                         </VStack>
                      </CustomAccordionPanel>
                   </AccordionItem>
-                  <WikiHtmlAccordianItem title="Kit contents" contents={selectedVariant.kitContents}/>
-                  <WikiHtmlAccordianItem title="Assembly contents" contents={selectedVariant.assemblyContents}/>
+                  <WikiHtmlAccordianItem
+                     title="Kit contents"
+                     contents={selectedVariant.kitContents}
+                  />
+                  <WikiHtmlAccordianItem
+                     title="Assembly contents"
+                     contents={selectedVariant.assemblyContents}
+                  />
                   <AccordionItem
                      hidden={
                         product.compatibility == null ||
@@ -527,7 +533,13 @@ function AlertText({ children, colorScheme }: AlertTextProps) {
    );
 }
 
-function WikiHtmlAccordianItem({title, contents}: {title:string, contents:string|null}) {
+function WikiHtmlAccordianItem({
+   title,
+   contents,
+}: {
+   title: string;
+   contents: string | null;
+}) {
    return (
       <AccordionItem hidden={contents == null}>
          <CustomAccordionButton>{title}</CustomAccordionButton>
@@ -549,7 +561,7 @@ function WikiHtmlAccordianItem({title, contents}: {title:string, contents:string
                   },
                }}
                dangerouslySetInnerHTML={{
-                  __html: contents ?? ''
+                  __html: contents ?? '',
                }}
             ></Box>
          </CustomAccordionPanel>


### PR DESCRIPTION
Closes #977

Hmm.. I wonder if there are any other product details sections that we forgot. Glancing at our shopify theme indicates that no, this was the only missing one.