### PR TITLE
Collections: Always show smallest price to pros

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
@@ -29,7 +29,7 @@ export function useProductSearchHitPricing(
             : defaultVariantPrice;
    }
 
-   const price = proTierPrice ?? product.price_float;
+   const price = Math.min(proTierPrice ?? Infinity, product.price_float);
    const compareAtPrice = product.compare_at_price ?? product.price_float;
 
    const percentage = computeDiscountPercentage(


### PR DESCRIPTION
Shows the normal product price to pro users if it is less than the pro price.

## QA

When a pro user is logged in on a collection page and their pro discount is less than (=final pro price is greater than) the price for regular users, they should see the price that regular users see. The flair color should be red in this case.
Check that the displayed price corresponds to the price they see on the product page and the price they get at checkout. 

CC @erinemay 

Closes #992