### PR TITLE
Collections: Render all item type facet links

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/FacetFilter.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/FacetFilter.tsx
@@ -8,13 +8,13 @@ import { RefinementDisplayType } from '@models/product-list/types';
 type FacetFilterProps = {
    attribute: string;
    productList: ProductList;
-   onClose?: () => void;
+   onItemClick?: () => void;
 };
 
 export function FacetFilter({
    attribute,
    productList,
-   onClose,
+   onItemClick,
 }: FacetFilterProps) {
    switch (getRefinementDisplayType(attribute)) {
       case RefinementDisplayType.SingleSelect:
@@ -24,7 +24,7 @@ export function FacetFilter({
                showMore
                showMoreLimit={200}
                productList={productList}
-               onClose={onClose}
+               onItemClick={onItemClick}
             />
          );
       case RefinementDisplayType.MultiSelect:

--- a/frontend/templates/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/FacetsAccordion.tsx
@@ -17,7 +17,7 @@ import * as React from 'react';
 import { useHits } from 'react-instantsearch-hooks-web';
 import { FacetFilter } from './FacetFilter';
 import { useCountRefinements } from './useCountRefinements';
-import { MAX_VALUES_PER_FACET, useFilteredFacets } from './useFacets';
+import { useFilteredFacets } from './useFacets';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { RefinementDisplayType } from '@models/product-list/types';
 import { getRefinementDisplayType } from '@helpers/product-list-helpers';
@@ -90,10 +90,7 @@ type FacetAccordionItemProps = AccordionItemProps & {
 
 export const FacetAccordionItem = forwardRef<FacetAccordionItemProps, 'div'>(
    ({ attribute, refinedCount, productList, isExpanded, ...props }, ref) => {
-      const { items } = useFilteredRefinementList({
-         attribute,
-         limit: MAX_VALUES_PER_FACET,
-      });
+      const { items } = useFilteredRefinementList({ attribute });
       const { hits } = useHits();
       const isProductListEmpty = hits.length === 0;
       const hasApplicableRefinements = items.length > 0;

--- a/frontend/templates/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
@@ -325,7 +325,7 @@ function FacetPanel({
             <FacetFilter
                attribute={attribute}
                productList={productList}
-               onClose={onClose}
+               onItemClick={onClose}
             />
          </VStack>
       </Box>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/FacetsDrawer.tsx
@@ -26,7 +26,7 @@ import {
 } from 'react-instantsearch-hooks-web';
 import { FacetFilter } from './FacetFilter';
 import { useCountRefinements } from './useCountRefinements';
-import { MAX_VALUES_PER_FACET, useFilteredFacets } from './useFacets';
+import { useFilteredFacets } from './useFacets';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 
 type FacetsDrawerProps = {
@@ -245,10 +245,7 @@ function FacetListItem({
    onSelect,
    productList,
 }: FacetListItemProps) {
-   const { items } = useFilteredRefinementList({
-      attribute,
-      limit: MAX_VALUES_PER_FACET,
-   });
+   const { items } = useFilteredRefinementList({ attribute });
    const hasApplicableRefinements = items.length > 0;
 
    if (!hasApplicableRefinements) {

--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementMultiSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementMultiSelect.tsx
@@ -1,13 +1,12 @@
-import { Box, Button, Checkbox, HStack, Text, VStack } from '@chakra-ui/react';
-import { faSort } from '@fortawesome/pro-solid-svg-icons';
+import { Box, Checkbox, HStack, Text, VStack } from '@chakra-ui/react';
 import * as React from 'react';
 
-import { FaIcon } from '@ifixit/icons';
 import { useDecoupledState } from '@ifixit/ui';
 import { RefinementListRenderState } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 import { UseRefinementListProps } from 'react-instantsearch-hooks-web';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { useSortBy } from './useSortBy';
+import { ShowMoreButton } from './ShowMoreButton';
 
 type RefinementMultiSelectProps = UseRefinementListProps;
 
@@ -32,18 +31,10 @@ export function RefinementMultiSelect(props: RefinementMultiSelectProps) {
             })}
          </VStack>
          {canToggleShowMore && (
-            <Button
-               variant="ghost"
-               fontWeight="normal"
-               leftIcon={<FaIcon icon={faSort} h="4" ml="1" color="gray.400" />}
-               mt="3"
-               p="0"
-               w="full"
-               justifyContent="flex-start"
+            <ShowMoreButton
+               isShowingMore={isShowingMore}
                onClick={toggleShowMore}
-            >
-               {isShowingMore ? 'Show less' : 'Show more'}
-            </Button>
+            />
          )}
       </Box>
    );

--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -1,7 +1,11 @@
-import { Box, Button, HStack, Text, VStack } from '@chakra-ui/react';
-import { faSort } from '@fortawesome/pro-solid-svg-icons';
+import {
+   Box,
+   HStack,
+   StackProps,
+   Text,
+   VStack,
+} from '@chakra-ui/react';
 import { stylizeDeviceItemType } from '@helpers/product-list-helpers';
-import { FaIcon } from '@ifixit/icons';
 import { ProductList, ProductListType } from '@models/product-list';
 import { RefinementListRenderState } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 import NextLink from 'next/link';
@@ -11,6 +15,7 @@ import {
    UseRefinementListProps,
    useInstantSearch,
 } from 'react-instantsearch-hooks-web';
+import { ShowMoreButton } from './ShowMoreButton';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { useSortBy } from './useSortBy';
 
@@ -32,32 +37,22 @@ export function RefinementSingleSelect({
 
    return (
       <Box>
-         <VStack align="stretch" spacing="1" role="listbox">
-            {items.map((item) => {
-               return (
-                  <SingleSelectItem
-                     key={item.label}
-                     item={item}
-                     attribute={otherProps.attribute}
-                     productListType={productList.type}
-                     onClose={onClose}
-                  />
-               );
-            })}
-         </VStack>
+         <SingleSelectStack>
+            {items.map((item) => (
+               <SingleSelectItem
+                  key={item.label}
+                  item={item}
+                  attribute={otherProps.attribute}
+                  shouldBeLink={isDevicePartsItemType}
+                  onClick={onItemClick}
+               />
+            ))}
+         </SingleSelectStack>
          {canToggleShowMore && (
-            <Button
-               variant="ghost"
-               fontWeight="normal"
-               leftIcon={<FaIcon icon={faSort} h="4" ml="1" color="gray.400" />}
-               mt="3"
-               p="0"
-               w="full"
-               justifyContent="flex-start"
+            <ShowMoreButton
+               isShowingMore={isShowingMore}
                onClick={toggleShowMore}
-            >
-               {isShowingMore ? 'Show less' : 'Show more'}
-            </Button>
+            />
          )}
       </Box>
    );
@@ -154,3 +149,7 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
       </HStack>
    );
 });
+
+function SingleSelectStack(props: StackProps) {
+   return <VStack align="stretch" spacing="1" role="listbox" {...props} />;
+}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/RefinementSingleSelect.tsx
@@ -19,14 +19,17 @@ import { ShowMoreButton } from './ShowMoreButton';
 import { useFilteredRefinementList } from './useFilteredRefinementList';
 import { useSortBy } from './useSortBy';
 
-type RefinementSingleSelectProps = UseRefinementListProps & {
+type RefinementSingleSelectProps = Omit<
+   UseRefinementListProps,
+   'sortBy'
+> & {
    productList: ProductList;
-   onClose?: () => void;
+   onItemClick?: () => void;
 };
 
 export function RefinementSingleSelect({
    productList,
-   onClose,
+   onItemClick,
    ...otherProps
 }: RefinementSingleSelectProps) {
    const { items, refine, isShowingMore, toggleShowMore, canToggleShowMore } =
@@ -62,14 +65,14 @@ type SingleSelectItemProps = {
    item: RefinementListRenderState['items'][0];
    attribute: string;
    productListType: ProductListType;
-   onClose?: () => void;
+   onClick?: () => void;
 };
 
 const SingleSelectItem = React.memo(function SingleSelectItem({
    item,
    attribute,
    productListType,
-   onClose,
+   onClick,
 }: SingleSelectItemProps) {
    const { createURL } = useCurrentRefinements();
    const { setIndexUiState } = useInstantSearch();
@@ -99,7 +102,7 @@ const SingleSelectItem = React.memo(function SingleSelectItem({
                   refinementList: refinementList,
                };
             });
-            onClose?.();
+            onClick?.();
          }}
          _hover={{
             textDecoration: 'underline',

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ShowMoreButton.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ShowMoreButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@chakra-ui/react';
+import { faSort } from '@fortawesome/pro-solid-svg-icons';
+import { FaIcon } from '@ifixit/icons';
+
+type ShowMoreButtonProps = {
+   isShowingMore: boolean;
+   onClick?: () => void;
+};
+
+export function ShowMoreButton({
+   isShowingMore,
+   onClick,
+}: ShowMoreButtonProps) {
+   return (
+      <Button
+         variant="ghost"
+         fontWeight="normal"
+         leftIcon={<FaIcon icon={faSort} h="4" ml="1" color="gray.400" />}
+         mt="3"
+         p="0"
+         w="full"
+         justifyContent="flex-start"
+         onClick={onClick}
+      >
+         {isShowingMore ? 'Show less' : 'Show more'}
+      </Button>
+   );
+}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/useFacets.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useFacets.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { ProductList, ProductListType } from '@models/product-list';
 import { formatFacetName } from '@helpers/algolia-helpers';
 
-export const MAX_VALUES_PER_FACET = 200;
-
 export function useFacets() {
    return [
       'facet_tags.Capacity',

--- a/frontend/templates/product-list/sections/FilterableProductsSection/useFilteredRefinementList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useFilteredRefinementList.tsx
@@ -4,6 +4,8 @@ import {
    UseRefinementListProps,
 } from 'react-instantsearch-hooks-web';
 
+export const DEFAULT_SHOW_MORE_LIMIT = 10;
+
 export function useFilteredRefinementList(props: UseRefinementListProps) {
    const isPriceRange = props.attribute == 'price_range';
    const { items, ...rest } = useRefinementList({ ...props });

--- a/frontend/templates/product-list/sections/FilterableProductsSection/useSortBy.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useSortBy.ts
@@ -53,7 +53,7 @@ const sortAlphabetically: UseRefinementListProps['sortBy'] = (a, b) => {
 };
 
 export function useSortBy(
-   props: UseRefinementListProps
+   props: Omit<UseRefinementListProps, 'sortBy'>
 ): UseRefinementListProps['sortBy'] {
    switch (props.attribute) {
       case 'price_range':


### PR DESCRIPTION
Renders all the item type facet links for SEO reasons, and visually hides the extra ones until the "show more" button is clicked.

## QA

Visit /Parts, and verify the item type facets aren't links and when you inspect theres only 10.

![image](https://user-images.githubusercontent.com/52104630/200031696-e2b39fc9-7395-4d80-a731-e8b0ace4b89a.png)

Visit /Parts/iPhone and verify that they are links and that all of them show up when inspected, but only 10 are visually shown.

![image](https://user-images.githubusercontent.com/52104630/200031572-aedcf38f-3a8d-40b3-a1e6-3ff417ab6bb1.png)

Make sure the item type facets still work normally. Make sure that the show more/ show less button still works normally.

Thanks!

CC @sterlinghirsh 

Closes #819