### PR TITLE
Playwright Debug Fix: Update package.json script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
       "cypress:open": "cypress open",
       "cypress:run": "cypress run",
       "playwright:run": "NEXT_PUBLIC_MOCK_API=true playwright test",
-      "playwright:debug": "NEXT_PUBLIC_MOCK_API=true DEBUG=pw:api playwright test --project=chromium --debug",
+      "playwright:debug": "NEXT_PUBLIC_MOCK_API=true DEBUG=pw:api playwright test --project=\"Desktop Chrome\" --debug",
       "transform-svg": "npx @svgr/cli --typescript -d assets/svg assets/svg/files && prettier --write assets/svg"
    },
    "dependencies": {


### PR DESCRIPTION
## Description

We made this script in #1216 but recently changed our playwright project names https://github.com/iFixit/react-commerce/pull/1223. As a result, the script fails because the project name `chromium` no longer exists in the playwright config. This updates the script to use the new project name `Desktop Chromium`.

## QA Notes:

- [ ] Confirm running `(cd frontend && pnpm playwright:debug)` works.