### PR TITLE
Add tests for product compatibility section

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -207,10 +207,10 @@ export function ProductSection({
                         product.compatibility.devices.length <= 0
                      }
                   >
-                     <CustomAccordionButton>
+                     <CustomAccordionButton data-testid="product-compatibility-dropdown-button">
                         Compatibility
                      </CustomAccordionButton>
-                     <CustomAccordionPanel>
+                     <CustomAccordionPanel data-testid="product-compatibility-dropdown">
                         <CompatibleDevices product={product} />
                      </CustomAccordionPanel>
                   </AccordionItem>
@@ -259,9 +259,12 @@ const ProductTitle = chakra(
 
 type CustomAccordionButtonProps = React.PropsWithChildren<{}>;
 
-function CustomAccordionButton({ children }: CustomAccordionButtonProps) {
+function CustomAccordionButton({
+   children,
+   ...other
+}: CustomAccordionButtonProps) {
    return (
-      <AccordionButton py="5" px="1.5">
+      <AccordionButton py="5" px="1.5" {...other}>
          <Box
             flex="1"
             textAlign="left"
@@ -278,9 +281,12 @@ function CustomAccordionButton({ children }: CustomAccordionButtonProps) {
 
 type CustomAccordionPanelProps = React.PropsWithChildren<{}>;
 
-function CustomAccordionPanel({ children }: CustomAccordionPanelProps) {
+function CustomAccordionPanel({
+   children,
+   ...other
+}: CustomAccordionPanelProps) {
    return (
-      <AccordionPanel pb={4} px="1.5">
+      <AccordionPanel pb={4} px="1.5" {...other}>
          {children}
       </AccordionPanel>
    );

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -207,7 +207,7 @@ export function ProductSection({
                         product.compatibility.devices.length <= 0
                      }
                   >
-                     <CustomAccordionButton data-testid="product-compatibility-dropdown-button">
+                     <CustomAccordionButton>
                         Compatibility
                      </CustomAccordionButton>
                      <CustomAccordionPanel data-testid="product-compatibility-dropdown">
@@ -259,12 +259,9 @@ const ProductTitle = chakra(
 
 type CustomAccordionButtonProps = React.PropsWithChildren<{}>;
 
-function CustomAccordionButton({
-   children,
-   ...other
-}: CustomAccordionButtonProps) {
+function CustomAccordionButton({ children }: CustomAccordionButtonProps) {
    return (
-      <AccordionButton py="5" px="1.5" {...other}>
+      <AccordionButton py="5" px="1.5">
          <Box
             flex="1"
             textAlign="left"

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -133,9 +133,9 @@ describe('ProductSection Tests', () => {
             expect(screen.getByTestId('product-compatibility-dropdown')) as any
          ).not.toBeVisible();
 
-         await (screen
-            .findByTestId('product-compatibility-dropdown-button')as any)
-            .click();
+         await (
+            screen.findByTestId('product-compatibility-dropdown-button') as any
+         ).click();
 
          (
             expect(screen.getByTestId('product-compatibility-dropdown')) as any

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -145,6 +145,25 @@ describe('ProductSection Tests', () => {
             ).toBeVisible()
          );
       });
+
+      test('compatibility does not render', async () => {
+         const mockProduct = getMockProduct({
+            compatibility: null,
+         });
+
+         renderWithAppContext(
+            <ProductSection
+               product={mockProduct}
+               selectedVariant={getMockProductVariant()}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+
+         expect(
+            screen.getByTestId('product-compatibility-dropdown-button')
+         ).not.toBeVisible();
+      });
    });
 
    describe('Product Price Tests', () => {

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -129,8 +129,8 @@ describe('ProductSection Tests', () => {
             />
          );
 
-         expect(
-            screen.getByTestId('product-compatibility-dropdown')
+         (
+            expect(screen.getByTestId('product-compatibility-dropdown')) as any
          ).not.toBeVisible();
 
          const compatibilityButton = await screen.findByTestId(
@@ -140,8 +140,10 @@ describe('ProductSection Tests', () => {
          await act(() => compatibilityButton.click());
 
          waitFor(() =>
-            expect(
-               screen.getByTestId('product-compatibility-dropdown')
+            (
+               expect(
+                  screen.getByTestId('product-compatibility-dropdown')
+               ) as any
             ).toBeVisible()
          );
       });
@@ -160,8 +162,10 @@ describe('ProductSection Tests', () => {
             />
          );
 
-         expect(
-            screen.getByTestId('product-compatibility-dropdown-button')
+         (
+            expect(
+               screen.getByTestId('product-compatibility-dropdown-button')
+            ) as any
          ).not.toBeVisible();
       });
    });

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -133,8 +133,8 @@ describe('ProductSection Tests', () => {
             expect(screen.getByTestId('product-compatibility-dropdown')) as any
          ).not.toBeVisible();
 
-         await screen
-            .findByTestId('product-compatibility-dropdown-button')
+         await (screen
+            .findByTestId('product-compatibility-dropdown-button')as any)
             .click();
 
          (

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -133,19 +133,13 @@ describe('ProductSection Tests', () => {
             expect(screen.getByTestId('product-compatibility-dropdown')) as any
          ).not.toBeVisible();
 
-         const compatibilityButton = await screen.findByTestId(
-            'product-compatibility-dropdown-button'
-         );
+         await screen
+            .findByTestId('product-compatibility-dropdown-button')
+            .click();
 
-         await act(() => compatibilityButton.click());
-
-         waitFor(() =>
-            (
-               expect(
-                  screen.getByTestId('product-compatibility-dropdown')
-               ) as any
-            ).toBeVisible()
-         );
+         (
+            expect(screen.getByTestId('product-compatibility-dropdown')) as any
+         ).toBeVisible();
       });
 
       test('compatibility does not render', async () => {

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import {
    mockMatchMedia,
    renderWithAppContext,
@@ -117,6 +117,33 @@ describe('ProductSection Tests', () => {
          (expect(warning) as any).not.toBeInTheDocument();
          (expect(note) as any).not.toBeInTheDocument();
          (expect(disclaimer) as any).not.toBeInTheDocument();
+      });
+
+      test('compatibility renders', async () => {
+         renderWithAppContext(
+            <ProductSection
+               product={getMockProduct()}
+               selectedVariant={getMockProductVariant()}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+
+         expect(
+            screen.getByTestId('product-compatibility-dropdown')
+         ).not.toBeVisible();
+
+         const compatibilityButton = await screen.findByTestId(
+            'product-compatibility-dropdown-button'
+         );
+
+         await act(() => compatibilityButton.click());
+
+         waitFor(() =>
+            expect(
+               screen.getByTestId('product-compatibility-dropdown')
+            ).toBeVisible()
+         );
       });
    });
 

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -133,13 +133,17 @@ describe('ProductSection Tests', () => {
             expect(screen.getByTestId('product-compatibility-dropdown')) as any
          ).not.toBeVisible();
 
-         await (
-            screen.findByTestId('product-compatibility-dropdown-button') as any
-         ).click();
+         act(() => {
+            screen.getByRole('button', { name: /compatibility/i }).click();
+         });
 
-         (
-            expect(screen.getByTestId('product-compatibility-dropdown')) as any
-         ).toBeVisible();
+         waitFor(() => {
+            (
+               expect(
+                  screen.getByTestId('product-compatibility-dropdown')
+               ) as any
+            ).toBeVisible();
+         });
       });
 
       test('compatibility does not render', async () => {
@@ -158,7 +162,10 @@ describe('ProductSection Tests', () => {
 
          (
             expect(
-               screen.getByTestId('product-compatibility-dropdown-button')
+               screen.getByRole('button', {
+                  name: /compatibility/i,
+                  hidden: true,
+               })
             ) as any
          ).not.toBeVisible();
       });
@@ -183,7 +190,7 @@ describe('ProductSection Tests', () => {
          (expect(price.textContent) as any).toBe('$29.99');
       });
 
-      test.only('Discounted Price Renders', async () => {
+      test('Discounted Price Renders', async () => {
          const originalPrice = 29.99;
          const discountPercentage = 10;
          const discountPrice = (


### PR DESCRIPTION
This is the final part in testing the compatibility section. This just loads the `ProductSection` for a product and ensures the compatibility section is shown and is hidden when expected. It also asserts that clicking the dropdown displays the inner accordion element.

QA:
-- 
CI passing should be good enough here.

Closes: #1143 

cc @batbattur @ardelato 

