### PR TITLE
Correct product image aspect ratio

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -409,16 +409,24 @@ function ImageWithZoom({ index, image, enableZoom }: ImageWithZoomProps) {
 
    return (
       <Flex
-         borderColor="gray.200"
-         borderWidth={1}
+         bg="white"
          borderRadius="md"
          overflow="hidden"
          justify="center"
-         bg="white"
          position="relative"
          h="0"
          pb="100%"
       >
+         <Box
+            position="absolute"
+            top="0"
+            width="100%"
+            height="100%"
+            borderColor="gray.200"
+            borderWidth={1}
+            borderRadius="md"
+            pointerEvents="none"
+         />
          <Flex
             position="absolute"
             alignItems="center"


### PR DESCRIPTION
connects #1101 

Product page images were not perfectly squared because the image height was computed as 100% + the 2px border.
This PR changes the way in which the gallery border is rendered to eliminate the problem.

<img width="737" alt="Screenshot 2023-02-01 at 18 04 41" src="https://user-images.githubusercontent.com/7805759/216111860-f9d3b75b-40f7-40a4-9043-474b215d14ee.png">


### QA

1. Visit Vercel preview
2. Verify that the gallery image aspect ratio is now exactly 1:1
3. No interaction (changing slide, zoom, etc) with the carousel should be compromised