### PR TITLE
String.replaceAll(): Use more available .replace()

### DIFF
--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -17,7 +17,7 @@ export function computeProductListAlgoliaFilterPreset<
 
    if (filters && filters.length > 0) {
       // Algolia can't handle newlines in the filter, so replace with space.
-      conditions.push(filters.replaceAll('\n', ' '));
+      conditions.push(filters.replace(/(\n|\r)+/g, ' '));
    } else if (deviceTitle && deviceTitle.length > 0) {
       conditions.push(`device:${JSON.stringify(deviceTitle)}`);
    }


### PR DESCRIPTION
.replaceAll() isn't available on older browsers (Chrome 84 and below). Quite a fair number of users visit our site on older browsers (like web-TVs?) and report errors on this not being a thing.

Closes #1003

CC @sterlinghirsh 