### PR TITLE
Disable caching for `react-commerce`

### DIFF
--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -43,6 +43,8 @@ export const DEFAULT_STORE_CODE = requireEnvVariable(
 
 export const POLYFILL_DOMAIN = process.env.NEXT_PUBLIC_POLYFILL_DOMAIN;
 
+export const CACHE_DISABLED = process.env.NEXT_PUBLIC_CACHE_DISABLED === 'true';
+
 function requireEnvVariable(
    env: string | null | undefined,
    envName: string

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -20,11 +20,6 @@ export function serverSidePropsWrapper<T extends { [key: string]: any }>(
          ...context.params,
          ...context.query,
       });
-      console.log({
-         'x-forwarded-host': context.req.headers['x-forwarded-host'],
-         'x-ifixit-forwarded-host':
-            context.req.headers['x-ifixit-forwarded-host'],
-      });
       return logAsync('getServerSideProps', () =>
          getServerSidePropsInternal(context)
       )

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -3,6 +3,8 @@ import { logAsync } from '@ifixit/helpers';
 import { setSentryPageContext } from '@ifixit/sentry';
 import * as Sentry from '@sentry/nextjs';
 import { PROD_USER_AGENT } from '@config/constants';
+import { clearCache } from '@lib/cache';
+import { CACHE_DISABLED } from '@config/env';
 
 export function serverSidePropsWrapper<T extends { [key: string]: any }>(
    getServerSidePropsInternal: GetServerSideProps<T>
@@ -25,10 +27,21 @@ export function serverSidePropsWrapper<T extends { [key: string]: any }>(
       });
       return logAsync('getServerSideProps', () =>
          getServerSidePropsInternal(context)
-      ).catch((err) => {
-         setSentryPageContext(context);
-         throw err;
-      });
+      )
+         .then((result) => {
+            if (CACHE_DISABLED || context.query._vercel_no_cache === '1') {
+               context.res.setHeader(
+                  'Cache-Control',
+                  'no-store, no-cache, must-revalidate, stale-if-error=0'
+               );
+               clearCache();
+            }
+            return result;
+         })
+         .catch((err) => {
+            setSentryPageContext(context);
+            throw err;
+         });
    };
 }
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -56,6 +56,7 @@ const moduleExports = {
       NEXT_PUBLIC_DEFAULT_STORE_CODE:
          process.env.NEXT_PUBLIC_DEFAULT_STORE_CODE,
       NEXT_PUBLIC_POLYFILL_DOMAIN: process.env.NEXT_PUBLIC_POLYFILL_DOMAIN,
+      NEXT_PUBLIC_CACHE_DISABLED: process.env.NEXT_PUBLIC_CACHE_DISABLED,
    },
    async rewrites() {
       return [

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -1,10 +1,8 @@
 import { Box } from '@chakra-ui/react';
-import { IFIXIT_ORIGIN } from '@config/env';
 import { flags } from '@config/flags';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { assertNever } from '@ifixit/helpers';
 import { DefaultLayout, getLayoutServerSideProps } from '@layouts/default';
-import { clearCache } from '@lib/cache';
 import { findPage } from '@models/page';
 import { GetServerSideProps } from 'next';
 import {
@@ -51,16 +49,6 @@ export const getServerSideProps: GetServerSideProps<PageTemplateProps> = async (
       };
    }
 
-   const ifixitOrigin = ifixitOriginFromHost(context);
-   const isProxied = ifixitOrigin !== IFIXIT_ORIGIN;
-   if (isProxied) {
-      context.res.setHeader(
-         'Cache-Control',
-         'no-store, no-cache, must-revalidate, stale-if-error=0'
-      );
-      clearCache();
-   }
-
    const layoutProps = await getLayoutServerSideProps();
    const page = await findPage({
       path: '/Store',
@@ -75,7 +63,7 @@ export const getServerSideProps: GetServerSideProps<PageTemplateProps> = async (
    const pageProps: PageTemplateProps = {
       layoutProps,
       appProps: {
-         ifixitOrigin,
+         ifixitOrigin: ifixitOriginFromHost(context),
       },
       page,
    };

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -3,7 +3,7 @@ import {
    AppProvidersProps,
    WithProvidersProps,
 } from '@components/common';
-import { ALGOLIA_PRODUCT_INDEX_NAME, IFIXIT_ORIGIN } from '@config/env';
+import { ALGOLIA_PRODUCT_INDEX_NAME } from '@config/env';
 import { noindexDevDomains } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import {
@@ -20,7 +20,6 @@ import {
    DefaultLayoutProps,
    WithLayoutProps,
 } from '@layouts/default';
-import { clearCache } from '@lib/cache';
 import {
    findProductList,
    ProductList,
@@ -58,20 +57,10 @@ export const getProductListServerSideProps = ({
    productListType,
 }: GetProductListServerSidePropsOptions): GetServerSideProps<ProductListTemplateProps> => {
    return async (context) => {
-      const ifixitOrigin = ifixitOriginFromHost(context);
-      const isProxied = ifixitOrigin !== IFIXIT_ORIGIN;
-      if (context.query._vercel_no_cache === '1' || isProxied) {
-         context.res.setHeader(
-            'Cache-Control',
-            'no-store, no-cache, must-revalidate, stale-if-error=0'
-         );
-         clearCache();
-      } else {
-         context.res.setHeader(
-            'Cache-Control',
-            'public, s-maxage=10, stale-while-revalidate=600'
-         );
-      }
+      context.res.setHeader(
+         'Cache-Control',
+         'public, s-maxage=10, stale-while-revalidate=600'
+      );
       noindexDevDomains(context);
 
       const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
@@ -80,6 +69,7 @@ export const getProductListServerSideProps = ({
       let productList: ProductList | null;
       let shouldRedirectToCanonical = false;
       let canonicalPath: string | null = null;
+      const ifixitOrigin = ifixitOriginFromHost(context);
 
       switch (productListType) {
          case ProductListType.AllParts: {

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -31,8 +31,6 @@ import { ReviewsSection } from './sections/ReviewsSection';
 import { ServiceValuePropositionSection } from './sections/ServiceValuePropositionSection';
 import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
-import { IFIXIT_ORIGIN } from '@config/env';
-import { clearCache } from '@lib/cache';
 
 export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    const { product } = useProductTemplateProps();
@@ -104,16 +102,6 @@ ProductTemplate.getLayout = function getLayout(page, pageProps) {
 
 export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
    serverSidePropsWrapper<ProductTemplateProps>(async (context) => {
-      const ifixitOrigin = ifixitOriginFromHost(context);
-      const isProxied = ifixitOrigin !== IFIXIT_ORIGIN;
-      if (isProxied) {
-         context.res.setHeader(
-            'Cache-Control',
-            'no-store, no-cache, must-revalidate, stale-if-error=0'
-         );
-         clearCache();
-      }
-
       noindexDevDomains(context);
       const { handle } = context.params || {};
       invariant(typeof handle === 'string', 'handle param is missing');
@@ -140,7 +128,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       const pageProps: ProductTemplateProps = {
          layoutProps,
          appProps: {
-            ifixitOrigin,
+            ifixitOrigin: ifixitOriginFromHost(context),
          },
          product,
       };


### PR DESCRIPTION
Turns off caching when the `CACHE_DISABLED` environment variable is set.

### Motivation

@danielbeardsley and I believe that caching in dev can lead to inconsistent results when QA'ing, and thus outweighs the benefits of snappy responses.

## QA

Make sure caching is turned on react-commerce, but not react-commerce-prod.

Connects #1022