### PR TITLE
Add placeholder OEM partnership image

### DIFF
--- a/frontend/templates/product/sections/ProductSection/GenuinePartBanner.tsx
+++ b/frontend/templates/product/sections/ProductSection/GenuinePartBanner.tsx
@@ -14,6 +14,8 @@ import {
 import { Flex, Link, Text, useTheme } from '@chakra-ui/react';
 import type { Product } from '@pages/api/nextjs/cache/product';
 import React from 'react';
+import { faBadgeCheck } from '@fortawesome/pro-duotone-svg-icons';
+import { FaIcon } from '@ifixit/icons';
 
 export type GenuinePartBannerProps = {
    oemPartnership: NonNullable<Product['oemPartnership']>;
@@ -45,17 +47,13 @@ export function GenuinePartBanner({ oemPartnership }: GenuinePartBannerProps) {
    );
    const theme = useTheme();
 
+   const hasPartnerLogo = partnerCodeToComponentMap[code] !== undefined;
    const PartnerLogo = partnerCodeToComponentMap[code];
-
-   if (!PartnerLogo) {
-      return null;
-   }
 
    return (
       <Flex
          mt="4"
          minH="16"
-         align="center"
          borderWidth="1px"
          borderStyle="solid"
          borderColor="brand.500"
@@ -65,14 +63,19 @@ export function GenuinePartBanner({ oemPartnership }: GenuinePartBannerProps) {
       >
          <Flex
             w="24"
-            h="full"
+            flex="none"
             borderRightWidth="1px"
             borderRightStyle="solid"
-            borderRightColor="gray.200"
-            bg="gray.100"
+            borderRightColor={hasPartnerLogo ? 'gray.200' : 'brand.200'}
+            bg={hasPartnerLogo ? 'gray.100' : 'brand.100'}
             alignItems="center"
+            justifyContent="center"
          >
-            <PartnerLogo />
+            {hasPartnerLogo ? (
+               <PartnerLogo />
+            ) : (
+               <FaIcon icon={faBadgeCheck} color="brand.500" h="8" />
+            )}
          </Flex>
          <Flex
             direction="column"
@@ -81,6 +84,7 @@ export function GenuinePartBanner({ oemPartnership }: GenuinePartBannerProps) {
             py="2"
             fontWeight="medium"
             lineHeight="short"
+            justify="center"
          >
             <Text lineHeight="shorter">This is a {lowerCaseText}.</Text>
             {url && (


### PR DESCRIPTION
closes #1304 

Added the new placeholder image.
Un-suppressed the Google badge.

As for the previous implementation, the logo-only badge was not implemented since there is still no plan to use it.

<img width="439" alt="Screenshot 2023-02-01 at 12 04 15" src="https://user-images.githubusercontent.com/7805759/216025814-9e812432-e77e-47aa-83b3-3ca968ab29e4.png">
