### PR TITLE
Increase product page alert paragraph spacing

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -525,6 +525,9 @@ function AlertText({ children, colorScheme }: AlertTextProps) {
             'a:hover': {
                color: `${colorScheme}.800`,
             },
+            'p:not(:first-of-type)': {
+               mt: 2,
+            },
          }}
          dangerouslySetInnerHTML={{
             __html: children,


### PR DESCRIPTION
closes #954 

## QA

1. Open [Vercel preview](https://react-commerce-git-increase-product-page-alert-pa-bc6d9e-ifixit.vercel.app/products/iphone-xr-screen)
2. Verify that #954 is fixed