### PR TITLE
Polyfill `Object.fromEntries()`

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -27,7 +27,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout<any>) {
    return (
       <>
          <Script
-            src={`${polyfillDomain}/v3/polyfill.min.js?features=default,Intl.RelativeTimeFormat,Intl.RelativeTimeFormat.~locale.en`}
+            src={`${polyfillDomain}/v3/polyfill.min.js?features=default,Intl.RelativeTimeFormat,Intl.RelativeTimeFormat.~locale.en,Object.fromEntries`}
             strategy="beforeInteractive"
          />
          <ServerSidePropsProvider props={pageProps}>


### PR DESCRIPTION
Fixes errors on older browsers that don't have Object.fromEntries(). These errors started happening when we upgraded Chakra in #1255.

See #1280 for background.

## QA

Visit a product list page on an older browser that doesn't have Object.fromEntries, and confirm there is no Sentry event reported and that you can view the price of the product.