### PR TITLE
Fix lifetime guarantee wording

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductGrid.tsx
@@ -112,7 +112,7 @@ export function ProductGridItem({ product }: ProductGridItemProps) {
                )}
                {showLifetimeWarrantyBadge && (
                   <ProductCardBadge colorScheme="blue">
-                     Lifetime Warranty
+                     Lifetime Guarantee
                   </ProductCardBadge>
                )}
             </ProductCardBadgeList>

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -197,7 +197,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                         )}
                         {showLifetimeWarrantyBadge && (
                            <ProductListItemBadge colorScheme="blue">
-                              Lifetime Warranty
+                              Lifetime Guarantee
                            </ProductListItemBadge>
                         )}
                      </Flex>

--- a/frontend/templates/product/sections/FeaturedProductsSection/index.tsx
+++ b/frontend/templates/product/sections/FeaturedProductsSection/index.tsx
@@ -179,7 +179,7 @@ function ProductGridItem({
                )}
                {hasLifetimeWarranty && (
                   <ProductGridItemBadge colorScheme="blue">
-                     Lifetime Warranty
+                     Lifetime Guarantee
                   </ProductGridItemBadge>
                )}
             </Flex>


### PR DESCRIPTION
closes #1292 

## QA

1. Open Vercel preview
2. Go to product list pages and product pages
3. Verify that lifetime warranty badges now read "lifetime guarantee" as requested in #1292  