### PR TITLE
Playwright: Last Batch of Utility Functions

### DIFF
--- a/frontend/tests/playwright/fixtures/cart-drawer.ts
+++ b/frontend/tests/playwright/fixtures/cart-drawer.ts
@@ -89,4 +89,12 @@ export class CartDrawer {
    async assertItemIsNotPresent(sku: string): Promise<void> {
       expect(await this.getItem(sku)).not.toBeVisible();
    }
+
+   async assertDrawerIsOpen(): Promise<void> {
+      expect(await this.getDrawerStatus()).toBe('open');
+   }
+
+   async assertDrawerIsClosed(): Promise<void> {
+      expect(await this.getDrawerStatus()).toBe('closed');
+   }
 }

--- a/frontend/tests/playwright/fixtures/cart-drawer.ts
+++ b/frontend/tests/playwright/fixtures/cart-drawer.ts
@@ -15,6 +15,13 @@ export class CartDrawer {
       await this.page.getByTestId('cart-drawer-open').click();
    }
 
+   async getDrawerStatus(): Promise<'open' | 'closed'> {
+      if (await this.page.getByTestId('cart-drawer-close').isVisible()) {
+         return 'open';
+      }
+      return 'closed';
+   }
+
    async getItem(sku: string): Promise<Locator> {
       const cartDrawer = this.page.getByTestId('cart-drawer');
       return cartDrawer.getByRole('listitem').filter({ hasText: sku });

--- a/frontend/tests/playwright/fixtures/product-page.ts
+++ b/frontend/tests/playwright/fixtures/product-page.ts
@@ -89,4 +89,19 @@ export class ProductPage {
    async switchSelectedVariant(): Promise<void> {
       await (await this.getInactiveVariant()).click();
    }
+
+   /**
+    * @description Will assert that the inventory message has the given message. If no message is given, it will assert that the inventory message is not visible.
+    */
+   async assertInventoryMessage(message: string | null = null): Promise<void> {
+      if (message === null) {
+         await expect(
+            this.page.getByTestId('product-inventory-message')
+         ).not.toBeVisible();
+      } else {
+         await expect(
+            this.page.getByTestId('product-inventory-message')
+         ).toHaveText(message);
+      }
+   }
 }

--- a/frontend/tests/playwright/fixtures/product-page.ts
+++ b/frontend/tests/playwright/fixtures/product-page.ts
@@ -16,14 +16,16 @@ export class ProductPage {
    }
 
    /**
-    * @description Navigates to the product page of the product with the given product handle
+    * @description Navigates to the product page of the product with the given
+    * product handle
     */
    async gotoProduct(productHandle: string) {
       await this.page.goto(`/products/${productHandle}`);
    }
 
    /**
-    * @description Locates and returns the product sku as a string with the format IF###-###-## or IF###-###
+    * @description Locates and returns the product sku as a string with the
+    * format IF###-###-## or IF###-###
     */
    async getSku(): Promise<string> {
       const sku =
@@ -37,7 +39,8 @@ export class ProductPage {
    }
 
    /**
-    * @description Locates and returns the current product price as a string with the format $###.## or $###
+    * @description Locates and returns the current product price as a string
+    * with the format $###.## or $###
     */
    async getCurrentPrice(): Promise<number> {
       const price = await this.page
@@ -50,7 +53,8 @@ export class ProductPage {
    }
 
    /**
-    * @description Locates and returns the original product price as a string with the format $###.## or $###
+    * @description Locates and returns the original product price as a string
+    * with the format $###.## or $###
     */
    async getDiscountedPrice(): Promise<number> {
       const price = await this.page
@@ -64,7 +68,8 @@ export class ProductPage {
 
    /**
     * @note This is for the image based selector type.
-    * @description returns the locator for the currently selected variant shown on the product page.
+    * @description returns the locator for the currently selected variant
+    * shown on the product page.
     */
    async getActiveVariant(): Promise<Locator> {
       return this.page
@@ -73,8 +78,10 @@ export class ProductPage {
    }
 
    /**
-    * @note This is for the image based selector type. This is also under the assumption that there are only two variants.
-    * @description returns the locator for the other variant options in the product page.
+    * @note This is for the image based selector type. This is also under the
+    * assumption that there are only two variants.
+    * @description returns the locator for the other variant options in the
+    * product page.
     */
    async getInactiveVariant(): Promise<Locator> {
       return this.page
@@ -83,7 +90,8 @@ export class ProductPage {
    }
 
    /**
-    * @note This is for the image based selector type. This is also under the assumption that there are only two variants.
+    * @note This is for the image based selector type. This is also under the
+    * assumption that there are only two variants.
     * @description switches the selected variant to the inactive variant.
     */
    async switchSelectedVariant(): Promise<void> {
@@ -91,7 +99,9 @@ export class ProductPage {
    }
 
    /**
-    * @description Will assert that the inventory message has the given message. If no message is given, it will assert that the inventory message is not visible.
+    * @description Will assert that the inventory message has the given message.
+    * If no message is given, it will assert that the inventory message is
+    * not visible.
     */
    async assertInventoryMessage(message: string | null = null): Promise<void> {
       if (message === null) {

--- a/frontend/tests/playwright/product/add_to_cart.spec.ts
+++ b/frontend/tests/playwright/product/add_to_cart.spec.ts
@@ -90,9 +90,7 @@ test.describe.serial('product page add to cart', () => {
       await cartDrawer.assertCartTotalQuantity(0);
       await cartDrawer.assertItemIsNotPresent(sku);
       await page.getByTestId('back-to-shopping').click();
-      await expect(
-         page.getByTestId('cart-drawer-item-count')
-      ).not.toBeVisible();
+      expect(await cartDrawer.getDrawerStatus()).toBe('closed');
 
       await productPage.addToCart();
       await cartDrawer.assertCartTotalQuantity(1);
@@ -103,10 +101,7 @@ test.describe.serial('product page add to cart', () => {
       await cartDrawer.assertCartTotalQuantity(0);
       await cartDrawer.assertItemIsNotPresent(sku);
       await page.getByTestId('back-to-shopping').click();
-      await expect(
-         page.getByTestId('cart-drawer-item-count')
-      ).not.toBeVisible();
-      await expect(page.getByTestId('cart-drawer-close')).not.toBeVisible();
+      expect(await cartDrawer.getDrawerStatus()).toBe('closed');
    });
 
    test.describe('Product Stock Levels', () => {

--- a/frontend/tests/playwright/product/add_to_cart.spec.ts
+++ b/frontend/tests/playwright/product/add_to_cart.spec.ts
@@ -90,7 +90,7 @@ test.describe.serial('product page add to cart', () => {
       await cartDrawer.assertCartTotalQuantity(0);
       await cartDrawer.assertItemIsNotPresent(sku);
       await page.getByTestId('back-to-shopping').click();
-      expect(await cartDrawer.getDrawerStatus()).toBe('closed');
+      await cartDrawer.assertDrawerIsClosed();
 
       await productPage.addToCart();
       await cartDrawer.assertCartTotalQuantity(1);
@@ -101,7 +101,7 @@ test.describe.serial('product page add to cart', () => {
       await cartDrawer.assertCartTotalQuantity(0);
       await cartDrawer.assertItemIsNotPresent(sku);
       await page.getByTestId('back-to-shopping').click();
-      expect(await cartDrawer.getDrawerStatus()).toBe('closed');
+      await cartDrawer.assertDrawerIsClosed();
    });
 
    test.describe('Product Stock Levels', () => {

--- a/frontend/tests/playwright/product/add_to_cart.spec.ts
+++ b/frontend/tests/playwright/product/add_to_cart.spec.ts
@@ -121,46 +121,33 @@ test.describe.serial('product page add to cart', () => {
 
          const firstOptionSku = await productPage.getSku();
 
-         await expect(
-            page.getByTestId('product-inventory-message')
-         ).toBeVisible();
-         await expect(page.getByTestId('product-inventory-message')).toHaveText(
-            'Only 3 left'
-         );
+         await productPage.assertInventoryMessage('Only 3 left');
          await productPage.addToCart();
          await cartDrawer.assertItemQuantity(firstOptionSku, 1);
 
          await cartDrawer.close();
-         await expect(page.getByTestId('product-inventory-message')).toHaveText(
-            'Only 2 left'
-         );
+         await productPage.assertInventoryMessage('Only 2 left');
 
          await cartDrawer.open();
          await cartDrawer.increaseItemQuantity(firstOptionSku);
          await cartDrawer.assertItemQuantity(firstOptionSku, 2);
 
          await cartDrawer.close();
-         await expect(page.getByTestId('product-inventory-message')).toHaveText(
-            'Only 1 left'
-         );
+         await productPage.assertInventoryMessage('Only 1 left');
 
          await cartDrawer.open();
          await cartDrawer.increaseItemQuantity(firstOptionSku);
          await cartDrawer.assertItemQuantity(firstOptionSku, 3);
 
          await cartDrawer.close();
-         await expect(page.getByTestId('product-inventory-message')).toHaveText(
-            'No more items available'
-         );
+         await productPage.assertInventoryMessage('No more items available');
          await expect(productPage.addToCartButton).toBeDisabled();
 
          await productPage.switchSelectedVariant();
          const secondOptionSku = await productPage.getSku();
 
          await expect(productPage.addToCartButton).toBeVisible();
-         await expect(
-            page.getByTestId('product-inventory-message')
-         ).not.toBeVisible();
+         await productPage.assertInventoryMessage();
          await productPage.addToCart();
 
          await cartDrawer.assertItemQuantity(secondOptionSku, 1);
@@ -171,9 +158,7 @@ test.describe.serial('product page add to cart', () => {
 
          await cartDrawer.close();
          await productPage.switchSelectedVariant();
-         await expect(page.getByTestId('product-inventory-message')).toHaveText(
-            'Only 1 left'
-         );
+         await productPage.assertInventoryMessage('Only 1 left');
       });
 
       test('Out of stock product cannot be added to cart', async ({
@@ -204,9 +189,7 @@ test.describe.serial('product page add to cart', () => {
          await productPage.switchSelectedVariant();
 
          await expect(productPage.addToCartButton).not.toBeVisible();
-         await expect(
-            page.getByTestId('product-inventory-message')
-         ).not.toBeVisible();
+         await productPage.assertInventoryMessage();
 
          const notifyMeForm = page.getByText(/this item is currently/i);
          await expect(notifyMeForm).toBeVisible();
@@ -224,9 +207,7 @@ test.describe.serial('product page add to cart', () => {
 
          await productPage.switchSelectedVariant();
          await expect(productPage.addToCartButton).toBeVisible();
-         await expect(
-            page.getByTestId('product-inventory-message')
-         ).not.toBeVisible();
+         await productPage.assertInventoryMessage();
 
          const partOnlySku = await productPage.getSku();
 
@@ -236,9 +217,7 @@ test.describe.serial('product page add to cart', () => {
 
          await cartDrawer.close();
          await expect(productPage.addToCartButton).toBeEnabled();
-         await expect(
-            page.getByTestId('product-inventory-message')
-         ).not.toBeVisible();
+         await productPage.assertInventoryMessage();
       });
    });
 });


### PR DESCRIPTION
## Description

This is a continuation of https://github.com/iFixit/react-commerce/pull/1258 and the last set of utility functions to close out #1217.

### Changes

- Adds a utility function to make it easier to assert a product's inventory message
- Adds a utility function to get the current `visibility` state of the cart drawer.

### QA 

qa_req 0
- [ ] CI Should Pass

Closes: #1217 