### PR TITLE
Drop deprecated metafield `locale` for hreflangs

### DIFF
--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -442,8 +442,7 @@ const EnabledDomainsSchema = z
    .object({
       code: z.string(),
       domain: z.string().url(),
-      locale: z.string().optional(),
-      locales: z.string().array().optional(),
+      locales: z.string().array(),
    })
    .array()
    .optional()

--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -53,9 +53,7 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
          <meta property="og:url" content={canonicalUrl} />
 
          {product.enabledDomains?.flatMap((store) => {
-            const locales =
-               store.locales || (store.locale ? [store.locale] : []);
-            return locales.map((locale) => (
+            return store.locales.map((locale) => (
                <link
                   key={store.domain}
                   rel="alternate"


### PR DESCRIPTION
The `locale` field was deprecated in favor of `locales`. We supported both in a transition period, and now we only want to use the plural.

Connects https://github.com/iFixit/ifixit/pull/45709