### PR TITLE
Footer: Move click tracking to context

### DIFF
--- a/frontend/layouts/default/DefaultLayout/Footer.tsx
+++ b/frontend/layouts/default/DefaultLayout/Footer.tsx
@@ -35,7 +35,7 @@ import {
    Footer,
    FooterLink,
    FooterDivider,
-   ClickTracker,
+   EventTracker,
 } from '@ifixit/footer';
 
 interface FooterProps {
@@ -53,7 +53,7 @@ export function CartFooter({
    const { menu1, menu2, partners, bottomMenu } = footer;
    const { newsletterForm } = globalSettings;
    return (
-      <ClickTracker value={{ trackClick: trackInMatomoAndGA }}>
+      <EventTracker value={{ trackClick: trackInMatomoAndGA }}>
          <Footer>
             <FooterNavigationSection>
                <FooterNavigationList>
@@ -243,6 +243,6 @@ export function CartFooter({
                </FooterLegalLinkList>
             </FooterLegalSection>
          </Footer>
-      </ClickTracker>
+      </EventTracker>
    );
 }

--- a/frontend/layouts/default/DefaultLayout/Footer.tsx
+++ b/frontend/layouts/default/DefaultLayout/Footer.tsx
@@ -1,4 +1,4 @@
-import { trackAddToCart } from '@ifixit/analytics';
+import { trackInMatomoAndGA } from '@ifixit/analytics';
 import { Menu, MenuList } from '@chakra-ui/react';
 import {
    FacebookLogo,
@@ -53,7 +53,7 @@ export function CartFooter({
    const { menu1, menu2, partners, bottomMenu } = footer;
    const { newsletterForm } = globalSettings;
    return (
-      <ClickTracker value={{ trackClick: trackAddToCart }}>
+      <ClickTracker value={{ trackClick: trackInMatomoAndGA }}>
          <Footer>
             <FooterNavigationSection>
                <FooterNavigationList>

--- a/frontend/layouts/default/DefaultLayout/Footer.tsx
+++ b/frontend/layouts/default/DefaultLayout/Footer.tsx
@@ -54,7 +54,6 @@ export function CartFooter({
    const { newsletterForm } = globalSettings;
    return (
       <ClickTracker value={{ trackClick: trackAddToCart }}>
-         >
          <Footer>
             <FooterNavigationSection>
                <FooterNavigationList>

--- a/frontend/layouts/default/DefaultLayout/Footer.tsx
+++ b/frontend/layouts/default/DefaultLayout/Footer.tsx
@@ -1,3 +1,4 @@
+import { trackAddToCart } from '@ifixit/analytics';
 import { Menu, MenuList } from '@chakra-ui/react';
 import {
    FacebookLogo,
@@ -34,6 +35,7 @@ import {
    Footer,
    FooterLink,
    FooterDivider,
+   ClickTracker,
 } from '@ifixit/footer';
 
 interface FooterProps {
@@ -51,192 +53,197 @@ export function CartFooter({
    const { menu1, menu2, partners, bottomMenu } = footer;
    const { newsletterForm } = globalSettings;
    return (
-      <Footer>
-         <FooterNavigationSection>
-            <FooterNavigationList>
-               {menu1?.items.map((item, index) => {
-                  if (item.type === 'link') {
-                     return (
-                        <FooterNavigationItem key={index}>
-                           <FooterNavigationLink href={item.url}>
-                              {item.name}
-                           </FooterNavigationLink>
-                        </FooterNavigationItem>
-                     );
-                  }
-               })}
-            </FooterNavigationList>
-            <FooterNavigationList>
-               {menu2?.items.map((item, index) => {
-                  if (item.type === 'link') {
-                     return (
-                        <FooterNavigationItem key={index}>
-                           <FooterNavigationLink href={item.url}>
-                              {item.name}
-                           </FooterNavigationLink>
-                        </FooterNavigationItem>
-                     );
-                  }
-               })}
-            </FooterNavigationList>
-            <FooterNavigationList>
-               {socialMediaAccounts.tiktok && (
-                  <FooterNavigationItem>
-                     <FooterNavigationLink
-                        href={socialMediaAccounts.tiktok}
-                        icon={TiktokLogo}
-                     >
-                        TikTok
-                     </FooterNavigationLink>
-                  </FooterNavigationItem>
-               )}
-               {socialMediaAccounts.facebook && (
-                  <FooterNavigationItem>
-                     <FooterNavigationLink
-                        href={socialMediaAccounts.facebook}
-                        icon={FacebookLogo}
-                     >
-                        Facebook
-                     </FooterNavigationLink>
-                  </FooterNavigationItem>
-               )}
-               {socialMediaAccounts.twitter && (
-                  <FooterNavigationItem>
-                     <FooterNavigationLink
-                        href={socialMediaAccounts.twitter}
-                        icon={TwitterLogo}
-                     >
-                        Twitter
-                     </FooterNavigationLink>
-                  </FooterNavigationItem>
-               )}
-               {socialMediaAccounts.instagram && (
-                  <FooterNavigationItem>
-                     <FooterNavigationLink
-                        href={socialMediaAccounts.instagram}
-                        icon={InstagramLogo}
-                     >
-                        Instagram
-                     </FooterNavigationLink>
-                  </FooterNavigationItem>
-               )}
-               {socialMediaAccounts.youtube && (
-                  <FooterNavigationItem>
-                     <FooterNavigationLink
-                        href={socialMediaAccounts.youtube}
-                        icon={YoutubeLogo}
-                     >
-                        YouTube
-                     </FooterNavigationLink>
-                  </FooterNavigationItem>
-               )}
-               {socialMediaAccounts.repairOrg && (
-                  <FooterNavigationItem>
-                     <FooterNavigationLink
-                        href={socialMediaAccounts.repairOrg}
-                        icon={RepairOrgLogo}
-                     >
-                        Repair.org
-                     </FooterNavigationLink>
-                  </FooterNavigationItem>
-               )}
-            </FooterNavigationList>
-            {partners && (
-               <FooterPartners>
-                  {partners.items.map((partner) => {
-                     if (partner.type === MenuItemType.ImageLink) {
+      <ClickTracker value={{ trackClick: trackAddToCart }}>
+         >
+         <Footer>
+            <FooterNavigationSection>
+               <FooterNavigationList>
+                  {menu1?.items.map((item, index) => {
+                     if (item.type === 'link') {
                         return (
-                           <FooterPartnerLink
-                              key={partner.name}
-                              href={partner.url}
-                              position="relative"
-                              p="0"
-                           >
-                              {partner.image?.url ? (
-                                 <IfixitImage
-                                    layout="fill"
-                                    objectFit="contain"
-                                    src={partner.image.url}
-                                    alt={
-                                       partner.image?.alternativeText ||
-                                       `${partner.name} logo`
-                                    }
-                                 />
-                              ) : (
-                                 <IfixitImage
-                                    layout="fill"
-                                    objectFit="contain"
-                                    src={noImageFixie}
-                                 />
-                              )}
-                           </FooterPartnerLink>
+                           <FooterNavigationItem key={index}>
+                              <FooterNavigationLink href={item.url}>
+                                 {item.name}
+                              </FooterNavigationLink>
+                           </FooterNavigationItem>
                         );
                      }
                   })}
-               </FooterPartners>
-            )}
-         </FooterNavigationSection>
-
-         <FooterDivider />
-
-         <FooterSettingsSection>
-            <FooterSettings>
-               {stores.length > 0 && (
-                  <Menu isLazy lazyBehavior="keepMounted">
-                     <StoreMenuButton icon={<Flag code={FlagCountryCode.US} />}>
-                        Region
-                     </StoreMenuButton>
-                     <MenuList>
-                        {stores.map((store) => {
+               </FooterNavigationList>
+               <FooterNavigationList>
+                  {menu2?.items.map((item, index) => {
+                     if (item.type === 'link') {
+                        return (
+                           <FooterNavigationItem key={index}>
+                              <FooterNavigationLink href={item.url}>
+                                 {item.name}
+                              </FooterNavigationLink>
+                           </FooterNavigationItem>
+                        );
+                     }
+                  })}
+               </FooterNavigationList>
+               <FooterNavigationList>
+                  {socialMediaAccounts.tiktok && (
+                     <FooterNavigationItem>
+                        <FooterNavigationLink
+                           href={socialMediaAccounts.tiktok}
+                           icon={TiktokLogo}
+                        >
+                           TikTok
+                        </FooterNavigationLink>
+                     </FooterNavigationItem>
+                  )}
+                  {socialMediaAccounts.facebook && (
+                     <FooterNavigationItem>
+                        <FooterNavigationLink
+                           href={socialMediaAccounts.facebook}
+                           icon={FacebookLogo}
+                        >
+                           Facebook
+                        </FooterNavigationLink>
+                     </FooterNavigationItem>
+                  )}
+                  {socialMediaAccounts.twitter && (
+                     <FooterNavigationItem>
+                        <FooterNavigationLink
+                           href={socialMediaAccounts.twitter}
+                           icon={TwitterLogo}
+                        >
+                           Twitter
+                        </FooterNavigationLink>
+                     </FooterNavigationItem>
+                  )}
+                  {socialMediaAccounts.instagram && (
+                     <FooterNavigationItem>
+                        <FooterNavigationLink
+                           href={socialMediaAccounts.instagram}
+                           icon={InstagramLogo}
+                        >
+                           Instagram
+                        </FooterNavigationLink>
+                     </FooterNavigationItem>
+                  )}
+                  {socialMediaAccounts.youtube && (
+                     <FooterNavigationItem>
+                        <FooterNavigationLink
+                           href={socialMediaAccounts.youtube}
+                           icon={YoutubeLogo}
+                        >
+                           YouTube
+                        </FooterNavigationLink>
+                     </FooterNavigationItem>
+                  )}
+                  {socialMediaAccounts.repairOrg && (
+                     <FooterNavigationItem>
+                        <FooterNavigationLink
+                           href={socialMediaAccounts.repairOrg}
+                           icon={RepairOrgLogo}
+                        >
+                           Repair.org
+                        </FooterNavigationLink>
+                     </FooterNavigationItem>
+                  )}
+               </FooterNavigationList>
+               {partners && (
+                  <FooterPartners>
+                     {partners.items.map((partner) => {
+                        if (partner.type === MenuItemType.ImageLink) {
                            return (
-                              <StoreMenuItem
-                                 key={store.code}
-                                 as="a"
-                                 href={store.url}
-                                 icon={
-                                    <Flag
-                                       code={store.code.toUpperCase() as any}
+                              <FooterPartnerLink
+                                 key={partner.name}
+                                 href={partner.url}
+                                 position="relative"
+                                 p="0"
+                              >
+                                 {partner.image?.url ? (
+                                    <IfixitImage
+                                       layout="fill"
+                                       objectFit="contain"
+                                       src={partner.image.url}
+                                       alt={
+                                          partner.image?.alternativeText ||
+                                          `${partner.name} logo`
+                                       }
                                     />
-                                 }
-                                 name={store.name}
-                                 currency={store.currency}
-                              />
+                                 ) : (
+                                    <IfixitImage
+                                       layout="fill"
+                                       objectFit="contain"
+                                       src={noImageFixie}
+                                    />
+                                 )}
+                              </FooterPartnerLink>
                            );
-                        })}
-                     </MenuList>
-                  </Menu>
+                        }
+                     })}
+                  </FooterPartners>
                )}
-               <FooterLink
-                  href="https://www.ifixit.com/Translate"
-                  icon={Language}
-               >
-                  Help translate
-               </FooterLink>
-            </FooterSettings>
-            <NewsletterForm
-               title={newsletterForm.title}
-               description={newsletterForm.subtitle}
-               subscribeLabel={newsletterForm.callToActionButtonTitle}
-               emailPlaceholder={newsletterForm.inputPlaceholder}
-            />
-         </FooterSettingsSection>
+            </FooterNavigationSection>
 
-         <FooterDivider />
+            <FooterDivider />
 
-         <FooterLegalSection>
-            <FooterCopyright />
-            <FooterLegalLinkList>
-               {bottomMenu?.items.map((item, index) => {
-                  if (item.type === 'link') {
-                     return (
-                        <FooterLegalLink key={index} href={item.url}>
-                           {item.name}
-                        </FooterLegalLink>
-                     );
-                  }
-               })}
-            </FooterLegalLinkList>
-         </FooterLegalSection>
-      </Footer>
+            <FooterSettingsSection>
+               <FooterSettings>
+                  {stores.length > 0 && (
+                     <Menu isLazy lazyBehavior="keepMounted">
+                        <StoreMenuButton
+                           icon={<Flag code={FlagCountryCode.US} />}
+                        >
+                           Region
+                        </StoreMenuButton>
+                        <MenuList>
+                           {stores.map((store) => {
+                              return (
+                                 <StoreMenuItem
+                                    key={store.code}
+                                    as="a"
+                                    href={store.url}
+                                    icon={
+                                       <Flag
+                                          code={store.code.toUpperCase() as any}
+                                       />
+                                    }
+                                    name={store.name}
+                                    currency={store.currency}
+                                 />
+                              );
+                           })}
+                        </MenuList>
+                     </Menu>
+                  )}
+                  <FooterLink
+                     href="https://www.ifixit.com/Translate"
+                     icon={Language}
+                  >
+                     Help translate
+                  </FooterLink>
+               </FooterSettings>
+               <NewsletterForm
+                  title={newsletterForm.title}
+                  description={newsletterForm.subtitle}
+                  subscribeLabel={newsletterForm.callToActionButtonTitle}
+                  emailPlaceholder={newsletterForm.inputPlaceholder}
+               />
+            </FooterSettingsSection>
+
+            <FooterDivider />
+
+            <FooterLegalSection>
+               <FooterCopyright />
+               <FooterLegalLinkList>
+                  {bottomMenu?.items.map((item, index) => {
+                     if (item.type === 'link') {
+                        return (
+                           <FooterLegalLink key={index} href={item.url}>
+                              {item.name}
+                           </FooterLegalLink>
+                        );
+                     }
+                  })}
+               </FooterLegalLinkList>
+            </FooterLegalSection>
+         </Footer>
+      </ClickTracker>
    );
 }

--- a/packages/footer/hooks/TrackingContext.ts
+++ b/packages/footer/hooks/TrackingContext.ts
@@ -1,0 +1,41 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * @see https://matomo.org/docs/event-tracking/
+ * @see https://developer.matomo.org/api-reference/tracking-javascript
+ */
+export type TrackEventMatomo = {
+   /**
+    * Describes the type of events you want to track.
+    * For example, Link Clicks, Videos, Outbound Links, and Form Events.
+    */
+   eventCategory: string;
+   /**
+    * The specific action that is taken.
+    * For example, with a Video category, you might have a Play, Pause and Complete action.
+    */
+   eventAction: string;
+   /**
+    * Usually the title of the element that is being interacted with, to aid with analysis.
+    * For example, it could be the name of a Video that was played or the specific
+    * form that is being submitted.
+    */
+   eventName?: string;
+   /**
+    * A numeric value and is often added dynamically. It could be the cost of a
+    * product that is added to a cart, or the completion percentage of a video.
+    */
+   eventValue?: number;
+};
+
+type Track = (trackData: TrackEventMatomo) => void;
+type TrackContext = {
+   trackClick: Track;
+};
+
+const defaultTracker: TrackContext = {
+   trackClick: (_trackData: TrackEventMatomo) => {},
+};
+
+export const TrackingContext = createContext(defaultTracker);
+export const ClickTracker = TrackingContext.Provider;

--- a/packages/footer/hooks/TrackingContext.ts
+++ b/packages/footer/hooks/TrackingContext.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext } from 'react';
 
 /**
  * @see https://matomo.org/docs/event-tracking/

--- a/packages/footer/hooks/TrackingContext.ts
+++ b/packages/footer/hooks/TrackingContext.ts
@@ -38,4 +38,4 @@ const defaultTracker: TrackContext = {
 };
 
 export const TrackingContext = createContext(defaultTracker);
-export const ClickTracker = TrackingContext.Provider;
+export const EventTracker = TrackingContext.Provider;

--- a/packages/footer/hooks/useTrackedOnClick.tsx
+++ b/packages/footer/hooks/useTrackedOnClick.tsx
@@ -1,5 +1,5 @@
-import { trackInMatomoAndGA } from '@ifixit/analytics';
 import * as React from 'react';
+import { TrackingContext } from './TrackingContext';
 
 type UseFooterLinkTrackingProps<T> = {
    href?: string;
@@ -10,9 +10,10 @@ export function useTrackedOnClick<T>({
    href,
    onClick,
 }: UseFooterLinkTrackingProps<T>) {
+   const { trackClick } = React.useContext(TrackingContext);
    const trackedOnClick: React.MouseEventHandler<T> = React.useCallback(
       (e) => {
-         trackInMatomoAndGA({
+         trackClick({
             eventCategory: 'Footer',
             eventAction: `Link Click - ${href}`,
          });

--- a/packages/footer/index.tsx
+++ b/packages/footer/index.tsx
@@ -5,4 +5,4 @@ export * from './components/Settings';
 export * from './components/Shared';
 export * from './components/StoreMenu';
 export * from './homepage-kpis';
-export { ClickTracker } from './hooks/TrackingContext.ts';
+export { ClickTracker } from './hooks/TrackingContext';

--- a/packages/footer/index.tsx
+++ b/packages/footer/index.tsx
@@ -5,3 +5,4 @@ export * from './components/Settings';
 export * from './components/Shared';
 export * from './components/StoreMenu';
 export * from './homepage-kpis';
+export { ClickTracker } from './hooks/TrackingContext.ts';

--- a/packages/footer/index.tsx
+++ b/packages/footer/index.tsx
@@ -5,4 +5,4 @@ export * from './components/Settings';
 export * from './components/Shared';
 export * from './components/StoreMenu';
 export * from './homepage-kpis';
-export { ClickTracker } from './hooks/TrackingContext';
+export { EventTracker } from './hooks/TrackingContext';

--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -9,9 +9,6 @@
       "build": "",
       "type-check": "tsc --pretty --noEmit"
    },
-   "dependencies": {
-      "@ifixit/analytics": "workspace:*"
-   },
    "peerDependencies": {
       "@chakra-ui/react": ">= 1.8.3 < 2",
       "@core-ds/primitives": ">2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,7 +290,6 @@ importers:
       '@babel/core': '>=7.0.0 <8.0.0'
       '@emotion/react': '>=11.0.0 <12.0.0'
       '@emotion/styled': '>=11.0.0 <12.0.0'
-      '@ifixit/analytics': workspace:*
       '@ifixit/tsconfig': workspace:*
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
@@ -300,8 +299,6 @@ importers:
       react-icons: 4.2.0
       regenerator-runtime: '*'
       typescript: 4.5.3
-    dependencies:
-      '@ifixit/analytics': link:../analytics
     devDependencies:
       '@babel/core': 7.18.6
       '@emotion/react': 11.7.1_yse24c3tnaw3czhkbk3q2k7woy


### PR DESCRIPTION
We don't want to use the same click tracking function in every location we use the footer. In particular, we don't want to use `@ifixit/analytics` from anywhere but this repo. This pull switches the footer component to fetch its click tracking function from a context, which enables us to swap it out per-use. It also adds that new context around the use of the `Footer` component in this repo, so we continue to use the same click tracking function within this repo.

## QA Suggestion
Please confirm that the footer click tracking seems to still be working as described in https://github.com/iFixit/react-commerce/issues/855 (only the footer parts; the rest should not have been affected).

CC @jyee27 @jordycosta
