### PR TITLE
Product Page: Transition to multiple hreflang locales

### DIFF
--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -440,8 +440,10 @@ function parseOemPartnership(
 
 const EnabledDomainsSchema = z
    .object({
+      code: z.string(),
       domain: z.string().url(),
-      locale: z.string(),
+      locale: z.string().optional(),
+      locales: z.string().array().optional(),
    })
    .array()
    .optional()

--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -52,14 +52,18 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
          <link rel="canonical" href={canonicalUrl} />
          <meta property="og:url" content={canonicalUrl} />
 
-         {product.enabledDomains?.map((store) => (
-            <link
-               key={store.domain}
-               rel="alternate"
-               hrefLang={store.locale}
-               href={`${store.domain}/products/${product.handle}`}
-            />
-         ))}
+         {product.enabledDomains?.flatMap((store) => {
+            const locales =
+               store.locales || (store.locale ? [store.locale] : []);
+            return locales.map((locale) => (
+               <link
+                  key={store.domain}
+                  rel="alternate"
+                  hrefLang={locale}
+                  href={`${store.domain}/products/${product.handle}`}
+               />
+            ));
+         })}
 
          {genericImages.length > 0 &&
             genericImages.map((image) => (


### PR DESCRIPTION
We're transitioning the product enabled_domains metafield to support multiple locales per store. Prefer the `locales` field if available, otherwise fallback to the `locale` field.

## QA

Make sure we still get the same hreflang link tags in the `<head>` as on main.

Connects https://github.com/iFixit/ifixit/issues/45707