### PR TITLE
Matomo: track "Help translate"

### DIFF
--- a/frontend/layouts/default/DefaultLayout/Footer.tsx
+++ b/frontend/layouts/default/DefaultLayout/Footer.tsx
@@ -220,6 +220,8 @@ export function CartFooter({
                   <FooterLink
                      href="https://www.ifixit.com/Translate"
                      icon={Language}
+                     eventCategory="Translate"
+                     eventAction='Translate - Btn "Help Translate iFixit" - Footer - Click'
                   >
                      Help translate
                   </FooterLink>

--- a/packages/footer/components/Shared.tsx
+++ b/packages/footer/components/Shared.tsx
@@ -31,11 +31,30 @@ export const Footer = forwardRef<FlexProps, 'footer'>(
 
 type FooterLinkProps = StackProps & {
    icon?: (props: React.SVGProps<SVGSVGElement>) => JSX.Element;
+   eventCategory?: string;
+   eventAction?: string;
 };
 
 export const FooterLink = forwardRef<FooterLinkProps, 'a'>(
-   ({ fontSize = 'sm', href, children, icon, onClick, ...otherProps }, ref) => {
-      const trackedOnClick = useTrackedOnClick({ href, onClick });
+   (
+      {
+         fontSize = 'sm',
+         href,
+         children,
+         icon,
+         onClick,
+         eventCategory,
+         eventAction,
+         ...otherProps
+      },
+      ref
+   ) => {
+      const trackedOnClick = useTrackedOnClick({
+         href,
+         onClick,
+         eventCategory,
+         eventAction,
+      });
       return (
          <HStack
             ref={ref}

--- a/packages/footer/hooks/useTrackedOnClick.tsx
+++ b/packages/footer/hooks/useTrackedOnClick.tsx
@@ -6,6 +6,8 @@ type UseFooterLinkTrackingProps<T> = {
    onClick?: React.MouseEventHandler<T>;
    clickName?: string;
    isStoreLink?: boolean;
+   eventCategory?: string;
+   eventAction?: string;
 };
 
 export function useTrackedOnClick<T>({
@@ -13,16 +15,20 @@ export function useTrackedOnClick<T>({
    onClick,
    clickName,
    isStoreLink,
+   eventCategory,
+   eventAction,
 }: UseFooterLinkTrackingProps<T>) {
    const linkType = isStoreLink ? 'Stores' : 'iFixit';
    const { trackClick } = React.useContext(TrackingContext);
    const trackedOnClick: React.MouseEventHandler<T> = React.useCallback(
       (e) => {
          trackClick({
-            eventCategory: `Footer ${linkType} Link`,
-            eventAction: `Footer ${linkType} Link - \"${
-               clickName || href || 'undefined'
-            }\" - Click`,
+            eventCategory: eventCategory || `Footer ${linkType} Link`,
+            eventAction:
+               eventAction ||
+               `Footer ${linkType} Link - \"${
+                  clickName || href || 'undefined'
+               }\" - Click`,
          });
          onClick?.(e);
       },


### PR DESCRIPTION
## Overview
This adds tracking for the "Help translate" link in the footer. 

## QA
Make sure that clicking on the `Help translate` link in the homepage footer _and_ the store footer tracks in matomo according to [the spreadsheet ](https://docs.google.com/spreadsheets/d/16Xas1pHf_K7FmfOX3yX2mYgeYr2DIENr8cyQp19FZkA/edit#gid=1839136207&fvid=415444935)line 123

Closes spreadsheet line 123.

Connects to https://github.com/iFixit/ifixit/issues/44540