### PR TITLE
Upgrade frontend prettier version to v2.7.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -120,7 +120,7 @@
       "jest-environment-jsdom": "28.1.2",
       "jest-watch-typeahead": "1.1.0",
       "next-transpile-modules": "9.0.0",
-      "prettier": "2.3.2",
+      "prettier": "2.7.1",
       "typescript": "4.8.4",
       "webpack": "5.73.0"
    }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
       next: 12.2.3
       next-transpile-modules: 9.0.0
       nextjs-progressbar: 0.0.14
-      prettier: 2.3.2
+      prettier: 2.7.1
       query-string: 7.0.1
       react: 18.2.0
       react-dom: 18.2.0
@@ -214,7 +214,7 @@ importers:
       jest-environment-jsdom: 28.1.2
       jest-watch-typeahead: 1.1.0_jest@28.1.2
       next-transpile-modules: 9.0.0
-      prettier: 2.3.2
+      prettier: 2.7.1
       typescript: 4.8.4
       webpack: 5.73.0
 
@@ -13344,12 +13344,6 @@ packages:
   /prepend-http/2.0.0:
     resolution: {integrity: sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=}
     engines: {node: '>=4'}
-    dev: true
-
-  /prettier/2.3.2:
-    resolution: {integrity: sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
     dev: true
 
   /prettier/2.7.1:


### PR DESCRIPTION
qa_req 0

The frontend package is not using the Prettier version of the project root `package.json`. This can cause mismatching when formatting with VSCode and the cli, because they can pick up different versions.