### PR TITLE
Avoid including the whole lodash

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
@@ -1,7 +1,7 @@
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { computeDiscountPercentage, Money } from '@ifixit/helpers';
 import { ProductSearchHit } from '@models/product-list';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 export type ProductSearchHitPricing = {
    price: Money;


### PR DESCRIPTION
connects #105 
connects #1015

Curly braces import implies including the whole lib (see [here](https://www.blazemeter.com/blog/import-lodash-libraries)) 