### PR TITLE
Apply review hiding logic to ReviewsSection

### DIFF
--- a/frontend/templates/product/sections/ReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ReviewsSection/index.tsx
@@ -59,20 +59,23 @@ export function ReviewsSection({
       return reviewsCount;
    }, [reviewsData?.groupedReviews]);
 
-   const allReviews = reviewsData?.reviews ?? [];
-   const visibleReviews = allReviews.slice(0, visibleReviewsCount) ?? [];
-   const hasMoreReviews = visibleReviewsCount < allReviews.length;
+   const allReviewsWithBody =
+      reviewsData?.reviews?.filter((review) => review.body) ?? [];
+   const visibleReviews =
+      allReviewsWithBody.slice(0, visibleReviewsCount) ?? [];
+   const hasMoreReviews = visibleReviewsCount < allReviewsWithBody.length;
 
    const showMoreReviews = () => {
       setVisibleReviewsCount(
-         Math.min(allReviews.length, visibleReviewsCount + 20)
+         Math.min(allReviewsWithBody.length, visibleReviewsCount + 20)
       );
    };
 
-   const hasReview =
+   const canShowReviews =
       reviewsData != null &&
-      reviewsData.reviews != null &&
-      reviewsData.reviews.length > 0;
+      reviewsData.count &&
+      reviewsData.average &&
+      (reviewsData.average >= 4 || reviewsData.count > 10);
 
    return (
       <Box
@@ -95,7 +98,7 @@ export function ReviewsSection({
             >
                Customer Reviews
             </Heading>
-            {hasReview ? (
+            {canShowReviews ? (
                <>
                   <ReviewsStats
                      ratingsCounts={reviewCountsByRating}

--- a/frontend/tests/jest/__mocks__/products.ts
+++ b/frontend/tests/jest/__mocks__/products.ts
@@ -3240,7 +3240,7 @@ export const mockedReviews: ProductReview[] = [
       headline: null,
       productName: 'Precision Cleaning Kit',
       productVariantName: 'New',
-      body: undefined,
+      body: 'Amazing product',
       date: '<time   title="Wed, 26 Oct 2022 11:15:54 -0700" datetime="2022-10-26T11:15:54-07:00">Oct 26, 2022</time>',
       created_date: 1666808154,
       modified_date: 1666808154,


### PR DESCRIPTION
closes #1140 

Show review section only if `reviewsData.average >= 4 || reviewsData.count > 10`

### QA

1. Visit Vercel preview
2. Verify that the reviews section is hidden for products that do not satisfy the condition above