### PR TITLE
Sentry: Ignore some specific errors

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -25,5 +25,12 @@ Sentry.init({
    ignoreErrors: [
       'TypeError: NetworkError when attempting to fetch resource.',
       'TypeError: Network request failed',
+      // Algolia error when network requests fail.
+      // Only happens on iOS devices (across all browsers)
+      'RetryError: Unreachable hosts - your application id may be incorrect',
+      // Can't reproduce, promise rejection with an instance of a CustomEvent
+      // is unhandled.
+      // Only happens on Macs, mostly Chrome, but some on safari
+      'CustomEvent: Non-Error promise rejection captured with keys: currentTarget, detail, isTrusted, target',
    ],
 });


### PR DESCRIPTION
We've tried to get to the bottom of these errors in sentry and can't.

They certainly tend to occur more on some devices that others, but we still can't figure out why. We also have no reports of actual issues from users, just error records in Sentry.

So, let's stop seeing this noise and move on with our lives.

Closes #765 
Closes #979 
qa_req 0