### PR TITLE
Playwright GitHub Actions: Move build step to separate step and cache it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,10 @@ jobs:
 
          - name: Build Next.js
            if: steps.nextjs-cache.outputs.cache-hit != 'true'
+           env:
+              NODE_ENV: test
+              NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
+              ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
            run: cd frontend && pnpm build
 
          - name: Run Playwright Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,17 @@ jobs:
            if: steps.playwright-cache.outputs.cache-hit != 'true'
            run: cd frontend && npx playwright install
 
+         - name: Cache Next.js build
+           uses: actions/cache@v3
+           id: nextjs-cache
+           with:
+              path: frontend/.next
+              key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+         - name: Build Next.js
+           if: steps.nextjs-cache.outputs.cache-hit != 'true'
+           run: cd frontend && pnpm build
+
          - name: Run Playwright Tests
            env:
               NODE_ENV: test

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -107,9 +107,7 @@ const config: PlaywrightTestConfig = {
    /* Run your local dev server before starting the tests */
    webServer: {
       cwd: process.env.CI ? './' : '../',
-      command: process.env.CI
-         ? 'pnpm run build && pnpm run start'
-         : 'pnpm run dev',
+      command: process.env.CI ? 'pnpm run start' : 'pnpm run dev',
       port: 3000,
       timeout: 120 * 1000,
       /* Reuse the same server if on local dev */


### PR DESCRIPTION
## Description

We occasionally fail to run the Playwright tests because it times out waiting for the app to finish building and for the server to start up.

By moving the build step to a prior step, in the GitHub action workflow, we can ensure that Playwright just needs to start and wait for the server to be ready.

In addition, this build step will help when we create the custom Next.js servers needed for the dynamic `msw` handlers.[^1]

### Changes

- Moves the `pnpm build` step from the Playwright config into a separate GitHub action step
- Ensures the app will be built using the `.env.test` values
- Caches the `.next` directory to help speed up future CI runs.[^2]

### CR:

I could not extract the `Frontend Server` to an external GitHub action step as requested in #1279 because it is quite messy to start the server as a background process and be able to know when the server has finished booting. In addition, we set the requirement that Playwright will not reuse an existing server in CI. By keeping Playwright in control of starting the Frontend server, we can ensure the tests will only be run when the server finishes booting and will not be reused. Hopefully, Playwright will not time out waiting on the server since we extracted the build step. 

### QA:

qa_req 0 CI should pass and I confirmed the caching works in https://github.com/iFixit/react-commerce/actions/runs/3971918976/jobs/6809453451#step:9:15 

Closes: #1279 
Closes: #1281 
Connects: #1238 

[^1]: #1238 
[^2]: [nextjs.org/docs/advanced-features/ci-build-caching#github-actions](https://nextjs.org/docs/advanced-features/ci-build-caching#github-actions)