### PR TITLE
Unskip tests for Product Section

### DIFF
--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -139,7 +139,7 @@ describe('ProductSection Tests', () => {
          (expect(price.textContent) as any).toBe('$29.99');
       });
 
-      test.only('Discounted Price Renders', async () => {
+      test('Discounted Price Renders', async () => {
          const originalPrice = 29.99;
          const discountPercentage = 10;
          const discountPrice = (


### PR DESCRIPTION
## Description

While testing the tests, I left the `only` keyword in a test. As a result, we were skipping all other tests in the suite. This removes that keyword and therefore unskips all other tests in the file.

|Before|After|
|:---:|:---:|
|  ![No longer skipping tests](https://user-images.githubusercontent.com/22064420/207700647-588f1212-e7ba-48fc-9ceb-89a3a918baa1.png)     |   ![Number of tests with changes](https://user-images.githubusercontent.com/22064420/207700704-851c5024-cc7c-4be3-813b-b8e828e3f94a.png)  |

## QA Notes:
- [ ] CI should pass and no longer have skipped tests

**cc:** @batbattur 

**Reference:** https://github.com/iFixit/react-commerce/pull/1134#discussion_r1048842900
