### PR TITLE
Product Page: Add Tests for Breadcrumbs

### DIFF
--- a/frontend/components/common/PageBreadcrumb.tsx
+++ b/frontend/components/common/PageBreadcrumb.tsx
@@ -60,7 +60,10 @@ export function PageBreadcrumb({ items, ...otherProps }: PageBreadcrumbProps) {
                   lg: 'none',
                }}
             >
-               <BreadcrumbMenu items={mobileCollapsedItems} />
+               <BreadcrumbMenu
+                  items={mobileCollapsedItems}
+                  data-testid="breadcrumb-menu-mobile"
+               />
             </BreadcrumbItem>
          )}
          {desktopCollapsedItems.length > 0 && (
@@ -70,7 +73,10 @@ export function PageBreadcrumb({ items, ...otherProps }: PageBreadcrumbProps) {
                   lg: 'inline-flex',
                }}
             >
-               <BreadcrumbMenu items={desktopCollapsedItems} />
+               <BreadcrumbMenu
+                  items={desktopCollapsedItems}
+                  data-testid="breadcrumb-menu-desktop"
+               />
             </BreadcrumbItem>
          )}
          {visibleAncestors.map((ancestor, index) => {
@@ -85,6 +91,7 @@ export function PageBreadcrumb({ items, ...otherProps }: PageBreadcrumbProps) {
                >
                   <NextLink href={ancestor.url} passHref>
                      <BreadcrumbLink
+                        data-testid="breadcrumb-ancestor-link-desktop"
                         color="gray.500"
                         whiteSpace="nowrap"
                         borderRadius="sm"
@@ -119,6 +126,7 @@ export function PageBreadcrumb({ items, ...otherProps }: PageBreadcrumbProps) {
                _hover={{
                   textDecoration: 'none',
                }}
+               data-testid="breadcrumb-last-child-link"
             >
                {currentItem.label}
             </BreadcrumbLink>
@@ -131,7 +139,7 @@ type BreadcrumbMenuProps = {
    items: TBreadcrumbItem[];
 };
 
-function BreadcrumbMenu({ items }: BreadcrumbMenuProps) {
+function BreadcrumbMenu({ items, ...otherProps }: BreadcrumbMenuProps) {
    return (
       <Menu>
          <MenuButton
@@ -142,6 +150,7 @@ function BreadcrumbMenu({ items }: BreadcrumbMenuProps) {
             bg="gray.300"
             size="xs"
             px="1.5"
+            {...otherProps}
          />
          <MenuList zIndex="dropdown">
             {items.map((ancestor, index) => (

--- a/frontend/tests/playwright/product/product_breadcrumb.spec.ts
+++ b/frontend/tests/playwright/product/product_breadcrumb.spec.ts
@@ -80,5 +80,40 @@ test.describe('Product breadcrumb test', () => {
          );
          await expect(mobileBreadcrumbMenu).not.toBeVisible();
       });
+
+      /*
+       * Same as the test above, but checks that the desktop breadcrumb menu is visible.
+       */
+      test('with more than 3 breacrumb links', async ({ page }) => {
+         await page.goto('/products/iphone-6s-plus-replacement-battery');
+
+         const lastChildBreadcrumb = page.getByTestId(
+            'breadcrumb-last-child-link'
+         );
+         await expect(lastChildBreadcrumb).toBeVisible();
+
+         const desktopBreadcrumbAncestorLinks = page.getByTestId(
+            'breadcrumb-ancestor-link-desktop'
+         );
+         const ancestorLinksCount =
+            await desktopBreadcrumbAncestorLinks.count();
+         for (let i = 0; i < ancestorLinksCount; i++) {
+            expect(desktopBreadcrumbAncestorLinks.nth(i)).toBeVisible();
+            expect(
+               await desktopBreadcrumbAncestorLinks.nth(i).getAttribute('href')
+            ).not.toBeNull();
+         }
+         expect(ancestorLinksCount).toBeLessThanOrEqual(3);
+
+         const desktopBreadcrumbMenu = page.getByTestId(
+            'breadcrumb-menu-desktop'
+         );
+         await expect(desktopBreadcrumbMenu).toBeVisible();
+
+         const mobileBreadcrumbMenu = page.getByTestId(
+            'breadcrumb-menu-mobile'
+         );
+         await expect(mobileBreadcrumbMenu).not.toBeVisible();
+      });
    });
 });

--- a/frontend/tests/playwright/product/product_breadcrumb.spec.ts
+++ b/frontend/tests/playwright/product/product_breadcrumb.spec.ts
@@ -36,4 +36,38 @@ test.describe('Product breadcrumb test', () => {
          }
       });
    });
+
+   test.describe('Desktop', () => {
+      test.skip(({ page }) => {
+         const viewPort = page.viewportSize();
+         return !viewPort || viewPort.width < 1000;
+      }, 'Only run on desktop.');
+
+      /*
+       * Makes sure that the ancestor and last child breadcrumbs are visible
+       * and the breadcrumb menu is not visible.
+       */
+      test('with less than or equal to 3 breacrumb links', async ({ page }) => {
+         await page.goto('/products/iflex-opening-tool');
+
+         const lastChildBreadcrumb = page.getByTestId(
+            'breadcrumb-last-child-link'
+         );
+         await expect(lastChildBreadcrumb).toBeVisible();
+
+         const desktopBreadcrumbAncestorLinks = page.getByTestId(
+            'breadcrumb-ancestor-link-desktop'
+         );
+         const ancestorLinksCount =
+            await desktopBreadcrumbAncestorLinks.count();
+
+         for (let i = 0; i < ancestorLinksCount; i++) {
+            expect(desktopBreadcrumbAncestorLinks.nth(i)).toBeVisible();
+            expect(
+               await desktopBreadcrumbAncestorLinks.nth(i).getAttribute('href')
+            ).not.toBeNull();
+         }
+         expect(ancestorLinksCount).toBeLessThanOrEqual(3);
+      });
+   });
 });

--- a/frontend/tests/playwright/product/product_breadcrumb.spec.ts
+++ b/frontend/tests/playwright/product/product_breadcrumb.spec.ts
@@ -68,6 +68,17 @@ test.describe('Product breadcrumb test', () => {
             ).not.toBeNull();
          }
          expect(ancestorLinksCount).toBeLessThanOrEqual(3);
+
+         // If the product has less than or equal to 3 breadcrumb links, we don't display the breadcrumb menu
+         const desktopBreadcrumbMenu = page.getByTestId(
+            'breadcrumb-menu-desktop'
+         );
+         await expect(desktopBreadcrumbMenu).not.toBeVisible();
+
+         const mobileBreadcrumbMenu = page.getByTestId(
+            'breadcrumb-menu-mobile'
+         );
+         await expect(mobileBreadcrumbMenu).not.toBeVisible();
       });
    });
 });

