### PR TITLE
Hide Cross Sell when current variant is sold out

### DIFF
--- a/frontend/components/common/AppProviders.tsx
+++ b/frontend/components/common/AppProviders.tsx
@@ -44,8 +44,8 @@ const queryClientConfig = shouldIgnoreUserAgent
               Sentry.captureException(error, (scope) => {
                  scope.setTag('react-query', 'mutation');
                  scope.setContext('Mutation', {
-                    variables,
-                    context,
+                    variables: JSON.stringify(variables, null, 2),
+                    context: JSON.stringify(context, null, 2),
                     mutationKey: mutation.options.mutationKey,
                  });
                  return scope;

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -165,7 +165,10 @@ export function CrossSellSection({
       }
    };
 
-   if (crossSellVariantsForSale.length === 0) {
+   if (
+      !selectedVariant.quantityAvailable ||
+      crossSellVariantsForSale.length === 0
+   ) {
       return null;
    }
 


### PR DESCRIPTION
- Hides the cross sell section when the main product is OOS.
- Stringifies mutation data that is sent to Sentry when errors happen.

## QA

Out of stock variants should have the cross sell section hidden.

Closes #1124