### PR TITLE
Bundle Analysis: add frontend/ for each step that takes a path

### DIFF
--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -35,7 +35,7 @@ jobs:
            with:
               # if you use a custom build directory, replace all instances of `.next` in this file with your build directory
               # ex: if your app builds to `dist`, replace `.next` with `dist`
-              path: .next/cache
+              path: frontend/.next/cache
               # change this if you prefer a more strict cache
               key: ${{ runner.os }}-build-${{ env.cache-name }}
 
@@ -55,7 +55,7 @@ jobs:
            uses: actions/upload-artifact@v2
            with:
               name: bundle
-              path: .next/analyze/__bundle_analysis.json
+              path: frontend/.next/analyze/__bundle_analysis.json
 
          - name: Download base branch bundle stats
            uses: dawidd6/action-download-artifact@v2
@@ -63,7 +63,7 @@ jobs:
            with:
               workflow: nextjs_bundle_analysis.yml
               branch: ${{ github.event.pull_request.base.ref }}
-              path: .next/analyze/base
+              path: frontend/.next/analyze/base
 
          # And here's the second place - this runs after we have both the current and
          # base branch bundle stats, and will compare them to determine what changed.


### PR DESCRIPTION
We have working_directory: frontend/ as a default for all the steps but I think that doesn't apply for these tasks that take a "path" input. It hopefully *does* apply for all the steps with a "run" input.

This has meant that the cache of the .next directory is empty and the bundle from main isn't being uploaded.