### PR TITLE
Hotfix: Handle malformed collection menu params

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -217,6 +217,16 @@ export function InstantSearchProvider({
                   ? filter
                   : {};
 
+            Object.entries(filterObject).forEach(([attribute, value]) => {
+               const widgetType = getFacetWidgetType(attribute);
+               if (
+                  widgetType === FacetWidgetType.Menu &&
+                  Array.isArray(value)
+               ) {
+                  filterObject[attribute] = value[0];
+               }
+            });
+
             if (deviceHandle && itemType) {
                filterObject['facet_tags.Item Type'] = destylizeDeviceItemType(
                   decodeURIComponent(itemType)

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -1,4 +1,5 @@
 import { FacetWidgetType, ProductListType } from '@models/product-list';
+import { z } from 'zod';
 
 type ProductListAttributes = {
    filters?: string | null;
@@ -73,6 +74,12 @@ const facetWidgetTypeMap: Record<string, FacetWidgetType> = {
 
 export function getFacetWidgetType(attribute: string) {
    return facetWidgetTypeMap[attribute] ?? FacetWidgetType.Menu;
+}
+
+const RefinementListValueSchema = z.string().array().nonempty();
+
+export function isValidRefinementListValue(value: unknown) {
+   return RefinementListValueSchema.safeParse(value).success;
 }
 
 export function isPartsProductList<


### PR DESCRIPTION
Prevents 500s when the menu param is malformed.

## CR

Multiselect (aka refinement) facets use array indeces in the query params (like `[facet_tags.Price Range][0]=10-20`);

Single selects don't have that (e.g. `[worksin]=Device Name`).

However, if a user visits a malformed url that uses array indices on a menu facet, and we tell Algolia that the menu has an array of values, Algolia's code will throw.

The solution: detect array indices on these facets and ignore them before sending the state object to Algolia.

## QA

Visit /Parts?filter[facet_tags.Item Type][0]=Batteries, and make sure the item type filter is set correctly and that the page doesn't 500, and the url is quickly reverted to /Parts?filter[facet_tags.Item Type]=Batteries

Also make sure that any invalid filter params are ignored. You'll have to do some creative url hacking.

Closes #1056