### PR TITLE
Product Page: Test Replacement Guides Section

### DIFF
--- a/frontend/tests/jest/tests/ProductReplacementGuide.test.tsx
+++ b/frontend/tests/jest/tests/ProductReplacementGuide.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from '@testing-library/react';
+import {
+   renderWithAppContext,
+   getMockProduct,
+} from '../utils';
+import { ReplacementGuidesSection } from '@templates/product/sections/ReplacementGuidesSection';
+
+describe('Product Replacement Guides Section Tests', () => {
+   test('renders Replacement Guides Section for a product with a replacement guide', async () => {
+      const mockedProduct = getMockProduct();
+      renderWithAppContext(
+         <ReplacementGuidesSection product={mockedProduct} />
+      );
+
+      const replacementGuidesSectionText = await screen.findByText(
+         /Replacement Guides/i
+      );
+      (expect(replacementGuidesSectionText) as any).toBeVisible();
+
+      const expectedGuideTitle = mockedProduct.replacementGuides[0].title;
+      const guideTitle = await screen.findByText(
+         new RegExp(expectedGuideTitle, 'i')
+      );
+      (expect(guideTitle) as any).toBeVisible();
+
+      const expectedGuideUrl = mockedProduct.replacementGuides[0].guide_url;
+      (
+         expect(screen.getByRole('link', { name: expectedGuideTitle })) as any
+      ).toHaveAttribute('href', expectedGuideUrl);
+   });
+});

--- a/frontend/tests/jest/tests/ProductReplacementGuide.test.tsx
+++ b/frontend/tests/jest/tests/ProductReplacementGuide.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react';
 import {
    renderWithAppContext,
    getMockProduct,
+   getProductOfType,
 } from '../utils';
 import { ReplacementGuidesSection } from '@templates/product/sections/ReplacementGuidesSection';
 
@@ -27,5 +28,20 @@ describe('Product Replacement Guides Section Tests', () => {
       (
          expect(screen.getByRole('link', { name: expectedGuideTitle })) as any
       ).toHaveAttribute('href', expectedGuideUrl);
+   });
+
+   test('does not render Replacement Guides Section for a product with no replacement guides', async () => {
+      const { container } = renderWithAppContext(
+         <ReplacementGuidesSection
+            product={getProductOfType('tool')} // The mocked tool doesn't have associated replacement guides
+         />
+      );
+
+      const replacementGuidesHeading = await screen.queryByText(
+         /Replacement Guides/i
+      );
+      (expect(replacementGuidesHeading) as any).not.toBeInTheDocument();
+
+      (expect(container.firstChild) as any).toBeEmptyDOMElement();
    });
 });

--- a/frontend/tests/jest/tests/ProductReplacementGuide.test.tsx
+++ b/frontend/tests/jest/tests/ProductReplacementGuide.test.tsx
@@ -1,9 +1,5 @@
 import { screen } from '@testing-library/react';
-import {
-   renderWithAppContext,
-   getMockProduct,
-   getProductOfType,
-} from '../utils';
+import { renderWithAppContext, getMockProduct } from '../utils';
 import { ReplacementGuidesSection } from '@templates/product/sections/ReplacementGuidesSection';
 
 describe('Product Replacement Guides Section Tests', () => {
@@ -33,7 +29,7 @@ describe('Product Replacement Guides Section Tests', () => {
    test('does not render Replacement Guides Section for a product with no replacement guides', async () => {
       const { container } = renderWithAppContext(
          <ReplacementGuidesSection
-            product={getProductOfType('tool')} // The mocked tool doesn't have associated replacement guides
+            product={getMockProduct({ replacementGuides: [] })}
          />
       );
 


### PR DESCRIPTION
## Summary
Added the following tests for checking the replacement guides section:
1. Checks if the replacement guide section renders when the product has associated guides.
   - Checks if the guide title and guide link are present.
2. Checks if the replacement guide section does not render when the product has no associated guides.


## QA notes 
Passing CI is enough. (qa_req 0)

closes #1166 