### PR TITLE
Increase CDN cache up to 1 day

### DIFF
--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -1,0 +1,30 @@
+import { GetServerSidePropsMiddleware } from '@lib/next-middleware';
+import { Duration } from '../lib/duration';
+
+interface CacheControlOptions {
+   sMaxAge: number;
+   staleWhileRevalidate: number;
+}
+
+export const withCacheControl =
+   (options: CacheControlOptions): GetServerSidePropsMiddleware =>
+   (next) =>
+   (context) => {
+      const sMaxAgeSeconds = options.sMaxAge / 1000;
+      const staleWhileRevalidateSeconds = options.staleWhileRevalidate / 1000;
+      context.res.setHeader(
+         'Cache-Control',
+         `public, s-maxage=${sMaxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`
+      );
+      return next(context);
+   };
+
+export const withCacheShort = withCacheControl({
+   sMaxAge: Duration(1).second,
+   staleWhileRevalidate: Duration(9).seconds,
+});
+
+export const withCacheLong = withCacheControl({
+   sMaxAge: Duration(1).minute,
+   staleWhileRevalidate: Duration(1).day,
+});

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -1,54 +1,69 @@
-import { GetServerSideProps, GetServerSidePropsContext } from 'next';
-import { logAsync } from '@ifixit/helpers';
-import { setSentryPageContext } from '@ifixit/sentry';
-import * as Sentry from '@sentry/nextjs';
 import { PROD_USER_AGENT } from '@config/constants';
-import { clearCache } from '@lib/cache';
 import { CACHE_DISABLED } from '@config/env';
+import { setSentryPageContext } from '@ifixit/sentry';
 import { timeAsync } from '@ifixit/stats';
+import { clearCache } from '@lib/cache';
+import type { GetServerSidePropsMiddleware } from '@lib/next-middleware';
+import * as Sentry from '@sentry/nextjs';
+import { GetServerSidePropsContext } from 'next';
 
