### PR TITLE
Shopify Storefront SDK: use `sentryFetch()`

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/index.ts
+++ b/frontend/lib/shopify-storefront-sdk/index.ts
@@ -2,6 +2,7 @@ import { SHOPIFY_STOREFRONT_VERSION } from '@config/env';
 import { getSdk, Requester } from './generated/sdk';
 import * as Sentry from '@sentry/nextjs';
 import { z } from 'zod';
+import { sentryFetch } from '@ifixit/sentry';
 export * from './generated/sdk';
 
 export type ShopCredentials = {
@@ -14,7 +15,7 @@ export function getShopifyStorefrontSdk(shop: ShopCredentials) {
       doc: string,
       variables: V
    ): Promise<R> => {
-      const response = await fetch(
+      const response = await sentryFetch(
          `https://${shop.shopDomain}/api/${SHOPIFY_STOREFRONT_VERSION}/graphql.json`,
          {
             method: 'POST',


### PR DESCRIPTION
This will report the query and variables in Sentry when we get a non-200 response from Shopify's api.

This is the same pattern we follow in frontend/lib/strapi-sdk/index.ts, for reference.

## QA

Since we can't make https://store.cominor.com/api/2022-10/graphql.json 500 easily, I think we should just merge this and as the sentry events roll in, we can check and see that they have all the data we want.

qa_req 0

Closes #1001