### PR TITLE
Handle top level shopify graphql api errors

### DIFF
--- a/packages/cart-sdk/hooks/use-checkout.ts
+++ b/packages/cart-sdk/hooks/use-checkout.ts
@@ -151,10 +151,12 @@ function useStandardCheckout() {
       const localCheckout = getLocalCheckout();
       let checkoutUrl: string | null = null;
       if (localCheckout != null) {
-         const checkout = await updateCheckout(localCheckout.id, lineItems);
-         if (checkout != null) {
-            checkoutUrl = checkout.webUrl;
-         }
+         try {
+            const checkout = await updateCheckout(localCheckout.id, lineItems);
+            if (checkout != null) {
+               checkoutUrl = checkout.webUrl;
+            }
+         } catch (error) {}
       }
       if (checkoutUrl == null) {
          const checkout = await createCheckout(lineItems);

--- a/packages/shopify-storefront-client/index.tsx
+++ b/packages/shopify-storefront-client/index.tsx
@@ -1,3 +1,4 @@
+import { reportException } from '@ifixit/sentry';
 import * as React from 'react';
 
 interface ShopifyStorefrontClientOptions {
@@ -35,6 +36,16 @@ export class ShopifyStorefrontClient {
          }
       );
       const json = await response.json();
+      if (json.errors) {
+         const msg = 'Shopify Storefront API error';
+         console.error(msg, json.errors);
+         reportException(new Error(msg), {
+            errors: json.errors,
+            response,
+            query,
+            variables: JSON.stringify(variables, null, 2),
+         });
+      }
       return json.data;
    }
 }


### PR DESCRIPTION
Handles an undocumented top level `errors` key that is sometimes returned by the Shopify API. When this is the case, the field of interest (e.g. `checkoutCreate`) can be null.

Example event reported by this new code: https://sentry.io/share/issue/15b33ce210ca49e0bd64328b4994e15d/

## QA 

Make sure you can still make two purchases as described in https://github.com/iFixit/react-commerce/issues/1002  and fixed by https://github.com/iFixit/react-commerce/pull/1011

CC @danielbeardsley 

Closes #1014