### PR TITLE
Tests: Add test for a product with different variants

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -59,6 +59,7 @@ export function ProductOptions({
                         onChange={(event) => {
                            onChange(event.target.value);
                         }}
+                        data-testid="product-option-selector"
                      >
                         {option.values.map((value) => {
                            const { exact, variant } = findVariant(

--- a/frontend/test/cypress/integration/product/product_option.cy.ts
+++ b/frontend/test/cypress/integration/product/product_option.cy.ts
@@ -1,0 +1,65 @@
+describe('Product option test', () => {
+   it('test different styles', function () {
+      cy.loadProductPageByPath('/products/repair-business-toolkit');
+
+      cy.findByText('Style').should('be.visible');
+      cy.findByTestId('product-option-selector').as('selector');
+
+      // Get the price, sku, and name for the first product option
+      cy.findAllByTestId('product-price')
+         .first()
+         .invoke('text')
+         .as('firstOptionPrice');
+      cy.findAllByTestId('product-sku')
+         .first()
+         .invoke('text')
+         .as('firstOptionSkuText');
+      cy.get('@selector')
+         .get('option:selected')
+         .invoke('text')
+         .as('firstOptionName');
+
+      // Add the first product option to the cart
+      cy.findByTestId('product-add-to-cart-button').click();
+      cy.findByTestId('cart-drawer-close').click();
+
+      cy.get('@selector').select(1);
+
+      // Get the price, sku, and name for the second product option
+      cy.findAllByTestId('product-price')
+         .first()
+         .invoke('text')
+         .as('secondOptionPrice');
+      cy.findAllByTestId('product-sku')
+         .first()
+         .invoke('text')
+         .as('secondOptionSkuText');
+      cy.get('@selector')
+         .get('option:selected')
+         .invoke('text')
+         .as('secondOptionName');
+
+      // Add the second product option to the cart
+      cy.findByTestId('product-add-to-cart-button').click();
+
+      // Assert that the cart drawer contains the skus and prices of the added products
+      cy.findByTestId('cart-drawer-body')
+         .should('be.visible')
+         .then((el) => {
+            // Parse out the skus from the skuTexts which are in form of "Item # IF145-278-14"
+            const sku1 = this.firstOptionSkuText.match(/IF\d*\-\d*\-\d*/g)[0];
+            const sku2 = this.secondOptionSkuText.match(/IF\d*\-\d*\-\d*/g)[0];
+
+            cy.wrap(el).contains(sku1);
+            cy.wrap(el).contains(sku2);
+            cy.wrap(el).contains(this.firstOptionPrice);
+            cy.wrap(el).contains(this.secondOptionPrice);
+
+            expect(sku1).to.not.eq(sku2);
+            expect(this.firstOptionName).to.not.eq(this.secondOptionName);
+            expect(this.firstOptionPrice).to.not.eq(this.secondOptionPrice);
+         });
+   });
+});
+
+export {};

--- a/frontend/test/cypress/integration/product/product_option.cy.ts
+++ b/frontend/test/cypress/integration/product/product_option.cy.ts
@@ -23,7 +23,11 @@ describe('Product option test', () => {
       cy.findByTestId('product-add-to-cart-button').click();
       cy.findByTestId('cart-drawer-close').click();
 
-      cy.get('@selector').select(1);
+      cy.get('@selector')
+         .select(1)
+         .then(() => {
+            cy.contains(this.firstOptionSkuText).should('not.exist');
+         });
 
       // Get the price, sku, and name for the second product option
       cy.findAllByTestId('product-price')

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -128,7 +128,7 @@ export function CartDrawer() {
                      </HStack>
                   </DrawerHeader>
 
-                  <DrawerBody p="0">
+                  <DrawerBody p="0" data-testid="cart-drawer-body">
                      {cart.isError && (
                         <Alert
                            status="error"


### PR DESCRIPTION
## Summary
Added a new test for a product with different variants.

It visits a product page, adds two product options/variants to the cart.
Then opens up the cart-drawer(on the right side), and checks that the cart
contains the price, and SKU for each of the added product variants. 

## QA notes
Make sure the Cypress tests are passing in CI.

Closes #1044