### PR TITLE
Reuse Redis connection

### DIFF
--- a/frontend/lib/redis/index.ts
+++ b/frontend/lib/redis/index.ts
@@ -1,0 +1,22 @@
+import { REDIS_URL } from '@config/env';
+import Redis from 'ioredis';
+
+function getClient() {
+   if (typeof REDIS_URL !== 'string') {
+      return undefined;
+   }
+   return new Redis(REDIS_URL, {
+      connectTimeout: 500,
+      // Retry, connect every once in a while as cache misses / failures are OK
+      retryStrategy: (times) => Math.min(50 + 2 ** (times + 3), 2 * 60 * 1000),
+      maxRetriesPerRequest: 0,
+      // Always try re-connecting since one instance is shared across the whole
+      // process
+      reconnectOnError: (err) => 1,
+      // When not connected to redis, return error, don't add operations to a
+      // queue
+      enableOfflineQueue: false,
+   });
+}
+
+export const client = getClient();

--- a/frontend/lib/swr-cache/adapters/index.ts
+++ b/frontend/lib/swr-cache/adapters/index.ts
@@ -1,24 +1,13 @@
-import { redisAdapter } from './redis-adapter';
-import Redis from 'ioredis';
-import { REDIS_URL } from '@config/env';
+import { client } from '@lib/redis';
 import { nullAdapter } from './null-adapter';
+import { redisAdapter } from './redis-adapter';
 
-export const getCache = () => {
-   if (REDIS_URL === undefined) {
+const getCache = () => {
+   if (client == null) {
       return nullAdapter();
    }
 
-   const client = new Redis(REDIS_URL, {
-      connectTimeout: 500,
-      // Retry, connect every once in a while as cache misses / failures are OK
-      retryStrategy: (times) => Math.min(50 + 2 ** (times + 3), 2 * 60 * 1000),
-      maxRetriesPerRequest: 0,
-      // Always try re-connecting since one instance is shared across the whole
-      // process
-      reconnectOnError: (err) => 1,
-      // When not connected to redis, return error, don't add operations to a
-      // queue
-      enableOfflineQueue: false,
-   });
    return redisAdapter(client);
 };
+
+export const cache = getCache();

--- a/frontend/lib/swr-cache/index.ts
+++ b/frontend/lib/swr-cache/index.ts
@@ -19,7 +19,7 @@ import { APP_ORIGIN } from '@config/env';
 import { log as defaultLog, Logger } from '@ifixit/helpers';
 import type { NextApiHandler } from 'next';
 import { z } from 'zod';
-import { getCache } from './adapters';
+import { cache } from './adapters';
 import {
    CacheEntry,
    createCacheEntry,
@@ -70,7 +70,6 @@ export const withCache = <
    z.infer<ValueSchema>
 > => {
    const logger: Logger = defaultLog;
-   const cache = getCache();
 
    const requestRevalidation = async (variables: z.infer<VariablesSchema>) => {
       fetch(`${APP_ORIGIN}/${endpoint}`, {


### PR DESCRIPTION
closes #1322 

Fix #1341 addressed issue #1322, however, I have spotted another optimization opportunity. The code may establish redundant connections to Redis, which currently shouldn't pose a problem since the cache is preserved in the `withCache` closure and there's only one endpoint. However, as we add more cache endpoints, multiple connections will be created.

## QA

1. Open [Vercel preview](https://react-commerce-git-reuse-redis-connection-ifixit.vercel.app/products/surface-pro-7-battery)
2. Verify that [product page](https://react-commerce-git-reuse-redis-connection-ifixit.vercel.app/products/surface-pro-7-battery) renders