### PR TITLE
Productlist: Use strapi `forceNoindex` toggle

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2690,6 +2690,7 @@ export type GetProductListQuery = {
             metaDescription?: string | null;
             metaTitle?: string | null;
             filters?: string | null;
+            forceNoindex?: boolean | null;
             childrenHeading?: string | null;
             image?: {
                __typename?: 'UploadFileEntityResponse';
@@ -3166,6 +3167,7 @@ export const GetProductListDocument = `
         metaDescription
         metaTitle
         filters
+        forceNoindex
         image {
           data {
             attributes {

--- a/frontend/lib/strapi-sdk/operations/getProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/getProductList.graphql
@@ -16,6 +16,7 @@ query getProductList($filters: ProductListFiltersInput) {
             metaDescription
             metaTitle
             filters
+            forceNoindex
             image {
                data {
                   attributes {

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -105,6 +105,7 @@ export async function findProductList(
       metaDescription: productList?.metaDescription ?? null,
       metaTitle: productList?.metaTitle ?? null,
       filters: productList?.filters ?? null,
+      forceNoindex: productList?.forceNoindex ?? null,
       image: null,
       ancestors,
       // Strapi sort order is case sensitive, so we need to improve on it in memory

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -128,7 +128,7 @@ export async function findProductList(
          apiKey: algoliaApiKey,
       },
       wikiInfo: deviceWiki?.info || [],
-      forceNoIndex: !productList,
+      isOnStrapi: !!productList,
    };
 
    return {

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -75,7 +75,7 @@ export interface BaseProductList {
       apiKey: string;
    };
    wikiInfo: WikiInfoEntry[];
-   forceNoIndex: boolean;
+   isOnStrapi: boolean;
 }
 
 interface AllPartsProductList extends BaseProductList {

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -66,6 +66,7 @@ export interface BaseProductList {
    metaDescription: string | null;
    metaTitle: string | null;
    filters: string | null;
+   forceNoindex: boolean | null;
    image: ProductListImage | null;
    ancestors: ProductListAncestor[];
    children: ProductListChild[];

--- a/frontend/templates/product-list/MetaTags.tsx
+++ b/frontend/templates/product-list/MetaTags.tsx
@@ -49,7 +49,11 @@ export function MetaTags({ productList }: MetaTagsProps) {
       ? productListExemptions?.itemTypes?.includes(itemType)
       : productListExemptions?.root;
    const hasResults = pagination.nbHits >= (isNoIndexExempt ? 1 : 2);
-   const shouldNoIndex = isFiltered || !hasResults || !productList.isOnStrapi;
+   const shouldNoIndex =
+      isFiltered ||
+      !hasResults ||
+      productList.forceNoindex ||
+      !productList.isOnStrapi;
    return (
       <Head>
          {shouldNoIndex ? (

--- a/frontend/templates/product-list/MetaTags.tsx
+++ b/frontend/templates/product-list/MetaTags.tsx
@@ -49,7 +49,7 @@ export function MetaTags({ productList }: MetaTagsProps) {
       ? productListExemptions?.itemTypes?.includes(itemType)
       : productListExemptions?.root;
    const hasResults = pagination.nbHits >= (isNoIndexExempt ? 1 : 2);
-   const shouldNoIndex = isFiltered || !hasResults || productList.forceNoIndex;
+   const shouldNoIndex = isFiltered || !hasResults || !productList.isOnStrapi;
    return (
       <Head>
          {shouldNoIndex ? (


### PR DESCRIPTION
## QA

* Turn on the `forceNoindex` toggle for a product list in productlist-force-noindex.govinor.com/admin
* Verify that the productlist has the `<meta name="robots" content="noindex,nofollow" />` tag

Closes #705