### PR TITLE
Avoid referencing /# for the leaf element

### DIFF
--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -120,7 +120,10 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
                      '@type': 'ListItem',
                      position: index + 1,
                      name: item.label,
-                     item: `${appContext.ifixitOrigin}${item.url}`,
+                     item:
+                        item.url && item.url !== '#'
+                           ? `${appContext.ifixitOrigin}${item.url}`
+                           : undefined,
                   })) || undefined,
             })}
          />


### PR DESCRIPTION
closes #1198 

### QA

1. Visit Vercel preview
2. Analyze a random product page via [rich result tester](https://search.google.com/test/rich-results)
3. Verify that the leaf element is not referencing any url anymore as [in the documentation](https://developers.google.com/search/docs/appearance/structured-data/breadcrumb#json-ld)
4. If the url is not crawlable it is possible to copy the source code of the page in the tool