### PR TITLE
Hide aggregate rating and reviewCount if needed

### DIFF
--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -135,7 +135,9 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
                name: metaTitle || undefined,
                url: selectedVariantUrl,
                aggregateRating:
-                  product.rating && product.reviewsCount
+                  product.rating?.value &&
+                  product.reviewsCount &&
+                  (product.rating.value >= 4 || product.reviewsCount > 10)
                      ? {
                           '@type': 'AggregateRating',
                           ratingValue: product.rating.value,


### PR DESCRIPTION
closes #1140

This PR removes review data from the ld+json structured data unless `product.rating.value >= 4 || product.reviewsCount > 10`.

### QA

1. Visit Vercel preview ([here](https://react-commerce-prod-git-review-hiding-logic-remov-c801ba-ifixit.vercel.app/products/anti-clamp) is a sample product with hidden reviews)
2. Verify that the review section in the product ld+json is not present anymore if `product.rating.value < 4 && product.reviewsCount <= 10`