### PR TITLE
withLogging(): Fix sad bug!

### DIFF
--- a/packages/helpers/generic-helpers.ts
+++ b/packages/helpers/generic-helpers.ts
@@ -55,7 +55,7 @@ export function withLogging<ARGS extends Array<any>, RETURN>(
    return (...args: ARGS) => {
       const done = time(name);
       return promiseFunction(...args).finally(done);
-   }
+   };
 }
 
 function noOp() {}

--- a/packages/helpers/generic-helpers.ts
+++ b/packages/helpers/generic-helpers.ts
@@ -52,8 +52,10 @@ export function withLogging<ARGS extends Array<any>, RETURN>(
    name: string,
    promiseFunction: (...args: ARGS) => Promise<RETURN>
 ) {
-   const done = time(name);
-   return (...args: ARGS) => promiseFunction(...args).finally(done);
+   return (...args: ARGS) => {
+      const done = time(name);
+      return promiseFunction(...args).finally(done);
+   }
 }
 
 function noOp() {}


### PR DESCRIPTION
When that initialization was in the outermost function, the time() call was only happening once per callsite. This resulted in calling the *same* `done()` closure over and over, logging larger and larger time values.

Effectively, it *was* show time-since-boot each time a request finished.

Previously: 
![image](https://user-images.githubusercontent.com/26855/212777287-9d92b3b6-fc0e-4f94-bad9-bc8d07183500.png)
