### PR TITLE
Empty Collections : Fix Redirect

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -256,7 +256,7 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
                   This collection does not have products.
                </Text>
                {parentCategory && (
-                  <Link href={productListPath(productList)}>
+                  <Link href={productListPath(parentCategory)}>
                      Return to {parentCategory.title}
                   </Link>
                )}


### PR DESCRIPTION
Previously, when we clicked on the `Return to {parentCategory}`, we changed the path by passing the productList. This was causing the redirect to go back to the empty collections page because the `deviceTitle` was that empty collection. Instead, we want to call the path function on the parent category. 

## CR

This code was changed in [this ](https://github.com/iFixit/react-commerce/commit/84f1ce0862504a16f2882366ba07a362286fe340#diff-146576464652341e2182a37a924bb88512b1ba7eeb233ca65277527588fc7dba)commit a couple months ago, which I believe might've caused this bug.

## QA
Make sure that the page redirects correctly to the parent category on an empty collections page [refer to issue].

Closes #1172 