### PR TITLE
Hotfix: Add timeout to Playwright Github Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ env:
    npm_config_userconfig: './.npmrc'
 jobs:
    playwright-run:
+      timeout-minutes: 15
       strategy:
          fail-fast: false
          matrix:


### PR DESCRIPTION
## Description

There is currently an issue with this action that requires further investigation. **Playwright** seems to be unable to communicate with the `backend` server (i.e. localhost:1337) which is causing the tests to be re-run multiple times and eventually fail with a total time of about 30 minutes.

For now, let's set a timeout of 15 minutes to prevent the action from running more than normal.

### QA

qa_req 0 CI should continue passing

Closes: #1293 