### PR TITLE
Product Page: Add tests for images

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -256,6 +256,7 @@ const CustomNavigation = ({
             </Circle>
          </Button>
          <Button
+            data-testid="swiper-next-image"
             pos="absolute"
             top="50%"
             right="2"

--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -535,5 +535,34 @@ describe('ProductSection Tests', () => {
             'This item is currently Out of Stock'
          );
       });
+
+      test('Product with no image', async () => {
+         const product = getMockProduct({
+            images: [],
+            variants: [
+               getMockProductVariant({
+                  image: null,
+               }),
+            ],
+         });
+
+         renderWithAppContext(
+            <ProductSection
+               product={product}
+               selectedVariant={product.variants[0]}
+               onVariantChange={jest.fn()}
+               internationalBuyBox={null}
+            />
+         );
+
+         const imagePlaceholders = screen.queryAllByText(
+            /No photos available for this product/i
+         );
+         // We have 2 image placeholders in the dom where one of them is hidden
+         // and the other is visible (due to different viewports).
+         imagePlaceholders.forEach((el) =>
+            (expect(el) as any).toBeInTheDocument()
+         );
+      });
    });
 });

--- a/frontend/tests/playwright/product/product_image.spec.ts
+++ b/frontend/tests/playwright/product/product_image.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 test.describe('Product image test', () => {
    test('product with a single image ', async ({ page }) => {
@@ -9,4 +9,33 @@ test.describe('Product image test', () => {
          .first();
       expect(image).toBeVisible;
    });
+
+   test('product with multiple images ', async ({ page }) => {
+      await page.goto('/products/repair-business-toolkit');
+
+      const firstImageSrc = await getCurrentActiveImgSrc(page);
+      const firstImage = page.locator(`img[src="${firstImageSrc}"]`).first();
+      await expect(firstImage).toBeVisible();
+
+      // Click on the arrow for the next image
+      await page.getByTestId('swiper-next-image').first().click();
+
+      const secondImageSrc = await getCurrentActiveImgSrc(page);
+      const secondImage = page.locator(`img[src="${secondImageSrc}"]`).first();
+      await expect(secondImage).toBeVisible();
+
+      // Assert that currently active image has different src than the first one
+      expect(firstImageSrc).not.toEqual(secondImageSrc);
+   });
+
+   /*
+    * Returns the src of the currently displayed active image
+    * Applies only for product variants with multiple images
+    */
+   async function getCurrentActiveImgSrc(page: Page) {
+      const divElement = await page.$('.swiper-slide.swiper-slide-active');
+      const imgElement = await divElement!.$$('img');
+      const src = await imgElement[0].getAttribute('src');
+      return src;
+   }
 });

--- a/frontend/tests/playwright/product/product_image.spec.ts
+++ b/frontend/tests/playwright/product/product_image.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Product image test', () => {
+   test('product with a single image ', async ({ page }) => {
+      await page.goto('/products/iflex-opening-tool');
+
+      const image = page
+         .getByRole('img', { name: 'iFlex Opening Tool' })
+         .first();
+      expect(image).toBeVisible;
+   });
+});

--- a/frontend/tests/playwright/product/product_image.spec.ts
+++ b/frontend/tests/playwright/product/product_image.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 test.describe('Product image test', () => {
    test('product with a single image ', async ({ page }) => {
@@ -13,29 +13,26 @@ test.describe('Product image test', () => {
    test('product with multiple images ', async ({ page }) => {
       await page.goto('/products/repair-business-toolkit');
 
-      const firstImageSrc = await getCurrentActiveImgSrc(page);
+      const firstImageSrc = await page
+         .locator('.swiper-slide.swiper-slide-active')
+         .getByRole('img')
+         .first()
+         .getAttribute('src');
       const firstImage = page.locator(`img[src="${firstImageSrc}"]`).first();
       await expect(firstImage).toBeVisible();
 
       // Click on the arrow for the next image
       await page.getByTestId('swiper-next-image').first().click();
 
-      const secondImageSrc = await getCurrentActiveImgSrc(page);
+      const secondImageSrc = await page
+         .locator('.swiper-slide.swiper-slide-active')
+         .getByRole('img')
+         .first()
+         .getAttribute('src');
       const secondImage = page.locator(`img[src="${secondImageSrc}"]`).first();
       await expect(secondImage).toBeVisible();
 
       // Assert that currently active image has different src than the first one
       expect(firstImageSrc).not.toEqual(secondImageSrc);
    });
-
-   /*
-    * Returns the src of the currently displayed active image
-    * Applies only for product variants with multiple images
-    */
-   async function getCurrentActiveImgSrc(page: Page) {
-      const divElement = await page.$('.swiper-slide.swiper-slide-active');
-      const imgElement = await divElement!.$$('img');
-      const src = await imgElement[0].getAttribute('src');
-      return src;
-   }
 });


### PR DESCRIPTION
## Summary
Added tests that:
-  checks a product with no image and asserts `No photos available for this product` image placeholder is visible.
-  checks a product with a single image and asserts that the image is visible.
-  checks a product with multiple images and asserts that clicking on the next image button shows the other image by checking that they have different sources. 

## QA Notes
Passing CI is enough. 

qa_req 0
closes #1200