### PR TITLE
Revert image widths in guideImageSizeMap

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -121,7 +121,6 @@ const moduleExports = {
          'guide-images.cdn.ifixit.com',
          process.env.STRAPI_IMAGE_DOMAIN,
       ].filter((domain) => domain),
-      imageSizes: [41, 70, 110, 170, 250, 400, 600],
    },
    i18n: {
       locales: ['en-US'],

--- a/packages/ui/misc/ResponsiveImage/iFixitUtils.ts
+++ b/packages/ui/misc/ResponsiveImage/iFixitUtils.ts
@@ -7,13 +7,13 @@ type SizeMap = {
 
 // The following lists should be sorted in order of ascending width.
 export const guideImageSizeMap: SizeMap = [
-   { name: 'mini', width: 41 },
-   { name: 'thumbnail', width: 70 },
-   { name: '140x105', width: 110 },
-   { name: '200x150', width: 170 },
-   { name: 'standard', width: 250 },
-   { name: '440x330', width: 400 },
-   { name: 'medium', width: 600 },
+   { name: 'mini', width: 56 },
+   { name: 'thumbnail', width: 96 },
+   { name: '140x105', width: 140 },
+   { name: '200x150', width: 200 },
+   { name: 'standard', width: 300 },
+   { name: '440x330', width: 440 },
+   { name: 'medium', width: 592 },
    { name: 'large', width: 800 },
    { name: 'huge', width: 1600 },
 ];


### PR DESCRIPTION
closes #1039 

### QA

1. Visit Vercel preview
2. Verify that images are now generated according to the default imageSizes + deviceSizes rounded up to the nearest available format offered by the ifixit api
