### PR TITLE
Add ResizeObserver polyfill

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -27,7 +27,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout<any>) {
    return (
       <>
          <Script
-            src={`${polyfillDomain}/v3/polyfill.min.js?features=default,Intl.RelativeTimeFormat,Intl.RelativeTimeFormat.~locale.en,Object.fromEntries`}
+            src={`${polyfillDomain}/v3/polyfill.min.js?features=default,Intl.RelativeTimeFormat,Intl.RelativeTimeFormat.~locale.en,Object.fromEntries,ResizeObserver`}
             strategy="beforeInteractive"
          />
          <ServerSidePropsProvider props={pageProps}>


### PR DESCRIPTION
closes #1311 

### QA

1. Visit Vercel preview using a device that has no native support for ResizeObserver
2. Verify that this PR correctly polyfill ResizeObserver.