### PR TITLE
Cross Sell: Cards should be links

### DIFF
--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -438,9 +438,12 @@ function CrossSellItem({
                         >
                            <FaIcon
                               icon={faCircleCheck}
-                              color={isSelected ? 'brand.500' : 'gray.300'}
+                              color={isSelected ? 'brand.500' : 'gray.300'}                        
                               h="6"
                               transition="color 300ms"
+                              _hover={ isSelected ? {color: 'gray.300'} :
+                                 {color: 'brand.500'}
+                              }
                            />
                         </Center>
                      </Box>

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -97,7 +97,7 @@ export function CrossSellSection({
          reviewsCount: product?.reviewsCount,
       };
    }, [
-      product?.handle,
+      product.handle,
       product?.rating?.value,
       product?.reviewsCount,
       product.title,
@@ -265,6 +265,7 @@ export function CrossSellSection({
                         </Box>
                      </Box>
                      <Button
+                        disabled={!selectedCrossSellVariantIds.length}
                         colorScheme="brand"
                         minW="240px"
                         onClick={handleAddToCart}

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -443,9 +443,7 @@ function CrossSellItem({
                               h="6"
                               transition="color 300ms"
                               _hover={
-                                 isSelected
-                                    ? { color: 'gray.300' }
-                                    : { color: 'brand.500' }
+                                 isSelected ? { color: 'brand.700' } : undefined
                               }
                            />
                         </Center>

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -3,6 +3,7 @@ import {
    Badge,
    Box,
    Button,
+   Center,
    Circle,
    Divider,
    Flex,
@@ -30,6 +31,7 @@ import {
 } from '@ifixit/ui';
 import { MoneyV2 } from '@lib/shopify-storefront-sdk';
 import { Product, ProductVariant } from '@models/product';
+import NextLink from 'next/link';
 import React from 'react';
 
 export type CrossSellSectionProps = {
@@ -89,11 +91,17 @@ export function CrossSellSection({
 
    const currentProduct = React.useMemo<CrossSellProduct>(() => {
       return {
+         handle: product.handle,
          title: product.title,
          rating: product?.rating?.value,
          reviewsCount: product?.reviewsCount,
       };
-   }, [product?.rating?.value, product?.reviewsCount, product.title]);
+   }, [
+      product?.handle,
+      product?.rating?.value,
+      product?.reviewsCount,
+      product.title,
+   ]);
 
    const handleAddToCart = () => {
       const input = selectedCrossSellVariantIds.map(
@@ -280,6 +288,7 @@ type CrossSellItemProps = {
 };
 
 type CrossSellProduct = {
+   handle: string;
    title: string;
    rating: number | undefined | null;
    reviewsCount: number | undefined | null;
@@ -303,137 +312,150 @@ function CrossSellItem({
    onChange,
 }: CrossSellItemProps) {
    return (
-      <Card
-         overflow="hidden"
-         onClick={() => onChange(!isSelected)}
-         onKeyUp={(event) => {
-            if (['Enter'].includes(event.code)) {
-               onChange(!isSelected);
-               event.preventDefault();
-               event.stopPropagation();
-            }
-         }}
-         tabIndex={0}
-         flexBasis={{
-            md: 0,
-         }}
-         flexGrow={1}
-         outline="none"
-         _focus={{
-            boxShadow: 'outline',
-         }}
-         cursor="pointer"
-      >
-         <Flex
-            direction={{
-               base: 'row',
-               md: 'column',
+      <NextLink href={`/products/${product.handle}`} passHref legacyBehavior>
+         <Card
+            as="a"
+            overflow="hidden"
+            flexBasis={{
+               md: 0,
             }}
-            bg="white"
-            position="relative"
-            align={{
-               base: 'flex-start',
-               md: 'stretch',
-            }}
-            p={{
-               base: 3,
-               md: 4,
-            }}
-            h="full"
-            borderWidth="2px"
-            borderColor={isSelected ? 'brand.500' : 'transparent'}
-            borderRadius="lg"
-            transition="all 300ms"
+            flexGrow={1}
          >
-            <CardImage src={variant.image?.url ?? null} alt={product.title} />
             <Flex
-               direction="column"
-               w="full"
+               direction={{
+                  base: 'row',
+                  md: 'column',
+               }}
+               bg="white"
+               position="relative"
+               align={{
+                  base: 'flex-start',
+                  md: 'stretch',
+               }}
+               p={{
+                  base: 3,
+                  md: 4,
+               }}
                h="full"
-               justify="space-between"
-               flexGrow={1}
+               borderWidth="2px"
+               borderColor={isSelected ? 'brand.500' : 'transparent'}
+               borderRadius="lg"
+               transition="all 300ms"
             >
-               <Flex w="full">
-                  <Flex
-                     w="full"
-                     direction={{
-                        base: 'column',
-                     }}
-                     ml={{
-                        base: 3,
-                        md: 0,
-                     }}
-                  >
-                     {isCurrentItem && (
-                        <HStack
-                           position={{
-                              base: 'relative',
-                              md: 'absolute',
-                           }}
-                           top={{
-                              base: 'auto',
-                              md: 4,
-                           }}
-                           right={{
-                              base: 'auto',
-                              md: 4,
-                           }}
-                           spacing="1"
-                           mb="3"
-                        >
-                           <Badge colorScheme="brand">Current item</Badge>
-                        </HStack>
-                     )}
-                     <Flex direction="column" h="full" align="flex-start">
-                        <Text
-                           fontSize="md"
-                           mb="2"
-                           _groupHover={{ color: 'brand.500' }}
-                        >
-                           {product.title}
-                        </Text>
-                        {product.rating != null &&
-                           product.reviewsCount != null && (
-                              <ProductRating
-                                 mb="3"
-                                 rating={product.rating}
-                                 count={product.reviewsCount}
-                              />
-                           )}
-                     </Flex>
-                  </Flex>
-                  <Box
-                     position={{
-                        base: 'relative',
-                        md: 'absolute',
-                     }}
-                     pl={{
-                        base: 3,
-                        md: 0,
-                     }}
-                     top={{
-                        base: 0,
-                        md: 4,
-                     }}
-                  >
-                     <FaIcon
-                        icon={faCircleCheck}
-                        color={isSelected ? 'brand.500' : 'gray.300'}
-                        h="6"
-                        transition="color 300ms"
-                     />
-                  </Box>
-               </Flex>
-               <ProductVariantPrice
-                  price={variant.price}
-                  compareAtPrice={variant.compareAtPrice}
-                  proPricesByTier={variant.proPricesByTier}
-                  direction="column-reverse"
-                  alignSelf="flex-end"
+               <CardImage
+                  src={variant.image?.url ?? null}
+                  alt={product.title}
                />
+               <Flex
+                  direction="column"
+                  w="full"
+                  h="full"
+                  justify="space-between"
+                  flexGrow={1}
+               >
+                  <Flex w="full">
+                     <Flex
+                        w="full"
+                        direction={{
+                           base: 'column',
+                        }}
+                        ml={{
+                           base: 3,
+                           md: 0,
+                        }}
+                     >
+                        {isCurrentItem && (
+                           <HStack
+                              position={{
+                                 base: 'relative',
+                                 md: 'absolute',
+                              }}
+                              top={{
+                                 base: 'auto',
+                                 md: 4,
+                              }}
+                              right={{
+                                 base: 'auto',
+                                 md: 4,
+                              }}
+                              spacing="1"
+                              mb="3"
+                           >
+                              <Badge colorScheme="brand">Current item</Badge>
+                           </HStack>
+                        )}
+                        <Flex direction="column" h="full" align="flex-start">
+                           <Text
+                              fontSize="md"
+                              mb="2"
+                              _groupHover={{ color: 'brand.500' }}
+                           >
+                              {product.title}
+                           </Text>
+                           {product.rating != null &&
+                              product.reviewsCount != null && (
+                                 <ProductRating
+                                    mb="3"
+                                    rating={product.rating}
+                                    count={product.reviewsCount}
+                                 />
+                              )}
+                        </Flex>
+                     </Flex>
+                     <Box
+                        position={{
+                           base: 'relative',
+                           md: 'absolute',
+                        }}
+                        pl={{
+                           base: 3,
+                           md: 0,
+                        }}
+                        top={{
+                           base: 0,
+                           md: 4,
+                        }}
+                     >
+                        <Center
+                           onClick={(event) => {
+                              onChange(!isSelected);
+                              event.preventDefault();
+                              event.stopPropagation();
+                           }}
+                           onKeyDown={(event) => {
+                              if (['Enter'].includes(event.code)) {
+                                 onChange(!isSelected);
+                                 event.preventDefault();
+                                 event.stopPropagation();
+                              }
+                           }}
+                           tabIndex={0}
+                           outline="none"
+                           _focus={{
+                              boxShadow: 'outline',
+                           }}
+                           cursor="pointer"
+                        >
+                           <FaIcon
+                              icon={faCircleCheck}
+                              color={isSelected ? 'brand.500' : 'gray.300'}
+                              h="6"
+                              transition="color 300ms"
+                           />
+                        </Center>
+                     </Box>
+                  </Flex>
+                  <ProductVariantPrice
+                     price={variant.price}
+                     compareAtPrice={variant.compareAtPrice}
+                     proPricesByTier={variant.proPricesByTier}
+                     direction="column-reverse"
+                     alignSelf="flex-end"
+                  />
+               </Flex>
             </Flex>
-         </Flex>
-      </Card>
+         </Card>
+      </NextLink>
    );
 }
 

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -93,13 +93,13 @@ export function CrossSellSection({
       return {
          handle: product.handle,
          title: product.title,
-         rating: product?.rating?.value,
-         reviewsCount: product?.reviewsCount,
+         rating: product.rating?.value,
+         reviewsCount: product.reviewsCount,
       };
    }, [
       product.handle,
-      product?.rating?.value,
-      product?.reviewsCount,
+      product.rating?.value,
+      product.reviewsCount,
       product.title,
    ]);
 

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -438,11 +438,13 @@ function CrossSellItem({
                         >
                            <FaIcon
                               icon={faCircleCheck}
-                              color={isSelected ? 'brand.500' : 'gray.300'}                        
+                              color={isSelected ? 'brand.500' : 'gray.300'}
                               h="6"
                               transition="color 300ms"
-                              _hover={ isSelected ? {color: 'gray.300'} :
-                                 {color: 'brand.500'}
+                              _hover={
+                                 isSelected
+                                    ? { color: 'gray.300' }
+                                    : { color: 'brand.500' }
                               }
                            />
                         </Center>

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -424,7 +424,7 @@ function CrossSellItem({
                               event.stopPropagation();
                            }}
                            onKeyDown={(event) => {
-                              if (['Enter'].includes(event.code)) {
+                              if ('Enter' === event.code) {
                                  onChange(!isSelected);
                                  event.preventDefault();
                                  event.stopPropagation();


### PR DESCRIPTION
Makes the cross sell product cards links. Clicking the checkbox will select/deselect the cross sell product.

Note that `onKeyUp` was changed to `onKeyDown`. Without this change, clicking "Enter" with the checkbox focused caused the link to be followed (and the checkbox to be toggled). The expected behavior is to toggle the checkbox and not follow the link, and using `onKeyDown` achieves that.

Next link docs: https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag

## CR

Easiest to view with whitespace hidden.

## QA

Make sure the cards are now links, and that you are still able to toggle the selections as before using the checkbox.

Closes #924