### PR TITLE
Playwright: Fix broken pro_user test

### DIFF
--- a/frontend/tests/playwright/utils.ts
+++ b/frontend/tests/playwright/utils.ts
@@ -6,6 +6,7 @@ export const interceptLogin = async (page: Page, userParams?: Object) => {
       algoliaApiKeyProduct: null,
       username: 'john',
       unique_username: 'john123',
+      privileges: [],
    };
 
    await page.route('**/api/2.0/user', (route) =>


### PR DESCRIPTION
We forgot to add this param when we switched this to a Playwright test. It's needed so we can set pro user discounts.

QA:
--
The test should pass.

`pnpm playwright test --project=chromium --headed pro_user` 

Closes: https://github.com/ifixit/react-commerce/issues/1181

cc @ardelato 