### PR TITLE
Product Page: Add reviews test

### DIFF
--- a/frontend/templates/product/sections/ReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ReviewsSection/index.tsx
@@ -221,7 +221,12 @@ type ProductReviewLineItemProps = {
 };
 function ProductReviewLineItem({ review }: ProductReviewLineItemProps) {
    return (
-      <Box py="6" borderBottomWidth="1px" borderColor="gray.200">
+      <Box
+         py="6"
+         borderBottomWidth="1px"
+         borderColor="gray.200"
+         data-testid="product-review-line-item"
+      >
          {review.author && (
             <HStack>
                <Avatar

--- a/frontend/tests/playwright/product/product_reviews.spec.ts
+++ b/frontend/tests/playwright/product/product_reviews.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Product Page Reviews test', () => {
+   test('see more reviews button displays more reviews', async ({ page }) => {
+      await page.goto('products/repair-business-toolkit');
+
+      const reviewsCountBefore = await page
+         .getByTestId('product-review-line-item')
+         .count();
+
+      await page.getByText('see more reviews').click();
+
+      const reviewsAfter = page.getByTestId('product-review-line-item');
+      const reviewsCountAfter = await reviewsAfter.count();
+      expect(reviewsCountAfter).toBeGreaterThan(reviewsCountBefore);
+
+      for (let i = 0; i < reviewsCountAfter; i++) {
+         await expect(reviewsAfter.nth(i)).toBeVisible();
+      }
+   });
+});


### PR DESCRIPTION
## Summary
Added a test for a product with multiple reviews.

The test compares the number of reviews before hitting the `see more reviews` button and after. 
Also expects that all of the reviews are visible after clicking the button.

## QA notes
Passing CI is enough (qa_req 0).


closes: #1201 Note: currently, we don't have the `filter by` or `sort by` buttons implemented for the reviews
