### PR TITLE
GitHub Actions: Change Nextjs Caching Logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,10 @@ jobs:
            id: nextjs-cache
            with:
               path: frontend/.next
-              key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}
+              key: ${{ github.ref_name }}-nextjs-${{github.sha}}
+              restore-keys: |
+                 ${{ github.ref_name }}-nextjs-${{github.event.before}}
+                 ${{ github.ref_name }}-nextjs-
 
          - name: Build Next.js
            if: steps.nextjs-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Description

If we change some logic to the `getServerSideProps` function we need to bust the cache. We currently only rely on the packages installed to bust the cache which is not enough. 

This will implement the same cache-busting logic we use for Webpack in iFixit/ifixit.
https://github.com/iFixit/ifixit/blob/master/.github/workflows/E2E.yml#L35-L42

## QA: 

- [ ] CI should now pass
- [ ] Caching should still work for Nextjs

**cc:** @andyg0808 