### PR TITLE
Add store selector product links

### DIFF
--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -440,6 +440,7 @@ function parseOemPartnership(
 
 const EnabledDomainsSchema = z
    .object({
+      code: z.string(),
       domain: z.string().url(),
       locale: z.string(),
    })

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -110,7 +110,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       noindexDevDomains(context);
       const { handle } = context.params || {};
       invariant(typeof handle === 'string', 'handle param is missing');
-      const layoutProps = await getLayoutServerSideProps({
+      const { stores, ...otherLayoutProps } = await getLayoutServerSideProps({
          storeCode: DEFAULT_STORE_CODE,
       });
       const product = await findProduct({
@@ -129,8 +129,27 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
          context.res.setHeader('X-Robots-Tag', 'noindex, follow');
       }
 
+      const codeToDomain =
+         product.enabledDomains?.reduce((acc, { code, domain }) => {
+            acc[code] = domain;
+            return acc;
+         }, {} as Record<string, string>) ?? {};
+      const storesWithProductUrls = stores.map((store) => {
+         const domain =
+            store.code === DEFAULT_STORE_CODE
+               ? new URL(store.url).origin
+               : codeToDomain[store.code];
+         if (domain) {
+            store.url = `${domain}/products/${product.handle}`;
+         }
+         return store;
+      });
+
       const pageProps: ProductTemplateProps = {
-         layoutProps,
+         layoutProps: {
+            ...otherLayoutProps,
+            stores: storesWithProductUrls,
+         },
          appProps: {
             ifixitOrigin: ifixitOriginFromHost(context),
          },

--- a/packages/icons/flags/Flag.tsx
+++ b/packages/icons/flags/Flag.tsx
@@ -12,6 +12,7 @@ export enum FlagCountryCode {
    CA = 'CA',
    DE = 'DE',
    FR = 'FR',
+   UK = 'UK',
    GB = 'GB',
    EU = 'EU',
    US = 'US',
@@ -63,6 +64,7 @@ const Flag = forwardRef<FlagProps, 'svg'>(({ code, ...otherProps }, ref) => {
                {...otherProps}
             />
          );
+      case FlagCountryCode.UK:
       case FlagCountryCode.GB:
          return (
             <Icon


### PR DESCRIPTION
Makes the links in the store selector product links for stores that the current product is enabled in. If the product is disable/doesn't exist, then we link to the homepage of the store as before.

## CR

I chose to augment the `stores` prop instead of introduce a new prop. Given that the `stores` prop could in theory be used for components besides the store selector, I'm open to adding a new prop like `storeSelectorUrlOverrides` (or any other implementation you can think of).

## QA

Pick a product page. Make sure the `product.enabled_domains` metafield has a value with store codes on ifixit test. Scroll to the footer, open the store selector, and verify that the links point directly to the product page of other stores (if the product is enabled on that store) or to the homepage of the store otherwise.

## On deploy

Change the store code of the United Kingdom store from `gb` to `uk` on strapi.ifixit.com

Closes https://github.com/iFixit/react-commerce/issues/969