### PR TITLE
Make hreflang key unique

### DIFF
--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -57,7 +57,7 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
                store.locales || (store.locale ? [store.locale] : []);
             return locales.map((locale) => (
                <link
-                  key={store.domain}
+                  key={`${store.domain}-${locale}`}
                   rel="alternate"
                   hrefLang={locale}
                   href={`${store.domain}/products/${product.handle}`}


### PR DESCRIPTION
Fixes a bug where only one locale per store was showing up in the hreflangs.

## QA

Make sure all the different locales are showing up for the FR and DE stores in the hreflang tags in teh `<head>`. (list is [here](https://github.com/iFixit/react-commerce/pull/1068#issuecomment-1332965850))

Connects #1068