### PR TITLE
CI: Add datadog workflow to send job metrics

### DIFF
--- a/.github/workflows/datadog.yml
+++ b/.github/workflows/datadog.yml
@@ -1,0 +1,19 @@
+name: Datadog
+
+on:
+   workflow_run:
+      workflows:
+         - '**'
+      types:
+         - completed
+
+jobs:
+   send:
+      runs-on: ubuntu-latest
+      timeout-minutes: 10
+      steps:
+         - uses: iFixit/datadog-actions-metrics@v1
+           with:
+              datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
+              send-pull-request-labels: true
+              collect-job-metrics: true

--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -78,7 +78,7 @@ test.describe('Cross-sell test', () => {
 
       // Assert total price matches the sum of all products
       await expect(
-         page.getByText('Total Price: $' + expectedTotalPrice)
+         page.getByText('Total Price: $' + expectedTotalPrice.toFixed(2))
       ).toBeVisible();
 
       // Assert adding to cart adds all products


### PR DESCRIPTION
## Summary
1. This is a copy of `datadog.yml` workflow from `iFixit/ifixit`. 
The only difference is that this runs on github hosted ubuntu-latest machine (free).

2. Deflakes a test that's flaky in https://github.com/iFixit/react-commerce/pull/1235/commits/74674f6e889da10c76e470d37d57cb793c45a45d

Note: I created a new API key on Datadog and added it to this repo's secrets

## QA notes
We can test this after merging it, same as in https://github.com/iFixit/ifixit/pull/44282.

After merging it, the data should be visible on https://app.datadoghq.com/dashboard/3xd-yax-e2h/github-actions. 
Cloned the existing graphs and added filtering for each repo. 

qa_req 0

connects #1234