### PR TITLE
Run Playwright tests on Mobile Devices

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,16 @@ jobs:
               path: frontend/test/cypress/screenshots
 
    playwright-run:
+      strategy:
+         fail-fast: false
+         matrix:
+            project:
+               [
+                  'Desktop Chrome',
+                  'Desktop Firefox',
+                  'Mobile Chrome',
+                  'Tablet Chrome',
+               ]
       runs-on: ubuntu-latest
       steps:
          - name: Checkout
@@ -88,7 +98,7 @@ jobs:
               NODE_ENV: test
               NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
               ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-           run: cd frontend && pnpm playwright:run
+           run: cd frontend && pnpm playwright:run --project="${{ matrix.project }}"
 
          - uses: actions/upload-artifact@v2
            if: failure()

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -61,14 +61,14 @@ const config: PlaywrightTestConfig = {
    /* Configure projects for major browsers */
    projects: [
       {
-         name: 'chromium',
+         name: 'Desktop Chrome',
          use: {
             ...devices['Desktop Chrome'],
          },
       },
 
       {
-         name: 'firefox',
+         name: 'Desktop Firefox',
          use: {
             ...devices['Desktop Firefox'],
          },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -74,26 +74,26 @@ const config: PlaywrightTestConfig = {
          },
       },
 
+      /* Test against mobile viewports. */
+      {
+         name: 'Mobile Chrome',
+         use: {
+            ...devices['Pixel 5'],
+         },
+      },
+      {
+         name: 'Tablet Chrome',
+         use: {
+            ...devices['Galaxy Tab S4'],
+         },
+      },
+
       // We need to enable cross-site tracking for Safari to work locally.
       // {
       //    name: 'webkit',
       //    use: {
       //       ...devices['Desktop Safari'],
       //    },
-      // },
-
-      /* Test against mobile viewports. */
-      // {
-      //   name: 'Mobile Chrome',
-      //   use: {
-      //     ...devices['Pixel 5'],
-      //   },
-      // },
-      // {
-      //   name: 'Mobile Safari',
-      //   use: {
-      //     ...devices['iPhone 12'],
-      //   },
       // },
 
       /* Test against branded browsers. */

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -2,6 +2,11 @@ import { test, expect } from '@playwright/test';
 import { waitForAlgoliaSearch, resolvePath } from '../utils';
 
 test.describe('product list filters', () => {
+   test.skip(({ page }) => {
+      const viewPort = page.viewportSize();
+      return !viewPort || viewPort.width < 768;
+   }, 'Only run on desktop. Still need to rework this test for mobile.');
+
    test.beforeEach(async ({ page }) => {
       await page.goto('/Parts');
    });

--- a/frontend/tests/playwright/product-list/parts_page_devices.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_devices.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('parts page devices', () => {
+   test.skip(({ page }) => {
+      const viewPort = page.viewportSize();
+      return !viewPort || viewPort.width < 768;
+   }, 'Only run on desktop. Still need to rework this test for mobile.');
+
    test.beforeEach(async ({ page }) => {
       await page.goto('/Parts');
    });


### PR DESCRIPTION
## Description

This will add a `mobile` and `tablet` device for the current playwright tests. This emulates the device's viewport size and user agent and does not actually emulate the hardware.

## CR Notes

There were two tests that we had to skip for mobile testing because UI changes on mobile and therefore the selectors we are using do not work.

In addition, we are using a matrix to run each `device - browser` combo in parallel but as independent Playwright jobs.

## QA Notes

- [ ] CI passes
	- [ ] For mobile and tablet, there should be 2 tests skipped
	- [ ] For the desktops, there should be no tests skipped

Closes: https://github.com/ifixit/react-commerce/issues/1204
