### PR TITLE
Actions: Add linter workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,46 @@
+name: ESlint
+
+on:
+   push:
+      branches-ignore:
+         - 'main'
+
+jobs:
+   linter:
+      runs-on: ubuntu-latest
+      steps:
+         - name: Checkout
+           uses: actions/checkout@v2
+           with:
+              token: ${{ secrets.ACTION_PAT }}
+         - name: Setup and cache pnpm
+           uses: ./.github/actions/pnpm-setup
+         - name: Install workspaces
+           env:
+              FONT_AWESOME_NPM_TOKEN: ${{ secrets.FONT_AWESOME_NPM_TOKEN }}
+           run: pnpm install
+         - name: Run ESlint
+           run: cd frontend && pnpm lint --fix
+         - name: Detect diff
+           id: detect-diff
+           run: |
+              if [ ! -z "$(git status --short)" ]; then
+                 echo "HAS_DIFF=true" >> $GITHUB_OUTPUT
+              else
+                 echo "HAS_DIFF=false" >> $GITHUB_OUTPUT
+              fi
+         - name: Fail if Dependabot
+           if: steps.detect-diff.outputs.HAS_DIFF == 'true' && github.actor == 'dependabot[bot]'
+           run: exit 1
+         - name: Commit changes
+           if: steps.detect-diff.outputs.HAS_DIFF == 'true'
+           run: |
+              git fetch --depth=1 origin "$GITHUB_REF_NAME"
+              git stash
+              git checkout "$GITHUB_REF_NAME"
+              git stash pop
+              git config user.name "github-actions[bot]"
+              git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
+              git add .
+              git commit -m "style: apply linter formatting diff"
+              git push

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,6 +1,6 @@
 {
    "parser": "@typescript-eslint/parser",
-   "plugins": ["@typescript-eslint", "eslint-plugin-cypress"],
+   "plugins": ["@typescript-eslint", "eslint-plugin-cypress", "jest"],
    "extends": [
       "eslint:recommended",
       "plugin:@typescript-eslint/recommended",
@@ -20,6 +20,7 @@
       }
    },
    "rules": {
+      "jest/no-focused-tests": "error",
       "no-console": "off",
       "react/display-name": 0,
       "@typescript-eslint/explicit-function-return-type": 0,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,6 +110,7 @@
       "eslint-config-next": "11.0.1",
       "eslint-config-prettier": "7.2.0",
       "eslint-plugin-cypress": "2.12.1",
+      "eslint-plugin-jest": "27.2.0",
       "eslint-plugin-react": "7.23.0",
       "eslint-plugin-react-hooks": "4.2.0",
       "graphql-tag": "2.12.6",

--- a/frontend/tests/cypress/integration/product/product_option.cy.ts
+++ b/frontend/tests/cypress/integration/product/product_option.cy.ts
@@ -51,6 +51,7 @@ describe('Product option test', () => {
          .should('be.visible')
          .then((el) => {
             // Parse out the skus from the skuTexts which are in form of "Item # IF145-278-14"
+            /* eslint-disable no-useless-escape */
             const sku1 = this.firstOptionSkuText.match(/IF\d*\-\d*\-\d*/g)[0];
             const sku2 = this.secondOptionSkuText.match(/IF\d*\-\d*\-\d*/g)[0];
 

--- a/frontend/tests/cypress/integration/product/product_page.cy.ts
+++ b/frontend/tests/cypress/integration/product/product_page.cy.ts
@@ -25,7 +25,7 @@ describe('Product page test', () => {
          .should('be.visible')
          .invoke('text')
          .then((originalPriceString) => {
-            // regex to match $299.99 with dollar sign 
+            // regex to match $299.99 with dollar sign
             expect(originalPriceString).to.match(/\$\d*\.\d*/g);
          });
    });

--- a/frontend/tests/cypress/integration/product/product_page.cy.ts
+++ b/frontend/tests/cypress/integration/product/product_page.cy.ts
@@ -15,6 +15,7 @@ describe('Product page test', () => {
          .should('be.visible')
          .invoke('text')
          .then((productSku) => {
+            /* eslint-disable no-useless-escape */
             expect(productSku).to.match(/IF\d*\-\d*/g);
          });
 
@@ -24,7 +25,7 @@ describe('Product page test', () => {
          .should('be.visible')
          .invoke('text')
          .then((originalPriceString) => {
-            // regex to match $299.99 with dollar sign
+            // regex to match $299.99 with dollar sign 
             expect(originalPriceString).to.match(/\$\d*\.\d*/g);
          });
    });

--- a/frontend/tests/jest/tests/CompatibleDevice.test.tsx
+++ b/frontend/tests/jest/tests/CompatibleDevice.test.tsx
@@ -5,8 +5,8 @@ import { getMockProduct } from '../utils';
 
 describe('CompatibleDevice', () => {
    it('renders and matches the snapshot', () => {
-      let product = getMockProduct();
-      let device = product!.compatibility!.devices[0];
+      const product = getMockProduct();
+      const device = product!.compatibility!.devices[0];
 
       // @ts-ignore
       const { asFragment } = renderWithAppContext(
@@ -20,8 +20,8 @@ describe('CompatibleDevice', () => {
    });
 
    it('renders and matches the snapshot with truncated variants', async () => {
-      let product = getMockProduct();
-      let device = product!.compatibility!.devices[0];
+      const product = getMockProduct();
+      const device = product!.compatibility!.devices[0];
 
       // @ts-ignore
       const { asFragment } = renderWithAppContext(

--- a/frontend/tests/playwright/product/product_page.spec.ts
+++ b/frontend/tests/playwright/product/product_page.spec.ts
@@ -12,6 +12,7 @@ test.describe('Product page test', () => {
 
       // Assert product sku is visible
       await expect(page.getByTestId('product-sku')).toBeVisible();
+      /* eslint-disable no-useless-escape */
       await expect(page.getByTestId('product-sku')).toHaveText(/IF\d*\-\d*/g);
 
       // Get price from page

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,7 @@ importers:
       eslint-config-next: 11.0.1
       eslint-config-prettier: 7.2.0
       eslint-plugin-cypress: 2.12.1
+      eslint-plugin-jest: 27.2.0
       eslint-plugin-react: 7.23.0
       eslint-plugin-react-hooks: 4.2.0
       framer-motion: 6.2.7
@@ -204,6 +205,7 @@ importers:
       eslint-config-next: 11.0.1_46bez636duzful4jrqublvwgi4
       eslint-config-prettier: 7.2.0_eslint@7.23.0
       eslint-plugin-cypress: 2.12.1_eslint@7.23.0
+      eslint-plugin-jest: 27.2.0_juujdrscewc33g745opjwdzqfe
       eslint-plugin-react: 7.23.0_eslint@7.23.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.23.0
       graphql-tag: 2.12.6_graphql@15.5.3
@@ -6768,6 +6770,10 @@ packages:
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
 
+  /@types/semver/7.3.13:
+    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: true
+
   /@types/shopify-buy/2.10.5:
     resolution: {integrity: sha512-12Le/iXPynrONntux/OaXf9+yx0zbMBKhwywdej9mfR8YhXB82pPZYzU3o6j8cjK1uCQ/wWkqLTftpaXpeMKig==}
     dev: true
@@ -6952,6 +6958,14 @@ packages:
       '@typescript-eslint/visitor-keys': 4.33.0
     dev: true
 
+  /@typescript-eslint/scope-manager/5.48.0:
+    resolution: {integrity: sha512-0AA4LviDtVtZqlyUQnZMVHydDATpD9SAX/RC5qh6cBd3xmyWvmXYF+WT1oOmxkeMnWDlUVTwdODeucUnjz3gow==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.48.0
+      '@typescript-eslint/visitor-keys': 5.48.0
+    dev: true
+
   /@typescript-eslint/types/4.14.2:
     resolution: {integrity: sha512-LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
@@ -6960,6 +6974,11 @@ packages:
   /@typescript-eslint/types/4.33.0:
     resolution: {integrity: sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dev: true
+
+  /@typescript-eslint/types/5.48.0:
+    resolution: {integrity: sha512-UTe67B0Ypius0fnEE518NB2N8gGutIlTojeTg4nt0GQvikReVkurqxd2LvYa9q9M5MQ6rtpNyWTBxdscw40Xhw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree/4.14.2_typescript@4.8.4:
@@ -7005,6 +7024,47 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.48.0_typescript@4.8.4:
+    resolution: {integrity: sha512-7pjd94vvIjI1zTz6aq/5wwE/YrfIyEPLtGJmRfyNR9NYIW+rOvzzUv3Cmq2hRKpvt6e9vpvPUQ7puzX7VSmsEw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.48.0
+      '@typescript-eslint/visitor-keys': 5.48.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.48.0_d6djodu674rxuopabqarwp27ee:
+    resolution: {integrity: sha512-x2jrMcPaMfsHRRIkL+x96++xdzvrdBCnYRd5QiW5Wgo1OB4kDYPbC1XjWP/TNqlfK93K/lUL92erq5zPLgFScQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.48.0
+      '@typescript-eslint/types': 5.48.0
+      '@typescript-eslint/typescript-estree': 5.48.0_typescript@4.8.4
+      eslint: 7.23.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.23.0
+      semver: 7.3.7
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys/4.14.2:
     resolution: {integrity: sha512-KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
@@ -7019,6 +7079,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 4.33.0
       eslint-visitor-keys: 2.1.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.48.0:
+    resolution: {integrity: sha512-5motVPz5EgxQ0bHjut3chzBkJ3Z3sheYVcSwS5BpHZpLqSptSmELNtGixmgj65+rIfhvtQTz5i9OP2vtzdDH7Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.48.0
+      eslint-visitor-keys: 3.3.0
     dev: true
 
   /@webassemblyjs/ast/1.11.1:
@@ -9331,6 +9399,28 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-plugin-jest/27.2.0_juujdrscewc33g745opjwdzqfe:
+    resolution: {integrity: sha512-KGIYtelk4rIhKocxRKUEeX+kJ0ZCab/CiSgS8BMcKD7AY7YxXhlg/d51oF5jq2rOrtuJEDYWRwXD95l6l2vtrA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^5.0.0
+      eslint: ^7.0.0 || ^8.0.0
+      jest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      jest:
+        optional: true
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 4.14.2_unxprlgwzryxbloshammutlwmi
+      '@typescript-eslint/utils': 5.48.0_d6djodu674rxuopabqarwp27ee
+      eslint: 7.23.0
+      jest: 28.1.2_@types+node@18.11.5
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /eslint-plugin-jsx-a11y/6.5.1_eslint@7.23.0:
     resolution: {integrity: sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==}
     engines: {node: '>=4.0'}
@@ -9419,6 +9509,16 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
+  /eslint-utils/3.0.0_eslint@7.23.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      eslint: 7.23.0
+      eslint-visitor-keys: 2.1.0
+    dev: true
+
   /eslint-visitor-keys/1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
     engines: {node: '>=4'}
@@ -9427,6 +9527,11 @@ packages:
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-visitor-keys/3.3.0:
+    resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /eslint/7.23.0:


### PR DESCRIPTION
## Summary
1. Installed `eslint-plugin-jest` plugin and added `no-focused-tests` eslint rule to prevent `.only` in jest tests.
2. Fixed existing errors from the linter.
3. Added a new workflow to run the linter.
 
Note: Playwright tests already have `forbidOnly` (checks for `.only`) set correctly in the config so we don't have to worry about it.

## QA notes
1. Find a jest test and add `.only` like the following:
```diff
frontend/tests/jest/tests/CompatibleDevice.test.tsx

 describe('CompatibleDevice', () => {
-   it('renders and matches the snapshot', () => {
+   it.only('renders and matches the snapshot', () => {
       const product = getMockProduct();

 ```

2. Then run `cd frontend && pnpm lint`. 
4. Make sure the linter returns the following error: `Unexpected focused test  jest/no-focused-tests`

connects: https://github.com/iFixit/ifixit/issues/45873