### PR TITLE
Tests: Skip product_image test on mobile and tablet

### DIFF
--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -13,7 +13,7 @@ test.describe('Cross-sell test', () => {
 
       let currentProductTitle = null;
       let currentProductPrice = null;
-      let otherProductTitles = [];
+      const otherProductTitles = [];
 
       for (let i = 0; i < count; i++) {
          const product = products.nth(i);
@@ -61,7 +61,7 @@ test.describe('Cross-sell test', () => {
       const products = await page.getByTestId('cross-sell-item');
       const count = await products.count();
 
-      let allProductTitles = [];
+      const allProductTitles = [];
       let expectedTotalPrice = 0;
 
       for (let i = 0; i < count; i++) {

--- a/frontend/tests/playwright/product/product_image.spec.ts
+++ b/frontend/tests/playwright/product/product_image.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Product image test', () => {
+   test.skip(({ page }) => {
+      const viewPort = page.viewportSize();
+      return !viewPort || viewPort.width < 1000;
+   }, 'Only run on desktop. Still working on mobile.');
+
    test('product with a single image ', async ({ page }) => {
       await page.goto('/products/iflex-opening-tool');
 


### PR DESCRIPTION
## Background
Recently we enabled mobile testing and it's merged into the main branch.

We added a product image test (written for desktop viewport) in https://github.com/iFixit/react-commerce/pull/1218 but it didn't have the main branch merged in, so it started failing in the mobile and tablet ci.

## Summary

Skips product image test on mobile and tablet.

## QA notes
Passing CI is fine.

qa_req 0
