### PR TITLE
Collections: Don't strip query params

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -11,7 +11,6 @@ import algoliasearch from 'algoliasearch/lite';
 import { history } from 'instantsearch.js/es/lib/routers';
 import { RouterProps } from 'instantsearch.js/es/middlewares';
 import { UiState } from 'instantsearch.js/es/types';
-import { mapValues } from 'lodash';
 import { useRouter } from 'next/router';
 import * as React from 'react';
 import {
@@ -153,13 +152,14 @@ export function InstantSearchProvider({
                // Item Type is the slug on device pages, not in the query.
                delete filterCopy['facet_tags.Item Type'];
             }
-            const customQueryParams = new URLSearchParams(location.search);
+            const initialQuery = qsModule.parse(location.search, {
+               ignoreQueryPrefix: true,
+            });
             const queryString = qsModule.stringify(
                {
+                  ...initialQuery,
                   ...routeState,
                   filter: filterCopy,
-                  _vercel_no_cache:
-                     customQueryParams.get('_vercel_no_cache') || undefined,
                },
                {
                   addQueryPrefix: true,
@@ -176,7 +176,9 @@ export function InstantSearchProvider({
             const deviceHandle = pathParts.length >= 2 ? pathParts[1] : '';
             const itemType = pathParts.length >= 3 ? pathParts[2] : '';
 
-            const { q, p, filter } = qsModule.parse(location.search.slice(1));
+            const { q, p, filter } = qsModule.parse(location.search, {
+               ignoreQueryPrefix: true,
+            });
 
             const filterObject =
                typeof filter === 'object' && !Array.isArray(filter)

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -152,12 +152,15 @@ export function InstantSearchProvider({
                // Item Type is the slug on device pages, not in the query.
                delete filterCopy['facet_tags.Item Type'];
             }
-            const initialQuery = qsModule.parse(location.search, {
-               ignoreQueryPrefix: true,
-            });
+            const { q, p, filter, ...otherParams } = qsModule.parse(
+               location.search,
+               {
+                  ignoreQueryPrefix: true,
+               }
+            );
             const queryString = qsModule.stringify(
                {
-                  ...initialQuery,
+                  ...otherParams,
                   ...routeState,
                   filter: filterCopy,
                },


### PR DESCRIPTION
Fixes a bug where query params on collection pages that weren't used by Algolia were stripped from the url.

This keeps all query params in the url, even if they aren't used in Algolia search.

This means we don't have to manually forward the `_vercel_no_cache` param anymore.

I also noticed that we can pass an option to `qs` to ignore the leading '?' in the query, instead of slicing it out ourselves.
https://github.com/ljharb/qs

## QA

- Make sure filtering on collections pages still works.
- Make sure when visiting a collections page from an external link, all query parameters are persisted in the url.
  - Specifically, make sure `_vercel_no_cache=1` still works and doesn't get stripped.

You'll notice that www.ifixit.com/Parts?dogs=cats the `dogs=cats` gets stripped. On this branch, it shouldn't be stripped, and search should still work as usual.

CC @sterlinghirsh

Noticed in #817
