### PR TITLE
Shopify storefront client: throw errors instead of always reporting

### DIFF
--- a/packages/shopify-storefront-client/index.tsx
+++ b/packages/shopify-storefront-client/index.tsx
@@ -39,12 +39,14 @@ export class ShopifyStorefrontClient {
       if (json.errors) {
          const msg = 'Shopify Storefront API error';
          console.error(msg, json.errors);
-         throw new Error(msg, { cause: {
-            errors: json.errors,
-            response: json,
-            query,
-            variables: JSON.stringify(variables, null, 2),
-         }});
+         throw new Error(msg, {
+            cause: {
+               errors: json.errors,
+               response: json,
+               query,
+               variables: JSON.stringify(variables, null, 2),
+            },
+         });
       }
       return json.data;
    }

--- a/packages/shopify-storefront-client/index.tsx
+++ b/packages/shopify-storefront-client/index.tsx
@@ -39,6 +39,8 @@ export class ShopifyStorefrontClient {
       if (json.errors) {
          const msg = 'Shopify Storefront API error';
          console.error(msg, json.errors);
+         // Current typescript target doesn't know about second argument to Error
+         // @ts-ignore
          throw new Error(msg, {
             cause: {
                errors: json.errors,

--- a/packages/shopify-storefront-client/index.tsx
+++ b/packages/shopify-storefront-client/index.tsx
@@ -39,12 +39,12 @@ export class ShopifyStorefrontClient {
       if (json.errors) {
          const msg = 'Shopify Storefront API error';
          console.error(msg, json.errors);
-         reportException(new Error(msg), {
+         throw new Error(msg, { cause: {
             errors: json.errors,
-            response,
+            response: json,
             query,
             variables: JSON.stringify(variables, null, 2),
-         });
+         }});
       }
       return json.data;
    }


### PR DESCRIPTION
This allows the caller to handle errors when they want to, or leave them unhandled and let them be reported.

Closes #1186