### PR TITLE
Redis: reconnect sooner

### DIFF
--- a/frontend/lib/swr-cache/adapters/index.ts
+++ b/frontend/lib/swr-cache/adapters/index.ts
@@ -11,7 +11,10 @@ export const getCache = () => {
    const client = new Redis(REDIS_URL, {
       connectTimeout: 500,
       // Retry, connect every once in a while as cache misses / failures are OK
-      retryStrategy: (times) => Math.min(times * 5000, 10 * 60 * 1000),
+      retryStrategy: (times) => {
+         times = Math.min(20, times);
+         return Math.min(50 + 2 ^ (times + 3), 10 * 60 * 1000);
+      },
       maxRetriesPerRequest: 0,
       // Always try re-connecting since one instance is shared across the whole
       // process

--- a/frontend/lib/swr-cache/adapters/index.ts
+++ b/frontend/lib/swr-cache/adapters/index.ts
@@ -11,10 +11,7 @@ export const getCache = () => {
    const client = new Redis(REDIS_URL, {
       connectTimeout: 500,
       // Retry, connect every once in a while as cache misses / failures are OK
-      retryStrategy: (times) => {
-         times = Math.min(20, times);
-         return Math.min(50 + 2 ** (times + 3), 2 * 60 * 1000);
-      },
+      retryStrategy: (times) => Math.min(50 + 2 ** (times + 3), 2 * 60 * 1000),
       maxRetriesPerRequest: 0,
       // Always try re-connecting since one instance is shared across the whole
       // process

--- a/frontend/lib/swr-cache/adapters/index.ts
+++ b/frontend/lib/swr-cache/adapters/index.ts
@@ -13,7 +13,7 @@ export const getCache = () => {
       // Retry, connect every once in a while as cache misses / failures are OK
       retryStrategy: (times) => {
          times = Math.min(20, times);
-         return Math.min((50 + 2) ^ (times + 3), 10 * 60 * 1000);
+         return Math.min((50 + 2) ** (times + 3), 10 * 60 * 1000);
       },
       maxRetriesPerRequest: 0,
       // Always try re-connecting since one instance is shared across the whole

--- a/frontend/lib/swr-cache/adapters/index.ts
+++ b/frontend/lib/swr-cache/adapters/index.ts
@@ -13,7 +13,7 @@ export const getCache = () => {
       // Retry, connect every once in a while as cache misses / failures are OK
       retryStrategy: (times) => {
          times = Math.min(20, times);
-         return Math.min(50 + 2 ^ (times + 3), 10 * 60 * 1000);
+         return Math.min((50 + 2) ^ (times + 3), 10 * 60 * 1000);
       },
       maxRetriesPerRequest: 0,
       // Always try re-connecting since one instance is shared across the whole

--- a/frontend/lib/swr-cache/adapters/index.ts
+++ b/frontend/lib/swr-cache/adapters/index.ts
@@ -13,7 +13,7 @@ export const getCache = () => {
       // Retry, connect every once in a while as cache misses / failures are OK
       retryStrategy: (times) => {
          times = Math.min(20, times);
-         return Math.min(50 + (2 ** (times + 3)), 2 * 60 * 1000);
+         return Math.min(50 + 2 ** (times + 3), 2 * 60 * 1000);
       },
       maxRetriesPerRequest: 0,
       // Always try re-connecting since one instance is shared across the whole

--- a/frontend/lib/swr-cache/adapters/index.ts
+++ b/frontend/lib/swr-cache/adapters/index.ts
@@ -13,7 +13,7 @@ export const getCache = () => {
       // Retry, connect every once in a while as cache misses / failures are OK
       retryStrategy: (times) => {
          times = Math.min(20, times);
-         return Math.min((50 + 2) ** (times + 3), 10 * 60 * 1000);
+         return Math.min(50 + (2 ** (times + 3)), 2 * 60 * 1000);
       },
       maxRetriesPerRequest: 0,
       // Always try re-connecting since one instance is shared across the whole


### PR DESCRIPTION
We're seeing errors talking to redis on occasion; short several-second
bursts of errors, totalling ~600 per day.

It's a 3rd party service, interruptions happen, let's try reconnecting
more quickly. Delays look like this:

58ms
66ms
82ms
114ms
178ms
306ms
...

with a cap at 10 minutes (as before)

qa_req 0

Connect #1322

CC @dhmacs 