### PR TITLE
Product Page: "Not for Sale" alert styling

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -368,25 +368,9 @@ function ProOnlyAlert(props: AlertProps) {
 
 function NotForSaleAlert(props: AlertProps) {
    return (
-      <Alert
-         status="warning"
-         borderWidth={1}
-         borderColor="orange.300"
-         borderRadius="md"
-         alignItems="flex-start"
-         {...props}
-      >
-         <FaIcon
-            icon={faCircleExclamation}
-            h="4"
-            mt="0.5"
-            mr="2.5"
-            color="orange.500"
-         />
-
-         <Box fontSize="sm">
-            <p>Not for Sale.</p>
-         </Box>
+      <Alert status="warning" {...props}>
+         <FaIcon icon={faCircleExclamation} h="5" mr="2" color="amber.600" />
+         <span>Not for Sale.</span>
       </Alert>
    );
 }


### PR DESCRIPTION
Updates the "Not for Sale" alert styling to match the out of stock alert as updated in #1317.

## QA

Make sure the "Not for Sale" alert matches the styling of the out of stock alert.