### PR TITLE
sentry sourcemaps: upload framework sourcemaps too

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -140,11 +140,14 @@ const moduleExports = {
       return config;
    },
    sentry: {
+      autoInstrumentServerFunctions: false,
+      // Upload artifacts in dist/framework as well; this includes sourcemaps
+      // for react and other next.js code
+      widenClientFileUpload: true,
       ...(!SENTRY_AUTH_TOKEN && {
          disableServerWebpackPlugin: true,
          disableClientWebpackPlugin: true,
       }),
-      autoInstrumentServerFunctions: false,
    },
 };
 


### PR DESCRIPTION
We still see a fair number of errors (hydration errors) who's source maps are unavailable because the stack frames are in dist/framework.

Adding this option enables uploading those too. Unclear how bigger this makes the uploads, but we'll find out!

Connect #1209 

qa_req 0 - vercel does a `next build` which covers this.

See the docs: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#widen-the-upload-scope