### PR TITLE
breakpoints: use consistent units

### DIFF
--- a/packages/ui/theme/foundations/breakpoints.ts
+++ b/packages/ui/theme/foundations/breakpoints.ts
@@ -2,7 +2,7 @@ import type { ThemeOverride } from '@chakra-ui/react';
 import primitives from '@core-ds/primitives';
 
 export const breakpoints: ThemeOverride['breakpoints'] = {
-   base: '0em',
+   base: '0px',
    sm: primitives.breakpoint.sm, // 576px
    md: primitives.breakpoint.md, // 768px
    lg: primitives.breakpoint.lg, // 1000px


### PR DESCRIPTION
The docs say chakra breakpoints should all be the same units because the JS must sort these by their literal values.

Thankfully, this didn't break for us, but if any other breakpoint was not in PX (besides base), it completely borks `useBreakpoint()`

See this codepen:
https://codesandbox.io/s/sparkling-wildflower-o2ww7z?file=/src/index.tsx

qa_req 0 -- These are equivalent values and this just works around what is effectively a bug in chakra.

CC @jarstelfox 