### PR TITLE
Revert "Use `redirect_url` product metafield"

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6332,7 +6332,6 @@ export type FindProductQuery = {
       prop65Chemicals?: { __typename?: 'Metafield'; value: string } | null;
       productVideos?: { __typename?: 'Metafield'; value: string } | null;
       productVideosJson?: { __typename?: 'Metafield'; value: string } | null;
-      redirectUrl?: { __typename?: 'Metafield'; value: string } | null;
       replacementGuides?: { __typename?: 'Metafield'; value: string } | null;
       featuredProductVariants?: {
          __typename?: 'Metafield';
@@ -6661,9 +6660,6 @@ export const FindProductDocument = `
       value
     }
     productVideosJson: metafield(namespace: "ifixit", key: "product_videos_json") {
-      value
-    }
-    redirectUrl: metafield(namespace: "ifixit", key: "redirect_url") {
       value
     }
     replacementGuides: metafield(namespace: "ifixit", key: "replacement_guides") {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -37,9 +37,6 @@ query findProduct($handle: String) {
       ) {
          value
       }
-      redirectUrl: metafield(namespace: "ifixit", key: "redirect_url") {
-         value
-      }
       replacementGuides: metafield(
          namespace: "ifixit"
          key: "replacement_guides"

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -109,7 +109,6 @@ export async function findProduct({ handle, storeCode }: FindProductArgs) {
       enabledDomains: parseEnabledDomains(
          response.product.enabledDomains?.value
       ),
-      redirectUrl: response.product.redirectUrl?.value ?? null,
    };
 }
 

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -11,7 +11,6 @@ import {
    trackMatomoEcommerceView,
 } from '@ifixit/analytics';
 import { invariant, moneyToNumber, parseItemcode } from '@ifixit/helpers';
-import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { DefaultLayout, getLayoutServerSideProps } from '@layouts/default';
 import { findProduct } from '@models/product';
 import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
@@ -127,16 +126,6 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       if (product == null) {
          return {
             notFound: true,
-         };
-      }
-
-      if (product.redirectUrl) {
-         const query = new URL(urlFromContext(context)).search;
-         return {
-            redirect: {
-               destination: `${product.redirectUrl}${query}`,
-               permanent: true,
-            },
          };
       }
 


### PR DESCRIPTION
Pushed this one out a little too early.
Reverts iFixit/react-commerce#1099