### PR TITLE
View Stats Tracking: add view count pixel

### DIFF
--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -18,6 +18,8 @@ export const STRAPI_ORIGIN = requireEnvVariable(
    'NEXT_PUBLIC_STRAPI_ORIGIN'
 );
 
+export const PIXEL_PING_URL = process.env.NEXT_PUBLIC_PIXEL_PING_URL;
+
 export const MATOMO_URL = process.env.NEXT_PUBLIC_MATOMO_URL;
 
 export const GA_URL = process.env.NEXT_PUBLIC_GA_URL;

--- a/frontend/templates/product/components/PixelPing.tsx
+++ b/frontend/templates/product/components/PixelPing.tsx
@@ -1,0 +1,12 @@
+import { PIXEL_PING_URL } from '@config/env';
+
+export const PixelPing = ({ productcode }: { productcode: string }) => {
+   if (!PIXEL_PING_URL) {
+      return null;
+   }
+   const key = `ifixit/product/${productcode}/en`;
+   const url = `${PIXEL_PING_URL}?key=${encodeURIComponent(key)}`;
+   return (
+      <img src={url} width="1" height="1" alt="" style={{ display: 'none' }} />
+   );
+};

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -94,7 +94,9 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
             <FeaturedProductsSection product={product} />
             <LifetimeWarrantySection variant={selectedVariant} />
          </Box>
-         {product.productcode && <PixelPing productcode={product.productcode} />}
+         {product.productcode && (
+            <PixelPing productcode={product.productcode} />
+         )}
       </React.Fragment>
    );
 };

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -16,6 +16,7 @@ import { findProduct } from '@models/product';
 import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
 import { GetServerSideProps } from 'next';
 import * as React from 'react';
+import { PixelPing } from './components/PixelPing';
 import { SecondaryNavigation } from './components/SecondaryNavigation';
 import { useIsProductForSale } from './hooks/useIsProductForSale';
 import {
@@ -93,6 +94,7 @@ export const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
             <FeaturedProductsSection product={product} />
             <LifetimeWarrantySection variant={selectedVariant} />
          </Box>
+         {product.productcode && <PixelPing productcode={product.productcode} />}
       </React.Fragment>
    );
 };


### PR DESCRIPTION
Our old product page used a tracking pixel from our internal pixel-ping service. This only counts views in aggregate, no PII is kept or cookies set. this is the same service and stats used on other doc types.

We forgot to include this when re-creating the product page because there's no visible component.

Closes #1060 