### PR TITLE
Add quick and dirty headphone redirect

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -105,6 +105,11 @@ const moduleExports = {
             destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/Store/Tools/Manta-Driver-Kit--112-Bit-Driver-Kit/IF145-392`,
             permanent: false,
          },
+         {
+            source: '/Parts/Over-Ear_Headphone',
+            destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/Parts/Headphone`,
+            permanent: true,
+         },
       ];
    },
    images: {


### PR DESCRIPTION
We wanted to redirect https://www.ifixit.com/Parts/Over-Ear_Headphone to https://www.ifixit.com/Parts/Headphone

qa_req 0 I tried it and it works. It's just a redirect.

Closes https://github.com/iFixit/ifixit/issues/45749