### PR TITLE
Handle Redis errors as cache misses in SWR cache library

### DIFF
--- a/frontend/lib/swr-cache/utils.ts
+++ b/frontend/lib/swr-cache/utils.ts
@@ -17,7 +17,7 @@ const CacheEntrySchema = z.object({
    value: z.unknown(),
 });
 
-type CacheEntry = z.infer<typeof CacheEntrySchema>;
+export type CacheEntry = z.infer<typeof CacheEntrySchema>;
 
 interface CreateCacheEntryOptions {
    ttl?: number;


### PR DESCRIPTION
Related to https://github.com/iFixit/react-commerce/issues/1156

qa_req 0

This address concern expressed here https://github.com/iFixit/react-commerce/pull/1232#issuecomment-1377527739
> Uptime [looks okay](https://status.upstash.com/uptime/x20f3jcqg1vq?page=1) (one 16 minute incident in the last year). What kind of fault-tolerance have we implemented here for if Redis goes down?