### PR TITLE
Stats Timing: re-add logging

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -1,7 +1,7 @@
 import { PROD_USER_AGENT } from '@config/constants';
 import { CACHE_DISABLED } from '@config/env';
 import { setSentryPageContext } from '@ifixit/sentry';
-import { timeAsync } from '@ifixit/stats';
+import { withTiming } from '@ifixit/stats';
 import { clearCache } from '@lib/cache';
 import type { GetServerSidePropsMiddleware } from '@lib/next-middleware';
 import * as Sentry from '@sentry/nextjs';
@@ -18,8 +18,9 @@ interface WithLoggingMiddleware {
 export const withLogging: WithLoggingMiddleware =
    ({ pageName }) =>
    (next) => {
-      return async (context) => {
-         return timeAsync(`page.${pageName}.server_side_props`, async () => {
+      return withTiming(
+         `page.${pageName}.server_side_props`,
+         async (context) => {
             console.log('context.resolvedUrl', context.resolvedUrl);
             console.log('context.req.url', context.req.url);
             Sentry.setContext('Extra Info', {
@@ -50,8 +51,8 @@ export const withLogging: WithLoggingMiddleware =
                   setSentryPageContext(context);
                   throw err;
                });
-         });
-      };
+         }
+      );
    };
 
 export function noindexDevDomains(context: GetServerSidePropsContext) {

--- a/packages/helpers/generic-helpers.ts
+++ b/packages/helpers/generic-helpers.ts
@@ -48,6 +48,14 @@ export function logSync<T>(name: string, syncFunction: () => T): T {
    return response;
 }
 
+export function withLogging<ARGS extends Array<any>, RETURN>(
+   name: string,
+   promiseFunction: (...args: ARGS) => Promise<RETURN>
+) {
+   const done = time(name);
+   return (...args: ARGS) => promiseFunction(...args).finally(done);
+}
+
 function noOp() {}
 const silentTimer = function (timerName: string) {
    return noOp;

--- a/packages/stats/stats.ts
+++ b/packages/stats/stats.ts
@@ -1,6 +1,6 @@
 import StatsD from 'hot-shots';
 
-import { logAsync } from '@ifixit/helpers';
+import { logAsync, withLogging } from '@ifixit/helpers';
 
 const STATSD_HOST = process.env.STATSD_HOST;
 
@@ -29,9 +29,16 @@ if (!STATSD_HOST) {
    console.log(`Sending statsd stats to ${STATSD_HOST}`);
 }
 
-export function timeAsync<T>(
+export function timeAsync<Return>(
    statName: string,
-   promiseFunc: () => Promise<T>
-): Promise<T> {
-   return stats.asyncTimer(promiseFunc, statName)();
+   promiseFunc: () => Promise<Return>
+): Promise<Return> {
+   return withTiming(statName, promiseFunc)();
+}
+
+export function withTiming<Args extends unknown[], Return>(
+   statName: string,
+   promiseFunc: (...args: Args) => Promise<Return>
+) {
+   return withLogging(statName, stats.asyncTimer(promiseFunc, statName));
 }


### PR DESCRIPTION
In the pull that added statsd timing, we accidentally removed logging in a refactor that simplified some code in a response to a comment.

This adds both withLogging and withTiming helpers that wrap promise-Returning functions and changes the next logging middleware to use the withTiming helper (which wraps withLogging).

See [comment in #1162](https://github.com/iFixit/react-commerce/pull/1162#discussion_r1061912170)