### PR TITLE
Footer Copyright: remove year

### DIFF
--- a/packages/footer/components/Legal.tsx
+++ b/packages/footer/components/Legal.tsx
@@ -40,10 +40,9 @@ export const FooterLegalSection = forwardRef<StackProps, 'div'>(
 
 export const FooterCopyright = forwardRef<Omit<BoxProps, 'children'>, 'div'>(
    (props, ref) => {
-      const year = new Date().getFullYear();
       return (
          <Box ref={ref} fontSize="sm" {...props}>
-            &copy; {year} iFixit
+            &copy; iFixit
          </Box>
       );
    }


### PR DESCRIPTION
We got 1000s of hydration errors around new-years when this value was different between server and client.

The year isn't particularly relevant here as copyrights last a long time. Technically, we don't even need a copyright message, but claims are more defensible if it was clear your content is copyrighted by you.

CC @sterlinghirsh @davidrans 