### PR TITLE
Product Page: Add Product Specifications Tests

### DIFF
--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -215,7 +215,9 @@ describe('ProductSection Tests', () => {
             />
          );
 
-         const specificationsAccordion = await screen.queryByText(/Specification/i);
+         const specificationsAccordion = await screen.queryByText(
+            /Specification/i
+         );
          (expect(specificationsAccordion) as any).not.toBeVisible();
       });
    });

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -183,4 +183,40 @@ describe('ProductSection Tests', () => {
          });
       });
    });
+
+   describe('Product Specification Tests', () => {
+      test('renders product specifications', async () => {
+         renderWithAppContext(
+            <ProductSection
+               product={getMockProduct()}
+               selectedVariant={getMockProductVariant({
+                  specifications: 'Mocked Product Specification',
+               })}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+
+         const specification = await screen.findByText(
+            /mocked product specification/i
+         );
+         (expect(specification) as any).toBeInTheDocument();
+      });
+
+      test('specifications accordion is hidden if no specifications', async () => {
+         renderWithAppContext(
+            <ProductSection
+               product={getMockProduct()}
+               selectedVariant={getMockProductVariant({
+                  specifications: null,
+               })}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+
+         const specificationsAccordion = await screen.queryByText(/Specification/i);
+         (expect(specificationsAccordion) as any).not.toBeVisible();
+      });
+   });
 });


### PR DESCRIPTION
## Summary
Added the following tests for product specifications:
- Checks if the provided product specification renders.
- Checks if the specification button/accordion is hidden if we provide `null` to product specifications.

## QA notes 
Passing CI is enough.

closes #1144