### PR TITLE
Playwright Tests: Extract Search Query Response to Utils

### DIFF
--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { resolvePath } from '../utils';
+import { waitForAlgoliaSearch, resolvePath } from '../utils';
 
 test.describe('product list filters', () => {
    test.beforeEach(async ({ page }) => {
@@ -25,13 +25,7 @@ test.describe('product list filters', () => {
       await firstCollapsedAccordionItem.click();
 
       // Define a Promise to wait for the search to be triggered and let the UI update.
-      const queryResponse = page.waitForResponse(async (response) => {
-         return (
-            response.url().includes('algolia') &&
-            response.url().includes('queries?') &&
-            response.status() === 200
-         );
-      });
+      const queryResponse = waitForAlgoliaSearch(page);
 
       // Click the first facet item
       const firstFacetOption = await firstCollapsedAccordionItem.$(

--- a/frontend/tests/playwright/product-list/parts_page_search.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_search.spec.ts
@@ -1,3 +1,4 @@
+import { waitForAlgoliaSearch } from './../utils';
 import { test, expect } from '@playwright/test';
 
 const NO_SEARCH_RESULT = 'No matching products found';
@@ -14,13 +15,7 @@ test.describe('parts page search', () => {
       expect(page.getByTestId('collections-search-box')).not.toBeDisabled();
 
       // Start listening for algolia search request
-      const queryResponse = page.waitForResponse((response) => {
-         return (
-            response.url().includes('algolia') &&
-            response.url().includes('queries?') &&
-            response.status() === 200
-         );
-      });
+      const queryResponse = waitForAlgoliaSearch(page);
 
       await page.getByTestId('collections-search-box').fill('iphone');
 
@@ -49,13 +44,7 @@ test.describe('parts page search', () => {
       expect(page.getByTestId('collections-search-box')).not.toBeDisabled();
 
       // Start listening for algolia search request
-      const queryResponse = page.waitForResponse((response) => {
-         return (
-            response.url().includes('algolia') &&
-            response.url().includes('queries?') &&
-            response.status() === 200
-         );
-      });
+      const queryResponse = waitForAlgoliaSearch(page);
 
       await page.getByTestId('collections-search-box').fill('asdasasdadasd');
 

--- a/frontend/tests/playwright/utils.ts
+++ b/frontend/tests/playwright/utils.ts
@@ -22,6 +22,15 @@ export const interceptLogin = async (page: Page, userParams?: Object) => {
    );
 };
 
+export const waitForAlgoliaSearch = async (page: Page) => {
+   return page.waitForResponse(async (response) => {
+      return (
+         response.url().includes('1/indexes/*/queries') &&
+         response.status() === 200
+      );
+   });
+};
+
 /*
  * This function is used to resolve a path in an object using dot notation.
  * It is a way to mimic the `its` function in Cypress by using


### PR DESCRIPTION
## Description

This came up in https://github.com/iFixit/react-commerce/pull/1180#discussion_r1055888310.
We have this piece of code duplicated across some of our current tests, let's just extract it to a utils file and reuse it.

While extracting it, I also simplified the matching logic a bit.

## QA 

- [ ] CI should pass

Connects: https://github.com/iFixit/react-commerce/issues/1111