### PR TITLE
Use `redirect_url` product metafield

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -6332,6 +6332,7 @@ export type FindProductQuery = {
       prop65Chemicals?: { __typename?: 'Metafield'; value: string } | null;
       productVideos?: { __typename?: 'Metafield'; value: string } | null;
       productVideosJson?: { __typename?: 'Metafield'; value: string } | null;
+      redirectUrl?: { __typename?: 'Metafield'; value: string } | null;
       replacementGuides?: { __typename?: 'Metafield'; value: string } | null;
       featuredProductVariants?: {
          __typename?: 'Metafield';
@@ -6660,6 +6661,9 @@ export const FindProductDocument = `
       value
     }
     productVideosJson: metafield(namespace: "ifixit", key: "product_videos_json") {
+      value
+    }
+    redirectUrl: metafield(namespace: "ifixit", key: "redirect_url") {
       value
     }
     replacementGuides: metafield(namespace: "ifixit", key: "replacement_guides") {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -37,6 +37,9 @@ query findProduct($handle: String) {
       ) {
          value
       }
+      redirectUrl: metafield(namespace: "ifixit", key: "redirect_url") {
+         value
+      }
       replacementGuides: metafield(
          namespace: "ifixit"
          key: "replacement_guides"

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -109,6 +109,7 @@ export async function findProduct({ handle, storeCode }: FindProductArgs) {
       enabledDomains: parseEnabledDomains(
          response.product.enabledDomains?.value
       ),
+      redirectUrl: response.product.redirectUrl?.value ?? null,
    };
 }
 

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -11,6 +11,7 @@ import {
    trackMatomoEcommerceView,
 } from '@ifixit/analytics';
 import { invariant, moneyToNumber, parseItemcode } from '@ifixit/helpers';
+import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { DefaultLayout, getLayoutServerSideProps } from '@layouts/default';
 import { findProduct } from '@models/product';
 import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
@@ -126,6 +127,16 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       if (product == null) {
          return {
             notFound: true,
+         };
+      }
+
+      if (product.redirectUrl) {
+         const query = new URL(urlFromContext(context)).search;
+         return {
+            redirect: {
+               destination: `${product.redirectUrl}${query}`,
+               permanent: true,
+            },
          };
       }
 


### PR DESCRIPTION
Redirects requests for product pages that have a `redirect_url` metafield set, along with any search params that were on the url.

## CR

The issue spec'd just forwarding the utm params. We could match any params that start with `utm_` and only forward those, I wasn't sure what was best here.

## QA

Set the redirect url product metafield on shopify for a product. Visit it's product page on the react-commerce preview, and make sure that you're redirected to the proper url. Also make sure utm parameters are forwarded to the redirect url.

Note: this was prematurely merged in https://github.com/iFixit/react-commerce/pull/1099 on accident, and the change was reverted in https://github.com/iFixit/react-commerce/pull/1116.

Closes #864