### PR TITLE
Git hooks: drop format and type-check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-
-pnpm format

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,2 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-
-pnpm type-check


### PR DESCRIPTION
Auto formatting is not setup to work on just changed files and so takes way too long. Typechecking is already done in CI and currently takes 30 - 60s. This is quite annoying and hampers productivity and interrupts development. I find myself constantly using `--no-verify` anyway.

We can re-add them if we improve their performance.

Connect #1026 