--- a/frontend/tests/playwright/product/product_breadcrumb.spec.ts
+++ b/frontend/tests/playwright/product/product_breadcrumb.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Product breadcrumb test', () => {
+   test.describe('Mobile and Tablet', () => {
+      test.skip(({ page }) => {
+         const viewPort = page.viewportSize();
+         return !viewPort || viewPort.width > 1000;
+      }, 'Only run on mobile and tablet.');
+
+      /*
+       * On viewport width sizes below 1000px, we display only the last child breadcrumb
+       * regardless of the number of breadcrumb links. Everything else is collapsed in
+       * the breadcrumb menu.
+       */
+      test('with number of any breadcrumb links', async ({ page }) => {
+         await page.goto('/products/iflex-opening-tool');
+
+         // Last child breadcrumb is visible on both mobile and desktop
+         const lastChildBreadcrumb = page.getByTestId(
+            'breadcrumb-last-child-link'
+         );
+         await expect(lastChildBreadcrumb).toBeVisible();
+
+         const mobileBreadcrumbMenu = page.getByTestId(
+            'breadcrumb-menu-mobile'
+         );
+         await expect(mobileBreadcrumbMenu).toBeVisible();
+
+         // Assert that the ancestor breadcrumb links are not visible on mobile
+         const desktopBreadcrumbAncestorLinks = page.getByTestId(
+            'breadcrumb-ancestor-link-desktop'
+         );
+         const count = await desktopBreadcrumbAncestorLinks.count();
+         for (let i = 0; i < count; i++) {
+            expect(desktopBreadcrumbAncestorLinks.nth(i)).not.toBeVisible();
+         }
+      });
+   });
+});

--- a/frontend/tests/playwright/product/product_breadcrumb.spec.ts
+++ b/frontend/tests/playwright/product/product_breadcrumb.spec.ts
@@ -67,7 +67,7 @@ test.describe('Product breadcrumb test', () => {
                await desktopBreadcrumbAncestorLinks.nth(i).getAttribute('href')
             ).not.toBeNull();
          }
