### PR TITLE
Add Next.js api endpoint

### DIFF
--- a/frontend/pages/api/nextjs/cache/product.ts
+++ b/frontend/pages/api/nextjs/cache/product.ts
@@ -1,0 +1,7 @@
+import type { NextApiHandler } from 'next';
+
+const handler: NextApiHandler = async (req, res) => {
+   res.status(200).json({ model: 'product' });
+};
+
+export default handler;

--- a/frontend/pages/api/nextjs/index.ts
+++ b/frontend/pages/api/nextjs/index.ts
@@ -1,0 +1,7 @@
+import type { NextApiHandler } from 'next';
+
+const handler: NextApiHandler = async (req, res) => {
+   res.status(200).json({ version: '3.0' });
+};
+
+export default handler;


### PR DESCRIPTION
Related to #1156 

The goal of this PR is to define a prefix path for APIs defined in Next.js. This sets the stage for caching revalidation endpoints.

Following current iFixit convention (e.g. `/api/2.0`) I'm proposing to use `/api/3.0` and forward this path and all subpaths to the Next.js app.
I understand that you might want to use this for new versions of the iFixit PHP api, so I'm open for ideas. An alternative that I have in mind is `/api/rest`.
Thoughts?

👁️ Once we agree on the prefix, a forwarding rule must be set to serve all /api/3.0 subpaths through the Next.js app.

cc @sterlinghirsh @danielbeardsley 

qa_req 0