### PR TITLE
Compute Strapi govinor handle to support longer branch names

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -10,7 +10,6 @@ NEXT_PUBLIC_IFIXIT_ORIGIN=https://www.cominor.com
 NEXT_PUBLIC_APP_ORIGIN=https://${VERCEL_URL} 
 
 # Overridden in prod
-NEXT_PUBLIC_STRAPI_ORIGIN=https://$NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF.govinor.com
 NEXT_PUBLIC_SHOPIFY_STOREFRONT_VERSION=2022-10
 STRAPI_IMAGE_DOMAIN=ifixit-strapi-uploads.s3.amazonaws.com
 # Overridden in prod

--- a/frontend/helpers/strapi-helpers.ts
+++ b/frontend/helpers/strapi-helpers.ts
@@ -1,6 +1,12 @@
-import { UploadFile } from '@lib/strapi-sdk';
+import type { UploadFile } from '@lib/strapi-sdk';
 
 export type StrapiImageFormat = 'large' | 'medium' | 'small' | 'thumbnail';
+
+interface Image {
+   url: string;
+   alternativeText: string | null;
+   formats: Record<string, { url: string }>;
+}
 
 export function getImageFromStrapiImage(
    image: Pick<UploadFile, 'formats' | 'alternativeText' | 'url'>,
@@ -20,10 +26,4 @@ export function getImageFromStrapiImage(
    }
 
    return result;
-}
-
-export interface Image {
-   url: string;
-   alternativeText: string | null;
-   formats: Record<string, { url: string }>;
 }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -44,30 +44,21 @@ const sentryWebpackPluginOptions = {
 };
 const SENTRY_AUTH_TOKEN = process.env.SENTRY_AUTH_TOKEN;
 
-console.log('Strapi API: ' + process.env.NEXT_PUBLIC_STRAPI_ORIGIN);
+const strapiOrigin = requireStrapiOrigin();
+
+console.log('Strapi API: ' + strapiOrigin);
 console.log('iFixit API: ' + process.env.NEXT_PUBLIC_IFIXIT_ORIGIN);
 
 const moduleExports = {
    distDir: process.env.NEXT_DIST_DIR ?? '.next',
    env: {
-      ALGOLIA_API_KEY: process.env.ALGOLIA_API_KEY,
-      NEXT_PUBLIC_ALGOLIA_APP_ID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
-      NEXT_PUBLIC_IFIXIT_ORIGIN: process.env.NEXT_PUBLIC_IFIXIT_ORIGIN,
-      NEXT_PUBLIC_STRAPI_ORIGIN: process.env.NEXT_PUBLIC_STRAPI_ORIGIN,
-      SENTRY_DSN: process.env.SENTRY_DSN,
-      NEXT_PUBLIC_MATOMO_URL: process.env.NEXT_PUBLIC_MATOMO_URL,
-      NEXT_PUBLIC_GA_URL: process.env.NEXT_PUBLIC_GA_URL,
-      NEXT_PUBLIC_GA_KEY: process.env.NEXT_PUBLIC_GA_KEY,
-      NEXT_PUBLIC_DEFAULT_STORE_CODE:
-         process.env.NEXT_PUBLIC_DEFAULT_STORE_CODE,
-      NEXT_PUBLIC_POLYFILL_DOMAIN: process.env.NEXT_PUBLIC_POLYFILL_DOMAIN,
-      NEXT_PUBLIC_CACHE_DISABLED: process.env.NEXT_PUBLIC_CACHE_DISABLED,
+      NEXT_PUBLIC_STRAPI_ORIGIN: strapiOrigin,
    },
    async rewrites() {
       return [
          {
             source: '/uploads/:name',
-            destination: `${process.env.NEXT_PUBLIC_STRAPI_ORIGIN}/uploads/:name`,
+            destination: `${strapiOrigin}/uploads/:name`,
          },
       ];
    },
@@ -162,3 +153,45 @@ module.exports = withSentryConfig(
    withBundleStats(withBundleAnalyzer(withTM(moduleExports))),
    SENTRY_AUTH_TOKEN ? sentryWebpackPluginOptions : undefined
 );
+
+function requireStrapiOrigin() {
+   if (process.env.NEXT_PUBLIC_STRAPI_ORIGIN) {
+      return process.env.NEXT_PUBLIC_STRAPI_ORIGIN;
+   }
+   const branch = process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF;
+   if (typeof branch !== 'string' || branch.trim().length === 0) {
+      throw new Error(
+         'NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF environment variable is not set'
+      );
+   }
+   return `https://${getGovinorBranchHandle(branch)}.govinor.com`;
+}
+
+/**
+ * This function takes a branch name and returns a handle that can be used to form the Strapi origin as
+ * setup by Govinor. The handle is a handleized version of the branch name, with a hash appended to the end
+ * if the handle is too long.
+ * @param {String} branchName
+ * @returns {String} handle for the branch
+ */
+function getGovinorBranchHandle(branchName) {
+   const MAX_DOMAIN_LENGTH = 63;
+   const BRANCH_HASH_LENGTH = 8;
+   const handle = branchName.replace(/\//g, '-').replace(/_/g, '-');
+
+   if (handle.length <= MAX_DOMAIN_LENGTH) {
+      return handle;
+   }
+
+   const crypto = require('crypto');
+   const hash = crypto
+      .createHash('sha1')
+      .update(branchName)
+      .digest('hex')
+      .substring(0, BRANCH_HASH_LENGTH);
+   const truncatedHandle = handle.substring(
+      0,
+      MAX_DOMAIN_LENGTH - BRANCH_HASH_LENGTH
+   );
+   return `${truncatedHandle}${hash}`;
+}


### PR DESCRIPTION
closes #1330 
closes #1270 

This branch is longer than 63 characters to test the url abbreviation works correctly

Changes on the Govinor side have already been deployed.

## QA

1. Open [Vercel preview](https://react-commerce-git-generate-govinor-url-handles-f-be9310-ifixit.vercel.app/Parts)
2. Verify that `/Parts` product list page renders with data from the [govinor Strapi instance](https://generate-govinor-url-handles-for-git-branches-with-max-50db9bd7.govinor.com/admin/auth/login)
