### PR TITLE
Add fixed size for child productlist images

### DIFF
--- a/frontend/components/product-list/ProductListCard.tsx
+++ b/frontend/components/product-list/ProductListCard.tsx
@@ -12,6 +12,17 @@ interface ProductListCardProps {
 
 export const ProductListCard = forwardRef<ProductListCardProps, 'div'>(
    ({ productList, variant = 'small', ...other }, ref) => {
+      const imageSizeProps = variant === 'small'
+        ? {
+          height: 60,
+          width: 80,
+          layout: "fixed",
+        }
+        : {
+          sizes: '20vw',
+          objectFit: "cover",
+          layout: "fill",
+        };
       return (
          <Box
             ref={ref}
@@ -62,10 +73,8 @@ export const ProductListCard = forwardRef<ProductListCardProps, 'div'>(
                            <ResponsiveImage
                               src={productList.imageUrl}
                               alt=""
-                              objectFit="cover"
-                              layout="fill"
-                              sizes="20vw"
                               priority
+                              {...imageSizeProps}
                            />
                         </Box>
                      </Flex>

--- a/frontend/components/product-list/ProductListCard.tsx
+++ b/frontend/components/product-list/ProductListCard.tsx
@@ -12,17 +12,18 @@ interface ProductListCardProps {
 
 export const ProductListCard = forwardRef<ProductListCardProps, 'div'>(
    ({ productList, variant = 'small', ...other }, ref) => {
-      const imageSizeProps = variant === 'small'
-        ? {
-          height: 60,
-          width: 80,
-          layout: "fixed",
-        }
-        : {
-          sizes: '20vw',
-          objectFit: "cover",
-          layout: "fill",
-        };
+      const imageSizeProps =
+         variant === 'small'
+            ? {
+                 height: 60,
+                 width: 80,
+                 layout: 'fixed',
+              }
+            : {
+                 sizes: '20vw',
+                 objectFit: 'cover',
+                 layout: 'fill',
+              };
       return (
          <Box
             ref={ref}

--- a/frontend/components/product-list/ProductListCard.tsx
+++ b/frontend/components/product-list/ProductListCard.tsx
@@ -1,5 +1,6 @@
 import { Box, Divider, Flex, forwardRef, Heading } from '@chakra-ui/react';
 import { ResponsiveImage } from '@ifixit/ui';
+import { ImageProps } from 'next/image';
 
 interface ProductListCardProps {
    variant?: 'small' | 'medium';
@@ -12,7 +13,7 @@ interface ProductListCardProps {
 
 export const ProductListCard = forwardRef<ProductListCardProps, 'div'>(
    ({ productList, variant = 'small', ...other }, ref) => {
-      const imageSizeProps =
+      const imageSizeProps: Partial<ImageProps> =
          variant === 'small'
             ? {
                  height: 60,


### PR DESCRIPTION
These were set to be responsive before, but they're actually used at 80x60 all the time.

Testing on http://localhost:3000/Parts/iPhone, I saw an 80% improvement in image bytes transferred. Most of the images on this page were child productlist images coming from the iFixit API. On the /Parts page, where images were mostly from Strapi, we didn't see much change, as expected.

Before
![image](https://user-images.githubusercontent.com/589425/207157654-053d6a12-a062-4375-b217-548feae78a29.png)

After
![image](https://user-images.githubusercontent.com/589425/207157495-41356837-4790-422b-ae8a-39f8ff734a06.png)

A few KB of HTML savings too.
Before:
![image](https://user-images.githubusercontent.com/589425/207163257-60c109c1-d029-4763-aa7c-2e0217d70908.png)
After:
![image](https://user-images.githubusercontent.com/589425/207163146-2280c518-c15d-4a4b-a6fc-a4d0f678d232.png)

Closes #1131