### PR TITLE
Manually scroll to newly shown facet details

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/accordion/FacetAccordionItem.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/accordion/FacetAccordionItem.tsx
@@ -30,6 +30,22 @@ export function FacetAccordionItem({
    children,
 }: FacetAccordionItemProps) {
    const formattedFacetName = formatFacetName(attribute);
+   const accordionItemRef = React.useRef<HTMLDivElement>(null);
+
+   React.useEffect(() => {
+      if (isExpanded) {
+         setTimeout(
+            () =>
+               accordionItemRef.current?.scrollIntoView({
+                  behavior: 'smooth',
+                  block: 'nearest',
+               }),
+            // We have to wait for the transition to complete
+            200
+         );
+      }
+   }, [isExpanded]);
+
    return (
       <AccordionItem
          hidden={isHidden}
@@ -39,6 +55,7 @@ export function FacetAccordionItem({
          }-facet-accordion-item-${attribute}`}
          data-facet-name={attribute}
          className={isHidden ? 'hidden' : 'visible'}
+         ref={accordionItemRef}
       >
          <AccordionButton
             aria-label={


### PR DESCRIPTION
closes #155 

### QA

1. Visit Vercel preview
2. Verify that newly shown facet are always scrolled into the viewport