### PR TITLE
Product pages: cache them

### DIFF
--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -107,6 +107,11 @@ ProductTemplate.getLayout = function getLayout(page, pageProps) {
 
 export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
    serverSidePropsWrapper<ProductTemplateProps>(async (context) => {
+      context.res.setHeader(
+         'Cache-Control',
+         'public, s-maxage=60, stale-while-revalidate=600'
+      );
+
       noindexDevDomains(context);
       const { handle } = context.params || {};
       invariant(typeof handle === 'string', 'handle param is missing');


### PR DESCRIPTION
Cache product pages for a minute and set "stale-while-revalidate" to 10 minutes. Product page data *doesn't* change much, so caching is fairly sensible. Let's start with 1/10 mins and see how we feel.