### PR TITLE
Add indexId to correctly handle the Algolia state

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -64,7 +64,7 @@ export function InstantSearchProvider({
    const routing: RouterProps<UiState, RouteState> = {
       stateMapping: {
          stateToRoute(uiState) {
-            const indexUiState = uiState[indexName];
+            const indexUiState = uiState['main-product-list-index'];
             const routeState: RouteState = {};
             if (indexUiState.query) {
                routeState.q = indexUiState.query;
@@ -114,7 +114,7 @@ export function InstantSearchProvider({
                });
             }
             return {
-               [indexName]: stateObject,
+               ['main-product-list-index']: stateObject,
             };
          },
       },

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -31,7 +31,7 @@ export function ProductListView({
          <SecondaryNavigation productList={productList} />
          <PageContentWrapper py="10">
             <VStack align="stretch" spacing="12">
-               <Index indexName={indexName}>
+               <Index indexName={indexName} indexId="main-product-list-index">
                   <Configure filters={filters} hitsPerPage={18} />
                   <MetaTags productList={productList} />
                   <HeroSection productList={productList} />

--- a/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
+++ b/frontend/templates/product-list/sections/FeaturedProductListSection.tsx
@@ -129,7 +129,7 @@ export function FeaturedProductListSection({
             <Box flexGrow={1}>
                <Index
                   indexName={productList.algolia.indexName}
-                  indexId={`feature-product-list-${index}`}
+                  indexId={`featured-product-list-${index}`}
                >
                   <Configure hitsPerPage={3} filters={filters} />
                   <ProductGrid />


### PR DESCRIPTION
closes #1191 

Exploiting multiple times the same index on a page requires that all instances of `<Index />` have a unique `indexId` prop specified.
Otherwise the Algolia internal state is not updated correctly.

### QA

1. Visit Vercel preview
2. Navigate to a product-list page via a url with some pre-filled filters
3. Try to remove the filters and check that they are correctly removed from the url
4. Verify that filters continue to work also for interaction without pre-filled filters in the url