### PR TITLE
Analytics: Add empty build/clean scripts

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -13,6 +13,8 @@
       "typescript": "4.5.3"
    },
    "scripts": {
+      "build": "",
+      "clean": "",
       "type-check": "tsc --pretty --noEmit"
    }
 }


### PR DESCRIPTION
This is for compatibility with the `ifixit` monorepo. Rush expects each package we depend on to have these scripts.

See https://github.com/iFixit/react-commerce/pull/633 for the last time we did this.

Connects: 
https://github.com/iFixit/ifixit/pull/45326
https://github.com/ifixit/ifixit/issues/44933

qa_req 0