### PR TITLE
Fix wiki text links style

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -257,14 +257,12 @@ export function ProductSection({
                         </VStack>
                      </CustomAccordionPanel>
                   </AccordionItem>
-                  <WikiHtmlAccordianItem
-                     title="Kit contents"
-                     contents={selectedVariant.kitContents}
-                  />
-                  <WikiHtmlAccordianItem
-                     title="Assembly contents"
-                     contents={selectedVariant.assemblyContents}
-                  />
+                  <WikiHtmlAccordianItem title="Kit contents">
+                     {selectedVariant.kitContents}
+                  </WikiHtmlAccordianItem>
+                  <WikiHtmlAccordianItem title="Assembly contents">
+                     {selectedVariant.assemblyContents}
+                  </WikiHtmlAccordianItem>
                   <AccordionItem
                      hidden={
                         product.compatibility == null ||
@@ -545,37 +543,49 @@ function AlertText({ children, colorScheme }: AlertTextProps) {
    );
 }
 
+interface WikiHtmlAccordianItemProps {
+   title: string;
+   children: string | null | undefined;
+}
+
 function WikiHtmlAccordianItem({
    title,
-   contents,
-}: {
-   title: string;
-   contents: string | null;
-}) {
+   children,
+}: WikiHtmlAccordianItemProps) {
    return (
-      <AccordionItem hidden={contents == null}>
+      <AccordionItem hidden={children == null}>
          <CustomAccordionButton>{title}</CustomAccordionButton>
          <CustomAccordionPanel>
-            <Box
-               fontSize="sm"
-               sx={{
-                  ul: {
-                     listStyle: 'none',
-                  },
-                  li: {
-                     borderTopWidth: '1px',
-                     borderTopColor: 'gray.200',
-                     py: 3,
-                     '& ul': {
-                        mt: 3,
-                        ml: 5,
+            {children && (
+               <Box
+                  fontSize="sm"
+                  sx={{
+                     ul: {
+                        listStyle: 'none',
                      },
-                  },
-               }}
-               dangerouslySetInnerHTML={{
-                  __html: contents ?? '',
-               }}
-            ></Box>
+                     li: {
+                        borderTopWidth: '1px',
+                        borderTopColor: 'gray.200',
+                        py: 3,
+                        '& ul': {
+                           mt: 3,
+                           ml: 5,
+                        },
+                     },
+                     a: {
+                        fontWeight: 'bold',
+                        transition: 'all 300ms',
+                        color: 'brand.500',
+                     },
+                     'a:hover': {
+                        color: 'brand.600',
+                     },
+                  }}
+                  dangerouslySetInnerHTML={{
+                     __html: children,
+                  }}
+               ></Box>
+            )}
          </CustomAccordionPanel>
       </AccordionItem>
    );


### PR DESCRIPTION
closes #925 

## QA

1. Open [Vercel preview](https://react-commerce-git-fix-product-page-wiki-text-link-style-ifixit.vercel.app/products/iphone-6s-plus-replacement-battery)
2. Visit a [product](https://react-commerce-git-fix-product-page-wiki-text-link-style-ifixit.vercel.app/products/iphone-6s-plus-replacement-battery) that has links in its content kit
3. Verify that links are visible