### PR TITLE
Matomo P3: Update Footer Tracking

### DIFF
--- a/packages/footer/components/Navigation.tsx
+++ b/packages/footer/components/Navigation.tsx
@@ -76,7 +76,10 @@ type FooterNavigationLinkProps = BoxProps & {
 
 export const FooterNavigationLink = forwardRef<FooterNavigationLinkProps, 'a'>(
    ({ icon, children, ...otherProps }, ref) => {
-      const trackedOnClick = useTrackedOnClick(otherProps);
+      const trackedOnClick = useTrackedOnClick({
+         clickName: children?.toString(),
+         ...otherProps,
+      });
       return (
          <Box
             ref={ref}

--- a/packages/footer/components/StoreMenu.tsx
+++ b/packages/footer/components/StoreMenu.tsx
@@ -11,6 +11,7 @@ import {
    MenuItemProps,
    Text,
 } from '@chakra-ui/react';
+import { useTrackedOnClick } from '../hooks/useTrackedOnClick';
 
 type StoreMenuButtonProps = MenuButtonProps & {
    icon?: React.ReactNode;
@@ -53,8 +54,19 @@ type StoreMenuItemProps = Omit<MenuItemProps, 'children'> & {
 
 export const StoreMenuItem = forwardRef<StoreMenuItemProps, 'div'>(
    ({ icon, name, currency, ...otherProps }, ref) => {
+      const trackedOnClick = useTrackedOnClick({
+         clickName: name,
+         isStoreLink: true,
+         ...otherProps,
+      });
       return (
-         <MenuItem ref={ref} fontSize="sm" color="black" {...otherProps}>
+         <MenuItem
+            ref={ref}
+            fontSize="sm"
+            color="black"
+            onClick={trackedOnClick}
+            {...otherProps}
+         >
             <Flex w="full" align="center">
                {icon}
                <Text ref={ref} ml="3" mt="-1px" flexGrow={1}>

--- a/packages/footer/hooks/useTrackedOnClick.tsx
+++ b/packages/footer/hooks/useTrackedOnClick.tsx
@@ -19,8 +19,10 @@ export function useTrackedOnClick<T>({
    const trackedOnClick: React.MouseEventHandler<T> = React.useCallback(
       (e) => {
          trackClick({
-            eventCategory: 'Footer',
-            eventAction: `Footer ${LinkType} Link - \"${clickName || href || 'undefined'}\" - Click`,
+            eventCategory: `Footer ${LinkType} Link`,
+            eventAction: `Footer ${LinkType} Link - \"${
+               clickName || href || 'undefined'
+            }\" - Click`,
          });
          onClick?.(e);
       },

--- a/packages/footer/hooks/useTrackedOnClick.tsx
+++ b/packages/footer/hooks/useTrackedOnClick.tsx
@@ -4,18 +4,20 @@ import { TrackingContext } from './TrackingContext';
 type UseFooterLinkTrackingProps<T> = {
    href?: string;
    onClick?: React.MouseEventHandler<T>;
+   clickName?: string;
 };
 
 export function useTrackedOnClick<T>({
    href,
    onClick,
+   clickName,
 }: UseFooterLinkTrackingProps<T>) {
    const { trackClick } = React.useContext(TrackingContext);
    const trackedOnClick: React.MouseEventHandler<T> = React.useCallback(
       (e) => {
          trackClick({
             eventCategory: 'Footer',
-            eventAction: `Link Click - ${href}`,
+            eventAction: `Footer Link - ${clickName || href || 'undefined'} - Click`,
          });
          onClick?.(e);
       },

--- a/packages/footer/hooks/useTrackedOnClick.tsx
+++ b/packages/footer/hooks/useTrackedOnClick.tsx
@@ -14,13 +14,13 @@ export function useTrackedOnClick<T>({
    clickName,
    isStoreLink,
 }: UseFooterLinkTrackingProps<T>) {
-   const LinkType = isStoreLink ? 'Stores' : 'iFixit';
+   const linkType = isStoreLink ? 'Stores' : 'iFixit';
    const { trackClick } = React.useContext(TrackingContext);
    const trackedOnClick: React.MouseEventHandler<T> = React.useCallback(
       (e) => {
          trackClick({
-            eventCategory: `Footer ${LinkType} Link`,
-            eventAction: `Footer ${LinkType} Link - \"${
+            eventCategory: `Footer ${linkType} Link`,
+            eventAction: `Footer ${linkType} Link - \"${
                clickName || href || 'undefined'
             }\" - Click`,
          });

--- a/packages/footer/hooks/useTrackedOnClick.tsx
+++ b/packages/footer/hooks/useTrackedOnClick.tsx
@@ -5,19 +5,22 @@ type UseFooterLinkTrackingProps<T> = {
    href?: string;
    onClick?: React.MouseEventHandler<T>;
    clickName?: string;
+   isStoreLink?: boolean;
 };
 
 export function useTrackedOnClick<T>({
    href,
    onClick,
    clickName,
+   isStoreLink,
 }: UseFooterLinkTrackingProps<T>) {
+   const LinkType = isStoreLink ? 'Stores' : 'iFixit';
    const { trackClick } = React.useContext(TrackingContext);
    const trackedOnClick: React.MouseEventHandler<T> = React.useCallback(
       (e) => {
          trackClick({
             eventCategory: 'Footer',
-            eventAction: `Footer Link - ${clickName || href || 'undefined'} - Click`,
+            eventAction: `Footer ${LinkType} Link - \"${clickName || href || 'undefined'}\" - Click`,
          });
          onClick?.(e);
       },


### PR DESCRIPTION
## Overview 
This pull updates the current tracking function we already use for the footer to match the spec from [the spreadsheet](https://docs.google.com/spreadsheets/d/16Xas1pHf_K7FmfOX3yX2mYgeYr2DIENr8cyQp19FZkA/edit?pli=1#gid=1839136207&fvid=1617862179).

We already had this tracking mechanism in place, so this just modifies what we actually send in the event action as well as adds tracking to the store change button.

## QA
Check that the event shows up in matomo or GA for events 125-143 from [the spreadsheet](https://docs.google.com/spreadsheets/d/16Xas1pHf_K7FmfOX3yX2mYgeYr2DIENr8cyQp19FZkA/edit?pli=1#gid=1839136207&fvid=1617862179).

Closes https://github.com/iFixit/ifixit/issues/44680 (and lines 125-143 from the spreadsheet)