### PR TITLE
Algolia: Missing null check

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -65,6 +65,9 @@ export function InstantSearchProvider({
       stateMapping: {
          stateToRoute(uiState) {
             const indexUiState = uiState['main-product-list-index'];
+            if (!indexUiState) {
+               return {};
+            }
             const routeState: RouteState = {};
             if (indexUiState.query) {
                routeState.q = indexUiState.query;


### PR DESCRIPTION
Fixes a bug where the code assumes the `indexUiState` is never undefined.

Sentry event: https://sentry.io/share/issue/ae902268ed2d4c2ebc4318ada29daeb4/

Bug introduced in #1272, where we started using the `indexId` instead of `indexName` to key the Algolia state.

## QA

Confirm that you can't reproduce the Sentry error on a product list page. Not sure on the exact reproduction steps, but it seems to be related to adding/removing facets or clicking on product list children links.