### PR TITLE
Add SWR caching lib value validation

### DIFF
--- a/frontend/lib/swr-cache/utils.ts
+++ b/frontend/lib/swr-cache/utils.ts
@@ -87,3 +87,7 @@ const stableHash = (variables: unknown): string => {
          : val
    );
 };
+
+export const printZodError = (error: z.ZodError) => {
+   return JSON.stringify(error.format(), null, 2);
+};


### PR DESCRIPTION
Related to #1156 

In the previously merged implementation, the value schema was used only to infer the correct return type. This PR actually uses the schema to verify that the entry value is valid. This mechanism will guard from cache entries not matching a schema change, automatically treating those entries as cache misses

qa_req 0