### PR TITLE
Fix Jest CI

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -8,17 +8,20 @@ jobs:
       steps:
          - name: Checkout
            uses: actions/checkout@v2
+         - uses: actions/setup-node@v3
+           with:
+              node-version: 16
          - name: Install pnpm
-           uses: pnpm/action-setup@v2.0.1
+           uses: pnpm/action-setup@v2.2.4
            with:
               version: 7
               run_install: false
          - name: Install workspaces
            env:
               FONT_AWESOME_NPM_TOKEN: ${{ secrets.FONT_AWESOME_NPM_TOKEN }}
-           run: pnpm install
+           run: pnpm install:all
          - name: Run Jest tests
-           run: cd frontend; pnpm test
+           run: pnpm test
            env:
               NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
               ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "start:frontend": "cd frontend && pnpm run start",
       "start": "cross-env FORCE_COLOR=1 npm-run-all -l -p start:*",
       "strapi": "cd backend && pnpm run strapi",
-      "test": "echo \"Error: no test specified\" && exit 1",
+      "test": "pnpm run -r test",
       "transform-svg": "cd frontend && pnpm run transform-svg",
       "cypress:open": "cd frontend && pnpm run cypress:open",
       "cypress:run": "cd frontend && pnpm run cypress:run",


### PR DESCRIPTION
This has been extracted from #975 

There are a few issues that break tests with updated dependencies, such as a version of the pnpm action that does not support pnpm v7 and a wrong command to install dependencies.

qa_req 0