### PR TITLE
Product images: use srcset for thumbnails

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -267,22 +267,7 @@ function ProductOptionImage({ image, exactMatch }: ProductOptionImageProps) {
          </Flex>
       );
    }
-   const ratio =
-      image.width != null && image.height != null
-         ? image.width / image.height
-         : null;
 
-   if (ratio == null) {
-      return (
-         <Img
-            h="16"
-            src={image.url}
-            alt=""
-            objectFit="contain"
-            opacity={exactMatch ? 1 : 0.4}
-         />
-      );
-   }
    return (
       <Box
          h="16"

--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -270,19 +270,13 @@ function ProductOptionImage({ image, exactMatch }: ProductOptionImageProps) {
    }
 
    return (
-      <Box
-         h="16"
-         position="relative"
-         overflow="hidden"
-         mb="1"
-         opacity={exactMatch ? 1 : 0.4}
-      >
+      <Box h="16" position="relative" mb="1" opacity={exactMatch ? 1 : 0.4}>
          <ResponsiveImage
+            height={64 /* chakra theme sizes.16 = 4em == 70 */}
+            width={64}
             src={image.url}
             alt=""
-            layout="fill"
             objectFit="contain"
-            sizes={theme.sizes[16]}
          />
       </Box>
    );

--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -4,7 +4,6 @@ import {
    Flex,
    HStack,
    Image,
-   Img,
    Select,
    SimpleGrid,
    Text,
@@ -15,6 +14,7 @@ import { faImageSlash } from '@fortawesome/pro-duotone-svg-icons';
 import type { Product } from '@models/product';
 import * as React from 'react';
 import { FaIcon } from '@ifixit/icons';
+import { ResponsiveImage } from '@ifixit/ui';
 
 export type ProductOptionsProps = {
    product: Product;
@@ -247,6 +247,7 @@ type ProductOptionImageProps = {
 };
 
 function ProductOptionImage({ image, exactMatch }: ProductOptionImageProps) {
+   const theme = useTheme();
    if (!image) {
       return (
          <Flex
@@ -276,14 +277,12 @@ function ProductOptionImage({ image, exactMatch }: ProductOptionImageProps) {
          mb="1"
          opacity={exactMatch ? 1 : 0.4}
       >
-         <Img
-            w="auto"
-            maxH="full"
-            maxW="full"
-            mx="auto"
+         <ResponsiveImage
             src={image.url}
             alt=""
+            layout="fill"
             objectFit="contain"
+            sizes={theme.sizes[16]}
          />
       </Box>
    );


### PR DESCRIPTION
Product Thumbnails: use ResponsiveImage.

Previously, this ended up using <img> tags with urls of the 2000px
images even though the visible size was only 70px.

ResponsiveImage uses a srcset and results in the browser choosing the
correct size.

Co-author @danielcliu-ifixit 

Connect #1015