### PR TITLE
Playwright: Unskip mobile tests

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/drawer/ListItem.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/drawer/ListItem.tsx
@@ -17,7 +17,12 @@ export function ListItem({
    onSelect,
 }: ListItemProps) {
    return (
-      <Box pl="4" onClick={() => onSelect(attribute)}>
+      <Box
+         data-testid="facets-drawer-list-item"
+         data-drawer-list-item-name={attribute}
+         pl="4"
+         onClick={() => onSelect(attribute)}
+      >
          <Flex py="4" pl="1.5" justify="space-between" align="center" pr="4">
             <Text fontSize="sm" color="gray.700">
                {formatFacetName(attribute)}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/drawer/MenuFacetPanel.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/drawer/MenuFacetPanel.tsx
@@ -40,7 +40,10 @@ export function MenuFacetPanel({
       [menuFacet, onClose]
    );
    return (
-      <Panel isOpen={isOpen}>
+      <Panel
+         isOpen={isOpen}
+         data-testid={`facet-panel${isOpen ? '-open' : ''}`}
+      >
          <MenuFacet
             items={menuFacet.items}
             limit={PRODUCT_LIST_DEFAULT_FACET_VALUES_COUNT}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/drawer/Panel.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/drawer/Panel.tsx
@@ -5,7 +5,7 @@ type PanelProps = PropsWithChildren<{
    isOpen: boolean;
 }>;
 
-export function Panel({ isOpen, children }: PanelProps) {
+export function Panel({ isOpen, children, ...otherProps }: PanelProps) {
    return (
       <Box
          position="absolute"
@@ -19,6 +19,7 @@ export function Panel({ isOpen, children }: PanelProps) {
          bg="white"
          shadow={isOpen ? 'lg' : 'none'}
          p="5"
+         {...otherProps}
       >
          <VStack align="stretch" spacing="3">
             {children}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/drawer/RefinementListFacetPanel.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/drawer/RefinementListFacetPanel.tsx
@@ -14,7 +14,10 @@ export function RefinementListFacetPanel({
    const { items, refine, canToggleShowMore, isShowingMore, toggleShowMore } =
       useRefinementListFacet({ attribute });
    return (
-      <Panel isOpen={isOpen}>
+      <Panel
+         isOpen={isOpen}
+         data-testid={`facet-panel${isOpen ? '-open' : ''}`}
+      >
          <RefinementListFacet
             items={items}
             refine={refine}

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -37,6 +37,7 @@ export function ProductGallery({
    showThumbnails,
    enableZoom,
    onChangeImage,
+   ...otherProps
 }: ProductGalleryProps) {
    const galleryContainerRef = React.useRef<HTMLDivElement | null>(null);
    const variantImages = useVariantImages(product, selectedVariant.id);
@@ -107,6 +108,7 @@ export function ProductGallery({
             },
          }}
          w="full"
+         {...otherProps}
       >
          <Box ref={galleryContainerRef}>
             {variantImages.length > 1 ? (

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -80,6 +80,7 @@ export function ProductSection({
                zIndex="1"
             >
                <ProductGallery
+                  data-testid="product-gallery-desktop"
                   product={product}
                   selectedVariant={selectedVariant}
                   selectedImageId={selectedImageId}
@@ -138,6 +139,7 @@ export function ProductSection({
 
                <Flex display={{ base: 'flex', md: 'none' }} w="full" pt="6">
                   <ProductGallery
+                     data-testid="product-gallery-mobile"
                      product={product}
                      selectedVariant={selectedVariant}
                      selectedImageId={selectedImageId}

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -2,17 +2,22 @@ import { test, expect, Page } from '@playwright/test';
 import { waitForAlgoliaSearch, resolvePath } from '../utils';
 
 // Check that the refinement value is in the current refinements.
-async function checkRefinementValue(value: string | null | undefined, page: Page) {
+async function checkRefinementValue(
+   value: string | null | undefined,
+   page: Page
+) {
    if (!value) {
-      throw new Error("Could not find " + value);
+      throw new Error('Could not find ' + value);
    }
-   await expect(
-      page.getByTestId(`current-refinement-${value}`)
-   ).toBeVisible();
+   await expect(page.getByTestId(`current-refinement-${value}`)).toBeVisible();
 }
 
 // Check that the refinement value is in the search results
-async function checkRefinementInSearchResult(facetName: string | null, facetOptionValue: string | null | undefined, results: Array<any>) {
+async function checkRefinementInSearchResult(
+   facetName: string | null,
+   facetOptionValue: string | null | undefined,
+   results: Array<any>
+) {
    if (!facetName) {
       throw new Error('Could not find first facet name');
    }
@@ -24,13 +29,15 @@ async function checkRefinementInSearchResult(facetName: string | null, facetOpti
       []
    );
    filteredProducts.forEach((product: any) => {
-      expect(resolvePath(product, facetName)).toContain(
-         facetOptionValue
-      );
+      expect(resolvePath(product, facetName)).toContain(facetOptionValue);
    });
 }
 
-async function removeAndCheckRefinement(facetOptionValue: string | null | undefined, buttonText: string, page: Page) {
+async function removeAndCheckRefinement(
+   facetOptionValue: string | null | undefined,
+   buttonText: string,
+   page: Page
+) {
    // Remove the newest refinement.
    await page
       .getByTestId(`current-refinement-${facetOptionValue}`)
@@ -45,7 +52,9 @@ async function removeAndCheckRefinement(facetOptionValue: string | null | undefi
 
 async function resetAndCheckRefinements(buttonText: string, page: Page) {
    // Reset the filters.
-   await page.getByRole('button', { name: new RegExp(buttonText, 'i'), exact: true}).click();
+   await page
+      .getByRole('button', { name: new RegExp(buttonText, 'i'), exact: true })
+      .click();
 
    // Check that the current refinements are empty
    expect(
@@ -102,7 +111,11 @@ test.describe('product list filters', () => {
          const firstFacetName = await firstCollapsedAccordionItem.getAttribute(
             'data-facet-name'
          );
-         await checkRefinementInSearchResult(firstFacetName, firstFacetOptionValue, results);
+         await checkRefinementInSearchResult(
+            firstFacetName,
+            firstFacetOptionValue,
+            results
+         );
 
          // Click the second facet accordion item.
          if (!secondCollapsedAccordionItem) {
@@ -121,8 +134,8 @@ test.describe('product list filters', () => {
             'data-value'
          );
          await checkRefinementValue(secondFacetOptionValue, page);
-         await removeAndCheckRefinement(secondFacetOptionValue, "remove", page);
-         await resetAndCheckRefinements("Clear all filters", page);
+         await removeAndCheckRefinement(secondFacetOptionValue, 'remove', page);
+         await resetAndCheckRefinements('Clear all filters', page);
       });
    });
 
@@ -159,7 +172,11 @@ test.describe('product list filters', () => {
          await checkRefinementValue(firstFacetOptionValue, page);
 
          // Check that the refinement value is in the search results.
-         await checkRefinementInSearchResult(firstFacetName, firstFacetOptionValue, results);
+         await checkRefinementInSearchResult(
+            firstFacetName,
+            firstFacetOptionValue,
+            results
+         );
 
          // Select the second filter and close the drawer
          await page
@@ -179,8 +196,8 @@ test.describe('product list filters', () => {
 
          // Check that the refinement value is in the current refinements.
          await checkRefinementValue(secondFacetOptionValue, page);
-         await removeAndCheckRefinement(secondFacetOptionValue, "remove", page);
-         await resetAndCheckRefinements("Clear all filters", page);
+         await removeAndCheckRefinement(secondFacetOptionValue, 'remove', page);
+         await resetAndCheckRefinements('Clear all filters', page);
       });
 
       test('Apply and Clear all buttons work in Facet Drawer', async ({
@@ -228,7 +245,7 @@ test.describe('product list filters', () => {
          await page
             .getByRole('button', { name: 'Filters', exact: true })
             .click();
-         await resetAndCheckRefinements("Clear All", page);
+         await resetAndCheckRefinements('Clear All', page);
       });
    });
 });

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -52,9 +52,7 @@ async function removeAndCheckRefinement(
 
 async function resetAndCheckRefinements(buttonText: string, page: Page) {
    // Reset the filters.
-   await page
-      .getByRole('button', { name: new RegExp(buttonText, 'i'), exact: true })
-      .click();
+   await page.getByRole('button', { name: buttonText, exact: true }).click();
 
    // Check that the current refinements are empty
    expect(
@@ -241,11 +239,11 @@ test.describe('product list filters', () => {
          // Check that the refinement value is in the current refinements.
          await checkRefinementValue(secondFacetOptionValue, page);
 
-         // Click "Clear All" button and check if refinements are empty.
+         // Click "Clear all" button and check if refinements are empty.
          await page
             .getByRole('button', { name: 'Filters', exact: true })
             .click();
-         await resetAndCheckRefinements('Clear All', page);
+         await resetAndCheckRefinements('Clear all', page);
       });
    });
 });

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -211,5 +211,68 @@ test.describe('product list filters', () => {
             await page.locator('[data-testid^=current-refinement-]').count()
          ).toBe(0);
       });
+
+      test('Apply and Clear all buttons work in Facet Drawer', async ({
+         page,
+      }) => {
+         // Select the first filter and click Apply button
+         await page
+            .getByRole('button', { name: 'Filters', exact: true })
+            .click();
+         await page.getByTestId('facets-drawer-list-item').nth(1).click();
+         const firstFacetOption = page
+            .getByTestId('facet-panel-open')
+            .getByRole('option')
+            .first();
+         const firstFacetOptionValue = await firstFacetOption?.getAttribute(
+            'data-value'
+         );
+         await firstFacetOption.click();
+         await page.getByRole('button', { name: 'Apply' }).click();
+
+         // Check that the refinement value is in the current refinements.
+         if (!firstFacetOptionValue) {
+            throw new Error('Could not find first facet option value');
+         }
+         await expect(
+            page.getByTestId(`current-refinement-${firstFacetOptionValue}`)
+         ).toBeVisible();
+
+         // Select the second filter and click Apply button
+         await page
+            .getByRole('button', { name: 'Filters', exact: true })
+            .click();
+         await page.getByTestId('facets-drawer-list-item').nth(2).click();
+         const secondFacetOption = page
+            .getByTestId('facet-panel-open')
+            .getByRole('option')
+            .first();
+         const secondFacetOptionValue = await firstFacetOption?.getAttribute(
+            'data-value'
+         );
+         await secondFacetOption.click();
+         await page
+            .getByRole('button', { name: 'Apply' })
+            .click({ clickCount: 2 });
+
+         // Check that the refinement value is in the current refinements.
+         if (!secondFacetOptionValue) {
+            throw new Error('Could not find second facet option value');
+         }
+         await expect(
+            page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
+         ).toBeVisible();
+
+         // Click "Clear All" buttom amd check if refinements are empty.
+         await page
+            .getByRole('button', { name: 'Filters', exact: true })
+            .click();
+         await page
+            .getByRole('button', { name: 'Clear all', exact: true })
+            .click();
+         expect(
+            await page.locator('[data-testid^=current-refinement-]').count()
+         ).toBe(0);
+      });
    });
 });

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -15,7 +15,7 @@ async function checkRefinementValue(
 // Check that the refinement value is in the search results
 async function checkRefinementInSearchResult(
    facetName: string | null,
-   facetOptionValue: string | null | undefined,
+   facetOptionValue: string,
    results: Array<any>
 ) {
    if (!facetName) {
@@ -111,7 +111,7 @@ test.describe('product list filters', () => {
          );
          await checkRefinementInSearchResult(
             firstFacetName,
-            firstFacetOptionValue,
+            firstFacetOptionValue!,
             results
          );
 
@@ -176,7 +176,7 @@ test.describe('product list filters', () => {
          // Check that the refinement value is in the search results.
          await checkRefinementInSearchResult(
             firstFacetName,
-            firstFacetOptionValue,
+            firstFacetOptionValue!,
             results
          );
 

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -1,5 +1,15 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import { waitForAlgoliaSearch, resolvePath } from '../utils';
+
+// Check that the refinement value is in the current refinements.
+async function checkRefinementValue(value: string | null | undefined, page: Page) {
+   if (!value) {
+      throw new Error("Could not find " + value);
+   }
+   await expect(
+      page.getByTestId(`current-refinement-${value}`)
+   ).toBeVisible();
+}
 
 test.describe('product list filters', () => {
    test.beforeEach(async ({ page }) => {
@@ -44,12 +54,7 @@ test.describe('product list filters', () => {
          const firstFacetOptionValue = await firstFacetOption?.getAttribute(
             'data-value'
          );
-         if (!firstFacetOptionValue) {
-            throw new Error('Could not find first facet option value');
-         }
-         await expect(
-            page.getByTestId(`current-refinement-${firstFacetOptionValue}`)
-         ).toBeVisible();
+         await checkRefinementValue(firstFacetOptionValue, page);
 
          // Reduce the search results to a single array of products.
          const filteredProducts = results.reduce(
@@ -88,12 +93,7 @@ test.describe('product list filters', () => {
          const secondFacetOptionValue = await secondFacetOption?.getAttribute(
             'data-value'
          );
-         if (!secondFacetOptionValue) {
-            throw new Error('Could not find second facet option value');
-         }
-         await expect(
-            page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
-         ).toBeVisible();
+         await checkRefinementValue(secondFacetOptionValue, page);
 
          // Remove the newest refinement.
          await page
@@ -146,12 +146,7 @@ test.describe('product list filters', () => {
          const { results } = await (await queryResponse).json();
 
          // Check that the refinement value is in the current refinements.
-         if (!firstFacetOptionValue) {
-            throw new Error('Could not find first facet option value');
-         }
-         await expect(
-            page.getByTestId(`current-refinement-${firstFacetOptionValue}`)
-         ).toBeVisible();
+         await checkRefinementValue(firstFacetOptionValue, page);
 
          // Check that the refinement value is in the search results.
          if (!firstFacetName) {
@@ -186,12 +181,7 @@ test.describe('product list filters', () => {
          await page.getByRole('button', { name: 'Close' }).click();
 
          // Check that the refinement value is in the current refinements.
-         if (!secondFacetOptionValue) {
-            throw new Error('Could not find second facet option value');
-         }
-         await expect(
-            page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
-         ).toBeVisible();
+         await checkRefinementValue(secondFacetOptionValue, page);
 
          // Remove the newest refinement.
          await page
@@ -231,12 +221,7 @@ test.describe('product list filters', () => {
          await page.getByRole('button', { name: 'Apply' }).click();
 
          // Check that the refinement value is in the current refinements.
-         if (!firstFacetOptionValue) {
-            throw new Error('Could not find first facet option value');
-         }
-         await expect(
-            page.getByTestId(`current-refinement-${firstFacetOptionValue}`)
-         ).toBeVisible();
+         await checkRefinementValue(firstFacetOptionValue, page);
 
          // Select the second filter and click Apply button
          await page
@@ -256,12 +241,7 @@ test.describe('product list filters', () => {
             .click({ clickCount: 2 });
 
          // Check that the refinement value is in the current refinements.
-         if (!secondFacetOptionValue) {
-            throw new Error('Could not find second facet option value');
-         }
-         await expect(
-            page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
-         ).toBeVisible();
+         await checkRefinementValue(secondFacetOptionValue, page);
 
          // Click "Clear All" buttom amd check if refinements are empty.
          await page

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -43,6 +43,16 @@ async function removeAndCheckRefinement(facetOptionValue: string | null | undefi
    ).not.toBeVisible();
 }
 
+async function resetAndCheckRefinements(buttonText: string, page: Page) {
+   // Reset the filters.
+   await page.getByRole('button', { name: new RegExp(buttonText, 'i'), exact: true}).click();
+
+   // Check that the current refinements are empty
+   expect(
+      await page.locator('[data-testid^=current-refinement-]').count()
+   ).toBe(0);
+}
+
 test.describe('product list filters', () => {
    test.beforeEach(async ({ page }) => {
       await page.goto('/Parts');
@@ -112,14 +122,7 @@ test.describe('product list filters', () => {
          );
          await checkRefinementValue(secondFacetOptionValue, page);
          await removeAndCheckRefinement(secondFacetOptionValue, "remove", page);
-
-         // Reset the filters.
-         await page.getByRole('button', { name: /clear all filters/i }).click();
-
-         // Check that the current refinements are empty
-         expect(
-            await page.locator('[data-testid^=current-refinement-]').count()
-         ).toBe(0);
+         await resetAndCheckRefinements("Clear all filters", page);
       });
    });
 
@@ -177,13 +180,7 @@ test.describe('product list filters', () => {
          // Check that the refinement value is in the current refinements.
          await checkRefinementValue(secondFacetOptionValue, page);
          await removeAndCheckRefinement(secondFacetOptionValue, "remove", page);
-
-         await page.getByRole('button', { name: /clear all filters/i }).click();
-
-         // Check that the current refinements are empty
-         expect(
-            await page.locator('[data-testid^=current-refinement-]').count()
-         ).toBe(0);
+         await resetAndCheckRefinements("Clear all filters", page);
       });
 
       test('Apply and Clear all buttons work in Facet Drawer', async ({
@@ -227,16 +224,11 @@ test.describe('product list filters', () => {
          // Check that the refinement value is in the current refinements.
          await checkRefinementValue(secondFacetOptionValue, page);
 
-         // Click "Clear All" buttom amd check if refinements are empty.
+         // Click "Clear All" button and check if refinements are empty.
          await page
             .getByRole('button', { name: 'Filters', exact: true })
             .click();
-         await page
-            .getByRole('button', { name: 'Clear all', exact: true })
-            .click();
-         expect(
-            await page.locator('[data-testid^=current-refinement-]').count()
-         ).toBe(0);
+         await resetAndCheckRefinements("Clear All", page);
       });
    });
 });

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -11,6 +11,25 @@ async function checkRefinementValue(value: string | null | undefined, page: Page
    ).toBeVisible();
 }
 
+// Check that the refinement value is in the search results
+async function checkRefinementInSearchResult(facetName: string | null, facetOptionValue: string | null | undefined, results: Array<any>) {
+   if (!facetName) {
+      throw new Error('Could not find first facet name');
+   }
+   // Reduce the search results to a single array of products.
+   const filteredProducts = results.reduce(
+      (products: [], searchResults: { hits: [] }) => {
+         return [...products, ...searchResults.hits];
+      },
+      []
+   );
+   filteredProducts.forEach((product: any) => {
+      expect(resolvePath(product, facetName)).toContain(
+         facetOptionValue
+      );
+   });
+}
+
 test.describe('product list filters', () => {
    test.beforeEach(async ({ page }) => {
       await page.goto('/Parts');
@@ -56,26 +75,11 @@ test.describe('product list filters', () => {
          );
          await checkRefinementValue(firstFacetOptionValue, page);
 
-         // Reduce the search results to a single array of products.
-         const filteredProducts = results.reduce(
-            (products: [], searchResults: { hits: [] }) => {
-               return [...products, ...searchResults.hits];
-            },
-            []
-         );
-
          // Check that the refinement value is in the search results.
          const firstFacetName = await firstCollapsedAccordionItem.getAttribute(
             'data-facet-name'
          );
-         if (!firstFacetName) {
-            throw new Error('Could not find first facet name');
-         }
-         filteredProducts.forEach((product: any) => {
-            expect(resolvePath(product, firstFacetName)).toContain(
-               firstFacetOptionValue
-            );
-         });
+         await checkRefinementInSearchResult(firstFacetName, firstFacetOptionValue, results);
 
          // Click the second facet accordion item.
          if (!secondCollapsedAccordionItem) {
@@ -149,20 +153,7 @@ test.describe('product list filters', () => {
          await checkRefinementValue(firstFacetOptionValue, page);
 
          // Check that the refinement value is in the search results.
-         if (!firstFacetName) {
-            throw new Error('Could not find first facet name');
-         }
-         const filteredProducts = results.reduce(
-            (products: [], searchResults: { hits: [] }) => {
-               return [...products, ...searchResults.hits];
-            },
-            []
-         );
-         filteredProducts.forEach((product: any) => {
-            expect(resolvePath(product, firstFacetName)).toContain(
-               firstFacetOptionValue
-            );
-         });
+         await checkRefinementInSearchResult(firstFacetName, firstFacetOptionValue, results);
 
          // Select the second filter and close the drawer
          await page

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -2,115 +2,125 @@ import { test, expect } from '@playwright/test';
 import { waitForAlgoliaSearch, resolvePath } from '../utils';
 
 test.describe('product list filters', () => {
-   test.skip(({ page }) => {
-      const viewPort = page.viewportSize();
-      return !viewPort || viewPort.width < 768;
-   }, 'Only run on desktop. Still need to rework this test for mobile.');
-
    test.beforeEach(async ({ page }) => {
       await page.goto('/Parts');
    });
 
-   test('Should help user filter', async ({ page }) => {
-      const facetList = page
-         .getByTestId('facets-accordion')
-         .locator('[data-testid^=collapsed-facet-accordion-item-]');
+   test.describe('Desktop', () => {
+      test.skip(({ page }) => {
+         const viewPort = page.viewportSize();
+         return !viewPort || viewPort.width < 768;
+      }, 'Only run on desktop.');
 
-      const firstCollapsedAccordionItem = await facetList
-         .nth(0)
-         .elementHandle();
-      const secondCollapsedAccordionItem = await facetList
-         .nth(1)
-         .elementHandle();
+      test('Should help user filter', async ({ page }) => {
+         const facetList = page
+            .getByTestId('facets-accordion')
+            .locator('[data-testid^=collapsed-facet-accordion-item-]');
 
-      // Click the first facet accordion item.
-      if (!firstCollapsedAccordionItem) {
-         throw new Error('Could not find first collapsed accordion item');
-      }
-      await firstCollapsedAccordionItem.click();
+         const firstCollapsedAccordionItem = await facetList
+            .nth(0)
+            .elementHandle();
+         const secondCollapsedAccordionItem = await facetList
+            .nth(1)
+            .elementHandle();
 
-      // Define a Promise to wait for the search to be triggered and let the UI update.
-      const queryResponse = waitForAlgoliaSearch(page);
+         // Click the first facet accordion item.
+         if (!firstCollapsedAccordionItem) {
+            throw new Error('Could not find first collapsed accordion item');
+         }
+         await firstCollapsedAccordionItem.click();
 
-      // Click the first facet item
-      const firstFacetOption = await firstCollapsedAccordionItem.$(
-         'button[role="option"]'
-      );
-      await firstFacetOption?.click();
-      const { results } = await (await queryResponse).json();
+         // Define a Promise to wait for the search to be triggered and let the UI update.
+         const queryResponse = waitForAlgoliaSearch(page);
 
-      // Check that the refinement value is in the current refinements.
-      const firstFacetOptionValue = await firstFacetOption?.getAttribute(
-         'data-value'
-      );
-      if (!firstFacetOptionValue) {
-         throw new Error('Could not find first facet option value');
-      }
-      await expect(
-         page.getByTestId(`current-refinement-${firstFacetOptionValue}`)
-      ).toBeVisible();
-
-      // Reduce the search results to a single array of products.
-      const filteredProducts = results.reduce(
-         (products: [], searchResults: { hits: [] }) => {
-            return [...products, ...searchResults.hits];
-         },
-         []
-      );
-
-      // Check that the refinement value is in the search results.
-      const firstFacetName = await firstCollapsedAccordionItem.getAttribute(
-         'data-facet-name'
-      );
-      if (!firstFacetName) {
-         throw new Error('Could not find first facet name');
-      }
-      filteredProducts.forEach((product: any) => {
-         expect(resolvePath(product, firstFacetName)).toContain(
-            firstFacetOptionValue
+         // Click the first facet item
+         const firstFacetOption = await firstCollapsedAccordionItem.$(
+            'button[role="option"]'
          );
+         await firstFacetOption?.click();
+         const { results } = await (await queryResponse).json();
+
+         // Check that the refinement value is in the current refinements.
+         const firstFacetOptionValue = await firstFacetOption?.getAttribute(
+            'data-value'
+         );
+         if (!firstFacetOptionValue) {
+            throw new Error('Could not find first facet option value');
+         }
+         await expect(
+            page.getByTestId(`current-refinement-${firstFacetOptionValue}`)
+         ).toBeVisible();
+
+         // Reduce the search results to a single array of products.
+         const filteredProducts = results.reduce(
+            (products: [], searchResults: { hits: [] }) => {
+               return [...products, ...searchResults.hits];
+            },
+            []
+         );
+
+         // Check that the refinement value is in the search results.
+         const firstFacetName = await firstCollapsedAccordionItem.getAttribute(
+            'data-facet-name'
+         );
+         if (!firstFacetName) {
+            throw new Error('Could not find first facet name');
+         }
+         filteredProducts.forEach((product: any) => {
+            expect(resolvePath(product, firstFacetName)).toContain(
+               firstFacetOptionValue
+            );
+         });
+
+         // Click the second facet accordion item.
+         if (!secondCollapsedAccordionItem) {
+            throw new Error('Could not find second collapsed accordion item');
+         }
+         await secondCollapsedAccordionItem.click();
+
+         // Click the second facet item
+         const secondFacetOption = await secondCollapsedAccordionItem.$(
+            '[role="option"]'
+         );
+         await secondFacetOption?.click();
+
+         // Check that the refinement value is in the current refinements.
+         const secondFacetOptionValue = await secondFacetOption?.getAttribute(
+            'data-value'
+         );
+         if (!secondFacetOptionValue) {
+            throw new Error('Could not find second facet option value');
+         }
+         await expect(
+            page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
+         ).toBeVisible();
+
+         // Remove the newest refinement.
+         await page
+            .getByTestId(`current-refinement-${secondFacetOptionValue}`)
+            .getByRole('button', { name: /remove/i })
+            .click();
+
+         // Check that the refinement value is not in the current refinements.
+         await expect(
+            page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
+         ).not.toBeVisible();
+
+         // Reset the filters.
+         await page.getByRole('button', { name: /clear all filters/i }).click();
+
+         // Check that the current refinements are empty
+         expect(
+            await page.locator('[data-testid^=current-refinement-]').count()
+         ).toBe(0);
       });
+   });
 
-      // Click the second facet accordion item.
-      if (!secondCollapsedAccordionItem) {
-         throw new Error('Could not find second collapsed accordion item');
-      }
-      await secondCollapsedAccordionItem.click();
+   test.describe('Mobile and Tablet', () => {
+      test.skip(({ page }) => {
+         const viewPort = page.viewportSize();
+         return !viewPort || viewPort.width > 768;
+      }, 'Only run on mobile and tablet.');
 
-      // Click the second facet item
-      const secondFacetOption = await secondCollapsedAccordionItem.$(
-         '[role="option"]'
-      );
-      await secondFacetOption?.click();
-
-      // Check that the refinement value is in the current refinements.
-      const secondFacetOptionValue = await secondFacetOption?.getAttribute(
-         'data-value'
-      );
-      if (!secondFacetOptionValue) {
-         throw new Error('Could not find second facet option value');
-      }
-      await expect(
-         page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
-      ).toBeVisible();
-
-      // Remove the newest refinement.
-      await page
-         .getByTestId(`current-refinement-${secondFacetOptionValue}`)
-         .getByRole('button', { name: /remove/i })
-         .click();
-
-      // Check that the refinement value is not in the current refinements.
-      await expect(
-         page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
-      ).not.toBeVisible();
-
-      // Reset the filters.
-      await page.getByRole('button', { name: /clear all filters/i }).click();
-
-      // Check that the current refinements are empty
-      expect(
-         await page.locator('[data-testid^=current-refinement-]').count()
-      ).toBe(0);
    });
 });

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -30,6 +30,19 @@ async function checkRefinementInSearchResult(facetName: string | null, facetOpti
    });
 }
 
+async function removeAndCheckRefinement(facetOptionValue: string | null | undefined, buttonText: string, page: Page) {
+   // Remove the newest refinement.
+   await page
+      .getByTestId(`current-refinement-${facetOptionValue}`)
+      .getByRole('button', { name: new RegExp(buttonText, 'i') })
+      .click();
+
+   // Check that the refinement value is not in the current refinements.
+   await expect(
+      page.getByTestId(`current-refinement-${facetOptionValue}`)
+   ).not.toBeVisible();
+}
+
 test.describe('product list filters', () => {
    test.beforeEach(async ({ page }) => {
       await page.goto('/Parts');
@@ -98,17 +111,7 @@ test.describe('product list filters', () => {
             'data-value'
          );
          await checkRefinementValue(secondFacetOptionValue, page);
-
-         // Remove the newest refinement.
-         await page
-            .getByTestId(`current-refinement-${secondFacetOptionValue}`)
-            .getByRole('button', { name: /remove/i })
-            .click();
-
-         // Check that the refinement value is not in the current refinements.
-         await expect(
-            page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
-         ).not.toBeVisible();
+         await removeAndCheckRefinement(secondFacetOptionValue, "remove", page);
 
          // Reset the filters.
          await page.getByRole('button', { name: /clear all filters/i }).click();
@@ -173,17 +176,7 @@ test.describe('product list filters', () => {
 
          // Check that the refinement value is in the current refinements.
          await checkRefinementValue(secondFacetOptionValue, page);
-
-         // Remove the newest refinement.
-         await page
-            .getByTestId(`current-refinement-${secondFacetOptionValue}`)
-            .getByRole('button', { name: /remove/i })
-            .click();
-
-         // Check that the refinement value is not in the current refinements.
-         await expect(
-            page.getByTestId(`current-refinement-${secondFacetOptionValue}`)
-         ).not.toBeVisible();
+         await removeAndCheckRefinement(secondFacetOptionValue, "remove", page);
 
          await page.getByRole('button', { name: /clear all filters/i }).click();
 

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -34,7 +34,7 @@ async function checkRefinementInSearchResult(
 }
 
 async function removeAndCheckRefinement(
-   facetOptionValue: string | null | undefined,
+   facetOptionValue: string,
    buttonText: string,
    page: Page
 ) {
@@ -132,7 +132,7 @@ test.describe('product list filters', () => {
             'data-value'
          );
          await checkRefinementValue(secondFacetOptionValue, page);
-         await removeAndCheckRefinement(secondFacetOptionValue, 'remove', page);
+         await removeAndCheckRefinement(secondFacetOptionValue!, 'remove', page);
          await resetAndCheckRefinements('Clear all filters', page);
       });
    });
@@ -194,7 +194,7 @@ test.describe('product list filters', () => {
 
          // Check that the refinement value is in the current refinements.
          await checkRefinementValue(secondFacetOptionValue, page);
-         await removeAndCheckRefinement(secondFacetOptionValue, 'remove', page);
+         await removeAndCheckRefinement(secondFacetOptionValue!, 'remove', page);
          await resetAndCheckRefinements('Clear all filters', page);
       });
 

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -132,7 +132,11 @@ test.describe('product list filters', () => {
             'data-value'
          );
          await checkRefinementValue(secondFacetOptionValue, page);
-         await removeAndCheckRefinement(secondFacetOptionValue!, 'remove', page);
+         await removeAndCheckRefinement(
+            secondFacetOptionValue!,
+            'remove',
+            page
+         );
          await resetAndCheckRefinements('Clear all filters', page);
       });
    });
@@ -194,7 +198,11 @@ test.describe('product list filters', () => {
 
          // Check that the refinement value is in the current refinements.
          await checkRefinementValue(secondFacetOptionValue, page);
-         await removeAndCheckRefinement(secondFacetOptionValue!, 'remove', page);
+         await removeAndCheckRefinement(
+            secondFacetOptionValue!,
+            'remove',
+            page
+         );
          await resetAndCheckRefinements('Clear all filters', page);
       });
 

--- a/frontend/tests/playwright/product-list/parts_page_devices.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_devices.spec.ts
@@ -12,7 +12,7 @@ test.describe('parts page devices', () => {
          page.getByTestId('filterable-products-section')
       ).toBeVisible();
 
-      if (viewPort!.width > 1000) {
+      if (viewPort!.width > 768) {
          await page.getByTestId('facets-accordion').scrollIntoViewIfNeeded();
          await expect(page.getByTestId('facets-accordion')).toBeVisible();
       } else {

--- a/frontend/tests/playwright/product-list/parts_page_devices.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_devices.spec.ts
@@ -1,21 +1,25 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('parts page devices', () => {
-   test.skip(({ page }) => {
-      const viewPort = page.viewportSize();
-      return !viewPort || viewPort.width < 768;
-   }, 'Only run on desktop. Still need to rework this test for mobile.');
-
    test.beforeEach(async ({ page }) => {
       await page.goto('/Parts');
    });
 
    test('Should navigate until the last device page', async ({ page }) => {
+      const viewPort = page.viewportSize();
+
       await expect(
          page.getByTestId('filterable-products-section')
       ).toBeVisible();
-      await page.getByTestId('facets-accordion').scrollIntoViewIfNeeded();
-      await expect(page.getByTestId('facets-accordion')).toBeVisible();
+
+      if (viewPort!.width > 1000) {
+         await page.getByTestId('facets-accordion').scrollIntoViewIfNeeded();
+         await expect(page.getByTestId('facets-accordion')).toBeVisible();
+      } else {
+         await expect(
+            page.getByRole('button', { name: 'Filters' })
+         ).toBeVisible();
+      }
 
       // Makes sure there is at least 1 product available
       expect(

--- a/frontend/tests/playwright/product/product_image.spec.ts
+++ b/frontend/tests/playwright/product/product_image.spec.ts
@@ -21,7 +21,7 @@ test.describe('Product image test', () => {
          .getAttribute('src');
 
       const firstImage =
-         viewPort!.width > 1000
+         viewPort!.width > 768
             ? page
                  .getByTestId('product-gallery-desktop')
                  .locator(`img[src="${firstImageSrc}"]`)
@@ -34,7 +34,7 @@ test.describe('Product image test', () => {
       await expect(firstImage).toBeVisible();
 
       // Click on the arrow for the next image
-      if (viewPort!.width > 1000) {
+      if (viewPort!.width > 768) {
          await page
             .getByTestId('product-gallery-desktop')
             .getByTestId('swiper-next-image')

--- a/frontend/tests/playwright/product/product_image.spec.ts
+++ b/frontend/tests/playwright/product/product_image.spec.ts
@@ -1,11 +1,6 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Product image test', () => {
-   test.skip(({ page }) => {
-      const viewPort = page.viewportSize();
-      return !viewPort || viewPort.width < 1000;
-   }, 'Only run on desktop. Still working on mobile.');
-
    test('product with a single image ', async ({ page }) => {
       await page.goto('/products/iflex-opening-tool');
 
@@ -17,17 +12,39 @@ test.describe('Product image test', () => {
 
    test('product with multiple images ', async ({ page }) => {
       await page.goto('/products/repair-business-toolkit');
+      const viewPort = page.viewportSize();
 
       const firstImageSrc = await page
          .locator('.swiper-slide.swiper-slide-active')
          .getByRole('img')
          .first()
          .getAttribute('src');
-      const firstImage = page.locator(`img[src="${firstImageSrc}"]`).first();
+
+      const firstImage =
+         viewPort!.width > 1000
+            ? page
+                 .getByTestId('product-gallery-desktop')
+                 .locator(`img[src="${firstImageSrc}"]`)
+                 .first()
+            : page
+                 .getByTestId('product-gallery-mobile')
+                 .locator(`img[src="${firstImageSrc}"]`)
+                 .first();
+
       await expect(firstImage).toBeVisible();
 
       // Click on the arrow for the next image
-      await page.getByTestId('swiper-next-image').first().click();
+      if (viewPort!.width > 1000) {
+         await page
+            .getByTestId('product-gallery-desktop')
+            .getByTestId('swiper-next-image')
+            .click();
+      } else {
+         await page
+            .getByTestId('product-gallery-mobile')
+            .getByTestId('swiper-next-image')
+            .click();
+      }
 
       const secondImageSrc = await page
          .locator('.swiper-slide.swiper-slide-active')


### PR DESCRIPTION
## Summary
1. Fixed `product_image`, `parts_page_devices`, and `filters` tests to be run on both mobile/tablet and desktop.
2. Added a new test in the `filters` test for mobile.

Note: only `product_breadcrumb` and `filters` tests have `.skip` conditional for specific viewports. Both of them have tests for mobile/tablet and desktop.
## CR Notes
Commit by commit is probably the easiest (also hiding whitespaces in the diff).

## QA notes
Passing CI is enough.

qa_req 0
