### PR TITLE
Tests: Check for visible product title, price and sku

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -378,6 +378,7 @@ const ProductTitle = chakra(
             className={className}
             size="xl"
             fontFamily="Archivo Black"
+            data-testid="product-title"
          >
             {children}
          </Heading>

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -129,7 +129,9 @@ export function ProductSection({
                position="relative"
             >
                {selectedVariant.sku && (
-                  <Text color="gray.500">Item # {selectedVariant.sku}</Text>
+                  <Text color="gray.500" data-testid="product-sku">
+                     Item # {selectedVariant.sku}
+                  </Text>
                )}
                <ProductTitle mb="2.5">{product.title}</ProductTitle>
                {isForSale && (

--- a/frontend/test/cypress/integration/product/pro_user.cy.ts
+++ b/frontend/test/cypress/integration/product/pro_user.cy.ts
@@ -10,6 +10,14 @@ describe('Pro user test', () => {
             expect(productTitle).to.equal('Repair Business Toolkit');
          });
 
+      // Assert product sku is visible
+      cy.findByTestId('product-sku')
+         .should('be.visible')
+         .invoke('text')
+         .then((productSku) => {
+            expect(productSku).to.match(/IF\d*\-\d*/g);
+         });
+
       // Get price from page
       cy.findAllByTestId('product-price')
          .first()

--- a/frontend/test/cypress/integration/product/pro_user.cy.ts
+++ b/frontend/test/cypress/integration/product/pro_user.cy.ts
@@ -2,31 +2,11 @@ describe('Pro user test', () => {
    it('will give pro users a discount', () => {
       cy.loadProductPageByPath('/products/repair-business-toolkit');
 
-      // Assert product title is visible
-      cy.findByTestId('product-title')
-         .should('be.visible')
-         .invoke('text')
-         .then((productTitle) => {
-            expect(productTitle).to.equal('Repair Business Toolkit');
-         });
-
-      // Assert product sku is visible
-      cy.findByTestId('product-sku')
-         .should('be.visible')
-         .invoke('text')
-         .then((productSku) => {
-            expect(productSku).to.match(/IF\d*\-\d*/g);
-         });
-
       // Get price from page
       cy.findAllByTestId('product-price')
          .first()
-         .should('be.visible')
          .invoke('text')
          .then((originalPriceString) => {
-            // regex to match $299.99 with dollar sign
-            expect(originalPriceString).to.match(/\$\d*\.\d*/g);
-
             // Login as pro
             cy.interceptLogin({ discount_tier: 'pro_4' });
             cy.reload();

--- a/frontend/test/cypress/integration/product/pro_user.cy.ts
+++ b/frontend/test/cypress/integration/product/pro_user.cy.ts
@@ -21,8 +21,12 @@ describe('Pro user test', () => {
       // Get price from page
       cy.findAllByTestId('product-price')
          .first()
+         .should('be.visible')
          .invoke('text')
          .then((originalPriceString) => {
+            // regex to match $299.99 with dollar sign
+            expect(originalPriceString).to.match(/\$\d*\.\d*/g);
+
             // Login as pro
             cy.interceptLogin('pro_4');
             cy.reload();

--- a/frontend/test/cypress/integration/product/pro_user.cy.ts
+++ b/frontend/test/cypress/integration/product/pro_user.cy.ts
@@ -2,6 +2,14 @@ describe('Pro user test', () => {
    it('will give pro users a discount', () => {
       cy.loadProductPageByPath('/products/repair-business-toolkit');
 
+      // Assert product title is visible
+      cy.findByTestId('product-title')
+         .should('be.visible')
+         .invoke('text')
+         .then((productTitle) => {
+            expect(productTitle).to.equal('Repair Business Toolkit');
+         });
+
       // Get price from page
       cy.findAllByTestId('product-price')
          .first()

--- a/frontend/test/cypress/integration/product/pro_user.cy.ts
+++ b/frontend/test/cypress/integration/product/pro_user.cy.ts
@@ -28,7 +28,7 @@ describe('Pro user test', () => {
             expect(originalPriceString).to.match(/\$\d*\.\d*/g);
 
             // Login as pro
-            cy.interceptLogin('pro_4');
+            cy.interceptLogin({ discount_tier: 'pro_4' });
             cy.reload();
 
             // Wait until the pro icon is shown.

--- a/frontend/test/cypress/integration/product/product_page.cy.ts
+++ b/frontend/test/cypress/integration/product/product_page.cy.ts
@@ -1,0 +1,32 @@
+describe('Product page test', () => {
+   it('verify product title, price and sku are visible', () => {
+      cy.loadProductPageByPath('/products/repair-business-toolkit');
+
+      // Assert product title is visible
+      cy.findByTestId('product-title')
+         .should('be.visible')
+         .invoke('text')
+         .then((productTitle) => {
+            expect(productTitle).to.equal('Repair Business Toolkit');
+         });
+
+      // Assert product sku is visible
+      cy.findByTestId('product-sku')
+         .should('be.visible')
+         .invoke('text')
+         .then((productSku) => {
+            expect(productSku).to.match(/IF\d*\-\d*/g);
+         });
+
+      // Get price from page
+      cy.findAllByTestId('product-price')
+         .first()
+         .should('be.visible')
+         .invoke('text')
+         .then((originalPriceString) => {
+            // regex to match $299.99 with dollar sign
+            expect(originalPriceString).to.match(/\$\d*\.\d*/g);
+         });
+   });
+});
+export {};

--- a/frontend/test/cypress/support/commands.ts
+++ b/frontend/test/cypress/support/commands.ts
@@ -38,15 +38,19 @@ Cypress.Commands.add('loadProductPageByPath', (path: string) => {
    cy.wait('@user-api');
 });
 
-Cypress.Commands.add('interceptLogin', (discount_tier?: string) => {
+Cypress.Commands.add('interceptLogin', (optional?: Object) => {
+   let defaultParams = {
+      userid: 1,
+      algoliaApiKeyProduct: null,
+      username: 'john',
+      unique_username: 'john123',
+   };
+
    cy.intercept(
       { method: 'GET', url: '/api/2.0/user' },
       {
-         userid: 1,
-         algoliaApiKeyProduct: null,
-         username: 'john',
-         unique_username: 'john123',
-         discount_tier: discount_tier,
+         ...defaultParams,
+         ...optional,
       }
    ).as('user-api');
 });

--- a/frontend/test/cypress/support/index.d.ts
+++ b/frontend/test/cypress/support/index.d.ts
@@ -12,6 +12,6 @@ declare namespace Cypress {
       times(times: number, callback: (index: number) => void): Chainable;
       loadCollectionPageByPath(path: string): Chainable;
       loadProductPageByPath(path: string): Chainable;
-      interceptLogin(discount_tier?: string): Chainable;
+      interceptLogin(optional?: Object): Chainable;
    }
 }


### PR DESCRIPTION
## Summary
We recently added [pro user product page test](https://github.com/iFixit/react-commerce/pull/1049) which compares the product prices.

This pull adds additional assertions to check product title, sku and price. Added assertions 
in `pro_user` test since we already visit product page (instead of creating a new one). 

Also refactored `interceptLogin()` command to accept additional/optional params, 
instead of only passing the argument for `discount_tier`.

## QA 
Make sure the Cypress tests are passing in CI. 

cc: @mlahargou 
Closes: https://github.com/iFixit/react-commerce/issues/1043