### PR TITLE
Remove price facet from /Parts collections

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/useFacets.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/useFacets.tsx
@@ -59,7 +59,10 @@ export function useFilteredFacets(productList: ProductList) {
       return facets.filter((facet) => !excludedToolsFacets.includes(facet));
    }
 
-   return usefulFacets;
+   const excludedPartsAndMarketingFacets = ['price_range'];
+   return usefulFacets.filter(
+      (facet) => !excludedPartsAndMarketingFacets.includes(facet)
+   );
 }
 
 // Higher number == closer to top, default is 0


### PR DESCRIPTION
closes #533
closes #1190 

### QA

1. Visit Vercel Preview
2. Verify that the price-range filter is not showing anymore in /Parts collections but is still visible in /Tools collections