-         expect(ancestorLinksCount).toBeLessThanOrEqual(3);
+         expect(ancestorLinksCount).toBeLessThanOrEqual(2);
 
          // If the product has less than or equal to 3 breadcrumb links, we don't display the breadcrumb menu
          const desktopBreadcrumbMenu = page.getByTestId(
@@ -103,7 +103,7 @@ test.describe('Product breadcrumb test', () => {
                await desktopBreadcrumbAncestorLinks.nth(i).getAttribute('href')
             ).not.toBeNull();
          }
-         expect(ancestorLinksCount).toBeLessThanOrEqual(3);
+         expect(ancestorLinksCount).toBeLessThanOrEqual(2);
 
          const desktopBreadcrumbMenu = page.getByTestId(
             'breadcrumb-menu-desktop'

--- a/frontend/tests/playwright/product/product_breadcrumb.spec.ts
+++ b/frontend/tests/playwright/product/product_breadcrumb.spec.ts
@@ -16,15 +16,11 @@ test.describe('Product breadcrumb test', () => {
          await page.goto('/products/iflex-opening-tool');
 
          // Last child breadcrumb is visible on both mobile and desktop
-         const lastChildBreadcrumb = page.getByTestId(
-            'breadcrumb-last-child-link'
-         );
-         await expect(lastChildBreadcrumb).toBeVisible();
+         await expect(
+            page.getByTestId('breadcrumb-last-child-link')
+         ).toBeVisible();
 
-         const mobileBreadcrumbMenu = page.getByTestId(
-            'breadcrumb-menu-mobile'
-         );
-         await expect(mobileBreadcrumbMenu).toBeVisible();
+         await expect(page.getByTestId('breadcrumb-menu-mobile')).toBeVisible();
 
          // Assert that the ancestor breadcrumb links are not visible on mobile
          const desktopBreadcrumbAncestorLinks = page.getByTestId(
@@ -32,7 +28,9 @@ test.describe('Product breadcrumb test', () => {
          );
          const count = await desktopBreadcrumbAncestorLinks.count();
          for (let i = 0; i < count; i++) {
-            expect(desktopBreadcrumbAncestorLinks.nth(i)).not.toBeVisible();
+            await expect(
+               desktopBreadcrumbAncestorLinks.nth(i)
+            ).not.toBeVisible();
          }
       });
    });
@@ -50,10 +48,9 @@ test.describe('Product breadcrumb test', () => {
       test('with less than or equal to 3 breacrumb links', async ({ page }) => {
          await page.goto('/products/iflex-opening-tool');
 
-         const lastChildBreadcrumb = page.getByTestId(
-            'breadcrumb-last-child-link'
-         );
-         await expect(lastChildBreadcrumb).toBeVisible();
+         await expect(
+            page.getByTestId('breadcrumb-last-child-link')
+         ).toBeVisible();
 
          const desktopBreadcrumbAncestorLinks = page.getByTestId(
             'breadcrumb-ancestor-link-desktop'
@@ -70,15 +67,13 @@ test.describe('Product breadcrumb test', () => {
          expect(ancestorLinksCount).toBeLessThanOrEqual(2);
 
          // If the product has less than or equal to 3 breadcrumb links, we don't display the breadcrumb menu
-         const desktopBreadcrumbMenu = page.getByTestId(
-            'breadcrumb-menu-desktop'
-         );
-         await expect(desktopBreadcrumbMenu).not.toBeVisible();
+         await expect(
+            page.getByTestId('breadcrumb-menu-desktop')
+         ).not.toBeVisible();
 
-         const mobileBreadcrumbMenu = page.getByTestId(
-            'breadcrumb-menu-mobile'
-         );
-         await expect(mobileBreadcrumbMenu).not.toBeVisible();
+         await expect(
+            page.getByTestId('breadcrumb-menu-mobile')
+         ).not.toBeVisible();
       });
 
       /*
@@ -87,10 +82,9 @@ test.describe('Product breadcrumb test', () => {
       test('with more than 3 breacrumb links', async ({ page }) => {
          await page.goto('/products/iphone-6s-plus-replacement-battery');
 
-         const lastChildBreadcrumb = page.getByTestId(
-            'breadcrumb-last-child-link'
-         );
-         await expect(lastChildBreadcrumb).toBeVisible();
+         await expect(
+            page.getByTestId('breadcrumb-last-child-link')
+         ).toBeVisible();
 
          const desktopBreadcrumbAncestorLinks = page.getByTestId(
             'breadcrumb-ancestor-link-desktop'
@@ -105,15 +99,13 @@ test.describe('Product breadcrumb test', () => {
          }
          expect(ancestorLinksCount).toBeLessThanOrEqual(2);
 
-         const desktopBreadcrumbMenu = page.getByTestId(
-            'breadcrumb-menu-desktop'
-         );
-         await expect(desktopBreadcrumbMenu).toBeVisible();
+         await expect(
+            page.getByTestId('breadcrumb-menu-desktop')
+         ).toBeVisible();
 
-         const mobileBreadcrumbMenu = page.getByTestId(
-            'breadcrumb-menu-mobile'
-         );
-         await expect(mobileBreadcrumbMenu).not.toBeVisible();
+         await expect(
+            page.getByTestId('breadcrumb-menu-mobile')
+         ).not.toBeVisible();
       });
    });
 });


### PR DESCRIPTION
## Summary
Added tests that check breadcrumbs on mobile/tablet and desktop.

On mobile and tablet (viewport width sizes below 1000px), we display only the last child breadcrumb
regardless of the number of breadcrumb links. Everything else is collapsed in the breadcrumb menu.
The test for mobile asserts that the last child breadcrumb and the mobile breadcrumb menu are visible.

On the desktop, we display 2 ancestors and the last child breadcrumb (in total 3 breadcrumbs). 
Everything else is collapsed in the breadcrumb menu. The tests for the desktop assert that the 
last child and ancestor breadcrumbs are visible, and the menu is visible/hidden when appropriate.  

## QA notes
Passing CI is enough.


qa_req 0
closes: #1203