### PR TITLE
Fix product page cross sell section ui bug

### DIFF
--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -206,6 +206,7 @@ export function CrossSellSection({
                <VStack
                   spacing="6"
                   align="stretch"
+                  w="full"
                   divider={<Divider borderColor="gray.300" />}
                >
                   <Stack

--- a/packages/ui/commerce/ProductPrice.tsx
+++ b/packages/ui/commerce/ProductPrice.tsx
@@ -116,7 +116,7 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
       const priceFontSize =
          size === 'large' ? 'xl' : size === 'medium' ? 'md' : 'sm';
       const compareAtPriceFontSize = size === 'large' ? 'md' : 'sm';
-      const isRow = direction === 'row' || direction === 'row-reverse';
+      const isHorizontal = direction === 'row' || direction === 'row-reverse';
 
       return (
          <Box
@@ -124,22 +124,23 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
             display="flex"
             flexDir={direction}
             alignSelf="flex-start"
-            alignItems={isRow ? 'center' : 'flex-end'}
+            alignItems={isHorizontal ? 'center' : 'flex-end'}
             {...other}
          >
             <Text
-               mr={isRow ? 1 : 0}
+               mr={isHorizontal ? 1 : 0}
                fontSize={priceFontSize}
                fontWeight="semibold"
                color={isDiscounted ? `${colorScheme}.600` : 'gray.900'}
                data-testid="current-price"
             >
-               {showProBadge && !isRow && (
+               {showProBadge && !isHorizontal && (
                   <FaIcon
                      icon={faRectanglePro}
                      h="4"
                      mr="1.5"
                      color={`${colorScheme}.500`}
+                     display="inline-block"
                   />
                )}
                {formattedPrice}
@@ -147,7 +148,7 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
             {isDiscounted && (
                <>
                   <Text
-                     mr={isRow ? '10px' : 0}
+                     mr={isHorizontal ? '10px' : 0}
                      fontSize={compareAtPriceFontSize}
                      color="gray.500"
                      textDecor="line-through"
@@ -155,7 +156,7 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
                   >
                      {formattedCompareAtPrice}
                   </Text>
-                  {isDiscounted && showDiscountLabel && isRow && (
+                  {isDiscounted && showDiscountLabel && isHorizontal && (
                      <IconBadge
                         icon={showProBadge ? faRectanglePro : undefined}
                         colorScheme={colorScheme}


### PR DESCRIPTION
closes #1139 

This fixes also a bug in pro prices icon alignment

## QA

1. Open [Vercel preview](https://react-commerce-git-fix-cross-sell-ui-bug-ifixit.vercel.app/products/fixmat)
2. Verify that the bug described by #1139 is fixed