### PR TITLE
Tests: Add tests for Fix kit / Part Only selection

### DIFF
--- a/frontend/test/cypress/integration/product/fix_kit.cy.ts
+++ b/frontend/test/cypress/integration/product/fix_kit.cy.ts
@@ -1,0 +1,29 @@
+describe('Fix Kit and Part Only test', () => {
+   beforeEach(() => {
+      cy.loadProductPageByPath('/products/iphone-6s-plus-replacement-battery');
+   });
+
+   it('test kit contents and product skus', () => {
+      cy.findByText('Fix Kit').click();
+      cy.findByText('Kit contents').should('be.visible');
+      cy.findByText('Assembly contents').should('not.be.visible');
+
+      cy.findByTestId('product-sku')
+         .should('be.visible')
+         .invoke('text')
+         .then((fixKitSku) => {
+            cy.findByText('Part Only').click();
+
+            cy.findByText('Assembly contents').should('be.visible');
+            cy.findByText('Kit contents').should('not.be.visible');
+
+            cy.findByTestId('product-sku')
+               .should('be.visible')
+               .invoke('text')
+               .then((partOnlySku) => {
+                  expect(fixKitSku).to.not.equal(partOnlySku);
+               });
+         });
+   });
+});
+export {};

--- a/frontend/test/cypress/integration/product/fix_kit.cy.ts
+++ b/frontend/test/cypress/integration/product/fix_kit.cy.ts
@@ -25,5 +25,17 @@ describe('Fix Kit and Part Only test', () => {
                });
          });
    });
+
+   it('test product image changes', () => {
+      cy.findByText('Fix Kit').click();
+
+      cy.get('img[alt$="Fix Kit"]').should('be.visible');
+      cy.get('img[alt$="Part Only"]').should('not.exist');
+
+      cy.findByText('Part Only').click();
+
+      cy.get('img[alt$="Part Only"]').should('be.visible');
+      cy.get('img[alt$="Fix Kit"]').should('not.exist');
+   });
 });
 export {};


### PR DESCRIPTION
## Summary
Added test for `Fix Kit`/`Part Only` product selection which tests the following:
- If `Fix kit` is selected, verifies that the `kit contents` section is displayed.
- If `Part only` is selected/clicked, verifies that the `Assembly contents` section is displayed.
- Verifies that the product images and skus change when switching between `Fix kit` / `Part Only`.

Note: didn't test for the product price change since they could potentially be the same price. Sometimes, the fix kit is cheaper than the part only, for example: [when the fix kit is on sale](https://react-commerce.vercel.app/products/iphone-6s-plus-replacement-battery).

## QA notes
Make sure the Cypress tests are passing in CI.

Closes #1045