### PR TITLE
CompatibleDevice: Add tests

### DIFF
--- a/frontend/tests/jest/tests/CompatibleDevice.test.tsx
+++ b/frontend/tests/jest/tests/CompatibleDevice.test.tsx
@@ -5,26 +5,28 @@ import { getMockProduct } from '../utils';
 describe('CompatibleDevice', () => {
    it('renders and matches the snapshot', () => {
       let product = getMockProduct();
-      let device = product.compatibility.devices[0];
+      let device = product!.compatibility!.devices[0];
 
       // @ts-ignore
       const { getByText, asFragment } = renderWithAppContext(
          <CompatibleDevice device={device} />
       );
-      expect(() => getByText(/other models.../i)).toThrow();
+
+      // getByText throws an error if it can't find the text
+      (expect(() => getByText(/other models.../i)) as any).toThrow();
       (expect(asFragment()) as any).toMatchSnapshot();
    });
 
    it('renders and matches the snapshot with truncated variants', async () => {
       let product = getMockProduct();
-      let device = product.compatibility.devices[0];
+      let device = product!.compatibility!.devices[0];
 
       // @ts-ignore
       const { getByText, asFragment } = renderWithAppContext(
          <CompatibleDevice device={device} truncate={1} />
       );
 
-      expect(getByText(/other models.../i)).toBeTruthy();
+      (expect(getByText(/other models.../i)) as any).toBeTruthy();
       (expect(asFragment()) as any).toMatchSnapshot();
    });
 });

--- a/frontend/tests/jest/tests/CompatibleDevice.test.tsx
+++ b/frontend/tests/jest/tests/CompatibleDevice.test.tsx
@@ -1,0 +1,30 @@
+import { CompatibleDevice } from '@components/common';
+import { renderWithAppContext } from '../utils';
+import { getMockProduct } from '../utils';
+
+describe('CompatibleDevice', () => {
+   it('renders and matches the snapshot', () => {
+      let product = getMockProduct();
+      let device = product.compatibility.devices[0];
+
+      // @ts-ignore
+      const { getByText, asFragment } = renderWithAppContext(
+         <CompatibleDevice device={device} />
+      );
+      expect(() => getByText(/other models.../i)).toThrow();
+      (expect(asFragment()) as any).toMatchSnapshot();
+   });
+
+   it('renders and matches the snapshot with truncated variants', async () => {
+      let product = getMockProduct();
+      let device = product.compatibility.devices[0];
+
+      // @ts-ignore
+      const { getByText, asFragment } = renderWithAppContext(
+         <CompatibleDevice device={device} truncate={1} />
+      );
+
+      expect(getByText(/other models.../i)).toBeTruthy();
+      (expect(asFragment()) as any).toMatchSnapshot();
+   });
+});

--- a/frontend/tests/jest/tests/CompatibleDevice.test.tsx
+++ b/frontend/tests/jest/tests/CompatibleDevice.test.tsx
@@ -1,3 +1,4 @@
+import { screen } from '@testing-library/react';
 import { CompatibleDevice } from '@components/common';
 import { renderWithAppContext } from '../utils';
 import { getMockProduct } from '../utils';
@@ -8,12 +9,13 @@ describe('CompatibleDevice', () => {
       let device = product!.compatibility!.devices[0];
 
       // @ts-ignore
-      const { getByText, asFragment } = renderWithAppContext(
+      const { asFragment } = renderWithAppContext(
          <CompatibleDevice device={device} />
       );
 
-      // getByText throws an error if it can't find the text
-      (expect(() => getByText(/other models.../i)) as any).toThrow();
+      (
+         expect(screen.queryByText(/other models.../i)) as any
+      ).not.toBeInTheDocument();
       (expect(asFragment()) as any).toMatchSnapshot();
    });
 
@@ -22,11 +24,11 @@ describe('CompatibleDevice', () => {
       let device = product!.compatibility!.devices[0];
 
       // @ts-ignore
-      const { getByText, asFragment } = renderWithAppContext(
+      const { asFragment } = renderWithAppContext(
          <CompatibleDevice device={device} truncate={1} />
       );
 
-      (expect(getByText(/other models.../i)) as any).toBeTruthy();
+      (expect(screen.queryByText(/other models.../i)) as any).toBeVisible();
       (expect(asFragment()) as any).toMatchSnapshot();
    });
 });

--- a/frontend/tests/jest/tests/__snapshots__/CompatibleDevice.test.tsx.snap
+++ b/frontend/tests/jest/tests/__snapshots__/CompatibleDevice.test.tsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CompatibleDevice renders and matches the snapshot 1`] = `
+<DocumentFragment>
+  <img
+    alt="iPhone 6s Plus"
+    class="chakra-image css-yqon05"
+    src="https://mmcelvain.cominor.com/igi/cMVbyIbIrTEbi2j5.thumbnail"
+  />
+  <div
+    class="css-gislc8"
+  >
+    <p
+      class="chakra-text css-1h9z0di"
+    >
+      iPhone 6s Plus
+    </p>
+    <div
+      class="css-j7qwjs"
+    >
+      <p
+        class="chakra-text css-4137gr"
+      >
+        A1634 US AT&T Locked or SIM Free
+      </p>
+      <p
+        class="chakra-text css-4137gr"
+      >
+        A1687 US Sprint/Verizon and Global
+      </p>
+      <p
+        class="chakra-text css-4137gr"
+      >
+        A1699 Mainland China
+      </p>
+    </div>
+  </div>
+  <span
+    hidden=""
+    id="__chakra_env"
+  />
+</DocumentFragment>
+`;
+
+exports[`CompatibleDevice renders and matches the snapshot with truncated variants 1`] = `
+<DocumentFragment>
+  <img
+    alt="iPhone 6s Plus"
+    class="chakra-image css-yqon05"
+    src="https://mmcelvain.cominor.com/igi/cMVbyIbIrTEbi2j5.thumbnail"
+  />
+  <div
+    class="css-gislc8"
+  >
+    <p
+      class="chakra-text css-1h9z0di"
+    >
+      iPhone 6s Plus
+    </p>
+    <div
+      class="css-j7qwjs"
+    />
+    <p
+      class="chakra-text css-1ji9qma"
+    >
+      And 3 other models...
+    </p>
+  </div>
+  <span
+    hidden=""
+    id="__chakra_env"
+  />
+</DocumentFragment>
+`;


### PR DESCRIPTION
This is a basic test to ensure that the base component renders correctly as well as the component renders correctly when the number of variants exceeds the limit. In that case, the component should display the `And 3 other models...` text. In this case, I wanted to generalize it a bit more so I only included `other models...` in the query text.

QA:
--
Tests should pass.

Connects: https://github.com/iFixit/react-commerce/issues/1143