### PR TITLE
Product Page: Add Product Warranty Tests

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -303,6 +303,7 @@ function VariantWarranty({ variant, ...other }: VariantWarrantyProps) {
       >
          {isLifetimeWarranty(variant.warranty ?? '') && (
             <Icon
+               data-testid="quality-guarantee-icon"
                as={QualityGuarantee}
                boxSize="50px"
                color="brand.500"

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -7,6 +7,7 @@ import {
    getNonDiscountedProduct,
    getDiscountedProduct,
    getProductOfType,
+   getProductWithWarranty,
 } from '../utils';
 import { ProductSection } from '@templates/product/sections/ProductSection/index';
 
@@ -259,6 +260,36 @@ describe('ProductSection Tests', () => {
             /shipping restrictions apply/i
          );
          (expect(shippingRestrictionText) as any).not.toBeInTheDocument();
+      });
+   });
+
+   describe('Product Warranty Tests', () => {
+      test('renders the lifetime guarantee warranty', async () => {
+         const fullWarrantyProduct = getProductWithWarranty('full');
+
+         renderWithAppContext(
+            <ProductSection
+               product={fullWarrantyProduct}
+               selectedVariant={fullWarrantyProduct.variants[0]}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+         const lifetimeGuaranteeText = await screen.findByText(
+            /lifetime guarantee/i
+         );
+         (expect(lifetimeGuaranteeText) as any).toBeVisible();
+         (
+            expect(
+               screen.getByRole('link', { name: 'Lifetime Guarantee' })
+            ) as any
+         ).toHaveAttribute('href', 'www.cominor.com/Info/Warranty');
+
+         // We display quality guarantee icon for products with lifetime warrant
+         const qualityGuaranteeIcon = await screen.findByTestId(
+            'quality-guarantee-icon'
+         );
+         (expect(qualityGuaranteeIcon) as any).toBeVisible();
       });
    });
 });

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -291,5 +291,49 @@ describe('ProductSection Tests', () => {
          );
          (expect(qualityGuaranteeIcon) as any).toBeVisible();
       });
+
+      test('renders the limited warranty', async () => {
+         const limitedWarrantyProduct = getProductWithWarranty('limited');
+
+         renderWithAppContext(
+            <ProductSection
+               product={limitedWarrantyProduct}
+               selectedVariant={limitedWarrantyProduct.variants[0]}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+         const warrantyText = await screen.findByText(/One year warranty/i);
+         (expect(warrantyText) as any).toBeVisible();
+         (
+            expect(
+               screen.getByRole('link', { name: 'One year warranty' })
+            ) as any
+         ).toHaveAttribute('href', 'www.cominor.com/Info/Warranty');
+      });
+
+      test('renders the as-is warranty', async () => {
+         const asIsWarrantyProduct = getProductWithWarranty('as-is');
+
+         renderWithAppContext(
+            <ProductSection
+               product={asIsWarrantyProduct}
+               selectedVariant={asIsWarrantyProduct.variants[0]}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+         const warrantyText = await screen.findByText(
+            /Sold as-is; no refunds or returns/i
+         );
+         (expect(warrantyText) as any).toBeVisible();
+         (
+            expect(
+               screen.getByRole('link', {
+                  name: 'Sold as-is; no refunds or returns',
+               })
+            ) as any
+         ).toHaveAttribute('href', 'www.cominor.com/Info/Warranty');
+      });
    });
 });

--- a/frontend/tests/jest/utils.tsx
+++ b/frontend/tests/jest/utils.tsx
@@ -142,7 +142,7 @@ export const getProductWithWarranty = (
    guarantee: 'full' | 'limited' | 'as-is'
 ) => {
    enum Warranty {
-      'full' = 'Lifetime Guraantee',
+      'full' = 'Lifetime Guarantee',
       'limited' = 'One year warranty',
       'as-is' = 'Sold as-is; no refunds or returns',
    }


### PR DESCRIPTION
## Summary
Added the following tests for checking the warranty:
- Checks for the warranty text and its link for `limited`/`as-is` warranty products.
- Checks for the warranty text and its link for the `lifetime` warranty product. 
Also checks if the quality guarantee icon is visible (we display the quality guarantee icon for products with lifetime warranty).

## QA notes 
Passing CI is enough. (qa_req 0)

closes #1145