### PR TITLE
Reset page to zero when deselecting facets

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
@@ -49,12 +49,7 @@ export function CurrentRefinements() {
                                  aria-label={`Remove ${formattedFacetName}: ${refinement.label}`}
                                  onClick={() => {
                                     item.refine(refinement);
-                                    setIndexUiState((uiState) => {
-                                       return {
-                                          ...uiState,
-                                          page: NaN,
-                                       };
-                                    });
+                                    pagination.refine(0);
                                  }}
                               />
                            </Tag>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
@@ -11,11 +11,13 @@ import * as React from 'react';
 import {
    useClearRefinements,
    useCurrentRefinements,
+   useInstantSearch,
 } from 'react-instantsearch-hooks-web';
 
 export function CurrentRefinements() {
    const currentRefinements = useCurrentRefinements();
    const clearRefinements = useClearRefinements();
+   const { setIndexUiState } = useInstantSearch();
 
    return (
       <Collapse
@@ -47,6 +49,12 @@ export function CurrentRefinements() {
                                  aria-label={`Remove ${formattedFacetName}: ${refinement.label}`}
                                  onClick={() => {
                                     item.refine(refinement);
+                                    setIndexUiState((uiState) => {
+                                       return {
+                                          ...uiState,
+                                          page: NaN,
+                                       };
+                                    });
                                  }}
                               />
                            </Tag>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
@@ -17,7 +17,7 @@ import {
 export function CurrentRefinements() {
    const currentRefinements = useCurrentRefinements();
    const clearRefinements = useClearRefinements();
-   const { setIndexUiState } = useInstantSearch();
+   const pagination = usePagination();
 
    return (
       <Collapse

--- a/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
@@ -11,7 +11,7 @@ import * as React from 'react';
 import {
    useClearRefinements,
    useCurrentRefinements,
-   useInstantSearch,
+   usePagination,
 } from 'react-instantsearch-hooks-web';
 
 export function CurrentRefinements() {


### PR DESCRIPTION
Closes #1034 

Previously, when removing facet filters using the pill's `x` button, the page number would not reset to zero. This pulls fixes that by setting the page to `NaN` when a facet filter is removed using the `x` button.
<details>

![image](https://user-images.githubusercontent.com/95708883/202581350-e142f762-b817-4c5e-abb5-e055ca343c42.png)
</details>


QA
--

1. Visit the preview for this pull
2. Add filters to narrow your search
3. Go to any page other than the first page
4. Remove the filter by using the `X` button next to the filter.
5. Observe that the page is now on the first page
6. Check that the same behavior is on Tools