### PR TITLE
Logs: add colorless option

### DIFF
--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -56,6 +56,8 @@ export const CACHE_DISABLED = process.env.NEXT_PUBLIC_CACHE_DISABLED === 'true';
 
 export const REDIS_URL = process.env.REDIS_URL;
 
+export const COLORLESS_LOGS = process.env.COLORLESS_LOGS;
+
 function requireEnvVariable(
    env: string | null | undefined,
    envName: string

--- a/packages/helpers/logger.ts
+++ b/packages/helpers/logger.ts
@@ -13,24 +13,29 @@ export interface Logger {
 
 const colorless = Boolean(process.env.COLORLESS_LOGS);
 
-export const log: Logger = {
-   info: withExtensions((message: string) => console.log(message)),
-   success: withExtensions(
-      colorless
-         ? console.log
-         : (message: string) => console.log(`\x1b[32m${message} \x1b[0m`)
-   ),
-   warning: withExtensions(
-      colorless
-         ? console.log
-         : (message: string) => console.log(`\x1b[33m${message} \x1b[0m`)
-   ),
-   error: withExtensions(
-      colorless
-         ? console.log
-         : (message: string) => console.log(`\x1b[31m${message} \x1b[0m`)
-   ),
-};
+const colorlessLogger = withExtensions((message: string) =>
+   console.log(message)
+);
+
+export const log: Logger = colorless
+   ? {
+        info: colorlessLogger,
+        success: colorlessLogger,
+        warning: colorlessLogger,
+        error: colorlessLogger,
+     }
+   : {
+        info: colorlessLogger,
+        success: withExtensions((message: string) =>
+           console.log(`\x1b[32m${message} \x1b[0m`)
+        ),
+        warning: withExtensions((message: string) =>
+           console.log(`\x1b[33m${message} \x1b[0m`)
+        ),
+        error: withExtensions((message: string) =>
+           console.log(`\x1b[31m${message} \x1b[0m`)
+        ),
+     };
 
 function withExtensions(logger: Log): ExtendedLog {
    const extendedLog = (message: string) => logger(message);

--- a/packages/helpers/logger.ts
+++ b/packages/helpers/logger.ts
@@ -15,14 +15,20 @@ const colorless = Boolean(process.env.COLORLESS_LOGS);
 
 export const log: Logger = {
    info: withExtensions((message: string) => console.log(message)),
-   success: withExtensions(colorless ? console.log : (message: string) =>
-      console.log(`\x1b[32m${message} \x1b[0m`)
+   success: withExtensions(
+      colorless
+         ? console.log
+         : (message: string) => console.log(`\x1b[32m${message} \x1b[0m`)
    ),
-   warning: withExtensions(colorless ? console.log : (message: string) =>
-      console.log(`\x1b[33m${message} \x1b[0m`)
+   warning: withExtensions(
+      colorless
+         ? console.log
+         : (message: string) => console.log(`\x1b[33m${message} \x1b[0m`)
    ),
-   error: withExtensions(colorless ? console.log : (message: string) =>
-      console.log(`\x1b[31m${message} \x1b[0m`)
+   error: withExtensions(
+      colorless
+         ? console.log
+         : (message: string) => console.log(`\x1b[31m${message} \x1b[0m`)
    ),
 };
 

--- a/packages/helpers/logger.ts
+++ b/packages/helpers/logger.ts
@@ -11,16 +11,18 @@ export interface Logger {
    error: ExtendedLog;
 }
 
+const colorless = Boolean(process.env.COLORLESS_LOGS);
+
 export const log: Logger = {
    info: withExtensions((message: string) => console.log(message)),
-   success: withExtensions((message: string) =>
-      console.log(`\x1b[32m${message}\x1b[0m`)
+   success: withExtensions(colorless ? console.log : (message: string) =>
+      console.log(`\x1b[32m${message} \x1b[0m`)
    ),
-   warning: withExtensions((message: string) =>
-      console.log(`\x1b[33m${message}\x1b[0m`)
+   warning: withExtensions(colorless ? console.log : (message: string) =>
+      console.log(`\x1b[33m${message} \x1b[0m`)
    ),
-   error: withExtensions((message: string) =>
-      console.log(`\x1b[31m${message}\x1b[0m`)
+   error: withExtensions(colorless ? console.log : (message: string) =>
+      console.log(`\x1b[31m${message} \x1b[0m`)
    ),
 };
 


### PR DESCRIPTION
### Problem: (logs can't be parsed from these `[m33` lines)
![image](https://user-images.githubusercontent.com/26855/215624967-5ac23369-420a-4f05-88bd-fba50e206d65.png)

### With Env variable
![image](https://user-images.githubusercontent.com/26855/215624829-5c8379bd-827f-4be5-92ff-5822b9e156f3.png)
