### PR TITLE
Playwright: Mitigate Timeouts

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # next.js
-/.next/
+/.next*
 /out/
 
 # production

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -44,6 +44,7 @@ console.log('Strapi API: ' + process.env.NEXT_PUBLIC_STRAPI_ORIGIN);
 console.log('iFixit API: ' + process.env.NEXT_PUBLIC_IFIXIT_ORIGIN);
 
 const moduleExports = {
+   distDir: process.env.NEXT_DIST_DIR ?? '.next',
    env: {
       ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,
       NEXT_PUBLIC_ALGOLIA_APP_ID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -27,7 +27,7 @@ const config: PlaywrightTestConfig = {
    /* Retry on CI only */
    retries: process.env.CI ? 2 : 0,
    /* Opt out of parallel tests on CI. */
-   workers: process.env.CI ? '100%' : undefined,
+   workers: process.env.CI ? '100%' : '25%',
    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
    reporter: [
       process.env.CI

--- a/frontend/tests/playwright/test-fixtures.ts
+++ b/frontend/tests/playwright/test-fixtures.ts
@@ -30,7 +30,9 @@ export const test = base.extend<
    customServer: [
       // eslint-disable-next-line no-empty-pattern
       async ({}, use, workerInfo) => {
-         process.env.NEXT_DIST_DIR = `./.next-worker-${workerInfo.workerIndex}`;
+         process.env.NEXT_DIST_DIR = process.env.CI
+            ? './.next'
+            : `./.next-worker-${workerInfo.workerIndex}`;
          const props: CustomNextjsServer = await Server();
          await use(props);
          // Clean up the dist directory after the worker is done.

--- a/frontend/tests/playwright/test-fixtures.ts
+++ b/frontend/tests/playwright/test-fixtures.ts
@@ -28,7 +28,8 @@ export const test = base.extend<
 >({
    customServer: [
       // eslint-disable-next-line no-empty-pattern
-      async ({}, use) => {
+      async ({}, use, workerInfo) => {
+         process.env.NEXT_DIST_DIR = `./.next-worker-${workerInfo.workerIndex}`;
          const props: CustomNextjsServer = await Server();
          await use(props);
       },

--- a/frontend/tests/playwright/test-fixtures.ts
+++ b/frontend/tests/playwright/test-fixtures.ts
@@ -20,6 +20,7 @@ import { graphql, rest } from 'msw';
 import type { ProductFixtures, CustomNextjsServer } from './fixtures';
 import { ProductPage, CartDrawer, Server } from './fixtures';
 import { format } from 'util';
+import { exec } from 'node:child_process';
 
 export const test = base.extend<
    ProductFixtures &
@@ -32,6 +33,8 @@ export const test = base.extend<
          process.env.NEXT_DIST_DIR = `./.next-worker-${workerInfo.workerIndex}`;
          const props: CustomNextjsServer = await Server();
          await use(props);
+         // Clean up the dist directory after the worker is done.
+         exec('rm -rf .next-worker-*');
       },
       {
          /**


### PR DESCRIPTION
## Description

If we are running all the Playwright tests locally then the tests will often timeout. There are two main reasons this occurs.

Currently, we have no set limit to the number of workers we will use locally. Therefore, we could potentially have 4-8 workers running in parallel, all depending on the number of cores on the host machine. In CI, we use all available workers we can and since the GitHub action machine only has two cores, we really only use 2 workers in CI. To reduce the load on local runs, I've changed the number of workers to a quarter of available cores.

The other reason for the timeout is each worker will create its own custom Nextjs server but each server will use the same dist directory (i.e. `.next`). Therefore, while one instance is building files, another instance may be overwriting these files. As a result of this overlap, some files may not be present when trying to access a page which will cause a timeout. To resolve this, each worker will build to a different directory than the default `.next`.

### CR

In order to override the default dist folder for each custom server we need to set an environment variable because we cannot simply import the config file and override the `distDir` property. The `next.config.js` file is a regular Node.js module and not a JSON file.[^1] Then by using Playwright's `worker` context[^2] we can create a unique dist folder for each worker.

Lastly, this does not completely resolve timeouts. We do have some flaky tests that may fail so if we do want to run the entire Playwright test-suite then we should increment the number of retries. 

### QA

- [ ] Confirm running tests locally will not timeout
	```shell
	pnpm playwright:run --project="Desktop Chrome" --retries=2
	```

Closes: #1323 

[^1]: [next.config.js](https://nextjs.org/docs/api-reference/next.config.js/introduction#:~:text=next.config.js%20is%20a%20regular%20Node.js%20module%2C%20not%20a%20JSON%20file.%20It%20gets%20used%20by%20the%20Next.js%20server%20and%20build%20phases%2C%20and%20it%27s%20not%20included%20in%20the%20browser%20build.)
[^2]: [Playwright Worker Info](https://playwright.dev/docs/api/class-workerinfo#worker-info-worker-index)