### PR TITLE
Breadcrumbs: Copy from iFixit/ifixit

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -8,16 +8,17 @@ const {
 const withTM = require('next-transpile-modules')([
    '@ifixit/analytics',
    '@ifixit/app',
-   '@ifixit/ui',
-   '@ifixit/icons',
    '@ifixit/auth-sdk',
+   '@ifixit/breadcrumbs',
    '@ifixit/cart-sdk',
-   '@ifixit/newsletter-sdk',
-   '@ifixit/helpers',
-   '@ifixit/ifixit-api-client',
-   '@ifixit/shopify-storefront-client',
-   '@ifixit/sentry',
    '@ifixit/footer',
+   '@ifixit/helpers',
+   '@ifixit/icons',
+   '@ifixit/ifixit-api-client',
+   '@ifixit/newsletter-sdk',
+   '@ifixit/sentry',
+   '@ifixit/shopify-storefront-client',
+   '@ifixit/ui',
 ]);
 
 const { withSentryConfig } = require('@sentry/nextjs');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
       "@ifixit/analytics": "workspace:*",
       "@ifixit/app": "workspace:*",
       "@ifixit/auth-sdk": "workspace:*",
+      "@ifixit/breadcrumbs": "workspace:*",
       "@ifixit/cart-sdk": "workspace:*",
       "@ifixit/footer": "workspace:*",
       "@ifixit/helpers": "workspace:*",

--- a/packages/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/Breadcrumbs.tsx
@@ -146,7 +146,7 @@ const IFixitBreadcrumb = memo(function IFixitBreadcrumb({
    );
 }, isEqual);
 
-const IFixitBreadcrumbItem = memo(function IFixitBreadcrumbItem({
+const IFixitBreadcrumbItem = function IFixitBreadcrumbItem({
    url,
    label: name,
    isLast,
@@ -172,10 +172,9 @@ const IFixitBreadcrumbItem = memo(function IFixitBreadcrumbItem({
          </Text>
       </BreadcrumbItem>
    );
-},
-isEqual);
+};
 
-const IFixitCollapsedBreadcrumb = memo(function IFixitCollapsedBreadcrumb({
+const IFixitCollapsedBreadcrumb = function IFixitCollapsedBreadcrumb({
    breadCrumbs,
    breadcrumbIcon,
 }: Pick<BreadCrumbsProps, 'breadCrumbs' | 'breadcrumbIcon'>) {
@@ -208,8 +207,7 @@ const IFixitCollapsedBreadcrumb = memo(function IFixitCollapsedBreadcrumb({
          {breadcrumbIcon}
       </>
    );
-},
-isEqual);
+};
 
 function IFixitCollapsedBreadcrumbItem({
    url,

--- a/packages/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,211 @@
+import {
+   Flex,
+   Link,
+   Breadcrumb,
+   BreadcrumbItem,
+   Menu,
+   MenuButton,
+   MenuList,
+   MenuItem,
+   MenuItemProps,
+   IconButton,
+   Text,
+   BreadcrumbItemProps,
+   LinkProps,
+} from '@chakra-ui/react';
+import { FaIcon } from '@ifixit/icons';
+import { faEllipsis } from '@fortawesome/pro-regular-svg-icons';
+import { faChevronRight } from '@fortawesome/pro-solid-svg-icons';
+import { memo, useState, useCallback } from 'react';
+import isEqual from 'lodash/isEqual';
+import { HiddenWrapEffect, useHiddenWrap } from './FlexHiddenWrap';
+
+export interface BreadcrumbData {
+   name: string;
+   url: string;
+}
+
+export interface BreadCrumbsProps {
+   breadCrumbs: BreadcrumbData[];
+   breadcrumbsToShow?: number;
+   breadcrumbIcon?: JSX.Element;
+   usePlaceHolder?: boolean;
+}
+
+type IFixitBreadcrumbItemProps = BreadcrumbData & {
+   isLast: boolean;
+} & BreadcrumbItemProps;
+
+export const BreadCrumbs = memo(function DynamicBreadCrumbs({
+   breadCrumbs,
+   breadcrumbsToShow,
+   breadcrumbIcon = <DefaultBreadcrumbIcon />,
+}: BreadCrumbsProps) {
+   if (breadcrumbsToShow != undefined && breadcrumbsToShow <= 0) {
+      throw new Error('breadcrumbsToShow can only be undefined or must be greater than 0');
+   }
+
+   const isStatic = breadcrumbsToShow > 0;
+
+   const visibleBreadCrumbs = isStatic
+      ? breadCrumbs.slice(breadCrumbs.length - breadcrumbsToShow)
+      : breadCrumbs;
+
+   const hiddenBreadCrumbs = isStatic
+      ? breadCrumbs.slice(0, breadCrumbs.length - breadcrumbsToShow)
+      : [];
+
+   const [wrappedBreadcrumbs, setWrappedBreadcrumbs] =
+      useState<BreadcrumbData[]>(hiddenBreadCrumbs);
+
+   const wrappedChildrenEffect = useCallback(
+      (children: HTMLElement[]) => {
+         if (isStatic) {
+            return;
+         }
+         const wrappedNames = new Set(children.map(c => c.getAttribute('data-name')));
+         const wrapped = breadCrumbs.filter(b => wrappedNames.has(b.name));
+         setWrappedBreadcrumbs(() => wrapped);
+      },
+      [breadCrumbs, isStatic]
+   );
+
+   return (
+      <Flex display="flex" flexShrink={1} flexGrow={1} alignItems="center" gap="6px">
+         <IFixitCollapsedBreadcrumb
+            breadCrumbs={wrappedBreadcrumbs}
+            breadcrumbIcon={breadcrumbIcon}
+         />
+         <IFixitBreadcrumb
+            breadCrumbs={visibleBreadCrumbs}
+            breadcrumbIcon={breadcrumbIcon}
+            wrappedChildrenEffect={wrappedChildrenEffect}
+         />
+      </Flex>
+   );
+});
+
+function DefaultBreadcrumbIcon() {
+   return (
+      <Flex>
+         <FaIcon icon={faChevronRight} h="2.5" display="flex" color="gray.400" mt="1px" />
+      </Flex>
+   );
+}
+const IFixitBreadcrumb = memo(function IFixitBreadcrumb({
+   breadCrumbs,
+   breadcrumbIcon,
+   wrappedChildrenEffect,
+}: Pick<BreadCrumbsProps, 'breadCrumbs' | 'breadcrumbIcon'> & {
+   wrappedChildrenEffect: HiddenWrapEffect;
+}) {
+   const reversedBreadCrumbs = breadCrumbs.slice().reverse();
+
+   const BreadCrumbItems = reversedBreadCrumbs.map((props, index) => {
+      const isLastBreadCrumb = index === 0;
+      return (
+         <IFixitBreadcrumbItem
+            key={props.name}
+            spacing="6px"
+            {...props}
+            isLast={isLastBreadCrumb}
+         />
+      );
+   });
+
+   const hiddenWrapProps = useHiddenWrap({ wrappedChildrenEffect });
+
+   return (
+      <Breadcrumb
+         separator={breadcrumbIcon}
+         listProps={{
+            padding: '0px',
+            ...hiddenWrapProps,
+            flexDirection: 'row-reverse',
+            justifyContent: 'flex-end',
+            height: '20px',
+         }}
+      >
+         {BreadCrumbItems}
+      </Breadcrumb>
+   );
+}, isEqual);
+
+const IFixitBreadcrumbItem = memo(function IFixitBreadcrumbItem({
+   url,
+   name,
+   isLast,
+   ...breadcrumbItemProps
+}: IFixitBreadcrumbItemProps) {
+   const color = isLast ? 'gray.900' : 'gray.500';
+
+   return (
+      <BreadcrumbItem {...breadcrumbItemProps} isLastChild={isLast} data-name={name}>
+         <Text
+            as={Link}
+            noOfLines={1}
+            href={url}
+            color={color}
+            _visited={{ color: color }}
+            _hover={{ textDecoration: 'none' }}
+         >
+            {name}
+         </Text>
+      </BreadcrumbItem>
+   );
+},
+isEqual);
+
+const IFixitCollapsedBreadcrumb = memo(function IFixitCollapsedBreadcrumb({
+   breadCrumbs,
+   breadcrumbIcon,
+}: Pick<BreadCrumbsProps, 'breadCrumbs' | 'breadcrumbIcon'>) {
+   if (!breadCrumbs.length) {
+      return null;
+   }
+
+   const CollapsedBreadCrumbItems = breadCrumbs.map(({ name, url }) => {
+      return <IFixitCollapsedBreadcrumbItem url={url} name={name} key={name} />;
+   });
+
+   return (
+      <>
+         <Menu>
+            <MenuButton
+               as={IconButton}
+               aria-label="Options"
+               colorScheme="gray"
+               background="gray.300"
+               variant="solid"
+               size="xs"
+               marginLeft={{ base: 3, sm: 1 }}
+               marginRight="1"
+               icon={<FaIcon icon={faEllipsis} h="3" color="gray.500" />}
+            />
+            <MenuList>{CollapsedBreadCrumbItems.reverse()}</MenuList>
+         </Menu>
+         {breadcrumbIcon}
+      </>
+   );
+},
+isEqual);
+
+function IFixitCollapsedBreadcrumbItem({
+   url,
+   name,
+   ...menuItemProps
+}: BreadcrumbData & MenuItemProps & LinkProps) {
+   return (
+      <MenuItem
+         as={Link}
+         color="gray.900"
+         _visited={{ color: menuItemProps.color || 'gray.900' }}
+         _hover={{ textDecoration: 'none' }}
+         fontSize="14px"
+         href={url}
+         {...menuItemProps}
+      >
+         {name}
+      </MenuItem>
+   );
+}

--- a/packages/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/Breadcrumbs.tsx
@@ -14,7 +14,8 @@ import {
    LinkProps,
 } from '@chakra-ui/react';
 import { FaIcon } from '@ifixit/icons';
-import { faChevronRight, faEllipsis } from '@fortawesome/pro-solid-svg-icons';
+import { faChevronRight } from '@fortawesome/pro-solid-svg-icons/faChevronRight';
+import { faEllipsis } from '@fortawesome/pro-solid-svg-icons/faEllipsis';
 import { memo, useState, useCallback } from 'react';
 import isEqual from 'lodash/isEqual';
 import { HiddenWrapEffect, useHiddenWrap } from './FlexHiddenWrap';

--- a/packages/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/Breadcrumbs.tsx
@@ -29,7 +29,6 @@ export interface BreadCrumbsProps {
    breadCrumbs: BreadcrumbItem[];
    breadcrumbsToShow?: number;
    breadcrumbIcon?: JSX.Element;
-   usePlaceHolder?: boolean;
 }
 
 type IFixitBreadcrumbItemProps = BreadcrumbItem & {

--- a/packages/breadcrumbs/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/Breadcrumbs.tsx
@@ -14,25 +14,24 @@ import {
    LinkProps,
 } from '@chakra-ui/react';
 import { FaIcon } from '@ifixit/icons';
-import { faEllipsis } from '@fortawesome/pro-regular-svg-icons';
-import { faChevronRight } from '@fortawesome/pro-solid-svg-icons';
+import { faChevronRight, faEllipsis } from '@fortawesome/pro-solid-svg-icons';
 import { memo, useState, useCallback } from 'react';
 import isEqual from 'lodash/isEqual';
 import { HiddenWrapEffect, useHiddenWrap } from './FlexHiddenWrap';
 
-export interface BreadcrumbData {
-   name: string;
+export type BreadcrumbItem = {
+   label: string;
    url: string;
-}
+};
 
 export interface BreadCrumbsProps {
-   breadCrumbs: BreadcrumbData[];
+   breadCrumbs: BreadcrumbItem[];
    breadcrumbsToShow?: number;
    breadcrumbIcon?: JSX.Element;
    usePlaceHolder?: boolean;
 }
 
-type IFixitBreadcrumbItemProps = BreadcrumbData & {
+type IFixitBreadcrumbItemProps = BreadcrumbItem & {
    isLast: boolean;
 } & BreadcrumbItemProps;
 
@@ -42,10 +41,12 @@ export const BreadCrumbs = memo(function DynamicBreadCrumbs({
    breadcrumbIcon = <DefaultBreadcrumbIcon />,
 }: BreadCrumbsProps) {
    if (breadcrumbsToShow != undefined && breadcrumbsToShow <= 0) {
-      throw new Error('breadcrumbsToShow can only be undefined or must be greater than 0');
+      throw new Error(
+         'breadcrumbsToShow can only be undefined or must be greater than 0'
+      );
    }
 
-   const isStatic = breadcrumbsToShow > 0;
+   const isStatic = !!breadcrumbsToShow;
 
    const visibleBreadCrumbs = isStatic
       ? breadCrumbs.slice(breadCrumbs.length - breadcrumbsToShow)
@@ -56,22 +57,30 @@ export const BreadCrumbs = memo(function DynamicBreadCrumbs({
       : [];
 
    const [wrappedBreadcrumbs, setWrappedBreadcrumbs] =
-      useState<BreadcrumbData[]>(hiddenBreadCrumbs);
+      useState<BreadcrumbItem[]>(hiddenBreadCrumbs);
 
    const wrappedChildrenEffect = useCallback(
       (children: HTMLElement[]) => {
          if (isStatic) {
             return;
          }
-         const wrappedNames = new Set(children.map(c => c.getAttribute('data-name')));
-         const wrapped = breadCrumbs.filter(b => wrappedNames.has(b.name));
+         const wrappedNames = new Set(
+            children.map((c) => c.getAttribute('data-name'))
+         );
+         const wrapped = breadCrumbs.filter((b) => wrappedNames.has(b.label));
          setWrappedBreadcrumbs(() => wrapped);
       },
       [breadCrumbs, isStatic]
    );
 
    return (
-      <Flex display="flex" flexShrink={1} flexGrow={1} alignItems="center" gap="6px">
+      <Flex
+         display="flex"
+         flexShrink={1}
+         flexGrow={1}
+         alignItems="center"
+         gap="6px"
+      >
          <IFixitCollapsedBreadcrumb
             breadCrumbs={wrappedBreadcrumbs}
             breadcrumbIcon={breadcrumbIcon}
@@ -88,7 +97,13 @@ export const BreadCrumbs = memo(function DynamicBreadCrumbs({
 function DefaultBreadcrumbIcon() {
    return (
       <Flex>
-         <FaIcon icon={faChevronRight} h="2.5" display="flex" color="gray.400" mt="1px" />
+         <FaIcon
+            icon={faChevronRight}
+            h="2.5"
+            display="flex"
+            color="gray.400"
+            mt="1px"
+         />
       </Flex>
    );
 }
@@ -105,7 +120,7 @@ const IFixitBreadcrumb = memo(function IFixitBreadcrumb({
       const isLastBreadCrumb = index === 0;
       return (
          <IFixitBreadcrumbItem
-            key={props.name}
+            key={props.label}
             spacing="6px"
             {...props}
             isLast={isLastBreadCrumb}
@@ -133,14 +148,18 @@ const IFixitBreadcrumb = memo(function IFixitBreadcrumb({
 
 const IFixitBreadcrumbItem = memo(function IFixitBreadcrumbItem({
    url,
-   name,
+   label: name,
    isLast,
    ...breadcrumbItemProps
 }: IFixitBreadcrumbItemProps) {
    const color = isLast ? 'gray.900' : 'gray.500';
 
    return (
-      <BreadcrumbItem {...breadcrumbItemProps} isLastChild={isLast} data-name={name}>
+      <BreadcrumbItem
+         {...breadcrumbItemProps}
+         isLastChild={isLast}
+         data-name={name}
+      >
          <Text
             as={Link}
             noOfLines={1}
@@ -164,8 +183,10 @@ const IFixitCollapsedBreadcrumb = memo(function IFixitCollapsedBreadcrumb({
       return null;
    }
 
-   const CollapsedBreadCrumbItems = breadCrumbs.map(({ name, url }) => {
-      return <IFixitCollapsedBreadcrumbItem url={url} name={name} key={name} />;
+   const CollapsedBreadCrumbItems = breadCrumbs.map(({ label: name, url }) => {
+      return (
+         <IFixitCollapsedBreadcrumbItem url={url} label={name} key={name} />
+      );
    });
 
    return (
@@ -192,9 +213,9 @@ isEqual);
 
 function IFixitCollapsedBreadcrumbItem({
    url,
-   name,
+   label: name,
    ...menuItemProps
-}: BreadcrumbData & MenuItemProps & LinkProps) {
+}: BreadcrumbItem & MenuItemProps & LinkProps) {
    return (
       <MenuItem
          as={Link}

--- a/packages/breadcrumbs/FlexHiddenWrap.tsx
+++ b/packages/breadcrumbs/FlexHiddenWrap.tsx
@@ -1,0 +1,49 @@
+import { SystemProps } from '@chakra-ui/react';
+import { useRef, useLayoutEffect, ReactNode, RefObject } from 'react';
+
+export type HiddenWrapEffect = (_children: HTMLElement[], _container: HTMLElement) => void;
+export function useHiddenWrap<T extends HTMLElement>({
+   wrappedChildrenEffect,
+   shownChildrenEffect,
+}: {
+   wrappedChildrenEffect?: HiddenWrapEffect;
+   shownChildrenEffect?: HiddenWrapEffect;
+}): {
+   ref: RefObject<T>;
+   display: SystemProps['display'];
+   flexWrap: SystemProps['flexWrap'];
+   overflow: SystemProps['overflow'];
+} {
+   const ref = useRef<T>();
+
+   useLayoutEffect(() => {
+      if (!ref?.current) {
+         return;
+      }
+
+      const measure = () => {
+         onBrowserRender(ref.current, wrappedChildrenEffect, shownChildrenEffect);
+      };
+
+      measure();
+      window.addEventListener('resize', measure);
+      return () => {
+         window.removeEventListener('resize', measure);
+      };
+   }, [ref.current, wrappedChildrenEffect, shownChildrenEffect]);
+   return { ref, display: 'flex', flexWrap: 'wrap', overflow: 'hidden' };
+}
+
+function onBrowserRender<T extends HTMLElement>(
+   container: T,
+   wrappedEffect: HiddenWrapEffect,
+   shownEffect: HiddenWrapEffect
+) {
+   const containerStart = container.offsetTop;
+   const children = Array.from(container.children) as HTMLElement[];
+
+   const wrappedChildren = children.filter(child => child.offsetTop > containerStart);
+   const shownChildren = children.filter(child => child.offsetTop <= containerStart);
+   wrappedEffect?.(wrappedChildren, container);
+   shownEffect?.(shownChildren, container);
+}

--- a/packages/breadcrumbs/FlexHiddenWrap.tsx
+++ b/packages/breadcrumbs/FlexHiddenWrap.tsx
@@ -48,14 +48,15 @@ function onBrowserRender<T extends HTMLElement>(
    wrappedEffect: undefined | HiddenWrapEffect,
    shownEffect: undefined | HiddenWrapEffect
 ) {
-   const containerStart = container.offsetTop;
+   const buffer = container.offsetHeight / 2;
+   const wrappedPX = container.offsetTop + buffer;
    const children = Array.from(container.children) as HTMLElement[];
 
    const wrappedChildren = children.filter(
-      (child) => child.offsetTop > containerStart
+      (child) => child.offsetTop > wrappedPX
    );
    const shownChildren = children.filter(
-      (child) => child.offsetTop <= containerStart
+      (child) => child.offsetTop <= wrappedPX
    );
    wrappedEffect?.(wrappedChildren, container);
    shownEffect?.(shownChildren, container);

--- a/packages/breadcrumbs/FlexHiddenWrap.tsx
+++ b/packages/breadcrumbs/FlexHiddenWrap.tsx
@@ -1,7 +1,10 @@
 import { SystemProps } from '@chakra-ui/react';
 import { useRef, useLayoutEffect, ReactNode, RefObject } from 'react';
 
-export type HiddenWrapEffect = (_children: HTMLElement[], _container: HTMLElement) => void;
+export type HiddenWrapEffect = (
+   _children: HTMLElement[],
+   _container: HTMLElement
+) => void;
 export function useHiddenWrap<T extends HTMLElement>({
    wrappedChildrenEffect,
    shownChildrenEffect,
@@ -9,7 +12,7 @@ export function useHiddenWrap<T extends HTMLElement>({
    wrappedChildrenEffect?: HiddenWrapEffect;
    shownChildrenEffect?: HiddenWrapEffect;
 }): {
-   ref: RefObject<T>;
+   ref: RefObject<T | undefined>;
    display: SystemProps['display'];
    flexWrap: SystemProps['flexWrap'];
    overflow: SystemProps['overflow'];
@@ -22,7 +25,13 @@ export function useHiddenWrap<T extends HTMLElement>({
       }
 
       const measure = () => {
-         onBrowserRender(ref.current, wrappedChildrenEffect, shownChildrenEffect);
+         if (ref.current) {
+            onBrowserRender(
+               ref.current,
+               wrappedChildrenEffect,
+               shownChildrenEffect
+            );
+         }
       };
 
       measure();
@@ -36,14 +45,18 @@ export function useHiddenWrap<T extends HTMLElement>({
 
 function onBrowserRender<T extends HTMLElement>(
    container: T,
-   wrappedEffect: HiddenWrapEffect,
-   shownEffect: HiddenWrapEffect
+   wrappedEffect: undefined | HiddenWrapEffect,
+   shownEffect: undefined | HiddenWrapEffect
 ) {
    const containerStart = container.offsetTop;
    const children = Array.from(container.children) as HTMLElement[];
 
-   const wrappedChildren = children.filter(child => child.offsetTop > containerStart);
-   const shownChildren = children.filter(child => child.offsetTop <= containerStart);
+   const wrappedChildren = children.filter(
+      (child) => child.offsetTop > containerStart
+   );
+   const shownChildren = children.filter(
+      (child) => child.offsetTop <= containerStart
+   );
    wrappedEffect?.(wrappedChildren, container);
    shownEffect?.(shownChildren, container);
 }

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -1,0 +1,25 @@
+{
+   "name": "@ifixit/breadcrumbs",
+   "version": "0.0.0",
+   "main": "./Breadcrumbs.tsx",
+   "types": "./Breadcrumbs.tsx",
+   "license": "MIT",
+   "dependencies": {
+      "@ifixit/icons": "workspace:*"
+   },
+   "peerDependencies": {
+      "@fortawesome/pro-solid-svg-icons": "*"
+   },
+   "devDependencies": {
+      "@ifixit/tsconfig": "workspace:*",
+      "@types/react-dom": "18.0.8",
+      "@types/react": "18.0.24",
+      "react": ">=18.2.0",
+      "typescript": "4.8.4"
+   },
+   "scripts": {
+      "build": "",
+      "clean": "",
+      "type-check": "tsc --pretty --noEmit"
+   }
+}

--- a/packages/breadcrumbs/tsconfig.json
+++ b/packages/breadcrumbs/tsconfig.json
@@ -1,0 +1,5 @@
+{
+   "extends": "@ifixit/tsconfig/react-library.json",
+   "include": ["."],
+   "exclude": ["dist", "build", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,11 +289,17 @@ importers:
     specifiers:
       '@ifixit/icons': workspace:*
       '@ifixit/tsconfig': workspace:*
+      '@types/react': 18.0.24
+      '@types/react-dom': 18.0.8
+      react: '>=18.2.0'
       typescript: 4.8.4
     dependencies:
       '@ifixit/icons': link:../icons
     devDependencies:
       '@ifixit/tsconfig': link:../tsconfig
+      '@types/react': 18.0.24
+      '@types/react-dom': 18.0.8
+      react: 18.2.0
       typescript: 4.8.4
 
   packages/cart-sdk:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,17 @@ importers:
       ts-node: 10.9.1_cj5mtiz27ejqqym7lopgjtf5ya
       typescript: 4.8.4
 
+  packages/breadcrumbs:
+    specifiers:
+      '@ifixit/icons': workspace:*
+      '@ifixit/tsconfig': workspace:*
+      typescript: 4.8.4
+    dependencies:
+      '@ifixit/icons': link:../icons
+    devDependencies:
+      '@ifixit/tsconfig': link:../tsconfig
+      typescript: 4.8.4
+
   packages/cart-sdk:
     specifiers:
       '@ifixit/analytics': workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,7 @@ importers:
       '@ifixit/analytics': workspace:*
       '@ifixit/app': workspace:*
       '@ifixit/auth-sdk': workspace:*
+      '@ifixit/breadcrumbs': workspace:*
       '@ifixit/cart-sdk': workspace:*
       '@ifixit/footer': workspace:*
       '@ifixit/helpers': workspace:*
@@ -129,6 +130,7 @@ importers:
       '@ifixit/analytics': link:../packages/analytics
       '@ifixit/app': link:../packages/app
       '@ifixit/auth-sdk': link:../packages/auth-sdk
+      '@ifixit/breadcrumbs': link:../packages/breadcrumbs
       '@ifixit/cart-sdk': link:../packages/cart-sdk
       '@ifixit/footer': link:../packages/footer
       '@ifixit/helpers': link:../packages/helpers


### PR DESCRIPTION
This pull copies the breadcrumbs from the iFixit repo and modifies them to work here.

The iFixit/ifixit breadcrumbs potentially have a nicer small-screen behavior than the existing ones here.

Connects https://github.com/iFixit/ifixit/issues/46349

qa_req 0