### PR TITLE
Don't reject null compatibility variants

### DIFF
--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -4,12 +4,12 @@ import { Product } from '@models/product';
 
 export type CompatibleDeviceProps = {
    device: NonNullable<Product['compatibility']>['devices'][number];
-   truncate?: number;
+   maxModelLines?: number;
 };
 
 export function CompatibleDevice({
    device,
-   truncate = 0,
+   maxModelLines = 0,
 }: CompatibleDeviceProps) {
    const variants = React.useMemo(
       () => device.variants.filter(Boolean),
@@ -17,10 +17,13 @@ export function CompatibleDevice({
    );
    const [visibleVariants, hiddenVariantCount] = React.useMemo(
       () =>
-         truncate > 0 && variants.length > truncate
-            ? [variants.slice(0, truncate), variants.length - truncate]
+         maxModelLines > 0 && variants.length > maxModelLines
+            ? [
+                 variants.slice(0, maxModelLines - 1),
+                 variants.length - maxModelLines + 1,
+              ]
             : [variants, 0],
-      [truncate, variants]
+      [maxModelLines, variants]
    );
    return (
       <>

--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -1,5 +1,5 @@
-import { Flex, Img, Link, Text } from '@chakra-ui/react';
-import NextLink from 'next/link';
+import * as React from 'react';
+import { Flex, Img, Text } from '@chakra-ui/react';
 import { Product } from '@models/product';
 
 export type CompatibleDeviceProps = {
@@ -11,12 +11,17 @@ export function CompatibleDevice({
    device,
    truncate = 0,
 }: CompatibleDeviceProps) {
-   let variants = device.variants;
-   let unlistedVariants = 0;
-   if (truncate > 0 && variants.length > truncate) {
-      variants = device.variants.slice(0, truncate - 1);
-      unlistedVariants = device.variants.length - variants.length;
-   }
+   const variants = React.useMemo(
+      () => device.variants.filter(Boolean),
+      [device.variants]
+   );
+   const [visibleVariants, hiddenVariantCount] = React.useMemo(
+      () =>
+         truncate > 0 && variants.length > truncate
+            ? [variants.slice(0, truncate), variants.length - truncate]
+            : [variants, 0],
+      [truncate, variants]
+   );
    return (
       <>
          <Img
@@ -43,7 +48,7 @@ export function CompatibleDevice({
                {device.deviceName}
             </Text>
             <Flex flexDir="column">
-               {variants.map((variant) => (
+               {visibleVariants.map((variant) => (
                   <Text
                      key={variant}
                      lineHeight="short"
@@ -54,9 +59,10 @@ export function CompatibleDevice({
                   </Text>
                ))}
             </Flex>
-            {unlistedVariants !== 0 && (
+            {hiddenVariantCount > 0 && (
                <Text mb="2px" lineHeight="short" fontSize="xs" color="gray.600">
-                  And {unlistedVariants} other models...
+                  And {hiddenVariantCount} other model
+                  {hiddenVariantCount > 1 ? 's' : ''}...
                </Text>
             )}
          </Flex>

--- a/frontend/models/product.ts
+++ b/frontend/models/product.ts
@@ -383,7 +383,7 @@ const CompatibilityMetafieldSchema = z
             imageUrl: z.string(),
             deviceUrl: z.string(),
             deviceName: z.string(),
-            variants: z.array(z.string()),
+            variants: z.array(z.string().nullable()),
          })
       ),
       hasMoreDevices: z.boolean(),

--- a/frontend/templates/product/sections/ProductSection/CompatibleDevices.tsx
+++ b/frontend/templates/product/sections/ProductSection/CompatibleDevices.tsx
@@ -8,7 +8,7 @@ export type CompatibleDevicesProps = {
 };
 
 const MAX_VISIBLE_DEVICES = 3;
-const MAX_VISIBLE_MODELS_PER_DEVICE = 4;
+const MAX_MODEL_LINES_PER_DEVICE = 4;
 
 export function CompatibleDevices({ product }: CompatibleDevicesProps) {
    const devices = product.compatibility?.devices ?? [];
@@ -16,7 +16,7 @@ export function CompatibleDevices({ product }: CompatibleDevicesProps) {
    const hasMoreToShow =
       devices.length > MAX_VISIBLE_DEVICES ||
       devices.some(
-         (device) => device.variants.length > MAX_VISIBLE_MODELS_PER_DEVICE
+         (device) => device.variants.length > MAX_MODEL_LINES_PER_DEVICE
       );
 
    return (
@@ -32,7 +32,7 @@ export function CompatibleDevices({ product }: CompatibleDevicesProps) {
                >
                   <CompatibleDevice
                      device={device}
-                     truncate={MAX_VISIBLE_MODELS_PER_DEVICE}
+                     maxModelLines={MAX_MODEL_LINES_PER_DEVICE}
                   />
                </chakra.a>
             </NextLink>

--- a/frontend/tests/jest/tests/CompatibleDevice.test.tsx
+++ b/frontend/tests/jest/tests/CompatibleDevice.test.tsx
@@ -25,7 +25,7 @@ describe('CompatibleDevice', () => {
 
       // @ts-ignore
       const { asFragment } = renderWithAppContext(
-         <CompatibleDevice device={device} truncate={1} />
+         <CompatibleDevice device={device} maxModelLines={2} />
       );
 
       (expect(screen.queryByText(/other models.../i)) as any).toBeVisible();

--- a/frontend/tests/jest/tests/__snapshots__/CompatibleDevice.test.tsx.snap
+++ b/frontend/tests/jest/tests/__snapshots__/CompatibleDevice.test.tsx.snap
@@ -59,11 +59,17 @@ exports[`CompatibleDevice renders and matches the snapshot with truncated varian
     </p>
     <div
       class="css-j7qwjs"
-    />
+    >
+      <p
+        class="chakra-text css-4137gr"
+      >
+        A1634 US AT&T Locked or SIM Free
+      </p>
+    </div>
     <p
       class="chakra-text css-1ji9qma"
     >
-      And 3 other models...
+      And 2 other models...
     </p>
   </div>
   <span


### PR DESCRIPTION
- Fixes a bug where the compatibility section was hidden if any device had a `null` variant.
- Memoizes variant calculations in the compatibility section.
- Prevents empty variant `<p>` tags from being rendered in the compatibility section.
- Properly uses the plural for the hidden variant indicator in the compatibility section.

@sterlinghirsh 

Closes #1182