### PR TITLE
Fontawesome: use deep imports for duo-tone icons

### DIFF
--- a/frontend/components/ui/Rating.tsx
+++ b/frontend/components/ui/Rating.tsx
@@ -1,5 +1,5 @@
 import { HStack, StackProps } from '@chakra-ui/react';
-import { faStarHalf } from '@fortawesome/pro-duotone-svg-icons';
+import { faStarHalf } from '@fortawesome/pro-duotone-svg-icons/faStarHalf';
 import { faStar } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon, FaIconProps } from '@ifixit/icons';
 

--- a/frontend/templates/product/components/ImagePlaceholder.tsx
+++ b/frontend/templates/product/components/ImagePlaceholder.tsx
@@ -1,5 +1,5 @@
 import { Box, BoxProps, Circle, forwardRef } from '@chakra-ui/react';
-import { faImage } from '@fortawesome/pro-duotone-svg-icons';
+import { faImage } from '@fortawesome/pro-duotone-svg-icons/faImage';
 import { FaIcon } from '@ifixit/icons';
 
 export const ImagePlaceholder = forwardRef<BoxProps, 'div'>(

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '@chakra-ui/react';
 import { ProductRating } from '@components/common';
 import { Card } from '@components/ui';
-import { faImage } from '@fortawesome/pro-duotone-svg-icons';
+import { faImage } from '@fortawesome/pro-duotone-svg-icons/faImage';
 import { faCircleCheck } from '@fortawesome/pro-solid-svg-icons';
 import { filterNullableItems } from '@helpers/application-helpers';
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Circle, Flex, Img, Text, VStack } from '@chakra-ui/react';
-import { faImage } from '@fortawesome/pro-duotone-svg-icons';
+import { faImage } from '@fortawesome/pro-duotone-svg-icons/faImage';
 import { faArrowLeft, faArrowRight } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon } from '@ifixit/icons';
 import { ResponsiveImage } from '@ifixit/ui';

--- a/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductOptions.tsx
@@ -10,7 +10,7 @@ import {
    useTheme,
    VStack,
 } from '@chakra-ui/react';
-import { faImageSlash } from '@fortawesome/pro-duotone-svg-icons';
+import { faImageSlash } from '@fortawesome/pro-duotone-svg-icons/faImageSlash';
 import { FaIcon } from '@ifixit/icons';
 import { ResponsiveImage } from '@ifixit/ui';
 import type { Product } from '@models/product.server';

--- a/frontend/templates/product/sections/ReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ReviewsSection/index.tsx
@@ -16,8 +16,9 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { Rating } from '@components/ui';
-import { faStar } from '@fortawesome/pro-duotone-svg-icons';
-import { faPenToSquare, faShieldCheck } from '@fortawesome/pro-solid-svg-icons';
+import { faStar } from '@fortawesome/pro-duotone-svg-icons/faStar';
+import { faShieldCheck } from '@fortawesome/pro-solid-svg-icons/faShieldCheck';
+import { faPenToSquare } from '@fortawesome/pro-solid-svg-icons/faPenToSquare';
 import { useAppContext } from '@ifixit/app';
 import { FaIcon } from '@ifixit/icons';
 import { PageContentWrapper } from '@ifixit/ui';

--- a/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
+++ b/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
@@ -2,24 +2,12 @@ import type { ProductVariant } from '@models/product.server';
 import { Heading, Stack, Text, VStack } from '@chakra-ui/react';
 import React from 'react';
 import { List, ListIcon, ListItem } from '@chakra-ui/react';
