### PR TITLE
Add a flag to control the show all default value of product list children on large screen (frontend changes)

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -1873,6 +1873,7 @@ export type GetProductListQuery = {
             description: string;
             metaDescription?: string | null;
             metaTitle?: string | null;
+            defaultShowAllChildrenOnLgSizes: boolean;
             filters?: string | null;
             childrenHeading?: string | null;
             image?: {
@@ -3116,6 +3117,7 @@ export const GetProductListDocument = `
         description
         metaDescription
         metaTitle
+        defaultShowAllChildrenOnLgSizes
         filters
         image {
           data {

--- a/frontend/lib/strapi-sdk/operations/getProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/getProductList.graphql
@@ -15,6 +15,7 @@ query getProductList($filters: ProductListFiltersInput) {
             description
             metaDescription
             metaTitle
+            defaultShowAllChildrenOnLgSizes
             filters
             image {
                data {

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -91,6 +91,8 @@ export async function findProductList(
       description: description,
       metaDescription: productList?.metaDescription ?? null,
       metaTitle: productList?.metaTitle ?? null,
+      defaultShowAllChildrenOnLgSizes:
+         productList?.defaultShowAllChildrenOnLgSizes ?? false,
       filters: productList?.filters ?? null,
       image: null,
       ancestors,

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -58,6 +58,7 @@ export interface BaseProductList {
    description: string;
    metaDescription: string | null;
    metaTitle: string | null;
+   defaultShowAllChildrenOnLgSizes: boolean;
    filters: string | null;
    image: ProductListImage | null;
    ancestors: ProductListAncestor[];

--- a/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
@@ -27,15 +27,20 @@ export function ProductListChildrenSection({
          computeMaskMaxHeight(
             60,
             16,
+            gridRef.current?.clientHeight,
             isShowingMore,
-            gridRef.current?.clientHeight
+            productList.defaultShowAllChildrenOnLgSizes
          ),
-      [isShowingMore]
+      [isShowingMore, productList]
    );
 
    const showMoreVisibility = React.useMemo(
-      () => computeShowMoreVisibility(productListChildren.length),
-      [productListChildren]
+      () =>
+         computeShowMoreVisibility(
+            productListChildren.length,
+            productList.defaultShowAllChildrenOnLgSizes
+         ),
+      [productListChildren, productList]
    );
 
    const onToggle = React.useCallback(() => {
@@ -134,8 +139,9 @@ export function ProductListChildrenSection({
 const computeMaskMaxHeight = (
    pixelLinkHeight: number,
    pixelGap: number,
-   isShowingMore: boolean,
-   maxHeight = 10000
+   maxHeight = 10000,
+   isShowingMore = false,
+   defaultShowAllChildrenOnLgSizes = false
 ) => {
    const shadowMargin = 4;
    if (isShowingMore) {
@@ -144,12 +150,18 @@ const computeMaskMaxHeight = (
    return {
       base: `${4 * pixelLinkHeight + 3 * pixelGap + shadowMargin}px`,
       sm: `${3 * pixelLinkHeight + 2 * pixelGap + shadowMargin}px`,
+      lg: defaultShowAllChildrenOnLgSizes
+         ? `${maxHeight + shadowMargin}px`
+         : undefined,
    };
 };
 
-const computeShowMoreVisibility = (itemCount: number) => ({
+const computeShowMoreVisibility = (
+   itemCount: number,
+   defaultShowAllChildrenOnLgSizes: boolean
+) => ({
    base: itemCount > 4 ? 'block' : 'none',
    sm: itemCount > 6 ? 'block' : 'none',
    md: itemCount > 9 ? 'block' : 'none',
-   lg: itemCount > 12 ? 'block' : 'none',
+   lg: itemCount > 12 && !defaultShowAllChildrenOnLgSizes ? 'block' : 'none',
 });


### PR DESCRIPTION
closes #682 
closes #741 

completes #974 

A new product list flag is now giving the possibility to show all product list children on large screen.
If enabled the list is not showing the `Show more` / `Show less` button on `> lg` screen sizes.
On smaller screen sized nothing should change.

Here is a preview of the `/Tools` page with the flag enabled:

<img width="1139" alt="Screenshot 2022-11-03 at 08 51 52" src="https://user-images.githubusercontent.com/7805759/199670800-8a20453e-c541-438a-90b7-642e655962de.png">

The same page on mobile is showing the `Show more` / `Show less` button as before:

<img width="539" alt="Screenshot 2022-11-03 at 09 03 54" src="https://user-images.githubusercontent.com/7805759/199672067-9414b278-afd5-49b4-8974-4d516b55de11.png">

### QA

1. Visit Vercel preview
2. Verify that the implementation is coherent with the spec described above