### PR TITLE
Making two purchases: allow it!

### DIFF
--- a/packages/cart-sdk/hooks/use-checkout.ts
+++ b/packages/cart-sdk/hooks/use-checkout.ts
@@ -145,10 +145,12 @@ function useStandardCheckout() {
       const localCheckout = getLocalCheckout();
       let checkoutUrl: string | null = null;
       if (localCheckout != null) {
-         const checkout = await updateCheckout(localCheckout.id, lineItems);
-         if (checkout != null) {
-            checkoutUrl = checkout.webUrl;
-         }
+         try {
+            const checkout = await updateCheckout(localCheckout.id, lineItems);
+            if (checkout != null) {
+               checkoutUrl = checkout.webUrl;
+            }
+         } catch (error) {}
       }
       if (checkoutUrl == null) {
          const checkout = await createCheckout(lineItems);

--- a/packages/cart-sdk/hooks/use-checkout.ts
+++ b/packages/cart-sdk/hooks/use-checkout.ts
@@ -206,6 +206,12 @@ function useUpdateCheckout() {
          lineItems,
       });
 
+      // Seems like the "already completed" state results in top-level errors
+      // and checkoutLineItemsReplace === null, sometimes, even response is
+      // undefined
+      if (!response?.checkoutLineItemsReplace) {
+         return null;
+      }
       const { checkout, userErrors } = response.checkoutLineItemsReplace;
       if (userErrors.length > 0) {
          if (


### PR DESCRIPTION
See the issue for a description of the problem. In short, if you make a purchase, then try to make another one, it fails to create the checkout.

We have code that will try to use the shopify checkoutId from
LocalStorage. This code also seems to deal with the error state of that
checkoutId having already been completed or just plain invalid.

The code is written to the spec of the API docs and appears to do that
correctly. The API however, doesn't behave as the docs say.
Specifically, when these errors are encountered, the error messages come
back out of band:

Expected response:

    {
       data: {
          checkoutLineItemsReplace: {
             checkout: { ... },
             userErrors: [{code: "ALREADY_COMPLETED"}]
       }
    }

Actual response:

    {
       data: {
          checkoutLineItemsReplace: null
       },
       errors: [
          {
             "message":"Checkout is already completed.",
             "locations":[{"line":3,"column":7}],
             "path":["checkoutLineItemsReplace"]
          }
       ]
    }

Anyway, I've checked the other endpoint here (checkoutCreate) and it has
the same failure mode (errors come out of band and look different than
the docs say). Sometimes the top level "data" property is event absent.

We may need to catch this situation deeper in the stack, but that will
come separately.

Closes #1002 