-import {
-   faBoxCircleCheck as faBoxCircleCheckDuo,
-} from '@fortawesome/pro-duotone-svg-icons/faBoxCircleCheck';
-import {
-   faRocket as faRocketDuo,
-} from '@fortawesome/pro-duotone-svg-icons/faRocket';
-import {
-   faShieldCheck as faShieldCheckDuo,
-} from '@fortawesome/pro-duotone-svg-icons/faShieldCheck';
-import {
-   faBadgeDollar,
-} from '@fortawesome/pro-solid-svg-icons/faBadgeDollar';
-import {
-   faRocket,
-} from '@fortawesome/pro-solid-svg-icons/faRocket';
-import {
-   faShieldCheck,
-} from '@fortawesome/pro-solid-svg-icons/faShieldCheck';
+import { faBoxCircleCheck as faBoxCircleCheckDuo } from '@fortawesome/pro-duotone-svg-icons/faBoxCircleCheck';
+import { faRocket as faRocketDuo } from '@fortawesome/pro-duotone-svg-icons/faRocket';
+import { faShieldCheck as faShieldCheckDuo } from '@fortawesome/pro-duotone-svg-icons/faShieldCheck';
+import { faBadgeDollar } from '@fortawesome/pro-solid-svg-icons/faBadgeDollar';
+import { faRocket } from '@fortawesome/pro-solid-svg-icons/faRocket';
+import { faShieldCheck } from '@fortawesome/pro-solid-svg-icons/faShieldCheck';
 import { FaIcon, FaIconProps } from '@ifixit/icons';
 
 export type ServiceValuePropositionSectionProps = {

--- a/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
+++ b/frontend/templates/product/sections/ServiceValuePropositionSection/index.tsx
@@ -4,14 +4,22 @@ import React from 'react';
 import { List, ListIcon, ListItem } from '@chakra-ui/react';
 import {
    faBoxCircleCheck as faBoxCircleCheckDuo,
+} from '@fortawesome/pro-duotone-svg-icons/faBoxCircleCheck';
+import {
    faRocket as faRocketDuo,
+} from '@fortawesome/pro-duotone-svg-icons/faRocket';
+import {
    faShieldCheck as faShieldCheckDuo,
-} from '@fortawesome/pro-duotone-svg-icons';
+} from '@fortawesome/pro-duotone-svg-icons/faShieldCheck';
 import {
    faBadgeDollar,
+} from '@fortawesome/pro-solid-svg-icons/faBadgeDollar';
+import {
    faRocket,
+} from '@fortawesome/pro-solid-svg-icons/faRocket';
+import {
    faShieldCheck,
-} from '@fortawesome/pro-solid-svg-icons';
+} from '@fortawesome/pro-solid-svg-icons/faShieldCheck';
 import { FaIcon, FaIconProps } from '@ifixit/icons';
 
 export type ServiceValuePropositionSectionProps = {

--- a/packages/ui/cart/drawer/CartEmptyState.tsx
+++ b/packages/ui/cart/drawer/CartEmptyState.tsx
@@ -1,5 +1,5 @@
 import { Button, Circle, Text, VStack } from '@chakra-ui/react';
-import { faCartCircleExclamation } from '@fortawesome/pro-duotone-svg-icons';
+import { faCartCircleExclamation } from '@fortawesome/pro-duotone-svg-icons/faCartCircleExclamation';
 import { FaIcon } from '@ifixit/icons';
 
 export interface CartEmptyStateProps {

--- a/packages/ui/cart/drawer/CartLineItemImage.tsx
+++ b/packages/ui/cart/drawer/CartLineItemImage.tsx
@@ -1,5 +1,5 @@
 import { Box, Center } from '@chakra-ui/react';
-import { faImage } from '@fortawesome/pro-duotone-svg-icons';
+import { faImage } from '@fortawesome/pro-duotone-svg-icons/faImage';
 import { FaIcon } from '@ifixit/icons';
 import { ResponsiveImage } from '../../misc';
 


### PR DESCRIPTION
This is one of the recommended ways to reduce bundle size in case tree-shaking isn't happening like it should:

https://fontawesome.com/v5/docs/apis/javascript/tree-shaking

Hard to know until bundle-analysis tells us.

Let's try this on the duo-tone imports cause it's way fewer changes.