### PR TITLE
Playwright: Abstract Handler Creation for MSW

### DIFF
--- a/frontend/tests/playwright/msw/handlers.ts
+++ b/frontend/tests/playwright/msw/handlers.ts
@@ -1,4 +1,5 @@
-import { RequestHandler, rest } from 'msw';
+import { RequestHandler } from 'msw';
+import Handler from './request-handler';
 
 /**
  * @see https://mswjs.io/docs/basics/request-handler for
@@ -10,10 +11,13 @@ export const handlers: RequestHandler[] = [
     * Prepending the wildcard to the path would capture requests regardless of
     * origin. Therefore, API requests to Cominor will also be matched against.
     */
-   rest.get(
-      '*/api/2.0/internal/international_store_promotion/buybox',
-      (req, res, ctx) => {
-         return res(ctx.status(200));
+   Handler.create(
+      {
+         endpoint: '*/api/2.0/internal/international_store_promotion/buybox',
+         method: 'get',
+      },
+      {
+         status: 200,
       }
    ),
 ];

--- a/frontend/tests/playwright/msw/handlers.ts
+++ b/frontend/tests/playwright/msw/handlers.ts
@@ -11,13 +11,13 @@ export const handlers: RequestHandler[] = [
     * Prepending the wildcard to the path would capture requests regardless of
     * origin. Therefore, API requests to Cominor will also be matched against.
     */
-   Handler.create(
-      {
+   Handler.create({
+      request: {
          endpoint: '*/api/2.0/internal/international_store_promotion/buybox',
          method: 'get',
       },
-      {
+      response: {
          status: 200,
-      }
-   ),
+      },
+   }),
 ];

--- a/frontend/tests/playwright/msw/handlers.ts
+++ b/frontend/tests/playwright/msw/handlers.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'msw';
-import Handler from './request-handler';
+import { createRestHandler } from './request-handler';
 
 /**
  * @see https://mswjs.io/docs/basics/request-handler for
@@ -11,7 +11,7 @@ export const handlers: RequestHandler[] = [
     * Prepending the wildcard to the path would capture requests regardless of
     * origin. Therefore, API requests to Cominor will also be matched against.
     */
-   Handler.create({
+   createRestHandler({
       request: {
          endpoint: '*/api/2.0/internal/international_store_promotion/buybox',
          method: 'get',

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -1,0 +1,1 @@
+export default class Handler {}

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -1,1 +1,12 @@
-export default class Handler {}
+import { RequestHandler } from 'msw';
+
+export type RequestInfo = {
+   endpoint: string;
+   method: string;
+};
+
+export default class Handler {
+   static create(request: RequestInfo): RequestHandler {
+      const { endpoint, method } = request;
+   }
+}

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -1,12 +1,65 @@
 import { RequestHandler } from 'msw';
 
+/**
+ * These methods are a subset of the GraphQL operational methods that are
+ * supported by MSW's `graphql` handler. There are of course other methods
+ * `MSW` supports, but we are only interested in these two for now.
+ *
+ * @see https://mswjs.io/docs/api/graphql#operation-kind
+ */
+export type GraphQLMethods = 'mutation' | 'query';
+
+/**
+ * These methods are a subset of the REST methods that are
+ * supported by MSW's `rest` handler - _with the exception of
+ * `options`_.
+ *
+ * @see https://mswjs.io/docs/api/rest#methods
+ */
+export type RestMethods = 'all' | 'get' | 'post' | 'put' | 'patch' | 'delete';
+
 export type RequestInfo = {
    endpoint: string;
-   method: string;
+   method: GraphQLMethods | RestMethods;
 };
 
 export default class Handler {
    static create(request: RequestInfo): RequestHandler {
       const { endpoint, method } = request;
+
+      if (isGraphQLMethod(method)) {
+         // return GraphQLHandler
+      } else if (isRestMethod(method)) {
+         // return RestHandler
+      } else {
+         throw new Error(
+            `Invalid method ${method}. Must be 'mutation', 'query', 'all', 'get', 'post', 'put', 'patch', or 'delete'.`
+         );
+      }
    }
+}
+
+/**
+ * This is a type guard to ensure that the `method` is a valid GraphQLMethod
+ * by using Typescript Predicate Return Types.
+ * @see https://www.typescriptlang.org/docs/handbook/2/classes.html#this-based-type-guards
+ */
+function isGraphQLMethod(method: string): method is GraphQLMethods {
+   return method === 'mutation' || method === 'query';
+}
+
+/**
+ * This is a type guard to ensure that the `method` is a valid RestMethod
+ * by using Typescript Predicate Return Types.
+ * @see https://www.typescriptlang.org/docs/handbook/2/classes.html#this-based-type-guards
+ */
+function isRestMethod(method: string): method is RestMethods {
+   return (
+      method === 'all' ||
+      method === 'get' ||
+      method === 'post' ||
+      method === 'put' ||
+      method === 'patch' ||
+      method === 'delete'
+   );
 }

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -1,3 +1,4 @@
+import { isRecord } from '@ifixit/helpers';
 import { GraphQLHandler, RestHandler, RequestHandler } from 'msw';
 
 /**
@@ -53,6 +54,10 @@ export default class Handler {
       const { status, body, responseType } = response;
 
       if (isGraphQLMethod(method)) {
+         if (!isRecord(body)) {
+            throw new Error(`Invalid GraphQL body ${body}. Must be an object`);
+         }
+
          return new GraphQLHandler(
             method,
             endpoint,

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -61,6 +61,7 @@ export type RequestInfo = {
  * to configure what the response should return if the request is matched.
  *
  * @property `status` - The HTTP status code to return
+ * @property `headers` - The headers to return with the response
  * @property `body` - The body of the response.
  * @property `responseType` - This the kind of transformation to apply to the
  * body when it will be returned. This is only applicable to REST requests
@@ -85,6 +86,10 @@ export type MockedResponseInfo = {
  * @property `passthrough` - If true, the request will be bypassed and performed
  * as-is.
  * @see https://mswjs.io/docs/api/request/passthrough
+ * @property `customResolver` - If provided, this will be used as the resolver
+ * for the handler. This is useful if you want to do something more complex than
+ * just returning a static response.
+ * @see https://mswjs.io/docs/basics/response-resolver
  */
 export type HandlerOptions = {
    once: boolean;

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -93,6 +93,37 @@ export type HandlerOptions = {
 };
 
 export default class Handler {
+   /**
+    * Creates a new GraphQL handler.
+    */
+   static create({
+      request,
+      response,
+      options,
+   }: {
+      request: Omit<RequestInfo, 'method'> & { method: GraphQLMethods };
+      response: Omit<
+         MockedResponseInfo,
+         'headers' | 'body' | 'responseType'
+      > & {
+         body: Record<string, any>;
+      };
+      options?: HandlerOptions;
+   }): GraphQLHandler;
+
+   /**
+    * Creates a new Rest Handler.
+    */
+   static create({
+      request,
+      response,
+      options,
+   }: {
+      request: Omit<RequestInfo, 'method'> & { method: RestMethods };
+      response: MockedResponseInfo;
+      options?: HandlerOptions;
+   }): RestHandler;
+
    static create({
       request,
       response,

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -56,9 +56,18 @@ export type RestResolver = ResponseResolver<
    DefaultBodyType
 >;
 
-export type RequestInfo = {
+/**
+ * The `RequestInfo` type represents the information that is needed to
+ * understand which request we are trying to mock.
+ */
+type RequestInfo = {
    endpoint: string;
-   method: GraphQLMethods | RestMethods;
+};
+export type GraphQLRequestInfo = RequestInfo & {
+   method: GraphQLMethods;
+};
+export type RestRequestInfo = RequestInfo & {
+   method: RestMethods;
 };
 
 /**

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -93,11 +93,15 @@ export type HandlerOptions = {
 };
 
 export default class Handler {
-   static create(
-      request: RequestInfo,
-      response: MockedResponseInfo,
-      options: HandlerOptions = { once: false, passthrough: false }
-   ): RequestHandler {
+   static create({
+      request,
+      response,
+      options = { once: false, passthrough: false },
+   }: {
+      request: RequestInfo;
+      response: MockedResponseInfo;
+      options?: HandlerOptions;
+   }): RequestHandler {
       const { endpoint, method } = request;
       const { status, headers, body, responseType } = response;
       const { once, passthrough, customResolver } = options;

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -112,15 +112,32 @@ type RestBodyInfo = {
  * @property `passthrough` - If true, the request will be bypassed and performed
  * as-is.
  * @see https://mswjs.io/docs/api/request/passthrough
+ */
+type HandlerOptions = {
+   once?: boolean;
+   passthrough?: boolean;
+};
+
+/**
  * @property `customResolver` - If provided, this will be used as the resolver
  * for the handler. This is useful if you want to do something more complex than
  * just returning a static response.
  * @see https://mswjs.io/docs/basics/response-resolver
  */
-export type HandlerOptions = {
-   once: boolean;
-   passthrough: boolean;
-   customResolver?: GraphQLResolver | RestResolver;
+export type GraphQLHandlerOptions =
+   | HandlerOptions
+   | { customResolver: GraphQLResolver };
+
+/**
+ * @property `customResolver` - If provided, this will be used as the resolver
+ * for the handler. This is useful if you want to do something more complex than
+ * just returning a static response.
+ * @see https://mswjs.io/docs/basics/response-resolver
+ */
+export type RestHandlerOptions =
+   | HandlerOptions
+   | { customResolver: RestResolver };
+
 };
 
 export default class Handler {

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -11,6 +11,8 @@ import {
    ResponseResolver,
    RestContext,
    RestRequest,
+   rest,
+   graphql,
 } from 'msw';
 
 /**
@@ -20,7 +22,8 @@ import {
  *
  * @see https://mswjs.io/docs/api/graphql#operation-kind
  */
-export type GraphQLMethods = 'mutation' | 'query';
+export type GraphQLMethods = keyof Pick<typeof graphql, 'mutation' | 'query'>;
+
 /**
  * This is the type of the resolver that is used by the `graphql` handler.
  * The resolver is a function that accepts a captured request and may return
@@ -31,6 +34,7 @@ export type GraphQLResolver = ResponseResolver<
    GraphQLRequest<GraphQLVariables>,
    GraphQLContext<Record<string, any>>
 >;
+
 /**
  * These methods are a subset of the REST methods that are
  * supported by MSW's `rest` handler - _with the exception of
@@ -38,7 +42,8 @@ export type GraphQLResolver = ResponseResolver<
  *
  * @see https://mswjs.io/docs/api/rest#methods
  */
-export type RestMethods = 'all' | 'get' | 'post' | 'put' | 'patch' | 'delete';
+export type RestMethods = keyof Omit<typeof rest, 'options'>;
+
 /**
  * This is the type of the resolver that is used by the `rest` handler.
  * The resolver is a function that accepts a captured request and may return

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -70,11 +70,22 @@ export type RestRequestInfo = RequestInfo & {
    method: RestMethods;
 };
 
+/*
+ * These types represent the response options that can be passed to each respective
+ * handler to configure what the response should return if the request is matched.
+ */
+type MockedResponseInfo = {
+   status: number;
+};
+
+export type GraphQLResponseInfo = MockedResponseInfo & {
+   body: Record<string, any>;
+};
+
 /**
- * This type represents the options that can be passed to the handler
- * to configure what the response should return if the request is matched.
+ * The response for a Rest request can be configured in a more ways than
+ * compared to a response for GraphQL request.
  *
- * @property `status` - The HTTP status code to return
  * @property `headers` - The headers to return with the response
  * @property `body` - The body of the response.
  * @property `responseType` - This the kind of transformation to apply to the
@@ -86,11 +97,12 @@ export type RestRequestInfo = RequestInfo & {
  * @see https://mswjs.io/docs/api/response
  *
  */
-export type MockedResponseInfo = {
-   status: number;
+export type RestResponseInfo = MockedResponseInfo & {
    headers?: Record<string, string | string[]>;
-   body?: Record<string, any> | string | number | boolean | null;
-   responseType?: 'json' | 'text' | 'xml' | 'raw';
+} & (RestBodyInfo | {});
+type RestBodyInfo = {
+   body: Record<string, any> | string | number | boolean | null;
+   responseType: 'json' | 'text' | 'xml' | 'raw';
 };
 
 /**

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -23,9 +23,34 @@ export type RequestInfo = {
    method: GraphQLMethods | RestMethods;
 };
 
+/**
+ * This type represents the options that can be passed to the handler
+ * to configure what the response should return if the request is matched.
+ *
+ * @property `status` - The HTTP status code to return
+ * @property `body` - The body of the response.
+ * @property `responseType` - This the kind of transformation to apply to the
+ * body when it will be returned. This is only applicable to REST requests
+ * since GraphQL responses will only use a `data` transformer.
+ *
+ * @see https://mswjs.io/docs/basics/response-transformer#standards-transformers
+ * @see https://mswjs.io/docs/api/context
+ * @see https://mswjs.io/docs/api/response
+ *
+ */
+export type MockedResponseInfo = {
+   status: number;
+   body?: Record<string, any> | string | number | boolean | null;
+   responseType?: 'json' | 'text' | 'xml' | 'raw';
+};
+
 export default class Handler {
-   static create(request: RequestInfo): RequestHandler {
+   static create(
+      request: RequestInfo,
+      response: MockedResponseInfo
+   ): RequestHandler {
       const { endpoint, method } = request;
+      const { status, body, responseType } = response;
 
       if (isGraphQLMethod(method)) {
          // return GraphQLHandler

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -73,8 +73,10 @@ export default class Handler {
          );
       } else if (isRestMethod(method)) {
          return new RestHandler(method, endpoint, (req, res, ctx) => {
-            return res(
-               ctx.status(status),
+            const transformers = [ctx.status(status)];
+
+            // Only transform the body if it and the response type are defined
+            if (body && responseType) {
                /**
                 * `raw` is for our own naming convention, but the actual
                 * transformer method is called `body`. This can be confusing
@@ -82,8 +84,12 @@ export default class Handler {
                 * clearer what response type we will be using.
                 * @see https://mswjs.io/docs/api/context/body
                 */
-               ctx[responseType === 'raw' ? 'body' : responseType](body)
-            );
+               transformers.push(
+                  ctx[responseType === 'raw' ? 'body' : responseType](body)
+               );
+            }
+
+            return res(...transformers);
          });
       } else {
          throw new Error(

--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -73,6 +73,7 @@ export type RequestInfo = {
  */
 export type MockedResponseInfo = {
    status: number;
+   headers?: Record<string, string | string[]>;
    body?: Record<string, any> | string | number | boolean | null;
    responseType?: 'json' | 'text' | 'xml' | 'raw';
 };
@@ -98,7 +99,7 @@ export default class Handler {
       options: HandlerOptions = { once: false, passthrough: false }
    ): RequestHandler {
       const { endpoint, method } = request;
-      const { status, body, responseType } = response;
+      const { status, headers, body, responseType } = response;
       const { once, passthrough, customResolver } = options;
 
       if (isGraphQLMethod(method)) {
@@ -132,6 +133,10 @@ export default class Handler {
                   if (passthrough) return req.passthrough();
 
                   const transformers = [ctx.status(status)];
+
+                  if (headers) {
+                     transformers.push(ctx.set(headers));
+                  }
 
                   // Only transform the body if it and the response type are defined
                   if (body && responseType) {

--- a/frontend/tests/playwright/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/tests/playwright/product-list/newsletter_subscribe.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../test-fixtures';
+import Handler from '../msw/request-handler';
 
 test.describe('Subscribe to newsletter', () => {
    test.beforeEach(async ({ page }) => {
@@ -36,12 +37,17 @@ test.describe('Subscribe to newsletter', () => {
    test('Shows confirmation when email is subscribed', async ({
       page,
       clientRequestHandler,
-      rest,
    }) => {
       clientRequestHandler.use(
-         rest.post('/api/2.0/cart/newsletter/subscribe', (req, res, ctx) => {
-            return res(ctx.status(200));
-         })
+         Handler.create(
+            {
+               endpoint: '/api/2.0/cart/newsletter/subscribe',
+               method: 'post',
+            },
+            {
+               status: 200,
+            }
+         )
       );
 
       await page.getByLabel(/enter your email/i).fill('test@example.com');
@@ -58,12 +64,17 @@ test.describe('Subscribe to newsletter', () => {
    test('Shows an error when server request fails', async ({
       page,
       clientRequestHandler,
-      rest,
    }) => {
       clientRequestHandler.use(
-         rest.post('/api/2.0/cart/newsletter/subscribe', (req, res, ctx) => {
-            return res(ctx.status(500));
-         })
+         Handler.create(
+            {
+               endpoint: '/api/2.0/cart/newsletter/subscribe',
+               method: 'post',
+            },
+            {
+               status: 500,
+            }
+         )
       );
 
       await page.getByLabel(/enter your email/i).fill('test@example.com');

--- a/frontend/tests/playwright/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/tests/playwright/product-list/newsletter_subscribe.spec.ts
@@ -39,15 +39,15 @@ test.describe('Subscribe to newsletter', () => {
       clientRequestHandler,
    }) => {
       clientRequestHandler.use(
-         Handler.create(
-            {
+         Handler.create({
+            request: {
                endpoint: '/api/2.0/cart/newsletter/subscribe',
                method: 'post',
             },
-            {
+            response: {
                status: 200,
-            }
-         )
+            },
+         })
       );
 
       await page.getByLabel(/enter your email/i).fill('test@example.com');
@@ -66,15 +66,15 @@ test.describe('Subscribe to newsletter', () => {
       clientRequestHandler,
    }) => {
       clientRequestHandler.use(
-         Handler.create(
-            {
+         Handler.create({
+            request: {
                endpoint: '/api/2.0/cart/newsletter/subscribe',
                method: 'post',
             },
-            {
+            response: {
                status: 500,
-            }
-         )
+            },
+         })
       );
 
       await page.getByLabel(/enter your email/i).fill('test@example.com');

--- a/frontend/tests/playwright/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/tests/playwright/product-list/newsletter_subscribe.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../test-fixtures';
-import Handler from '../msw/request-handler';
+import { createRestHandler } from './../msw/request-handler';
 
 test.describe('Subscribe to newsletter', () => {
    test.beforeEach(async ({ page }) => {
@@ -39,7 +39,7 @@ test.describe('Subscribe to newsletter', () => {
       clientRequestHandler,
    }) => {
       clientRequestHandler.use(
-         Handler.create({
+         createRestHandler({
             request: {
                endpoint: '/api/2.0/cart/newsletter/subscribe',
                method: 'post',
@@ -66,7 +66,7 @@ test.describe('Subscribe to newsletter', () => {
       clientRequestHandler,
    }) => {
       clientRequestHandler.use(
-         Handler.create({
+         createRestHandler({
             request: {
                endpoint: '/api/2.0/cart/newsletter/subscribe',
                method: 'post',

--- a/frontend/tests/playwright/product/add_to_cart.spec.ts
+++ b/frontend/tests/playwright/product/add_to_cart.spec.ts
@@ -109,16 +109,16 @@ test.describe('product page add to cart', () => {
          }
 
          serverRequestInterceptor.use(
-            Handler.create(
-               {
+            Handler.create({
+               request: {
                   endpoint: 'findProduct',
                   method: 'query',
                },
-               {
+               response: {
                   status: 200,
                   body: lowStockedProduct,
-               }
-            )
+               },
+            })
          );
 
          await page.goto(
@@ -176,15 +176,15 @@ test.describe('product page add to cart', () => {
          port,
       }) => {
          clientRequestHandler.use(
-            Handler.create(
-               {
+            Handler.create({
+               request: {
                   endpoint: '/api/2.0/cart/product/notifyWhenSkuInStock',
                   method: 'post',
                },
-               {
+               response: {
                   status: 200,
-               }
-            )
+               },
+            })
          );
 
          const outOfStockProduct = cloneDeep(mockedProductQuery);
@@ -193,16 +193,16 @@ test.describe('product page add to cart', () => {
          }
 
          serverRequestInterceptor.use(
-            Handler.create(
-               {
+            Handler.create({
+               request: {
                   endpoint: 'findProduct',
                   method: 'query',
                },
-               {
+               response: {
                   status: 200,
                   body: outOfStockProduct,
-               }
-            )
+               },
+            })
          );
 
          await page.goto(

--- a/frontend/tests/playwright/product/add_to_cart.spec.ts
+++ b/frontend/tests/playwright/product/add_to_cart.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from '../test-fixtures';
 import { mockedProductQuery } from '@tests/jest/__mocks__/products';
 import { cloneDeep } from 'lodash';
-import Handler from '../msw/request-handler';
+import {
+   createGraphQLHandler,
+   createRestHandler,
+} from './../msw/request-handler';
 
 test.describe('product page add to cart', () => {
    test('Clicking Add To Cart Adds Items To Cart', async ({
@@ -109,7 +112,7 @@ test.describe('product page add to cart', () => {
          }
 
          serverRequestInterceptor.use(
-            Handler.create({
+            createGraphQLHandler({
                request: {
                   endpoint: 'findProduct',
                   method: 'query',
@@ -176,7 +179,7 @@ test.describe('product page add to cart', () => {
          port,
       }) => {
          clientRequestHandler.use(
-            Handler.create({
+            createRestHandler({
                request: {
                   endpoint: '/api/2.0/cart/product/notifyWhenSkuInStock',
                   method: 'post',
@@ -193,7 +196,7 @@ test.describe('product page add to cart', () => {
          }
 
          serverRequestInterceptor.use(
-            Handler.create({
+            createGraphQLHandler({
                request: {
                   endpoint: 'findProduct',
                   method: 'query',

--- a/frontend/tests/playwright/product/disabled_product.spec.ts
+++ b/frontend/tests/playwright/product/disabled_product.spec.ts
@@ -17,16 +17,16 @@ test.describe('Disabled Product Test', () => {
       }
 
       serverRequestInterceptor.use(
-         Handler.create(
-            {
+         Handler.create({
+            request: {
                endpoint: 'findProduct',
                method: 'query',
             },
-            {
+            response: {
                status: 200,
                body: disabledProduct,
-            }
-         )
+            },
+         })
       );
 
       await page.goto(

--- a/frontend/tests/playwright/product/disabled_product.spec.ts
+++ b/frontend/tests/playwright/product/disabled_product.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../test-fixtures';
 import { mockedProductQuery } from '@tests/jest/__mocks__/products';
 import { cloneDeep } from 'lodash';
-import Handler from '../msw/request-handler';
+import { createGraphQLHandler } from '../msw/request-handler';
 
 test.describe('Disabled Product Test', () => {
    test('Not for Sale text renders and noindexed', async ({
@@ -17,7 +17,7 @@ test.describe('Disabled Product Test', () => {
       }
 
       serverRequestInterceptor.use(
-         Handler.create({
+         createGraphQLHandler({
             request: {
                endpoint: 'findProduct',
                method: 'query',


### PR DESCRIPTION
## Description

In #1275 we created the ability to set dynamic handlers for `MSW`. However, the API for creating a handler is rather bloated and a lot of it can be extracted to reduce the boilerplate.

As such, we created a new static helper function to create these handlers.

## CR:

Commit by commit would be the easiest way to understand the code as some obscure context is needed in some cases.

Overall, the end goal was to abstract creating these dynamic handlers just enough to reduce the boilerplate and still be simple to use. Most of this was accomplished by making use of Typescript's features. 

## QA:

Besides checking CI still passing, I am not sure if it will be worth validating if the error handling works, as that might be exhaustive. 

I already confirmed that the `international buybox` handler still works using similar steps as https://github.com/iFixit/react-commerce/pull/1319#issuecomment-1416451999.

I also confirmed that the type checking is working as expected for the overloaded signatures:


|Before|After|
|:---:|:---:|
|  ![GraphQL body type is allowed](https://user-images.githubusercontent.com/22064420/217672866-e36d2476-6155-44df-ac17-bea9889c653b.png) | ![Graphql only accepts an object not a string](https://user-images.githubusercontent.com/22064420/217672913-be2a3a05-58be-4f01-87e1-c6abc59485db.png)|
<p align=center> <strong>In the scenario above, a GraphQLHandler requires a body that is only of type <code>Object</code></strong></p>


cr_req 2
qa_req 0

Connects: #1290 