### PR TITLE
Revert "Display 4 rows devices on selected pages frontend"

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2692,7 +2692,6 @@ export type GetProductListQuery = {
             description: string;
             metaDescription?: string | null;
             metaTitle?: string | null;
-            defaultShowAllChildrenOnLgSizes?: boolean | null;
             filters?: string | null;
             forceNoindex?: boolean | null;
             childrenHeading?: string | null;
@@ -3170,7 +3169,6 @@ export const GetProductListDocument = `
         description
         metaDescription
         metaTitle
-        defaultShowAllChildrenOnLgSizes
         filters
         forceNoindex
         image {

--- a/frontend/lib/strapi-sdk/operations/getProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/getProductList.graphql
@@ -15,7 +15,6 @@ query getProductList($filters: ProductListFiltersInput) {
             description
             metaDescription
             metaTitle
-            defaultShowAllChildrenOnLgSizes
             filters
             forceNoindex
             image {

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -91,8 +91,6 @@ export async function findProductList(
       description: description,
       metaDescription: productList?.metaDescription ?? null,
       metaTitle: productList?.metaTitle ?? null,
-      defaultShowAllChildrenOnLgSizes:
-         productList?.defaultShowAllChildrenOnLgSizes ?? null,
       filters: productList?.filters ?? null,
       forceNoindex: productList?.forceNoindex ?? null,
       image: null,

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -65,7 +65,6 @@ export interface BaseProductList {
    description: string;
    metaDescription: string | null;
    metaTitle: string | null;
-   defaultShowAllChildrenOnLgSizes: boolean | null;
    filters: string | null;
    forceNoindex: boolean | null;
    image: ProductListImage | null;

--- a/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
@@ -28,19 +28,14 @@ export function ProductListChildrenSection({
             60,
             16,
             isShowingMore,
-            gridRef.current?.clientHeight,
-            productList.defaultShowAllChildrenOnLgSizes
+            gridRef.current?.clientHeight
          ),
-      [isShowingMore, productList]
+      [isShowingMore]
    );
 
    const showMoreVisibility = React.useMemo(
-      () =>
-         computeShowMoreVisibility(
-            productListChildren.length,
-            productList.defaultShowAllChildrenOnLgSizes
-         ),
-      [productListChildren, productList]
+      () => computeShowMoreVisibility(productListChildren.length),
+      [productListChildren]
    );
 
    const onToggle = React.useCallback(() => {
@@ -140,8 +135,7 @@ const computeMaskMaxHeight = (
    pixelLinkHeight: number,
    pixelGap: number,
    isShowingMore: boolean,
-   maxHeight = 10000,
-   defaultShowAllChildrenOnLgSizes: boolean | null = false
+   maxHeight = 10000
 ) => {
    const shadowMargin = 4;
    if (isShowingMore) {
@@ -150,18 +144,12 @@ const computeMaskMaxHeight = (
    return {
       base: `${4 * pixelLinkHeight + 3 * pixelGap + shadowMargin}px`,
       sm: `${3 * pixelLinkHeight + 2 * pixelGap + shadowMargin}px`,
-      lg: defaultShowAllChildrenOnLgSizes
-         ? `${maxHeight + shadowMargin}px`
-         : undefined,
    };
 };
 
-const computeShowMoreVisibility = (
-   itemCount: number,
-   defaultShowAllChildrenOnLgSizes: boolean | null
-) => ({
+const computeShowMoreVisibility = (itemCount: number) => ({
    base: itemCount > 4 ? 'block' : 'none',
    sm: itemCount > 6 ? 'block' : 'none',
    md: itemCount > 9 ? 'block' : 'none',
-   lg: itemCount > 12 && !defaultShowAllChildrenOnLgSizes ? 'block' : 'none',
+   lg: itemCount > 12 ? 'block' : 'none',
 });


### PR DESCRIPTION
Reverts iFixit/react-commerce#1158

See: https://ifixit.slack.com/archives/C0252FETV2S/p1674863795570009

Example log:

```
2023-01-28T00:09:49.116Z	20fecd52-a6c3-4ae6-83c8-2f18c1301edf	ERROR	GraphQL query failed with errors:
2023-01-28T00:09:49.116Z	20fecd52-a6c3-4ae6-83c8-2f18c1301edf	ERROR		[GRAPHQL_VALIDATION_FAILED] Cannot query field "defaultShowAllChildrenOnLgSizes" on type "ProductList".
strapi.getProductList: 56ms
findProductList: 58ms
server_side_props: 59ms
2023-01-28T00:09:49.261Z	20fecd52-a6c3-4ae6-83c8-2f18c1301edf	ERROR	Error: GraphQL query failed to execute: Bad Request
    at requester (/var/task/frontend/.next/server/chunks/786.js:1586:11)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Promise.all (index 0)
    at async findProductList (/var/task/frontend/.next/server/chunks/393.js:257:34)
    at async /var/task/frontend/.next/server/chunks/932.js:5277:35
    at async /var/task/node_modules/.pnpm/@sentry+nextjs@7.29.0_5cy3dema5qwip6n7exqk4sqtji/node_modules/@sentry/nextjs/cjs/config/wrappers/wrapperUtils.js:39:14
    at async Object.renderToHTML (/var/task/node_modules/.pnpm/next@12.2.3_t7ss3ubh4wigfvyfclbvqff3gm/node_modules/next/dist/server/render.js:573:20)
    at async doRender (/var/task/node_modules/.pnpm/next@12.2.3_t7ss3ubh4wigfvyfclbvqff3gm/node_modules/next/dist/server/base-server.js:915:38)
    at async cacheEntry.responseCache.get.isManualRevalidate.isManualRevalidate (/var/task/node_modules/.pnpm/next@12.2.3_t7ss3ubh4wigfvyfclbvqff3gm/node_modules/next/dist/server/base-server.js:1020:28)
    at async /var/task/node_modules/.pnpm/next@12.2.3_t7ss3ubh4wigfvyfclbvqff3gm/node_modules/next/dist/server/response-cache.js:69:36 {
  page: '/Parts/[...deviceHandleItemType]'
}
RequestId: 20fecd52-a6c3-4ae6-83c8-2f18c1301edf Error: Runtime exited with error: exit status 1
Runtime.ExitError
```