### PR TITLE
Have Cart Drawer Cross Sell Use Specific Matamo Event

### DIFF
--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -30,21 +30,21 @@ export const trackInMatomoAndGA = (trackData: TrackEventMatomo) => {
 export function trackAddToCart(
    cart: CartLineItem[],
    addToCartInput: AddToCartInput,
-   message?: string
+   eventSpecification?: string
 ) {
    if (typeof window === 'undefined') {
       return;
    }
    trackMatomoCartChange(cart);
    trackGoogleAddToCart(addToCartInput);
-   const actionPrefix = message ? `${message} - ` : '';
+   const event = `Add to Cart` + (eventSpecification ? ` - ${eventSpecification}` : '');
    const itemcodes =
       addToCartInput.type === 'product'
          ? addToCartInput.product.itemcode
          : addToCartInput.bundle.items.map((item) => item.itemcode).join(', ');
    trackInMatomoAndGA({
-      eventCategory: 'Add to Cart',
-      eventAction: `${actionPrefix}${itemcodes}`,
+      eventCategory: event,
+      eventAction: `${event} - ${itemcodes}`,
       eventName: `${window.location.origin}${window.location.pathname}`,
    });
 }

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -37,7 +37,8 @@ export function trackAddToCart(
    }
    trackMatomoCartChange(cart);
    trackGoogleAddToCart(addToCartInput);
-   const event = `Add to Cart` + (eventSpecification ? ` - ${eventSpecification}` : '');
+   const event =
+      `Add to Cart` + (eventSpecification ? ` - ${eventSpecification}` : '');
    const itemcodes =
       addToCartInput.type === 'product'
          ? addToCartInput.product.itemcode

--- a/packages/ui/cart/drawer/Upsell.tsx
+++ b/packages/ui/cart/drawer/Upsell.tsx
@@ -21,7 +21,7 @@ export interface UpsellProps {
 
 export function Upsell({ item }: UpsellProps) {
    const { onClose } = useCartDrawer();
-   const addToCart = useAddToCart("Cart Drawer");
+   const addToCart = useAddToCart('Cart Drawer');
    const userPrice = useUserPrice({
       price: item.price,
       compareAtPrice: item.compareAtPrice,

--- a/packages/ui/cart/drawer/Upsell.tsx
+++ b/packages/ui/cart/drawer/Upsell.tsx
@@ -21,7 +21,7 @@ export interface UpsellProps {
 
 export function Upsell({ item }: UpsellProps) {
    const { onClose } = useCartDrawer();
-   const addToCart = useAddToCart();
+   const addToCart = useAddToCart("Cart Drawer");
    const userPrice = useUserPrice({
       price: item.price,
       compareAtPrice: item.compareAtPrice,


### PR DESCRIPTION
## Overview
Basically we want matomo events for adding to cart to be slightly different if they were added in unique ways (the two current unorthodox ways we want to track are `Frequently Bought Together` and the cart drawer's cross sell button). This pull's main point is to add the specific event to track cart drawer cross sells, but it also changes our `trackAddToCart()` to have its parameters better match the expected values from the [spreadsheet](https://docs.google.com/spreadsheets/d/16Xas1pHf_K7FmfOX3yX2mYgeYr2DIENr8cyQp19FZkA/edit?pli=1#gid=1839136207&fvid=1843464925).  

## QA

Make sure that the matamo events fired by adding to the cart normally, adding to the cart view the frequently bought together section, and adding by the cart drawer cross sell section all create the correct Matomo events as specified by the spreadsheet or by this issues comment (specifically in regards to the cart drawer). 

Closes: #1266