### PR TITLE
Drop use of backwards-incompatible `Object.fromEntries()`

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useProductSearchHitPricing.ts
@@ -40,15 +40,13 @@ export function useProductSearchHitPricing(
 
    const proPricesByTier =
       product.price_tiers && !isEmpty(product.price_tiers)
-         ? Object.fromEntries(
-              Object.entries(product.price_tiers).map(([tier, price]) => [
-                 tier,
-                 {
-                    amount: price.default_variant_price,
-                    currencyCode: 'usd',
-                 },
-              ])
-           )
+         ? Object.entries(product.price_tiers).reduce((acc, [tier, price]) => {
+              acc[tier] = {
+                 amount: price.default_variant_price,
+                 currencyCode: 'usd',
+              };
+              return acc;
+           }, {} as Record<string, Money>)
          : undefined;
 
    return {


### PR DESCRIPTION
Fixes a bug where `Object.fromEntries` is undefined on older browsers.

https://sentry.io/share/issue/d4e90fc3843348c599777eec6e1484d2/

We could polyfill this function instead, but we already follow this reduce pattern elsewhere in our code.

https://github.com/iFixit/react-commerce/blob/50ec98ff8596e4d505e466821525e9750ac252cd/packages/cart-sdk/hooks/use-cart.ts#L122 https://github.com/iFixit/react-commerce/blob/aedbde5560847162eb2373d61f268560fe312674/frontend/models/product.server.ts#L497

CanIUse: https://caniuse.com/mdn-javascript_builtins_object_fromentries

## QA

Visit a product list page on an older browser that doesn't have Object.fromEntries, and confirm there is no Sentry event reported and that you can view the price of the product.