### PR TITLE
Fix store selector links

### DIFF
--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -61,7 +61,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
                ? new URL(store.url).origin
                : codeToDomain[store.code];
          if (domain) {
-            store.url = `${domain}/products/${product.handle}`;
+            return { ...store, url: `${domain}/products/${product.handle}` };
          }
          return store;
       });


### PR DESCRIPTION
closes #1174 

The product template was modifying in place the stores variable.
Since that variable was potentially preserved, this polluted the cache and led to unexpected results.

### QA

1. Visit Vercel preview
2. Verify that the store selector links are now pointing to the correct destination