### PR TITLE
Add error message in cache handler

### DIFF
--- a/frontend/lib/swr-cache/index.ts
+++ b/frontend/lib/swr-cache/index.ts
@@ -164,6 +164,7 @@ export const withCache = <
          await cache.set(key, cacheEntry);
          return res.status(200).json({ success: true });
       } catch (error) {
+         logger.error(printError(error));
          return res.status(500).json({ success: false });
       }
    };


### PR DESCRIPTION
This PR adds an error log in the catch of the `withCache` handler to have a clearer view of where [these errors](https://sentry.io/organizations/ifixit/issues/3908459644/?project=6469069&query=is%3Aunresolved&referrer=issue-stream) are originating from.