### PR TITLE
Prop 65 warning: Add tests

### DIFF
--- a/frontend/tests/cypress/integration/product-list/parts_page_devices.cy.ts
+++ b/frontend/tests/cypress/integration/product-list/parts_page_devices.cy.ts
@@ -31,6 +31,7 @@ describe('parts page devices', () => {
                cy.findByRole('heading', {
                   level: 1,
                   name: childTitleRegexp,
+                  timeout: 10000,
                }).should('exist');
 
                navigateUntilLastDevice();

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import {
    mockMatchMedia,
    renderWithAppContext,
@@ -265,6 +265,66 @@ describe('ProductSection Tests', () => {
             /shipping restrictions apply/i
          );
          (expect(shippingRestrictionText) as any).not.toBeInTheDocument();
+      });
+   });
+
+   describe('Prop 65 Warning Tests', () => {
+      test('renders prop 65 warning', async () => {
+         const battery = getProductOfType('battery');
+
+         renderWithAppContext(
+            <ProductSection
+               product={battery}
+               selectedVariant={battery.variants[0]}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+         const prop65WarningText = await screen.findByText(/prop 65 warning/i);
+         (expect(prop65WarningText) as any).toBeVisible();
+      });
+
+      test('does not render prop 65 warning', async () => {
+         const tool = getProductOfType('tool');
+
+         renderWithAppContext(
+            <ProductSection
+               product={tool}
+               selectedVariant={tool.variants[0]}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+         (
+            expect(screen.queryByText(/prop 65 warning/i)) as any
+         ).not.toBeInTheDocument();
+      });
+
+      test('renders prop 65 info popup', async () => {
+         const battery = getProductOfType('battery');
+
+         renderWithAppContext(
+            <ProductSection
+               product={battery}
+               selectedVariant={battery.variants[0]}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+
+         act(() => {
+            screen.getByLabelText('read more about the warning').click();
+         });
+
+         waitFor(() => {
+            (
+               expect(
+                  screen.queryByText(
+                     /This product can expose you to chemicals including lead/i
+                  )
+               ) as any
+            ).toBeVisible();
+         });
       });
    });
 


### PR DESCRIPTION
We display a prop 65 warning on all battery products. This adds some basic tests for when the warning should/shouldn't show up.

Also, test the basic functionality of the "more details" popup that displays on click.

QA:
--
The tetss should run and pass.

Connects: #1165 