### PR TITLE
Revert "refactor(product page):  Use first variant as default variant"

### DIFF
--- a/frontend/templates/product/hooks/useSelectedVariant.ts
+++ b/frontend/templates/product/hooks/useSelectedVariant.ts
@@ -46,7 +46,11 @@ export function useSelectedVariant(
 }
 
 function useDefaultVariantId(product: Product): string {
-   return product.variants[0].id;
+   const variant =
+      product.variants.find(
+         (variant) => variant.quantityAvailable && variant.quantityAvailable > 0
+      ) ?? product.variants[0];
+   return variant.id;
 }
 
 function useSearchParamVariantId(): string | null {


### PR DESCRIPTION
This reverts commit 262cc4af7157a10a61247533e68cd6c66a977eb8.

Specifically, after ordering by orderby, choose the first in-stock variant to show as the default instead of always showing the default even if it's out of stock.

Closes #1000

CC @ifixitmaxb @jeffsnyder 