-export function serverSidePropsWrapper<T extends { [key: string]: any }>(
-   pageName: string,
-   getServerSidePropsInternal: GetServerSideProps<T>
-): GetServerSideProps<T> {
-   return (context) => {
-      return timeAsync(`page.${pageName}.server_side_props`, async () => {
-         console.log('context.resolvedUrl', context.resolvedUrl);
-         console.log('context.req.url', context.req.url);
-         Sentry.setContext('Extra Info', {
-            headers: context.req.headers,
-            url: context.req.url,
-            method: context.req.method,
-            locale: context.locale,
-            ...context.params,
-            ...context.query,
-         });
-         const isCacheDisabled =
-            CACHE_DISABLED || context.query._vercel_no_cache === '1';
-         if (isCacheDisabled) {
-            clearCache();
-         }
-         return getServerSidePropsInternal(context)
-            .then((result) => {
-               if (isCacheDisabled) {
-                  context.res.setHeader(
-                     'Cache-Control',
-                     'no-store, no-cache, must-revalidate, stale-if-error=0'
-                  );
-                  clearCache();
-               }
-               return result;
-            })
-            .catch((err) => {
-               setSentryPageContext(context);
-               throw err;
-            });
-      });
-   };
+interface LoggingMiddlewareOptions {
+   pageName: string;
 }
+
+interface WithLoggingMiddleware {
+   (options: LoggingMiddlewareOptions): GetServerSidePropsMiddleware;
+}
+
+export const withLogging: WithLoggingMiddleware =
+   ({ pageName }) =>
+   (next) => {
+      return async (context) => {
+         return timeAsync(`page.${pageName}.server_side_props`, async () => {
+            console.log('context.resolvedUrl', context.resolvedUrl);
+            console.log('context.req.url', context.req.url);
+            Sentry.setContext('Extra Info', {
+               headers: context.req.headers,
+               url: context.req.url,
+               method: context.req.method,
+               locale: context.locale,
+               ...context.params,
+               ...context.query,
+            });
+            const isCacheDisabled =
+               CACHE_DISABLED || context.query._vercel_no_cache === '1';
+            if (isCacheDisabled) {
+               clearCache();
+            }
+            return next(context)
+               .then((result) => {
+                  if (isCacheDisabled) {
+                     context.res.setHeader(
+                        'Cache-Control',
+                        'no-store, no-cache, must-revalidate, stale-if-error=0'
+                     );
+                     clearCache();
+                  }
+                  return result;
+               })
+               .catch((err) => {
+                  setSentryPageContext(context);
+                  throw err;
+               });
+         });
+      };
+   };
 
 export function noindexDevDomains(context: GetServerSidePropsContext) {
    if (context.req.headers['user-agent'] !== PROD_USER_AGENT) {
       context.res.setHeader('X-Robots-Tag', 'noindex, nofollow');
    }
 }
+
+export const withNoindexDevDomains: GetServerSidePropsMiddleware = (next) => {
+   return (context) => {
+      const result = next(context);
+      noindexDevDomains(context);
+      return result;
+   };
+};

--- a/frontend/lib/duration.ts
+++ b/frontend/lib/duration.ts
@@ -1,0 +1,46 @@
+export const Duration = (value: number) => {
+   return {
+      get second() {
+         return value * 1000;
+      },
+      get seconds() {
+         return value * 1000;
+      },
+      get minute() {
+         return this.seconds * 60;
+      },
+      get minutes() {
+         return this.seconds * 60;
+      },
+      get hour() {
+         return this.minutes * 60;
+      },
+      get hours() {
+         return this.minutes * 60;
+      },
+      get day() {
+         return this.hours * 24;
+      },
+      get days() {
+         return this.hours * 24;
+      },
+      get week() {
+         return this.days * 7;
+      },
+      get weeks() {
+         return this.days * 7;
+      },
+      get month() {
+         return this.days * 30;
+      },
+      get months() {
+         return this.days * 30;
+      },
+      get year() {
+         return this.days * 365;
+      },
+      get years() {
+         return this.days * 365;
+      },
+   };
+};

--- a/frontend/lib/next-middleware.ts
+++ b/frontend/lib/next-middleware.ts
@@ -1,0 +1,10 @@
+import { GetServerSideProps, PreviewData } from 'next';
+import { ParsedUrlQuery } from 'querystring';
+
+export type GetServerSidePropsMiddleware = <
+   P extends { [key: string]: any } = { [key: string]: any },
+   Q extends ParsedUrlQuery = ParsedUrlQuery,
+   D extends PreviewData = PreviewData
+>(
+   next: GetServerSideProps<P, Q, D>
+) => GetServerSideProps<P, Q, D>;

--- a/frontend/pages/Parts/[...deviceHandleItemType].tsx
+++ b/frontend/pages/Parts/[...deviceHandleItemType].tsx
@@ -1,11 +1,12 @@
-import { serverSidePropsWrapper } from '@helpers/next-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import { ProductListType } from '@models/product-list';
 import { getProductListServerSideProps } from '@templates/product-list/server';
 
 export { default } from '@templates/product-list';
 
-export const getServerSideProps = serverSidePropsWrapper(
-   'parts-device',
+export const getServerSideProps = withLogging({
+   pageName: 'parts-device',
+})(
    getProductListServerSideProps({
       productListType: ProductListType.DeviceParts,
    })

--- a/frontend/pages/Parts/index.tsx
+++ b/frontend/pages/Parts/index.tsx
@@ -1,11 +1,10 @@
-import { serverSidePropsWrapper } from '@helpers/next-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import { ProductListType } from '@models/product-list';
 import { getProductListServerSideProps } from '@templates/product-list/server';
 
 export { default } from '@templates/product-list';
 
-export const getServerSideProps = serverSidePropsWrapper(
-   'parts',
+export const getServerSideProps = withLogging({ pageName: 'parts' })(
    getProductListServerSideProps({
       productListType: ProductListType.AllParts,
    })

--- a/frontend/pages/Shop/[handle].tsx
+++ b/frontend/pages/Shop/[handle].tsx
@@ -1,11 +1,12 @@
-import { serverSidePropsWrapper } from '@helpers/next-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import { ProductListType } from '@models/product-list';
 import { getProductListServerSideProps } from '@templates/product-list/server';
 
 export { default } from '@templates/product-list';
 
-export const getServerSideProps = serverSidePropsWrapper(
-   'shop',
+export const getServerSideProps = withLogging({
+   pageName: 'shop',
+})(
    getProductListServerSideProps({
       productListType: ProductListType.Marketing,
    })

--- a/frontend/pages/Tools/[handle].tsx
+++ b/frontend/pages/Tools/[handle].tsx
@@ -1,11 +1,12 @@
-import { serverSidePropsWrapper } from '@helpers/next-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import { ProductListType } from '@models/product-list';
 import { getProductListServerSideProps } from '@templates/product-list/server';
 
 export { default } from '@templates/product-list';
 
-export const getServerSideProps = serverSidePropsWrapper(
-   'tools-category',
+export const getServerSideProps = withLogging({
+   pageName: 'tools-category',
+})(
    getProductListServerSideProps({
       productListType: ProductListType.ToolsCategory,
    })

--- a/frontend/pages/Tools/index.tsx
+++ b/frontend/pages/Tools/index.tsx
@@ -1,11 +1,12 @@
-import { serverSidePropsWrapper } from '@helpers/next-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import { ProductListType } from '@models/product-list';
 import { getProductListServerSideProps } from '@templates/product-list/server';
 
 export { default } from '@templates/product-list';
 
-export const getServerSideProps = serverSidePropsWrapper(
-   'tools',
+export const getServerSideProps = withLogging({
+   pageName: 'tools',
+})(
    getProductListServerSideProps({
       productListType: ProductListType.AllTools,
    })


### PR DESCRIPTION
closes #1187 

This PR increases stale time for product page as we aim to reduce cache misses.

Other changes:
- Added a small convenient duration library
- Standardized get server side props middleware conventions

## QA

Not sure how to QA this given that Vercel seems to override cache control on preview links. Got any idea @danielbeardsley @masonmcelvain @sterlinghirsh  ?
qa_req 0