### PR TITLE
Mock buybox api and improve tests

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -26,5 +26,7 @@ export default defineConfig({
       baseUrl: 'http://localhost:3000',
       specPattern: 'test/cypress/integration/**/*.cy.{js,jsx,ts,tsx}',
       supportFile: 'test/cypress/support/index.ts',
+      // https://docs.cypress.io/guides/references/configuration#e2e
+      experimentalSessionAndOrigin: true,
    },
 });

--- a/frontend/lib/ifixit-api/international-buy-box.ts
+++ b/frontend/lib/ifixit-api/international-buy-box.ts
@@ -1,5 +1,4 @@
 import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
-import { invariant } from '@ifixit/helpers';
 
 export type BuyBoxVariant = {
    sku: string;

--- a/frontend/test/cypress/integration/product/add_to_cart.cy.ts
+++ b/frontend/test/cypress/integration/product/add_to_cart.cy.ts
@@ -1,42 +1,48 @@
 describe('product page add to cart', () => {
    beforeEach(() => {
-      cy.loadProductPageByPath(
-         '/products/spudger-retail-3-pack?variantid=39419992408154'
-      );
-      cy.findByTestId('cart-drawer-open').click();
-      cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
-      cy.findByTestId('cart-drawer-quantity').should('not.exist');
-      cy.findByTestId('cart-drawer-close').click();
-      cy.findByTestId('cart-drawer-close').should('not.exist');
+      cy.intercept('/api/2.0/internal/international_store_promotion/buybox*', {
+         statusCode: 200,
+         body: null,
+      }).as('buybox');
+      cy.loadProductPageByPath('/products/spudger-retail-3-pack');
    });
 
    it('Clicking Add To Cart Adds Items To Cart', () => {
-      for (let i = 1; i <= 5; i++) {
+      cy.times(5, (index) => {
          cy.findByTestId('product-add-to-cart-button').click();
-         cy.findAllByTestId('cart-drawer-quantity').should('have.text', i);
+         const expectedQuantity = index + 1;
+         cy.findAllByTestId('cart-drawer-quantity').should(
+            'have.text',
+            expectedQuantity
+         );
          cy.findByTestId('cart-drawer-close').click();
-      }
+      });
       cy.findByTestId('cart-drawer-open').click();
-      removeItemsFromCartAndCloseDrawer();
    });
 
    it('Clicking + and - Buttons Changes Item Quantity in Cart', () => {
       cy.findByTestId('product-add-to-cart-button').click();
       cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
-      for (let i = 2; i <= 6; i++) {
+      cy.times(5, (index) => {
          cy.findByTestId('cart-drawer-increase-quantity').click();
-         cy.findAllByTestId('cart-drawer-quantity').should('have.text', i);
-      }
+         const expectedQuantity = index + 2;
+         cy.findAllByTestId('cart-drawer-quantity').should(
+            'have.text',
+            expectedQuantity
+         );
+      });
       cy.findByTestId('cart-drawer-close').click();
-
       cy.findByTestId('cart-drawer-open').click();
-      for (let i = 5; i >= 1; i--) {
+      cy.times(5, (index) => {
          cy.findByTestId('cart-drawer-decrease-quantity').click();
-         cy.findAllByTestId('cart-drawer-quantity').should('have.text', i);
-      }
+         const expectedQuantity = 5 - index;
+         cy.findAllByTestId('cart-drawer-quantity').should(
+            'have.text',
+            expectedQuantity
+         );
+      });
       cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
       cy.findAllByTestId('cart-drawer-quantity').should('have.text', 1);
-      removeItemsFromCartAndCloseDrawer();
    });
 
    it('Item Can Be Added Again After Removing The Item', () => {
@@ -48,7 +54,6 @@ describe('product page add to cart', () => {
       cy.findByTestId('cart-drawer-close').click();
       cy.findByTestId('product-add-to-cart-button').click();
       cy.findAllByTestId('cart-drawer-item-count').should('have.text', 1);
-      removeItemsFromCartAndCloseDrawer();
    });
 
    it('Back to Shopping Button Works', () => {
@@ -69,13 +74,5 @@ describe('product page add to cart', () => {
       cy.findByTestId('cart-drawer-close').should('not.exist');
    });
 });
-
-function removeItemsFromCartAndCloseDrawer() {
-   cy.findAllByTestId('cart-drawer-remove-item').click();
-   cy.findAllByTestId('cart-drawer-item-count').should('have.text', 0);
-   cy.findByTestId('cart-drawer-quantity').should('not.exist');
-   cy.findByTestId('cart-drawer-close').click();
-   cy.findByTestId('cart-drawer-close').should('not.exist');
-}
 
 export {};

--- a/frontend/test/cypress/support/commands.ts
+++ b/frontend/test/cypress/support/commands.ts
@@ -19,6 +19,11 @@ Cypress.Commands.add(
    }
 );
 
+Cypress.Commands.add('times', (times, callback) => {
+   const items = Array.from({ length: times }, (_, i) => i);
+   cy.wrap(items).each(callback);
+});
+
 Cypress.Commands.add('loadCollectionPageByPath', (path: string) => {
    cy.intercept('/1/indexes/**').as('search');
    interceptLogin();

--- a/frontend/test/cypress/support/cypress.config.ts
+++ b/frontend/test/cypress/support/cypress.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from 'cypress';
-
-export default defineConfig({
-   e2e: {
-      // https://docs.cypress.io/guides/references/configuration#e2e
-      experimentalSessionAndOrigin: true,
-   },
-});

--- a/frontend/test/cypress/support/index.d.ts
+++ b/frontend/test/cypress/support/index.d.ts
@@ -3,6 +3,13 @@
 declare namespace Cypress {
    interface Chainable {
       isWithinViewport(): Chainable<JQuery<HTMLElement>>;
+      /**
+       * This command simulates the behavior of a foor loop in a way that is compatible with Cypress asyncronous commands.
+       * Read more here https://docs.cypress.io/guides/core-concepts/introduction-to-cypress#Avoid-loops
+       * @param {number} times
+       * @param {(index: number) => void} callback
+       */
+      times(times: number, callback: (index: number) => void): Chainable;
       loadCollectionPageByPath(path: string): Chainable;
       loadProductPageByPath(path: string): Chainable;
    }


### PR DESCRIPTION
closes #987 

## Changelog

- Drop unused Cypress config (and moved `experimentalSessionAndOrigin` to the actual config file)
- Add a commands for Cypress compatible loops
- Fixed issue described by #987 
- Cleaned up add to cart tests

## QA

I think it's not necessary, as this changes only affects CI