### PR TITLE
CORS: Use relative urls in dev

### DIFF
--- a/frontend/components/common/AppProviders.tsx
+++ b/frontend/components/common/AppProviders.tsx
@@ -60,18 +60,20 @@ export type WithProvidersProps<T> = T & { appProps: AppProvidersProps };
 
 export type AppProvidersProps = {
    algolia?: AlgoliaProps;
+   ifixitOrigin?: string;
 };
 
 export function AppProviders({
    children,
    algolia,
+   ifixitOrigin,
 }: React.PropsWithChildren<AppProvidersProps>) {
    const markup = (
       <ChakraProvider theme={customTheme}>{children}</ChakraProvider>
    );
 
    return (
-      <AppProvider ifixitOrigin={IFIXIT_ORIGIN}>
+      <AppProvider ifixitOrigin={ifixitOrigin ?? IFIXIT_ORIGIN}>
          <CartDrawerProvider>
             <QueryClientProvider client={queryClient}>
                {algolia ? (

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -1,5 +1,5 @@
 import { useSafeLayoutEffect } from '@chakra-ui/react';
-import { ALGOLIA_APP_ID } from '@config/env';
+import { ALGOLIA_APP_ID, IFIXIT_ORIGIN } from '@config/env';
 import { CLIENT_OPTIONS } from '@helpers/algolia-helpers';
 import {
    destylizeDeviceItemType,
@@ -275,11 +275,11 @@ function RefreshSearchResults({
 }
 
 function getBaseOrigin(location: Location): string {
-   if (typeof window === 'undefined' && process.env.NEXT_PUBLIC_IFIXIT_ORIGIN) {
+   if (typeof window === 'undefined' && IFIXIT_ORIGIN) {
       // On the server, use the IFIXIT_ORIGIN url
       // This ensures that the SSR produces the correct links on Vercel
       // (where the Host header doesn't match the page URL.)
-      const publicOrigin = new URL(process.env.NEXT_PUBLIC_IFIXIT_ORIGIN);
+      const publicOrigin = new URL(IFIXIT_ORIGIN);
       return publicOrigin.origin;
    }
    return location.origin;

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -11,12 +11,12 @@ export function serverSidePropsWrapper<T extends { [key: string]: any }>(
       console.log('context.resolvedUrl', context.resolvedUrl);
       console.log('context.req.url', context.req.url);
       Sentry.setContext('Extra Info', {
-         headers: context?.req.headers,
-         url: context?.req.url,
-         method: context?.req.method,
-         locale: context?.locale,
-         ...context?.params,
-         ...context?.query,
+         headers: context.req.headers,
+         url: context.req.url,
+         method: context.req.method,
+         locale: context.locale,
+         ...context.params,
+         ...context.query,
       });
       return logAsync('getServerSideProps', () =>
          getServerSidePropsInternal(context)

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -1,3 +1,4 @@
+import { IFIXIT_ORIGIN } from '@config/env';
 import { invariant } from '@ifixit/helpers';
 import {
    ProductList,
@@ -45,4 +46,8 @@ export function productListPath(
          throw new Error(`unknown product list type: ${productList.type}`);
       }
    }
+}
+
+export function ifixitOriginFromHost(host: string): string {
+   return host.match(/(?:\w*\.)*cominor\.com/) ? '' : IFIXIT_ORIGIN;
 }

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -55,7 +55,9 @@ export function ifixitOriginFromHost(
    const headers = context.req.headers;
    const host = (headers['x-ifixit-forwarded-host'] ||
       headers['x-forwarded-host']) as string | undefined;
-   const isDevProxy = !!host?.match(/\.(cominor\.com|ubreakit\.com)$/);
+   const isDevProxy = !!host?.match(
+      /^(?!react-commerce).*(\.cominor\.com|\.ubreakit\.com)$/
+   );
    const hostIfProxy = typeof window === 'undefined' ? `https://${host}` : '';
    return isDevProxy ? hostIfProxy! : IFIXIT_ORIGIN;
 }

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -50,6 +50,6 @@ export function productListPath(
 
 export function ifixitOriginFromHost(host?: string): string {
    const isDevProxy = !!host?.match(/\.(cominor\.com|ubreakit\.com)$/);
-   const hostIfProxy = typeof window === 'undefined' ? host : '';
+   const hostIfProxy = typeof window === 'undefined' ? `https://${host}` : '';
    return isDevProxy ? hostIfProxy! : IFIXIT_ORIGIN;
 }

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -48,6 +48,6 @@ export function productListPath(
    }
 }
 
-export function ifixitOriginFromHost(host: string): string {
-   return host.match(/(?:\w*\.)*cominor\.com/) ? '' : IFIXIT_ORIGIN;
+export function ifixitOriginFromHost(host?: string): string {
+   return host?.match(/\.(cominor\.com|ubreakit\.com)$/) ? '' : IFIXIT_ORIGIN;
 }

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -49,5 +49,7 @@ export function productListPath(
 }
 
 export function ifixitOriginFromHost(host?: string): string {
-   return host?.match(/\.(cominor\.com|ubreakit\.com)$/) ? '' : IFIXIT_ORIGIN;
+   const isDevProxy = !!host?.match(/\.(cominor\.com|ubreakit\.com)$/);
+   const hostIfProxy = typeof window === 'undefined' ? host : '';
+   return isDevProxy ? hostIfProxy! : IFIXIT_ORIGIN;
 }

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -6,6 +6,7 @@ import {
    iFixitPageType,
    iFixitPage,
 } from '@models/product-list';
+import { GetServerSidePropsContext } from 'next';
 import { stylizeDeviceTitle } from './product-list-helpers';
 
 type ProductListPathAttributes = Pick<
@@ -48,7 +49,12 @@ export function productListPath(
    }
 }
 
-export function ifixitOriginFromHost(host?: string): string {
+export function ifixitOriginFromHost(
+   context: GetServerSidePropsContext
+): string {
+   const headers = context.req.headers;
+   const host = (headers['x-ifixit-forwarded-host'] ||
+      headers['x-forwarded-host']) as string | undefined;
    const isDevProxy = !!host?.match(/\.(cominor\.com|ubreakit\.com)$/);
    const hostIfProxy = typeof window === 'undefined' ? `https://${host}` : '';
    return isDevProxy ? hostIfProxy! : IFIXIT_ORIGIN;

--- a/frontend/models/posts.ts
+++ b/frontend/models/posts.ts
@@ -1,4 +1,3 @@
-import { IFIXIT_ORIGIN } from '@config/env';
 import { sentryFetch } from '@ifixit/sentry';
 
 export interface Post {
@@ -14,9 +13,12 @@ export interface PostImage {
    url: string;
 }
 
-export async function fetchPosts(tags: string[]): Promise<Post[]> {
+export async function fetchPosts(
+   tags: string[],
+   ifixitOrigin: string
+): Promise<Post[]> {
    const response = await sentryFetch(
-      `${IFIXIT_ORIGIN}/api/2.0/related_posts?data=${encodeURIComponent(
+      `${ifixitOrigin}/api/2.0/related_posts?data=${encodeURIComponent(
          JSON.stringify({ tags })
       )}`
    );

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -63,7 +63,10 @@ export async function findProductList(
       logAsync('strapi:getProductList', () =>
          strapi.getProductList({ filters })
       ),
-      fetchDeviceWiki(createIFixitAPIClient(ifixitOrigin), filterDeviceTitle),
+      fetchDeviceWiki(
+         new IFixitAPIClient({ origin: ifixitOrigin }),
+         filterDeviceTitle
+      ),
    ]);
 
    const productList = result.productLists?.data?.[0]?.attributes;
@@ -166,7 +169,7 @@ async function fillMissingImagesFromApi(
    ) as string[]; // cast is safe cause we filter nulls above,
    // typescript just doesn't understand
    const imagesResponse = await fetchMultipleDeviceImages(
-      createIFixitAPIClient(ifixitOrigin),
+      new IFixitAPIClient({ origin: ifixitOrigin }),
       deviceTitlesWithoutImages,
       'thumbnail'
    );
@@ -412,8 +415,4 @@ function createPublicAlgoliaKey(appId: string, apiKey: string): string {
       filters: 'public=1 AND is_pro!=1',
    });
    return publicKey;
-}
-
-function createIFixitAPIClient(origin: string) {
-   return new IFixitAPIClient({ origin });
 }

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -51,8 +51,7 @@ export const getServerSideProps: GetServerSideProps<PageTemplateProps> = async (
       };
    }
 
-   const forwardedHost = context.req.headers['x-forwarded-host'] as string;
-   const ifixitOrigin = ifixitOriginFromHost(forwardedHost);
+   const ifixitOrigin = ifixitOriginFromHost(context);
    const isProxied = ifixitOrigin !== IFIXIT_ORIGIN;
    if (isProxied) {
       context.res.setHeader(

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import { flags } from '@config/flags';
+import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { assertNever } from '@ifixit/helpers';
 import { DefaultLayout, getLayoutServerSideProps } from '@layouts/default';
 import { findPage } from '@models/page';
@@ -61,7 +62,9 @@ export const getServerSideProps: GetServerSideProps<PageTemplateProps> = async (
 
    const pageProps: PageTemplateProps = {
       layoutProps,
-      appProps: {},
+      appProps: {
+         ifixitOrigin: ifixitOriginFromHost(context.req.headers.host ?? ''),
+      },
       page,
    };
    return {

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -60,10 +60,11 @@ export const getServerSideProps: GetServerSideProps<PageTemplateProps> = async (
       };
    }
 
+   const forwardedHost = context.req.headers['x-forwarded-host'] as string;
    const pageProps: PageTemplateProps = {
       layoutProps,
       appProps: {
-         ifixitOrigin: ifixitOriginFromHost(context.req.headers.host ?? ''),
+         ifixitOrigin: ifixitOriginFromHost(forwardedHost),
       },
       page,
    };

--- a/frontend/templates/page/sections/BrowseSection.tsx
+++ b/frontend/templates/page/sections/BrowseSection.tsx
@@ -11,8 +11,8 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { ProductListCard } from '@components/product-list/ProductListCard';
-import { IFIXIT_ORIGIN } from '@config/env';
 import { productListPath } from '@helpers/path-helpers';
+import { useAppContext } from '@ifixit/app';
 import { PageContentWrapper } from '@ifixit/ui';
 import { GetSection } from '@models/page';
 import Image from 'next/image';
@@ -86,11 +86,12 @@ function HeadingBackground({ image }: HeadingBackgroundProps) {
 }
 
 function SearchBox() {
+   const appContext = useAppContext();
    return (
       <Flex
          as="form"
          method="GET"
-         action={`${IFIXIT_ORIGIN}/Search`}
+         action={`${appContext.ifixitOrigin}/Search`}
          w="full"
          justify="center"
       >

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -59,8 +59,7 @@ export const getProductListServerSideProps = ({
    productListType,
 }: GetProductListServerSidePropsOptions): GetServerSideProps<ProductListTemplateProps> => {
    return async (context) => {
-      const forwardedHost = context.req.headers['x-forwarded-host'] as string;
-      const ifixitOrigin = ifixitOriginFromHost(forwardedHost);
+      const ifixitOrigin = ifixitOriginFromHost(context);
       const isProxied = ifixitOrigin !== IFIXIT_ORIGIN;
       if (context.query._vercel_no_cache === '1' || isProxied) {
          context.res.setHeader(

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -80,7 +80,8 @@ export const getProductListServerSideProps = ({
       let shouldRedirectToCanonical = false;
       let canonicalPath: string | null = null;
 
-      const ifixitOrigin = ifixitOriginFromHost(context.req.headers.host ?? '');
+      const forwardedHost = context.req.headers['x-forwarded-host'] as string;
+      const ifixitOrigin = ifixitOriginFromHost(forwardedHost);
 
       switch (productListType) {
          case ProductListType.AllParts: {

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -3,7 +3,7 @@ import {
    AppProvidersProps,
    WithProvidersProps,
 } from '@components/common';
-import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
+import { ALGOLIA_PRODUCT_INDEX_NAME, IFIXIT_ORIGIN } from '@config/env';
 import { noindexDevDomains } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import {
@@ -59,7 +59,10 @@ export const getProductListServerSideProps = ({
    productListType,
 }: GetProductListServerSidePropsOptions): GetServerSideProps<ProductListTemplateProps> => {
    return async (context) => {
-      if (context.query._vercel_no_cache === '1') {
+      const forwardedHost = context.req.headers['x-forwarded-host'] as string;
+      const ifixitOrigin = ifixitOriginFromHost(forwardedHost);
+      const isProxied = ifixitOrigin !== IFIXIT_ORIGIN;
+      if (context.query._vercel_no_cache === '1' || isProxied) {
          context.res.setHeader(
             'Cache-Control',
             'no-store, no-cache, must-revalidate, stale-if-error=0'
@@ -79,9 +82,6 @@ export const getProductListServerSideProps = ({
       let productList: ProductList | null;
       let shouldRedirectToCanonical = false;
       let canonicalPath: string | null = null;
-
-      const forwardedHost = context.req.headers['x-forwarded-host'] as string;
-      const ifixitOrigin = ifixitOriginFromHost(forwardedHost);
 
       switch (productListType) {
          case ProductListType.AllParts: {

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -5,6 +5,7 @@ import {
 } from '@components/common';
 import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { noindexDevDomains } from '@helpers/next-helpers';
+import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import {
    destylizeDeviceItemType,
    destylizeDeviceTitle as destylizeDeviceTitle,
@@ -79,10 +80,12 @@ export const getProductListServerSideProps = ({
       let shouldRedirectToCanonical = false;
       let canonicalPath: string | null = null;
 
+      const ifixitOrigin = ifixitOriginFromHost(context.req.headers.host ?? '');
+
       switch (productListType) {
          case ProductListType.AllParts: {
             productList = await logAsync('findProductList', () =>
-               findProductList({ handle: { eq: 'Parts' } })
+               findProductList({ handle: { eq: 'Parts' } }, ifixitOrigin)
             );
             break;
          }
@@ -114,6 +117,7 @@ export const getProductListServerSideProps = ({
                         eqi: deviceTitle,
                      },
                   },
+                  ifixitOrigin,
                   itemType
                )
             );
@@ -131,7 +135,7 @@ export const getProductListServerSideProps = ({
          }
          case ProductListType.AllTools: {
             productList = await logAsync('findProductList', () =>
-               findProductList({ handle: { eq: 'Tools' } })
+               findProductList({ handle: { eq: 'Tools' } }, ifixitOrigin)
             );
             break;
          }
@@ -143,7 +147,7 @@ export const getProductListServerSideProps = ({
             );
 
             productList = await logAsync('findProductList', () =>
-               findProductList({ handle: { eqi: handle } })
+               findProductList({ handle: { eqi: handle } }, ifixitOrigin)
             );
 
             shouldRedirectToCanonical =
@@ -164,14 +168,17 @@ export const getProductListServerSideProps = ({
             );
 
             productList = await logAsync('findProductList', () =>
-               findProductList({
-                  handle: {
-                     eqi: handle,
+               findProductList(
+                  {
+                     handle: {
+                        eqi: handle,
+                     },
+                     type: {
+                        eq: 'marketing',
+                     },
                   },
-                  type: {
-                     eq: 'marketing',
-                  },
-               })
+                  ifixitOrigin
+               )
             );
             shouldRedirectToCanonical =
                typeof productList?.handle === 'string' &&
@@ -210,6 +217,7 @@ export const getProductListServerSideProps = ({
             url: urlFromContext(context),
             apiKey: productList.algolia.apiKey,
          },
+         ifixitOrigin,
       };
 
       const appMarkup = (

--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -16,10 +16,10 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { Card } from '@components/ui';
-import { IFIXIT_ORIGIN } from '@config/env';
 import { productListPath } from '@helpers/path-helpers';
 import { getProductListTitle } from '@helpers/product-list-helpers';
 import { cypressReplace, cypressWindowLog } from '@helpers/test-helpers';
+import { useAppContext } from '@ifixit/app';
 import { useLocalPreference } from '@ifixit/ui';
 import {
    ProductList as TProductList,
@@ -173,6 +173,8 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
       const ancestors = productList.ancestors;
       const parentCategory = ancestors[ancestors.length - 1];
 
+      const appContext = useAppContext();
+
       if (isFiltered) {
          return (
             <VStack
@@ -198,7 +200,7 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
                <Link
                   maxW="500px"
                   color="brand.500"
-                  href={`${IFIXIT_ORIGIN}/Search?query=${encodedQuery}`}
+                  href={`${appContext.ifixitOrigin}/Search?query=${encodedQuery}`}
                >
                   Search all of iFixit for&nbsp;
                   <Text as="span" fontWeight="bold">

--- a/frontend/templates/product-list/sections/RelatedPostsSection/index.tsx
+++ b/frontend/templates/product-list/sections/RelatedPostsSection/index.tsx
@@ -1,4 +1,5 @@
 import { Heading, SimpleGrid, VStack } from '@chakra-ui/react';
+import { useAppContext } from '@ifixit/app';
 import { fetchPosts, Post } from '@models/posts';
 import { useQuery } from '@tanstack/react-query';
 import { PostCard } from './PostCard';
@@ -58,10 +59,11 @@ const computeRelatedPostsKey = (tags: string[]) => [
 ];
 
 function usePosts(tags: string[]) {
+   const appContext = useAppContext();
    const query = useQuery(
       computeRelatedPostsKey(tags),
       async (): Promise<Post[]> => {
-         return await fetchPosts(tags);
+         return await fetchPosts(tags, appContext.ifixitOrigin);
       },
       {
          retryOnMount: false,

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -125,10 +125,11 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
          context.res.setHeader('X-Robots-Tag', 'noindex, follow');
       }
 
+      const forwardedHost = context.req.headers['x-forwarded-host'] as string;
       const pageProps: ProductTemplateProps = {
          layoutProps,
          appProps: {
-            ifixitOrigin: ifixitOriginFromHost(context.req.headers.host ?? ''),
+            ifixitOrigin: ifixitOriginFromHost(forwardedHost),
          },
          product,
       };

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -104,8 +104,7 @@ ProductTemplate.getLayout = function getLayout(page, pageProps) {
 
 export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
    serverSidePropsWrapper<ProductTemplateProps>(async (context) => {
-      const forwardedHost = context.req.headers['x-forwarded-host'] as string;
-      const ifixitOrigin = ifixitOriginFromHost(forwardedHost);
+      const ifixitOrigin = ifixitOriginFromHost(context);
       const isProxied = ifixitOrigin !== IFIXIT_ORIGIN;
       if (isProxied) {
          context.res.setHeader(

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -30,6 +30,7 @@ import { ReplacementGuidesSection } from './sections/ReplacementGuidesSection';
 import { ReviewsSection } from './sections/ReviewsSection';
 import { ServiceValuePropositionSection } from './sections/ServiceValuePropositionSection';
 import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
+import { ifixitOriginFromHost } from '@helpers/path-helpers';
 
 export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    const { product } = useProductTemplateProps();
@@ -126,7 +127,9 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
 
       const pageProps: ProductTemplateProps = {
          layoutProps,
-         appProps: {},
+         appProps: {
+            ifixitOrigin: ifixitOriginFromHost(context.req.headers.host ?? ''),
+         },
          product,
       };
       return {


### PR DESCRIPTION
When we're proxying our Next app on cominor, use relative urls for external links and api requests. This will prevent CORS errors in dev, and keep developers on the same domain when clicking on links.

The only place we are still using a hard coded origin is in frontend/pages/_document.tsx, since I don't think we have access to the request context in that file.

If the app is being visited at *.vercel.app or ifixit.com, then the IFIXIT_ORIGIN value will be used as before, so there should be no change in behavior.

## QA

I'm not sure how to reproduce the original problem with localhost or the previews.

However, let's be sure we're still using `IFIXIT_ORIGIN` on *.vercel.app.

Closes #1022