### PR TITLE
Sentry: sample hydration errors with regex

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -43,7 +43,7 @@ Sentry.init({
       const ex = hint.originalException;
       if (ex && typeof ex == 'object' && ex.message) {
          // Sample hydration errors.
-         if (hydrationErrors.includes(ex.message)) {
+         if (hydrationErrors.some((msg) => ex.message.match(msg))) {
             return Math.random() < 0.05 ? event : null;
          }
       }


### PR DESCRIPTION
Fixes a bug where some hydration errors weren't matched because they were suffixed with 'See more info here: https://nextjs.org/docs/messages/react-hydration-error'

Followup to #1233