### PR TITLE
Cache: use null adapter while redis isn't ready

### DIFF
--- a/frontend/lib/swr-cache/adapters/index.ts
+++ b/frontend/lib/swr-cache/adapters/index.ts
@@ -8,7 +8,8 @@ export const getCache = () => {
    if (REDIS_URL) {
       const redisClient = getRedisClient(REDIS_URL);
       const redisCacheAdapter = redisAdapter(redisClient);
-      return () => redisClient.status == "ready" ? redisCacheAdapter : nullCacheAdapter;
+      return () =>
+         redisClient.status == 'ready' ? redisCacheAdapter : nullCacheAdapter;
    } else {
       return () => nullCacheAdapter;
    }

--- a/frontend/lib/swr-cache/index.ts
+++ b/frontend/lib/swr-cache/index.ts
@@ -96,7 +96,7 @@ export const withCache = <
       let start = performance.now();
       let cachedEntry: CacheEntry | null = null;
       try {
-         cachedEntry = await cache.get(key);
+         cachedEntry = await cache().get(key);
       } catch (error) {
          logger.warning(
             `${endpoint}.error: unable to get entry with key. ${printError(
@@ -135,7 +135,7 @@ export const withCache = <
          });
          try {
             start = performance.now();
-            await cache.set(key, cacheEntry);
+            await cache().set(key, cacheEntry);
             elapsed = performance.now() - start;
             logger.info.timing(`${statName}.set`, elapsed);
          } catch (error) {
@@ -161,7 +161,7 @@ export const withCache = <
             staleWhileRevalidate,
          });
          const key = createCacheKey(endpoint, variables);
-         await cache.set(key, cacheEntry);
+         await cache().set(key, cacheEntry);
          return res.status(200).json({ success: true });
       } catch (error) {
          logger.error(printError(error));


### PR DESCRIPTION
We seem to be getting about [~250 errors per day](https://app.datadoghq.com/logs?query=source%3Avercel%20service%3Areact-commerce-prod.vercel.app%20%22Stream%20isn%27t%20writeable%22&agg_m=count&agg_q=%40path&agg_t=count&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&top_n=5&top_o=top&viz=timeseries&from_ts=1675155609590&to_ts=1675760409590&live=true) that say the redis connection isn't a writable stream. These should be able to be caught and dealt with by returning as a miss, but they seem to be aborting the request.

Redis is communicated with via a persistent connection, so here we change caching to dynamically choose the backend based on the connection state. If it's anything other than "ready", we use the null adapter (everything looks like a miss).

Possible connection states from Typescript:
```typescript
type RedisStatus = "wait"
  | "reconnecting"
  | "connecting"
  | "connect"
  | "ready"
  | "close"
  | "end"
```

Looking at the client code, checking for `ready` seems like the right choice. I've also upped the connection timeout now that we have a fallback while connecting and that connecting won't delay any requests.

Connect #1322