### PR TITLE
Add delegate access token field in Strapi

### DIFF
--- a/backend/src/components/store/shopify-settings.json
+++ b/backend/src/components/store/shopify-settings.json
@@ -2,7 +2,8 @@
    "collectionName": "components_store_shopify_settings",
    "info": {
       "displayName": "shopifySettings",
-      "icon": "shopping-bag"
+      "icon": "shopping-bag",
+      "description": ""
    },
    "options": {},
    "attributes": {
@@ -13,6 +14,9 @@
       "storefrontAccessToken": {
          "type": "string",
          "required": true
+      },
+      "delegateAccessToken": {
+         "type": "string"
       }
    }
 }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -251,6 +251,7 @@ export type ComponentStoreHeaderInput = {
 
 export type ComponentStoreShopifySettings = {
    __typename?: 'ComponentStoreShopifySettings';
+   delegateAccessToken?: Maybe<Scalars['String']>;
    id: Scalars['ID'];
    storefrontAccessToken: Scalars['String'];
    storefrontDomain: Scalars['String'];
@@ -260,6 +261,7 @@ export type ComponentStoreShopifySettingsFiltersInput = {
    and?: InputMaybe<
       Array<InputMaybe<ComponentStoreShopifySettingsFiltersInput>>
    >;
+   delegateAccessToken?: InputMaybe<StringFilterInput>;
    not?: InputMaybe<ComponentStoreShopifySettingsFiltersInput>;
    or?: InputMaybe<
       Array<InputMaybe<ComponentStoreShopifySettingsFiltersInput>>
@@ -269,6 +271,7 @@ export type ComponentStoreShopifySettingsFiltersInput = {
 };
 
 export type ComponentStoreShopifySettingsInput = {
+   delegateAccessToken?: InputMaybe<Scalars['String']>;
    id?: InputMaybe<Scalars['ID']>;
    storefrontAccessToken?: InputMaybe<Scalars['String']>;
    storefrontDomain?: InputMaybe<Scalars['String']>;


### PR DESCRIPTION
This is a first step to address #1017. 

Changes to the frontend will be done in a separate PR

## QA

1. Open [Govinor instance](https://add-delegate-access-token-field.govinor.com/admin/content-manager/collectionType/api::store.store/4)
2. Verify that delegate access token field is present
    <img width="843" alt="image" src="https://user-images.githubusercontent.com/4640135/201999069-31cb7fe5-462d-489f-b968-bd4253f3aafa.png">

## ⚠️ After merge

Production instance of Strapi needs to be redeployed

cc @danielbeardsley @sterlinghirsh 
 