### PR TITLE
Product Page: Add test for disabled products

### DIFF
--- a/frontend/tests/playwright/msw/handlers.ts
+++ b/frontend/tests/playwright/msw/handlers.ts
@@ -22,6 +22,16 @@ export const handlers: RequestHandler[] = [
             outOfStockProduct.product.variants.nodes[0].quantityAvailable = 0;
          }
          return res(ctx.data(outOfStockProduct));
+      } else if (
+         req.variables.handle === 'iphone-6s-plus-replacement-battery-disabled'
+      ) {
+         const disabledProduct = cloneDeep(mockedProductQuery);
+         if (disabledProduct.product) {
+            disabledProduct.product.variants.nodes.forEach((variant) => {
+               variant.enabled = null;
+            });
+         }
+         return res(ctx.data(disabledProduct));
       } else {
          // Perform an original request to the intercepted request URL
          const originalResponse = await ctx.fetch(req);

--- a/frontend/tests/playwright/product/disabled_product.spec.ts
+++ b/frontend/tests/playwright/product/disabled_product.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Disabled Product Test', () => {
+   test('Not for Sale text renders and noindexed', async ({ page }) => {
+      await page.goto('products/iphone-6s-plus-replacement-battery-disabled');
+
+      await expect(page.getByText('Not for Sale')).toBeVisible();
+      await expect(page.getByText('Description')).toBeVisible();
+      await expect(
+         page.getByRole('link', { name: 'One year warranty' })
+      ).toHaveAttribute('href', 'https://www.cominor.com/Info/Warranty');
+
+      // Assert the following to be not visible
+      await expect(page.getByText('Add to Cart')).not.toBeVisible();
+      await expect(page.getByText(/Only \d left/i)).not.toBeVisible();
+      await expect(page.getByText('Notify me')).not.toBeVisible();
+      await expect(
+         page.getByText('Shipping restrictions apply')
+      ).not.toBeVisible();
+
+      // Assert that we noindex disabled product pages
+      const metaRobots = page.locator('meta[name="robots"]');
+      await expect(metaRobots).toHaveAttribute('content', 'noindex,nofollow');
+   });
+});

--- a/frontend/tests/playwright/product/disabled_product.spec.ts
+++ b/frontend/tests/playwright/product/disabled_product.spec.ts
@@ -17,6 +17,9 @@ test.describe('Disabled Product Test', () => {
       await expect(
          page.getByText('Shipping restrictions apply')
       ).not.toBeVisible();
+      await expect(page.getByTestId('product-option-selector')).not.toBeVisible();
+      await expect(page.getByText(/Buy from our Store in/i)).not.toBeVisible();
+      await expect(page.getByText(/Buy from our US Store/i)).not.toBeVisible();
 
       // Assert that we noindex disabled product pages
       const metaRobots = page.locator('meta[name="robots"]');

--- a/frontend/tests/playwright/product/disabled_product.spec.ts
+++ b/frontend/tests/playwright/product/disabled_product.spec.ts
@@ -17,7 +17,9 @@ test.describe('Disabled Product Test', () => {
       await expect(
          page.getByText('Shipping restrictions apply')
       ).not.toBeVisible();
-      await expect(page.getByTestId('product-option-selector')).not.toBeVisible();
+      await expect(
+         page.getByTestId('product-option-selector')
+      ).not.toBeVisible();
       await expect(page.getByText(/Buy from our Store in/i)).not.toBeVisible();
       await expect(page.getByText(/Buy from our US Store/i)).not.toBeVisible();
 


### PR DESCRIPTION
## Summary
1. Added a new `msw` handler for disabled products.
2. Added a test for the disabled product page that checks the following:
    - `Not for Sale`, description, and warranty texts are displayed.
    - `Add to cart`, `Notify me`, shipping restriction and stock details texts are **not** displayed.
    - Noindexed
    
Got the test specs from  https://github.com/iFixit/react-commerce/issues/1153.

## QA notes
Passing ci is enough.

qa_req 0
closes: #1163