### PR TITLE
Product Lists: Add Home to all Breadcrumbs

### DIFF
--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -1,5 +1,10 @@
 import { invariant } from '@ifixit/helpers';
-import { ProductList, ProductListType, iFixitPageType, iFixitPage } from '@models/product-list';
+import {
+   ProductList,
+   ProductListType,
+   iFixitPageType,
+   iFixitPage,
+} from '@models/product-list';
 import { stylizeDeviceTitle } from './product-list-helpers';
 
 type ProductListPathAttributes = Pick<

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -27,6 +27,9 @@ export function productListPath(
       case ProductListType.AllTools: {
          return '/Tools';
       }
+      case ProductListType.Store: {
+         return '/Store';
+      }
       case ProductListType.ToolsCategory: {
          return `/Tools/${productList.handle}`;
       }

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -1,9 +1,9 @@
 import { invariant } from '@ifixit/helpers';
-import { ProductList, ProductListType } from '@models/product-list';
+import { ProductList, ProductListType, iFixitPageType, iFixitPage } from '@models/product-list';
 import { stylizeDeviceTitle } from './product-list-helpers';
 
 type ProductListPathAttributes = Pick<
-   ProductList,
+   ProductList | iFixitPage,
    'type' | 'handle' | 'deviceTitle'
 >;
 
@@ -27,14 +27,14 @@ export function productListPath(
       case ProductListType.AllTools: {
          return '/Tools';
       }
-      case ProductListType.Store: {
-         return '/Store';
-      }
       case ProductListType.ToolsCategory: {
          return `/Tools/${productList.handle}`;
       }
       case ProductListType.Marketing: {
          return `/Shop/${productList.handle}`;
+      }
+      case iFixitPageType.Store: {
+         return '/Store';
       }
       default: {
          throw new Error(`unknown product list type: ${productList.type}`);

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -341,7 +341,6 @@ export enum Enum_Productlist_Type {
    Marketing = 'marketing',
    Parts = 'parts',
    Tools = 'tools',
-   Store = 'store',
 }
 
 export enum Enum_Store_Currency {

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -280,8 +280,8 @@ export type ComponentStoreSocialMediaAccounts = {
    id: Scalars['ID'];
    instagram?: Maybe<Scalars['String']>;
    repairOrg?: Maybe<Scalars['String']>;
-   twitter?: Maybe<Scalars['String']>;
    tiktok?: Maybe<Scalars['String']>;
+   twitter?: Maybe<Scalars['String']>;
    youtube?: Maybe<Scalars['String']>;
 };
 
@@ -296,8 +296,8 @@ export type ComponentStoreSocialMediaAccountsFiltersInput = {
       Array<InputMaybe<ComponentStoreSocialMediaAccountsFiltersInput>>
    >;
    repairOrg?: InputMaybe<StringFilterInput>;
-   twitter?: InputMaybe<StringFilterInput>;
    tiktok?: InputMaybe<StringFilterInput>;
+   twitter?: InputMaybe<StringFilterInput>;
    youtube?: InputMaybe<StringFilterInput>;
 };
 
@@ -306,8 +306,8 @@ export type ComponentStoreSocialMediaAccountsInput = {
    id?: InputMaybe<Scalars['ID']>;
    instagram?: InputMaybe<Scalars['String']>;
    repairOrg?: InputMaybe<Scalars['String']>;
-   twitter?: InputMaybe<Scalars['String']>;
    tiktok?: InputMaybe<Scalars['String']>;
+   twitter?: InputMaybe<Scalars['String']>;
    youtube?: InputMaybe<Scalars['String']>;
 };
 

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -341,6 +341,7 @@ export enum Enum_Productlist_Type {
    Marketing = 'marketing',
    Parts = 'parts',
    Tools = 'tools',
+   Store = 'store',
 }
 
 export enum Enum_Store_Currency {

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -232,7 +232,7 @@ function createProductListAncestors(
       return [
          {
             deviceTitle: '',
-            title: 'Home',
+            title: 'Store',
             type: getProductListType(Enum_Productlist_Type.Store),
             handle: 'Store',
          },

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -229,7 +229,14 @@ function createProductListAncestors(
 ): ProductListAncestor[] {
    const attributes = parent?.data?.attributes;
    if (attributes == null) {
-      return [];
+      return [
+         {
+            deviceTitle: '',
+            title: 'Home',
+            type: getProductListType(Enum_Productlist_Type.Store),
+            handle: 'Store',
+         },
+      ];
    }
    const ancestors = createProductListAncestors(attributes.parent);
 

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -33,7 +33,11 @@ import {
    ProductListType,
 } from './types';
 
-export { ProductListSectionType, ProductListType, iFixitPageType } from './types';
+export {
+   ProductListSectionType,
+   ProductListType,
+   iFixitPageType,
+} from './types';
 export type {
    FeaturedProductList,
    iFixitPage,

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -22,6 +22,8 @@ import {
 import algoliasearch from 'algoliasearch';
 import {
    BaseProductList,
+   iFixitPageType,
+   iFixitPage,
    ProductList,
    ProductListAncestor,
    ProductListChild,
@@ -30,11 +32,11 @@ import {
    ProductListSectionType,
    ProductListType,
 } from './types';
-import { productListPath } from '@helpers/path-helpers';
 
-export { ProductListSectionType, ProductListType } from './types';
+export { ProductListSectionType, ProductListType, iFixitPageType } from './types';
 export type {
    FeaturedProductList,
+   iFixitPage,
    ProductList,
    ProductListPreview,
    ProductListSection,
@@ -135,8 +137,6 @@ export function getProductListType(
          return ProductListType.ToolsCategory;
       case Enum_Productlist_Type.Marketing:
          return ProductListType.Marketing;
-      case Enum_Productlist_Type.Store:
-         return ProductListType.Store;
       default:
          return ProductListType.DeviceParts;
    }
@@ -233,7 +233,7 @@ function createProductListAncestors(
          {
             deviceTitle: '',
             title: 'Store',
-            type: getProductListType(Enum_Productlist_Type.Store),
+            type: iFixitPageType.Store,
             handle: 'Store',
          },
       ];

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -135,6 +135,8 @@ export function getProductListType(
          return ProductListType.ToolsCategory;
       case Enum_Productlist_Type.Marketing:
          return ProductListType.Marketing;
+      case Enum_Productlist_Type.Store:
+         return ProductListType.Store;
       default:
          return ProductListType.DeviceParts;
    }

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -36,6 +36,7 @@ export enum ProductListType {
    AllTools = 'tools',
    ToolsCategory = 'tools-category',
    Marketing = 'marketing',
+   Store = 'store',
 }
 
 export enum RefinementDisplayType {
@@ -48,7 +49,8 @@ export type ProductList =
    | DevicePartsProductList
    | AllToolsProductList
    | ToolsCategoryProductList
-   | MarketingProductList;
+   | MarketingProductList
+   | StoreProductList;
 
 export interface BaseProductList {
    title: string;
@@ -89,6 +91,10 @@ interface ToolsCategoryProductList extends BaseProductList {
 
 interface MarketingProductList extends BaseProductList {
    type: ProductListType.Marketing;
+}
+
+interface StoreProductList extends BaseProductList {
+   type: ProductListType.Store;
 }
 
 export interface ProductListAncestor {

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -54,7 +54,7 @@ export type ProductList =
    | ToolsCategoryProductList
    | MarketingProductList;
 
-export type iFixitPage = |StorePage;
+export type iFixitPage = StorePage;
 
 export interface BaseProductList {
    title: string;

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -36,6 +36,9 @@ export enum ProductListType {
    AllTools = 'tools',
    ToolsCategory = 'tools-category',
    Marketing = 'marketing',
+}
+
+export enum iFixitPageType {
    Store = 'store',
 }
 
@@ -49,8 +52,9 @@ export type ProductList =
    | DevicePartsProductList
    | AllToolsProductList
    | ToolsCategoryProductList
-   | MarketingProductList
-   | StoreProductList;
+   | MarketingProductList;
+
+export type iFixitPage = |StorePage;
 
 export interface BaseProductList {
    title: string;
@@ -93,14 +97,14 @@ interface MarketingProductList extends BaseProductList {
    type: ProductListType.Marketing;
 }
 
-interface StoreProductList extends BaseProductList {
-   type: ProductListType.Store;
+interface StorePage extends BaseProductList {
+   type: iFixitPageType.Store;
 }
 
 export interface ProductListAncestor {
    deviceTitle: string | null;
    title: string;
-   type: ProductListType;
+   type: ProductListType | iFixitPageType;
    handle: string;
 }
 

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -31,17 +31,16 @@ export function ProductListView({
    indexName,
 }: ProductListViewProps) {
    const filters = computeProductListAlgoliaFilterPreset(productList);
-   const isRootProductList = productList.ancestors.length === 0;
-   const isAllToolsPage = productList.type === ProductListType.AllTools;
    const isToolPage =
-      isAllToolsPage || productList.type === ProductListType.ToolsCategory;
+      productList.type === ProductListType.AllTools ||
+      productList.type === ProductListType.ToolsCategory;
 
    return (
       <>
          <SecondaryNavbar
             display={{
                base: isToolPage ? 'none' : 'initial',
-               sm: isAllToolsPage ? 'none' : 'initial',
+               sm: isToolPage ? 'none' : 'initial',
             }}
          >
             <PageContentWrapper h="full">
@@ -67,8 +66,8 @@ export function ProductListView({
          </SecondaryNavbar>
          <SecondaryNavbar
             display={{
-               base: isRootProductList ? 'none' : 'initial',
-               sm: 'none',
+               base: 'initial',
+               sm: !isToolPage ? 'none' : 'initial',
             }}
          >
             <PageContentWrapper h="full">

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -40,7 +40,6 @@ export function ProductListView({
          <SecondaryNavbar
             display={{
                base: isToolPage ? 'none' : 'initial',
-               sm: isToolPage ? 'none' : 'initial',
             }}
          >
             <PageContentWrapper h="full">

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -180,6 +180,9 @@ export const getProductListServerSideProps = ({
 
             break;
          }
+         case ProductListType.Store: {
+            throw new Error('Unexpected object: ' + productListType);
+         }
          default: {
             return assertNever(productListType);
          }

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -180,9 +180,6 @@ export const getProductListServerSideProps = ({
 
             break;
          }
-         case ProductListType.Store: {
-            throw new Error('Unexpected object: ' + productListType);
-         }
          default: {
             return assertNever(productListType);
          }


### PR DESCRIPTION
## Overview

Apparently people want to be able to go back to `/Store` from the product-list pages. This makes sure that all `ancestor` lists for strapi productlists have "Home" as an ancestor by inserting them into all ancestor lists.

## CR
I wasn't able to fix out a switch statement to be as clean as i wanted (the `throw Error` line) but Im not sure if its supposed to as it can type-wise reach that case still.

## QA
Do all product-list breadcrumb navbars seem correctly? The only new functionality should be that `/Parts` and `/Tools` have breadcrumbs now and that `/Tools/<category>` should have the desktop view breadcrumbs now.

Closes: #884 