### PR TITLE
Troubleshooting: Add styling for `code` and `pre`

### DIFF
--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -49,7 +49,13 @@ const renderStyles: SystemStyleObject = {
       backgroundColor: 'gray.200',
       borderRadius: '4px',
       color: 'coolGray.600',
+      borderStyle: 'none',
+   },
+
+   pre: {
       padding: '2px 4px',
+      maxWidth: '100%',
+      overflow: 'auto',
    },
 };
 

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -58,7 +58,7 @@ const renderStyles: SystemStyleObject = {
       maxWidth: '100%',
       overflow: 'auto',
    },
-  
+
    blockquote: {
       margin: '20px 0px',
       borderLeftColor: 'gray.200',

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -44,6 +44,13 @@ const renderStyles: SystemStyleObject = {
    'a:hover': {
       textDecoration: 'underline',
    },
+
+   'code, pre': {
+      backgroundColor: 'gray.200',
+      borderRadius: '4px',
+      color: 'coolGray.600',
+      padding: '2px 4px',
+   },
 };
 
 const Prerendered = chakra(function Prerendered({


### PR DESCRIPTION
This adds styles for the `code` and `pre` tags.

They now look about like the existing wikis do; the colors are a bit different, because I'm now using a core-primitives color:

![image](https://user-images.githubusercontent.com/1283490/217071923-a374be0a-dd7e-4353-9970-9b6296164b8b.png)
https://www.cominor.com/Wiki/troubleshooting-test

![image](https://user-images.githubusercontent.com/1283490/217071971-a6a415f8-834d-43a8-a088-ebf78155d6e6.png)
https://react-commerce-git-troubleshooting-add-code-styling-ifixit.vercel.app/Vulcan/troubleshooting-test

## QA Notes
I'd appreciate review from @mmarcon91, because I'm changing the color a bit. The actual QA should be really straightforward (links are provided above).

Closes https://github.com/iFixit/ifixit/issues/46386