### PR TITLE
Vulcan: Make Solution card look like mockup

### DIFF
--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -1,7 +1,7 @@
 import { WithProvidersProps } from '@components/common';
 import type { WithLayoutProps } from '@layouts/default/server';
 
-export type Problem = {
+export type Section = {
    heading: string;
    body: string;
 };
@@ -9,9 +9,9 @@ export type Problem = {
 export type TroubleshootingData = {
    title: string;
    toc: string;
-   introduction: Problem[];
-   solutions: Problem[];
-   conclusion: Problem[];
+   introduction: Section[];
+   solutions: Section[];
+   conclusion: Section[];
 };
 
 type TroubleshootingPageProps = {

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -4,7 +4,7 @@ import Head from 'next/head';
 import React from 'react';
 import { Box, Container, Flex, Heading } from '@chakra-ui/react';
 import Prerendered from './prerendered';
-import { Problem, TroubleshootingData } from './hooks/useTroubleshootingProps';
+import { Section, TroubleshootingData } from './hooks/useTroubleshootingProps';
 import SolutionCard from './solution';
 
 const Wiki: NextPageWithLayout<{
@@ -46,7 +46,7 @@ const Wiki: NextPageWithLayout<{
    );
 };
 
-function IntroductionSection({ intro }: { intro: Problem }) {
+function IntroductionSection({ intro }: { intro: Section }) {
    return (
       <Box>
          <Heading>{intro.heading}</Heading>
@@ -55,7 +55,7 @@ function IntroductionSection({ intro }: { intro: Problem }) {
    );
 }
 
-function ConclusionSection({ conclusion }: { conclusion: Problem }) {
+function ConclusionSection({ conclusion }: { conclusion: Section }) {
    return (
       <Box>
          <Heading>{conclusion.heading}</Heading>

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -2,43 +2,47 @@ import { DefaultLayout } from '@layouts/default';
 import { DefaultLayoutProps } from '@layouts/default/server';
 import Head from 'next/head';
 import React from 'react';
-import { Box, Container, Heading } from '@chakra-ui/react';
+import { Box, Container, Flex, Heading } from '@chakra-ui/react';
 import Prerendered from './prerendered';
 import { Problem, TroubleshootingData } from './hooks/useTroubleshootingProps';
 import SolutionCard from './solution';
-
-const renderStyles = {
-   a: {
-      color: 'blue.500',
-   },
-   'ul, ol': {
-      paddingLeft: 4,
-   },
-};
 
 const Wiki: NextPageWithLayout<{
    wikiData: TroubleshootingData;
    layoutProps: DefaultLayoutProps;
 }> = ({ wikiData }) => {
    return (
-      <Container sx={renderStyles}>
-         <Head>
-            <meta name="robots" content="noindex" />
-         </Head>
-         <Heading as="h1">{wikiData.title}</Heading>
-         {wikiData.introduction.map((intro) => (
-            <IntroductionSection key={intro.heading} intro={intro} />
-         ))}
-         {wikiData.solutions.map((solution) => (
-            <SolutionCard key={solution.heading} solution={solution} />
-         ))}
-         {wikiData.conclusion.map((conclusion) => (
-            <ConclusionSection
-               key={conclusion.heading}
-               conclusion={conclusion}
-            />
-         ))}
-      </Container>
+      <Flex
+         direction="column"
+         justifyContent="center"
+         width="100%"
+         fontSize="16px"
+      >
+         <Flex padding="0px 32px 32px" gap="48px" maxW="1280px" id="wrapper">
+            <Flex gap="16px" direction="column" id="main">
+               <Head>
+                  <meta name="robots" content="noindex" />
+               </Head>
+               <Heading as="h1">{wikiData.title}</Heading>
+               {wikiData.introduction.map((intro) => (
+                  <IntroductionSection key={intro.heading} intro={intro} />
+               ))}
+               {wikiData.solutions.map((solution, index) => (
+                  <SolutionCard
+                     key={solution.heading}
+                     index={index + 1}
+                     solution={solution}
+                  />
+               ))}
+               {wikiData.conclusion.map((conclusion) => (
+                  <ConclusionSection
+                     key={conclusion.heading}
+                     conclusion={conclusion}
+                  />
+               ))}
+            </Flex>
+         </Flex>
+      </Flex>
    );
 };
 

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Box, Container, Heading } from '@chakra-ui/react';
 import Prerendered from './prerendered';
 import { Problem, TroubleshootingData } from './hooks/useTroubleshootingProps';
+import SolutionCard from './solution';
 
 const renderStyles = {
    a: {
@@ -40,15 +41,6 @@ const Wiki: NextPageWithLayout<{
       </Container>
    );
 };
-
-function SolutionCard({ solution }: { solution: Problem }) {
-   return (
-      <Box>
-         <Heading>{solution.heading}</Heading>
-         <Prerendered html={solution.body} />
-      </Box>
-   );
-}
 
 function IntroductionSection({ intro }: { intro: Problem }) {
    return (

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -2,7 +2,7 @@ import { DefaultLayout } from '@layouts/default';
 import { DefaultLayoutProps } from '@layouts/default/server';
 import Head from 'next/head';
 import React from 'react';
-import { Box, Container, Heading } from '@chakra-ui/react';
+import { Box, chakra, Container, Heading } from '@chakra-ui/react';
 import { Problem, TroubleshootingData } from './hooks/useTroubleshootingProps';
 
 const renderStyles = {
@@ -44,7 +44,7 @@ function SolutionCard({ solution }: { solution: Problem }) {
    return (
       <Box>
          <Heading>{solution.heading}</Heading>
-         <Box dangerouslySetInnerHTML={{ __html: solution.body }} />
+         <Prerendered html={solution.body} />
       </Box>
    );
 }
@@ -53,7 +53,7 @@ function IntroductionSection({ intro }: { intro: Problem }) {
    return (
       <Box>
          <Heading>{intro.heading}</Heading>
-         <Box dangerouslySetInnerHTML={{ __html: intro.body }} />
+         <Prerendered html={intro.body} />
       </Box>
    );
 }
@@ -62,10 +62,43 @@ function ConclusionSection({ conclusion }: { conclusion: Problem }) {
    return (
       <Box>
          <Heading>{conclusion.heading}</Heading>
-         <Box dangerouslySetInnerHTML={{ __html: conclusion.body }} />
+         <Prerendered html={conclusion.body} />
       </Box>
    );
 }
+
+const Prerendered = chakra(function Prerendered({
+   html,
+   className,
+}: {
+   html: string;
+   className?: string;
+}) {
+   const renderStyles = {
+      a: {
+         color: 'blue.500',
+      },
+      'ul, ol': {
+         paddingLeft: 4,
+      },
+
+      p: {
+         marginBottom: '14px',
+      },
+
+      'p:last-child': {
+         marginBottom: 0,
+      },
+   };
+
+   return (
+      <Box
+         className={className}
+         sx={renderStyles}
+         dangerouslySetInnerHTML={{ __html: html }}
+      />
+   );
+});
 
 Wiki.getLayout = function getLayout(page, pageProps) {
    return <DefaultLayout {...pageProps.layoutProps}>{page}</DefaultLayout>;

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -2,7 +2,13 @@ import { DefaultLayout } from '@layouts/default';
 import { DefaultLayoutProps } from '@layouts/default/server';
 import Head from 'next/head';
 import React from 'react';
-import { Box, chakra, Container, Heading } from '@chakra-ui/react';
+import {
+   Box,
+   chakra,
+   Container,
+   Heading,
+   SystemStyleObject,
+} from '@chakra-ui/react';
 import { Problem, TroubleshootingData } from './hooks/useTroubleshootingProps';
 
 const renderStyles = {
@@ -74,20 +80,28 @@ const Prerendered = chakra(function Prerendered({
    html: string;
    className?: string;
 }) {
-   const renderStyles = {
-      a: {
-         color: 'blue.500',
-      },
-      'ul, ol': {
-         paddingLeft: 4,
+   const renderStyles: SystemStyleObject = {
+      '.headerContainer': {
+         display: 'flex',
+         alignItems: 'baseline',
       },
 
-      p: {
-         marginBottom: '14px',
+      '.selfLink': {
+         display: 'none',
       },
 
-      'p:last-child': {
-         marginBottom: 0,
+      h3: {
+         fontSize: 'xl',
+         lineHeight: '1.2',
+      },
+
+      'h3,h4': {
+         fontWeight: 590,
+      },
+
+      'h4,h5': {
+         fontSize: 'md',
+         lineHeight: '1.25',
       },
    };
 

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -13,7 +13,7 @@ const Wiki: NextPageWithLayout<{
 }> = ({ wikiData }) => {
    return (
       <Flex
-         direction="column"
+         direction="row"
          justifyContent="center"
          width="100%"
          fontSize="16px"

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -84,6 +84,7 @@ const Prerendered = chakra(function Prerendered({
       '.headerContainer': {
          display: 'flex',
          alignItems: 'baseline',
+         marginBottom: 2,
       },
 
       '.selfLink': {

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -2,13 +2,8 @@ import { DefaultLayout } from '@layouts/default';
 import { DefaultLayoutProps } from '@layouts/default/server';
 import Head from 'next/head';
 import React from 'react';
-import {
-   Box,
-   chakra,
-   Container,
-   Heading,
-   SystemStyleObject,
-} from '@chakra-ui/react';
+import { Box, Container, Heading } from '@chakra-ui/react';
+import Prerendered from './prerendered';
 import { Problem, TroubleshootingData } from './hooks/useTroubleshootingProps';
 
 const renderStyles = {
@@ -72,48 +67,6 @@ function ConclusionSection({ conclusion }: { conclusion: Problem }) {
       </Box>
    );
 }
-
-const Prerendered = chakra(function Prerendered({
-   html,
-   className,
-}: {
-   html: string;
-   className?: string;
-}) {
-   const renderStyles: SystemStyleObject = {
-      '.headerContainer': {
-         display: 'flex',
-         alignItems: 'baseline',
-         marginBottom: 2,
-      },
-
-      '.selfLink': {
-         display: 'none',
-      },
-
-      h3: {
-         fontSize: 'xl',
-         lineHeight: '1.2',
-      },
-
-      'h3,h4': {
-         fontWeight: 590,
-      },
-
-      'h4,h5': {
-         fontSize: 'md',
-         lineHeight: '1.25',
-      },
-   };
-
-   return (
-      <Box
-         className={className}
-         sx={renderStyles}
-         dangerouslySetInnerHTML={{ __html: html }}
-      />
-   );
-});
 
 Wiki.getLayout = function getLayout(page, pageProps) {
    return <DefaultLayout {...pageProps.layoutProps}>{page}</DefaultLayout>;

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -1,5 +1,39 @@
 import { Box, chakra, SystemStyleObject } from '@chakra-ui/react';
 
+const renderStyles: SystemStyleObject = {
+   '.headerContainer': {
+      display: 'flex',
+      alignItems: 'baseline',
+      marginBottom: 2,
+   },
+
+   '.selfLink': {
+      display: 'none',
+   },
+
+   h3: {
+      fontSize: 'xl',
+      lineHeight: '1.2',
+   },
+
+   'h3,h4': {
+      fontWeight: 590,
+   },
+
+   'h4,h5': {
+      fontSize: 'md',
+      lineHeight: '1.25',
+   },
+
+   p: {
+      lineHeight: '1.38',
+      fontWeight: 'regular',
+      fontSize: '16px',
+      color: 'gray.700',
+      alignSelf: 'stretch',
+   },
+};
+
 const Prerendered = chakra(function Prerendered({
    html,
    className,
@@ -7,40 +41,6 @@ const Prerendered = chakra(function Prerendered({
    html: string;
    className?: string;
 }) {
-   const renderStyles: SystemStyleObject = {
-      '.headerContainer': {
-         display: 'flex',
-         alignItems: 'baseline',
-         marginBottom: 2,
-      },
-
-      '.selfLink': {
-         display: 'none',
-      },
-
-      h3: {
-         fontSize: 'xl',
-         lineHeight: '1.2',
-      },
-
-      'h3,h4': {
-         fontWeight: 590,
-      },
-
-      'h4,h5': {
-         fontSize: 'md',
-         lineHeight: '1.25',
-      },
-
-      p: {
-         lineHeight: '1.38',
-         fontWeight: 'regular',
-         fontSize: '16px',
-         color: 'gray.700',
-         alignSelf: 'stretch',
-      },
-   };
-
    return (
       <Box
          className={className}

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -1,0 +1,45 @@
+import { Box, chakra, SystemStyleObject } from '@chakra-ui/react';
+
+const Prerendered = chakra(function Prerendered({
+   html,
+   className,
+}: {
+   html: string;
+   className?: string;
+}) {
+   const renderStyles: SystemStyleObject = {
+      '.headerContainer': {
+         display: 'flex',
+         alignItems: 'baseline',
+         marginBottom: 2,
+      },
+
+      '.selfLink': {
+         display: 'none',
+      },
+
+      h3: {
+         fontSize: 'xl',
+         lineHeight: '1.2',
+      },
+
+      'h3,h4': {
+         fontWeight: 590,
+      },
+
+      'h4,h5': {
+         fontSize: 'md',
+         lineHeight: '1.25',
+      },
+   };
+
+   return (
+      <Box
+         className={className}
+         sx={renderStyles}
+         dangerouslySetInnerHTML={{ __html: html }}
+      />
+   );
+});
+
+export default Prerendered;

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -31,6 +31,14 @@ const Prerendered = chakra(function Prerendered({
          fontSize: 'md',
          lineHeight: '1.25',
       },
+
+      p: {
+         lineHeight: '1.38',
+         fontWeight: 'regular',
+         fontSize: '16px',
+         color: 'gray.700',
+         alignSelf: 'stretch',
+      },
    };
 
    return (

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -11,18 +11,6 @@ import {
 import { Problem } from './hooks/useTroubleshootingProps';
 import Prerendered from './prerendered';
 
-export default function SolutionCard({ solution }: { solution: Problem }) {
-   return (
-      <Box background="white">
-         <SolutionHeader />
-         <Heading>{solution.heading}</Heading>
-         <SolutionTexts />
-         <Prerendered html={solution.body} />
-         <SolutionFooter />
-      </Box>
-   );
-}
-
 const SolutionFooter = () => (
    <Stack
       justify="flex-start"
@@ -257,22 +245,22 @@ const SolutionHeader = () => (
    </Stack>
 );
 
-const SolutionTexts = () => (
+const SolutionTexts = ({ title }: { title: string }) => (
    <Stack
       justify="flex-start"
       align="flex-start"
       width="798.74px"
       maxWidth="100%"
    >
-      <Text
+      <Heading
          fontFamily="SF Pro"
          fontWeight="medium"
          fontSize="24px"
          color="gray.900"
          alignSelf="stretch"
       >
-         Google Pixel 7 will Not Charge
-      </Text>
+         {title}
+      </Heading>
       <Text
          fontFamily="SF Pro"
          lineHeight="1.38"
@@ -297,3 +285,14 @@ const SolutionTexts = () => (
       </Text>
    </Stack>
 );
+
+export default function SolutionCard({ solution }: { solution: Problem }) {
+   return (
+      <Box background="white">
+         <SolutionHeader />
+         <SolutionTexts title={solution.heading} />
+         <Prerendered html={solution.body} />
+         <SolutionFooter />
+      </Box>
+   );
+}

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -25,7 +25,7 @@ const SolutionFooter = () => (
       justify="flex-start"
       align="flex-start"
       spacing="4px"
-      width="798.74px"
+      width="800px"
       maxWidth="100%"
    >
       <Stack

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -1,4 +1,13 @@
-import { Box, Heading } from '@chakra-ui/react';
+import {
+   Box,
+   Heading,
+   Stack,
+   Text,
+   Avatar,
+   Button,
+   Icon,
+   Badge,
+} from '@chakra-ui/react';
 import { Problem } from './hooks/useTroubleshootingProps';
 import Prerendered from './prerendered';
 
@@ -10,3 +19,278 @@ export default function SolutionCard({ solution }: { solution: Problem }) {
       </Box>
    );
 }
+
+const SolutionFooter = () => (
+   <Stack
+      justify="flex-start"
+      align="flex-start"
+      spacing="4px"
+      width="798.74px"
+      maxWidth="100%"
+   >
+      <Stack
+         paddingTop="12px"
+         paddingBottom="8px"
+         direction="row"
+         justify="flex-start"
+         align="center"
+         spacing="4px"
+         borderColor="gray.300"
+         borderTopWidth="1px"
+         alignSelf="stretch"
+      >
+         <Text
+            fontFamily="SF Pro"
+            fontWeight="regular"
+            fontSize="14px"
+            color="gray.900"
+            textAlign="center"
+         >
+            This solution was suggested by
+         </Text>
+         <Avatar size="24x24" border placeholder={false}>
+            <Box width="24px" height="24px" />
+         </Avatar>
+         <Text
+            fontFamily="SF Pro"
+            fontWeight="semibold"
+            fontSize="14px"
+            color="brand.500"
+            textAlign="center"
+         >
+            <span>Kyle Wiens</span>
+            <Box as="span" fontWeight="regular" color="gray.900">
+               {' '}
+               in{' '}
+            </Box>
+            <Box as="span">Pixel will not turn on</Box>
+         </Text>
+      </Stack>
+      <Stack
+         paddingTop="12px"
+         paddingBottom="8px"
+         direction="row"
+         justify="flex-start"
+         align="center"
+         spacing="6px"
+         borderColor="gray.300"
+         borderTopWidth="1px"
+         alignSelf="stretch"
+      >
+         <Button
+            label="82"
+            rightIcon={false}
+            leftIcon
+            variant="outline"
+            size="sm"
+            bgColor="white"
+            textColor="gray"
+         >
+            <Icon iconName="square-arrow-up" padding="square" scale="1x">
+               <Text
+                  fontFamily="Font Awesome 6 Pro"
+                  fontWeight="solid"
+                  fontSize="16px"
+                  color="gray.500"
+                  width="16px"
+                  textAlign="center"
+               >
+                  square-arrow-up
+               </Text>
+            </Icon>
+            <Text
+               fontFamily="SF Pro"
+               lineHeight="1.29"
+               fontWeight="semibold"
+               fontSize="14px"
+               color="gray.600"
+               textAlign="center"
+            >
+               82
+            </Text>
+         </Button>
+         <Stack
+            showActionsPanel={false}
+            size="md"
+            flex="1"
+            alignSelf="stretch"
+            justify="flex-start"
+            align="flex-end"
+            spacing="3px"
+         >
+            <Stack
+               direction="row"
+               justify="flex-start"
+               align="flex-start"
+               spacing="4px"
+            >
+               <Button
+                  label="Edit"
+                  rightIcon={false}
+                  leftIcon
+                  variant="outline"
+                  size="sm"
+                  bgColor="white"
+                  textColor="gray"
+               >
+                  <Icon iconName="pen-to-square" padding="square" scale="1x">
+                     <Text
+                        fontFamily="Font Awesome 6 Pro"
+                        fontWeight="solid"
+                        fontSize="16px"
+                        color="gray.500"
+                        width="16px"
+                        textAlign="center"
+                     >
+                        pen-to-square
+                     </Text>
+                  </Icon>
+                  <Text
+                     fontFamily="SF Pro"
+                     lineHeight="1.29"
+                     fontWeight="semibold"
+                     fontSize="14px"
+                     color="gray.600"
+                     textAlign="center"
+                  >
+                     Edit
+                  </Text>
+               </Button>
+               <Button
+                  label="Report"
+                  rightIcon={false}
+                  leftIcon
+                  variant="outline"
+                  size="sm"
+                  bgColor="white"
+                  textColor="gray"
+               >
+                  <Icon iconName="ellipsis" padding="square" scale="1x">
+                     <Text
+                        fontFamily="Font Awesome 6 Pro"
+                        fontWeight="solid"
+                        fontSize="16px"
+                        color="gray.500"
+                        width="16px"
+                        textAlign="center"
+                     >
+                        ellipsis
+                     </Text>
+                  </Icon>
+               </Button>
+            </Stack>
+         </Stack>
+      </Stack>
+   </Stack>
+);
+
+const SolutionHeader = () => (
+   <Stack
+      direction="row"
+      justify="flex-start"
+      align="flex-start"
+      spacing="16px"
+   >
+      <Stack
+         direction="row"
+         justify="flex-start"
+         align="center"
+         spacing="10px"
+         height="28px"
+      >
+         <Stack
+            paddingX="6px"
+            paddingY="4px"
+            borderRadius="4px"
+            direction="row"
+            justify="center"
+            align="center"
+            spacing="3px"
+            borderColor="brand.700"
+            borderStartWidth="1px"
+            borderEndWidth="1px"
+            borderTopWidth="1px"
+            borderBottomWidth="1px"
+            width="40px"
+            height="40px"
+            background="brand.500"
+         >
+            <Text
+               fontFamily="SF Pro"
+               fontWeight="semibold"
+               fontSize="18px"
+               color="white"
+            >
+               1
+            </Text>
+         </Stack>
+      </Stack>
+      <Stack direction="row" justify="flex-start" align="flex-start">
+         <Badge title="11.5%" showIcon color="Gray" size="Base">
+            <Icon iconName="circle-check" padding="square" scale="1x">
+               <Text
+                  fontFamily="Font Awesome 6 Pro"
+                  fontWeight="solid"
+                  fontSize="16px"
+                  color="gray.500"
+                  width="16px"
+                  textAlign="center"
+               >
+                  circle-check
+               </Text>
+            </Icon>
+            <Stack justify="center" align="flex-start" spacing="10px">
+               <Text
+                  fontFamily="SF Pro"
+                  fontWeight="semibold"
+                  fontSize="14px"
+                  color="gray.700"
+               >
+                  11.5%
+               </Text>
+            </Stack>
+         </Badge>
+      </Stack>
+   </Stack>
+);
+
+const SolutionTexts = () => (
+   <Stack
+      justify="flex-start"
+      align="flex-start"
+      width="798.74px"
+      maxWidth="100%"
+   >
+      <Text
+         fontFamily="SF Pro"
+         fontWeight="medium"
+         fontSize="24px"
+         color="gray.900"
+         alignSelf="stretch"
+      >
+         Google Pixel 7 will Not Charge
+      </Text>
+      <Text
+         fontFamily="SF Pro"
+         lineHeight="1.38"
+         fontWeight="regular"
+         fontSize="16px"
+         color="gray.700"
+         alignSelf="stretch"
+      >
+         It's possible that your battery may not have enough charge to turn on.
+         Plug in your phone to charge it and try again. Note: make sure that
+         your outlet, charging block, and power cable are all functional to
+         ensure your phone is actually getting a charge
+      </Text>
+      <Text
+         fontFamily="SF Pro"
+         fontWeight="semibold"
+         fontSize="20px"
+         color="gray.900"
+         alignSelf="stretch"
+      >
+         Lorem ipsum dolor sit amet H3
+      </Text>
+   </Stack>
+);

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -207,7 +207,14 @@ export default function SolutionCard({
    solution: Section;
 }) {
    return (
-      <Flex background="white" borderRadius="4px" padding="24px 24px 12px 24px">
+      <Flex
+         background="white"
+         borderRadius="4px"
+         borderColor="gray.300"
+         borderStyle="solid"
+         borderWidth="1px"
+         padding="24px 24px 12px 24px"
+      >
          <Flex gap="24px" direction="column">
             <SolutionHeader index={index} />
             <SolutionTexts title={solution.heading} body={solution.body} />

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -1,0 +1,12 @@
+import { Box, Heading } from '@chakra-ui/react';
+import { Problem } from './hooks/useTroubleshootingProps';
+import Prerendered from './prerendered';
+
+export default function SolutionCard({ solution }: { solution: Problem }) {
+   return (
+      <Box>
+         <Heading>{solution.heading}</Heading>
+         <Prerendered html={solution.body} />
+      </Box>
+   );
+}

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -17,7 +17,7 @@ import {
    faSquareArrowUp,
 } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon } from '@ifixit/icons';
-import { Problem } from './hooks/useTroubleshootingProps';
+import { Section } from './hooks/useTroubleshootingProps';
 import Prerendered from './prerendered';
 
 const SolutionFooter = () => (
@@ -204,7 +204,7 @@ export default function SolutionCard({
    solution,
 }: {
    index: number;
-   solution: Problem;
+   solution: Section;
 }) {
    return (
       <Flex background="white" borderRadius="4px" padding="24px 24px 12px 24px">

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -245,7 +245,7 @@ const SolutionHeader = () => (
    </Stack>
 );
 
-const SolutionTexts = ({ title }: { title: string }) => (
+const SolutionTexts = ({ title, body }: { title: string; body: string }) => (
    <Stack
       justify="flex-start"
       align="flex-start"
@@ -261,6 +261,7 @@ const SolutionTexts = ({ title }: { title: string }) => (
       >
          {title}
       </Heading>
+      <Prerendered html={body} />
       <Text
          fontFamily="SF Pro"
          lineHeight="1.38"
@@ -268,21 +269,7 @@ const SolutionTexts = ({ title }: { title: string }) => (
          fontSize="16px"
          color="gray.700"
          alignSelf="stretch"
-      >
-         It's possible that your battery may not have enough charge to turn on.
-         Plug in your phone to charge it and try again. Note: make sure that
-         your outlet, charging block, and power cable are all functional to
-         ensure your phone is actually getting a charge
-      </Text>
-      <Text
-         fontFamily="SF Pro"
-         fontWeight="semibold"
-         fontSize="20px"
-         color="gray.900"
-         alignSelf="stretch"
-      >
-         Lorem ipsum dolor sit amet H3
-      </Text>
+      ></Text>
    </Stack>
 );
 
@@ -290,8 +277,7 @@ export default function SolutionCard({ solution }: { solution: Problem }) {
    return (
       <Box background="white">
          <SolutionHeader />
-         <SolutionTexts title={solution.heading} />
-         <Prerendered html={solution.body} />
+         <SolutionTexts title={solution.heading} body={solution.body} />
          <SolutionFooter />
       </Box>
    );

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -7,7 +7,16 @@ import {
    Button,
    Icon,
    Badge,
+   Square,
+   Flex,
 } from '@chakra-ui/react';
+import {
+   faCircleCheck,
+   faEllipsis,
+   faPenToSquare,
+   faSquareArrowUp,
+} from '@fortawesome/pro-solid-svg-icons';
+import { FaIcon } from '@ifixit/icons';
 import { Problem } from './hooks/useTroubleshootingProps';
 import Prerendered from './prerendered';
 
@@ -162,11 +171,18 @@ const SolutionFooter = () => (
    </Stack>
 );
 
-const SolutionHeader = () => (
+const SolutionHeader = ({
+   index,
+   popularity,
+}: {
+   index: number;
+   popularity?: number;
+}) => (
    <Stack
       direction="row"
       justify="flex-start"
       align="flex-start"
+      alignContent="center"
       spacing="16px"
    >
       <Stack
@@ -176,71 +192,42 @@ const SolutionHeader = () => (
          spacing="10px"
          height="28px"
       >
-         <Stack
-            paddingX="6px"
-            paddingY="4px"
+         <Square
             borderRadius="4px"
-            direction="row"
-            justify="center"
-            align="center"
-            spacing="3px"
             borderColor="brand.700"
-            borderStartWidth="1px"
-            borderEndWidth="1px"
-            borderTopWidth="1px"
-            borderBottomWidth="1px"
-            width="40px"
-            height="40px"
-            background="brand.500"
+            borderWidth="1px"
+            size="40px"
+            bg="brand.500"
+            fontWeight="semibold"
+            fontSize="18px"
+            color="white"
          >
-            <Text
-               fontFamily="SF Pro"
-               fontWeight="semibold"
-               fontSize="18px"
-               color="white"
+            {index}
+         </Square>
+      </Stack>
+      {popularity !== undefined && (
+         <Stack direction="row" justify="flex-start" align="flex-start">
+            <Badge
+               title={`${popularity}%`}
+               w="fit-content"
+               color="Gray"
+               size="Base"
             >
-               1
-            </Text>
+               <FaIcon icon={faCircleCheck} />
+               <Stack justify="center" align="flex-start" spacing="10px">
+                  <Text fontWeight="semibold" fontSize="14px" color="gray.700">
+                     {popularity}%
+                  </Text>
+               </Stack>
+            </Badge>
          </Stack>
-      </Stack>
-      <Stack direction="row" justify="flex-start" align="flex-start">
-         <Badge title="11.5%" color="Gray" size="Base">
-            <Icon /*iconName="circle-check"*/ padding="square" scale="1x">
-               <Text
-                  fontFamily="Font Awesome 6 Pro"
-                  fontWeight="solid"
-                  fontSize="16px"
-                  color="gray.500"
-                  width="16px"
-                  textAlign="center"
-               >
-                  circle-check
-               </Text>
-            </Icon>
-            <Stack justify="center" align="flex-start" spacing="10px">
-               <Text
-                  fontFamily="SF Pro"
-                  fontWeight="semibold"
-                  fontSize="14px"
-                  color="gray.700"
-               >
-                  11.5%
-               </Text>
-            </Stack>
-         </Badge>
-      </Stack>
+      )}
    </Stack>
 );
 
 const SolutionTexts = ({ title, body }: { title: string; body: string }) => (
-   <Stack
-      justify="flex-start"
-      align="flex-start"
-      width="798.74px"
-      maxWidth="100%"
-   >
+   <Stack justify="flex-start" align="flex-start">
       <Heading
-         fontFamily="SF Pro"
          fontWeight="medium"
          fontSize="24px"
          color="gray.900"
@@ -249,22 +236,22 @@ const SolutionTexts = ({ title, body }: { title: string; body: string }) => (
          {title}
       </Heading>
       <Prerendered html={body} />
-      <Text
-         fontFamily="SF Pro"
-         lineHeight="1.38"
-         fontWeight="regular"
-         fontSize="16px"
-         color="gray.700"
-         alignSelf="stretch"
-      ></Text>
    </Stack>
 );
 
-export default function SolutionCard({ solution }: { solution: Problem }) {
+export default function SolutionCard({
+   index,
+   solution,
+}: {
+   index: number;
+   solution: Problem;
+}) {
    return (
-      <Box background="white">
-         <SolutionHeader />
-         <SolutionTexts title={solution.heading} body={solution.body} />
-      </Box>
+      <Flex background="white" borderRadius="4px" padding="24px 24px 12px 24px">
+         <Flex gap="24px" direction="column">
+            <SolutionHeader index={index} />
+            <SolutionTexts title={solution.heading} body={solution.body} />
+         </Flex>
+      </Flex>
    );
 }

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -13,9 +13,12 @@ import Prerendered from './prerendered';
 
 export default function SolutionCard({ solution }: { solution: Problem }) {
    return (
-      <Box>
+      <Box background="white">
+         <SolutionHeader />
          <Heading>{solution.heading}</Heading>
+         <SolutionTexts />
          <Prerendered html={solution.body} />
+         <SolutionFooter />
       </Box>
    );
 }

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -40,7 +40,6 @@ const SolutionFooter = () => (
          alignSelf="stretch"
       >
          <Text
-            fontFamily="SF Pro"
             fontWeight="regular"
             fontSize="14px"
             color="gray.900"
@@ -52,7 +51,6 @@ const SolutionFooter = () => (
             <Box width="24px" height="24px" />
          </Avatar>
          <Text
-            fontFamily="SF Pro"
             fontWeight="semibold"
             fontSize="14px"
             color="brand.500"
@@ -80,7 +78,6 @@ const SolutionFooter = () => (
          <Button variant="outline" size="sm" bgColor="white" textColor="gray">
             <FaIcon icon={faSquareArrowUp} />
             <Text
-               fontFamily="SF Pro"
                lineHeight="1.29"
                fontWeight="semibold"
                fontSize="14px"
@@ -111,7 +108,6 @@ const SolutionFooter = () => (
                >
                   <FaIcon icon={faPenToSquare} />
                   <Text
-                     fontFamily="SF Pro"
                      lineHeight="1.29"
                      fontWeight="semibold"
                      fontSize="14px"

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -39,7 +39,7 @@ const SolutionFooter = () => (
          >
             This solution was suggested by
          </Text>
-         <Avatar size="24x24" border placeholder={false}>
+         <Avatar size="24x24">
             <Box width="24px" height="24px" />
          </Avatar>
          <Text
@@ -68,16 +68,8 @@ const SolutionFooter = () => (
          borderTopWidth="1px"
          alignSelf="stretch"
       >
-         <Button
-            label="82"
-            rightIcon={false}
-            leftIcon
-            variant="outline"
-            size="sm"
-            bgColor="white"
-            textColor="gray"
-         >
-            <Icon iconName="square-arrow-up" padding="square" scale="1x">
+         <Button variant="outline" size="sm" bgColor="white" textColor="gray">
+            <Icon /**iconName="square-arrow-up"*/ padding="square" scale="1x">
                <Text
                   fontFamily="Font Awesome 6 Pro"
                   fontWeight="solid"
@@ -101,8 +93,6 @@ const SolutionFooter = () => (
             </Text>
          </Button>
          <Stack
-            showActionsPanel={false}
-            size="md"
             flex="1"
             alignSelf="stretch"
             justify="flex-start"
@@ -116,15 +106,15 @@ const SolutionFooter = () => (
                spacing="4px"
             >
                <Button
-                  label="Edit"
-                  rightIcon={false}
-                  leftIcon
                   variant="outline"
                   size="sm"
                   bgColor="white"
                   textColor="gray"
                >
-                  <Icon iconName="pen-to-square" padding="square" scale="1x">
+                  <Icon
+                     /*iconName="pen-to-square"*/ padding="square"
+                     scale="1x"
+                  >
                      <Text
                         fontFamily="Font Awesome 6 Pro"
                         fontWeight="solid"
@@ -148,15 +138,12 @@ const SolutionFooter = () => (
                   </Text>
                </Button>
                <Button
-                  label="Report"
-                  rightIcon={false}
-                  leftIcon
                   variant="outline"
                   size="sm"
                   bgColor="white"
                   textColor="gray"
                >
-                  <Icon iconName="ellipsis" padding="square" scale="1x">
+                  <Icon /*iconName="ellipsis"*/ padding="square" scale="1x">
                      <Text
                         fontFamily="Font Awesome 6 Pro"
                         fontWeight="solid"
@@ -217,8 +204,8 @@ const SolutionHeader = () => (
          </Stack>
       </Stack>
       <Stack direction="row" justify="flex-start" align="flex-start">
-         <Badge title="11.5%" showIcon color="Gray" size="Base">
-            <Icon iconName="circle-check" padding="square" scale="1x">
+         <Badge title="11.5%" color="Gray" size="Base">
+            <Icon /*iconName="circle-check"*/ padding="square" scale="1x">
                <Text
                   fontFamily="Font Awesome 6 Pro"
                   fontWeight="solid"
@@ -278,7 +265,6 @@ export default function SolutionCard({ solution }: { solution: Problem }) {
       <Box background="white">
          <SolutionHeader />
          <SolutionTexts title={solution.heading} body={solution.body} />
-         <SolutionFooter />
       </Box>
    );
 }

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -78,18 +78,7 @@ const SolutionFooter = () => (
          alignSelf="stretch"
       >
          <Button variant="outline" size="sm" bgColor="white" textColor="gray">
-            <Icon /**iconName="square-arrow-up"*/ padding="square" scale="1x">
-               <Text
-                  fontFamily="Font Awesome 6 Pro"
-                  fontWeight="solid"
-                  fontSize="16px"
-                  color="gray.500"
-                  width="16px"
-                  textAlign="center"
-               >
-                  square-arrow-up
-               </Text>
-            </Icon>
+            <FaIcon icon={faSquareArrowUp} />
             <Text
                fontFamily="SF Pro"
                lineHeight="1.29"
@@ -120,21 +109,7 @@ const SolutionFooter = () => (
                   bgColor="white"
                   textColor="gray"
                >
-                  <Icon
-                     /*iconName="pen-to-square"*/ padding="square"
-                     scale="1x"
-                  >
-                     <Text
-                        fontFamily="Font Awesome 6 Pro"
-                        fontWeight="solid"
-                        fontSize="16px"
-                        color="gray.500"
-                        width="16px"
-                        textAlign="center"
-                     >
-                        pen-to-square
-                     </Text>
-                  </Icon>
+                  <FaIcon icon={faPenToSquare} />
                   <Text
                      fontFamily="SF Pro"
                      lineHeight="1.29"
@@ -152,18 +127,7 @@ const SolutionFooter = () => (
                   bgColor="white"
                   textColor="gray"
                >
-                  <Icon /*iconName="ellipsis"*/ padding="square" scale="1x">
-                     <Text
-                        fontFamily="Font Awesome 6 Pro"
-                        fontWeight="solid"
-                        fontSize="16px"
-                        color="gray.500"
-                        width="16px"
-                        textAlign="center"
-                     >
-                        ellipsis
-                     </Text>
-                  </Icon>
+                  <FaIcon icon={faEllipsis} />
                </Button>
             </Stack>
          </Stack>


### PR DESCRIPTION
This should be mostly matching the mockup at this point.

## QA Notes
Not all the wikitext is formatted nicely yet; please ignore how ugly bulleted lists and links look for now.

Also, the mockup includes more parts that we're not supporting yet; I made a bunch of the extra things invisible on it to get a feel for what this should look like without upvotes or card footers. Please comment if something looks weird; it's kinda scrawny right now because of the lack of features.

You'll need to add
```
[comment]solutions[/comment]
```
markup to mark where the solutions begin on your test page. You can also add
```
[comment]conclusion[/comment]
```
to mark the place where the solutions end.

Example: https://www.cominor.com/Wiki/Dryer_Making_Loud_Noise
Append: `/Vulcan/Dryer_Making_Loud_Noise`

Closes iFixit/ifixit#46092