### PR TITLE
Homepage KPIs: Use required elements

### DIFF
--- a/packages/footer/homepage-kpis/index.tsx
+++ b/packages/footer/homepage-kpis/index.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-   Box,
-   SimpleGrid,
-   Stat,
-   StatHelpText,
-   StatNumber,
-} from '@chakra-ui/react';
+import { Box, SimpleGrid, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
 import { PageContentWrapper } from '../components/PageContentWrapper';
 
 interface Stat {
@@ -68,17 +62,17 @@ function Stats({ number, helpText }: StatsProps) {
          sx={{
             dl: {
                display: 'flex',
-               flexDirection: 'column',
+               flexDirection: 'column-reverse',
                alignItems: 'center',
             },
          }}
       >
+         <StatLabel fontSize="md" m="0">
+            {helpText}
+         </StatLabel>
          <StatNumber color="blue.500" fontSize="4xl" m="0">
             {number}
          </StatNumber>
-         <StatHelpText fontSize="md" m="0">
-            {helpText}
-         </StatHelpText>
       </Stat>
    );
 }


### PR DESCRIPTION
The `dl` element is required to have a `dt` element followed by `dd` elements (if `div` elements aren't being used).[^1] The Chakra docs seem to suggest that `StatLabel` is intended to be used for text of the sort we're rendering in `StatHelpText` right now.[^2] `StatLabel` renders as a `dt` while `StatNumber` and `StatHelpText` render as `dd`s; thus, using `StatLabel` would provide the required `dt` element. Because the docs require that the `dt` appear before the `dd`, this moves the `StatLabel` to before the `StatNumber` and uses the `flex-direction` `column-reverse` value to make them appear in the reverse order.

## QA Notes
Please check out this branch in the `react-commerce` subdirectory of your `Code` directory, then check that a Lighthouse run on the homepage isn't complaining about the `dl` elements anymore.

<details>
<summary>Lighthouse error which this is fixing</summary>

![image](https://user-images.githubusercontent.com/1283490/212163826-dc7ff1c0-bfa2-42bd-a8e6-c7c4aad78381.png)


</details>

Accessibility tracking issue: ifixit/ifixit#46131

Closes ifixit/ifixit#46132

[^1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
[^2]: https://chakra-ui.com/docs/components/stat/usage
