### PR TITLE
debug: log forwarded host headers

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -18,6 +18,11 @@ export function serverSidePropsWrapper<T extends { [key: string]: any }>(
          ...context.params,
          ...context.query,
       });
+      console.log({
+         'x-forwarded-host': context.req.headers['x-forwarded-host'],
+         'x-ifixit-forwarded-host':
+            context.req.headers['x-ifixit-forwarded-host'],
+      });
       return logAsync('getServerSideProps', () =>
          getServerSidePropsInternal(context)
       ).catch((err) => {


### PR DESCRIPTION
We tried to get around CORS errors in https://github.com/iFixit/react-commerce/pull/1025 by using the detected host for API requests when the app is proxied on cominor.

However, in https://github.com/iFixit/ifixit/pull/45577 it seems like the detected host isn't being used.

This logs the relevant headers so we can debug the problem.

qa_req 0

CC @danielbeardsley 