### PR TITLE
Fix minicart image size

### DIFF
--- a/packages/ui/cart/drawer/CartLineItem.tsx
+++ b/packages/ui/cart/drawer/CartLineItem.tsx
@@ -235,7 +235,8 @@ function LineItemImage({ lineItem }: LineItemImageProps) {
                src={lineItem.imageSrc}
                alt={lineItem.name}
                priority
-               layout="fill"
+               height={62}
+               width={62}
                objectFit="cover"
             />
          ) : (


### PR DESCRIPTION
It used to be a responsive image, and due to the default `sizes` attr being 100vw, it was downloading a huge (sometimes 2000px) image that would display at 62x62px.

Before:
![image](https://user-images.githubusercontent.com/589425/207231889-1dda7286-64ad-4325-991f-9beba39f0432.png)

After:
![image](https://user-images.githubusercontent.com/589425/207231791-9be272b1-972d-462b-b217-1d7f6cdc6db8.png)

Probably won't matter to most of us on gigabit connections, but for mobile users it's nice to be a little more efficient.

Connects #1136 