### PR TITLE
Use iFixit client for every iFixit related request

### DIFF
--- a/packages/newsletter-sdk/package.json
+++ b/packages/newsletter-sdk/package.json
@@ -8,7 +8,8 @@
       "@ifixit/analytics": "workspace:*",
       "@ifixit/app": "workspace:*",
       "@ifixit/helpers": "workspace:*",
-      "@ifixit/sentry": "workspace:*"
+      "@ifixit/sentry": "workspace:*",
+      "@ifixit/ifixit-api-client": "workspace:*"
    },
    "peerDependencies": {
       "@tanstack/react-query": "4.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,6 +402,7 @@ importers:
       '@ifixit/analytics': workspace:*
       '@ifixit/app': workspace:*
       '@ifixit/helpers': workspace:*
+      '@ifixit/ifixit-api-client': workspace:*
       '@ifixit/sentry': workspace:*
       '@ifixit/tsconfig': workspace:*
       '@types/react': 17.0.37
@@ -411,6 +412,7 @@ importers:
       '@ifixit/analytics': link:../analytics
       '@ifixit/app': link:../app
       '@ifixit/helpers': link:../helpers
+      '@ifixit/ifixit-api-client': link:../ifixit-api-client
       '@ifixit/sentry': link:../sentry
     devDependencies:
       '@ifixit/tsconfig': link:../tsconfig


### PR DESCRIPTION
closes #949 

The only instance I could find where iFixit client was not used is the newsletter sdk

## QA

I don't think is necessary since newsletter is already covered by integration tests

qa_req 0