### PR TITLE
Playwright: Remove mention of Safari project

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -88,14 +88,6 @@ const config: PlaywrightTestConfig = {
          },
       },
 
-      // We need to enable cross-site tracking for Safari to work locally.
-      // {
-      //    name: 'webkit',
-      //    use: {
-      //       ...devices['Desktop Safari'],
-      //    },
-      // },
-
       /* Test against branded browsers. */
       // {
       //   name: 'Microsoft Edge',


### PR DESCRIPTION
## Description

It doesn't look like there is a straightforward way to disable CORS for WebKit. As opposed to Chromium, there are no launch option argument flags that we can pass to WebKit to disable the security features. I also tried intercepting all requests and removing the `sec-fetch` headers as a way to fake a no-cors request but that didn't seem to work either.

Therefore, we will not be able to run the tests in WebKit without some convoluted setup to disable CORS. I don't think it's worth the effort to do that. We can revisit this if there is a need to run the tests in WebKit, but for now, let's drop the mention of the Safari project in the config.

## QA Notes

qa_req 0, CI should pass

Closes: #1224 