### PR TITLE
Add `hreflang`s to product page

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6405,6 +6405,7 @@ export type FindProductQuery = {
       metaTitle?: { __typename?: 'Metafield'; value: string } | null;
       shortDescription?: { __typename?: 'Metafield'; value: string } | null;
       oemPartnership?: { __typename?: 'Metafield'; value: string } | null;
+      enabledDomains?: { __typename?: 'Metafield'; value: string } | null;
       featuredImage?: { __typename?: 'Image'; id?: string | null } | null;
       images: {
          __typename?: 'ImageConnection';
@@ -6685,6 +6686,9 @@ export const FindProductDocument = `
       value
     }
     oemPartnership: metafield(namespace: "ifixit", key: "oem_partnership_json") {
+      value
+    }
+    enabledDomains: metafield(namespace: "ifixit", key: "enabled_domains") {
       value
     }
     featuredImage {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -72,6 +72,9 @@ query findProduct($handle: String) {
       ) {
          value
       }
+      enabledDomains: metafield(namespace: "ifixit", key: "enabled_domains") {
+         value
+      }
       featuredImage {
          id
       }

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -106,6 +106,9 @@ export async function findProduct({ handle, storeCode }: FindProductArgs) {
       oemPartnership: parseOemPartnership(
          response.product.oemPartnership?.value
       ),
+      enabledDomains: parseEnabledDomains(
+         response.product.enabledDomains?.value
+      ),
    };
 }
 
@@ -432,6 +435,31 @@ function parseOemPartnership(
       return result.data;
    }
    logParseErrors(result.error, 'oem partnership metafield');
+   return null;
+}
+
+const EnabledDomainsSchema = z
+   .object({
+      domain: z.string().url(),
+      locale: z.string(),
+   })
+   .array()
+   .optional()
+   .nullable();
+
+function parseEnabledDomains(value: string | null | undefined) {
+   if (value == null) {
+      return null;
+   }
+   const rawJson = JSON.parse(value);
+   if (rawJson == null) {
+      return null;
+   }
+   const result = EnabledDomainsSchema.safeParse(rawJson);
+   if (result.success) {
+      return result.data;
+   }
+   logParseErrors(result.error, 'enabled domains metafield');
    return null;
 }
 

--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -52,6 +52,15 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
          <link rel="canonical" href={canonicalUrl} />
          <meta property="og:url" content={canonicalUrl} />
 
+         {product.enabledDomains?.map((store) => (
+            <link
+               key={store.domain}
+               rel="alternate"
+               hrefLang={store.locale}
+               href={`${store.domain}/products/${product.handle}`}
+            />
+         ))}
+
          {genericImages.length > 0 &&
             genericImages.map((image) => (
                <meta key={image.id} property="og:image" content={image.url} />


### PR DESCRIPTION
Adds hreflangs to all other stores (including the US store) to the `<head>`, like we do on the shopify theme stores.

## QA

Make sure we get the hreflangs in the head for products that are enabled on other stores. Verify that the urls are correctly formatted by clicking on one of them.

Connects #976