### PR TITLE
Improve Compatibility Drawer in Product Page: Compatibility Link Is Used More Reasonably 

### DIFF
--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -42,7 +42,7 @@ export function CompatibleDevice({
             >
                {device.deviceName}
             </Text>
-            <Flex mb="2px" flexDir="column">
+            <Flex flexDir="column">
                {variants.map((variant) => (
                   <Text
                      key={variant}
@@ -55,8 +55,8 @@ export function CompatibleDevice({
                ))}
             </Flex>
             {unlistedVariants !== 0 && (
-               <Text my="1px" lineHeight="short" fontSize="xs">
-                  And {unlistedVariants} other devices...
+               <Text mb="2px" lineHeight="short" fontSize="xs" color="gray.600">
+                  And {unlistedVariants} other models...
                </Text>
             )}
          </Flex>

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -79,12 +79,10 @@ export function ProductSection({
       product.compatibility &&
       (product.compatibility.devices.length >
          compatibilityDrawerDeviceTruncate ||
-         product.compatibility.devices
-            .some(
-               (currentValue) =>
-                  currentValue.variants.length >
-                  compatibilityDrawerModelsTruncate
-            ));
+         product.compatibility.devices.some(
+            (currentValue) =>
+               currentValue.variants.length > compatibilityDrawerModelsTruncate
+         ));
    return (
       <PageContentWrapper as="section">
          <Flex px={{ base: 5, sm: 0 }}>

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -80,7 +80,6 @@ export function ProductSection({
       (product.compatibility.devices.length >
          compatibilityDrawerDeviceTruncate ||
          product.compatibility.devices
-            .slice(0, compatibilityDrawerDeviceTruncate)
             .some(
                (currentValue) =>
                   currentValue.variants.length >

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -73,6 +73,19 @@ export function ProductSection({
 
    const isForSale = useIsProductForSale(product);
 
+   const compatibilityDrawerModelsTruncate = 4;
+   const compatibilityDrawerDeviceTruncate = 3;
+   const compatibilityDrawerIncomplete =
+      product.compatibility &&
+      (product.compatibility.devices.length >
+         compatibilityDrawerDeviceTruncate ||
+         product.compatibility.devices
+            .slice(0, compatibilityDrawerDeviceTruncate)
+            .some(
+               (currentValue) =>
+                  currentValue.variants.length >
+                  compatibilityDrawerModelsTruncate
+            ));
    return (
       <PageContentWrapper as="section">
          <Flex px={{ base: 5, sm: 0 }}>
@@ -274,14 +287,15 @@ export function ProductSection({
                                  >
                                     <CompatibleDevice
                                        device={device}
-                                       truncate={4}
+                                       truncate={
+                                          compatibilityDrawerModelsTruncate
+                                       }
                                     />
                                  </chakra.a>
                               </NextLink>
                            ))}
 
-                        {product.compatibility &&
-                        product.compatibility.devices.length > 3 ? (
+                        {compatibilityDrawerIncomplete ? (
                            <NextLink href="#compatibility" passHref>
                               <Link
                                  mt={3}


### PR DESCRIPTION
## Overview 

We weren't rendering the compatibility link when we had devices with truncated models lists, leading to a confusing UI. Now if we have to truncate the model lists, we will always show the compatibility links so that people will be able to click and see all of the models.

## CR

Is there a better way to make this check?

## QA

Make sure that a device with more than 3 variants has the link, that a device with more than 4 models has the link, that a device with both has the link, and a device with neither doesn't have the link. 

Closes: #931