### PR TITLE
Fix isGuideImage() Regex

### DIFF
--- a/packages/ui/misc/IfixitImage.tsx
+++ b/packages/ui/misc/IfixitImage.tsx
@@ -52,7 +52,7 @@ export function IfixitImage({ alt = '', ...props }: ImageProps) {
 
 function isGuideImage(src: string) {
    return src.match(
-      /^https:\/\/(guide-images\.cdn\.ifixit\.com\/|([^/]+\.(ubreakit|cominor)\.com\/igi))\//
+      /^https:\/\/(guide-images\.cdn\.ifixit\.com|([^/]+\.(ubreakit|cominor)\.com\/igi))\//
    );
 }
 

--- a/packages/ui/misc/IfixitImage.tsx
+++ b/packages/ui/misc/IfixitImage.tsx
@@ -58,7 +58,7 @@ function isGuideImage(src: string) {
 
 function isCartImage(src: string) {
    return src.match(
-      /^https:\/\/(cart-products\.cdn\.ifixit\.com\/|([^/]+\.(ubreakit|cominor)\.com\/cart-products))/
+      /^https:\/\/(cart-products\.cdn\.ifixit\.com|([^/]+\.(ubreakit|cominor)\.com\/cart-products))\//
    );
 }
 


### PR DESCRIPTION
## Overview

Various images on our site are much lower res than we'd like. This is likely an issue with the product urls.

## CR
It turns out it was an issue with our `isGuideImage()` function, as the regex wasn't catching `.guide-image` urls due to looking for two `/` back to back. This removes the extra `/` from the regex, and also makes our `isCartImage()` more like `isGuideImage`.

## QA
Are the images on `/products/macbook-pro-13-retina-function-keys-late-2016-2017-battery` for Replacement Guides now higher res? This page in particular works because weve replaced the proper metafield on `ifixit-test` with production data (see replacement guides metafield https://ifixit-test.myshopify.com/admin/products/6556174286938). 

Also do the cart images still work after the slight changes? Production cartimage url (https://cart-products.cdn.ifixit.com/cart-products/jFsGZHKTWUGOJCUZ.size250?width=180) and its equivalent on dev (https://emay.cominor.com/cart-products/jFsGZHKTWUGOJCUZ.standard). These are from a product list page that had `Thunderbolt 3 (USB-C) Cable .5 Meter` on them

Closes: #953