### PR TITLE
Fix flaky Cypress test

### DIFF
--- a/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
@@ -79,7 +79,7 @@ export function ProductListChildrenSection({
          >
             <SimpleGrid
                ref={gridRef}
-               data-testid="product-list-devices"
+               data-testid="product-list-children"
                columns={{
                   base: 1,
                   sm: 2,


### PR DESCRIPTION
extracted from #975 

closes #1064

This PR fixes a test that becomes flaky once we upgrade to React 18

qa_req 0