### PR TITLE
Hero with background backend changes

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -54,7 +54,29 @@
          "type": "richtext",
          "required": true
       },
+      "heroImage": {
+         "type": "media",
+         "multiple": false,
+         "required": false,
+         "allowedTypes": ["images"],
+         "pluginOptions": {
+            "i18n": {
+               "localized": false
+            }
+         }
+      },
       "image": {
+         "type": "media",
+         "multiple": false,
+         "required": false,
+         "allowedTypes": ["images"],
+         "pluginOptions": {
+            "i18n": {
+               "localized": false
+            }
+         }
+      },
+      "brandLogo": {
          "type": "media",
          "multiple": false,
          "required": false,

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -971,6 +971,7 @@ export type PaginationArg = {
 
 export type ProductList = {
    __typename?: 'ProductList';
+   brandLogo?: Maybe<UploadFileEntityResponse>;
    children?: Maybe<ProductListRelationResponseCollection>;
    childrenHeading?: Maybe<Scalars['String']>;
    createdAt?: Maybe<Scalars['DateTime']>;
@@ -981,6 +982,7 @@ export type ProductList = {
    filters?: Maybe<Scalars['String']>;
    forceNoindex?: Maybe<Scalars['Boolean']>;
    handle: Scalars['String'];
+   heroImage?: Maybe<UploadFileEntityResponse>;
    image?: Maybe<UploadFileEntityResponse>;
    legacyDescription?: Maybe<Scalars['String']>;
    legacyPageId?: Maybe<Scalars['Int']>;
@@ -1060,6 +1062,7 @@ export type ProductListFiltersInput = {
 };
 
 export type ProductListInput = {
+   brandLogo?: InputMaybe<Scalars['ID']>;
    children?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
    childrenHeading?: InputMaybe<Scalars['String']>;
    defaultShowAllChildrenOnLgSizes?: InputMaybe<Scalars['Boolean']>;
@@ -1069,6 +1072,7 @@ export type ProductListInput = {
    filters?: InputMaybe<Scalars['String']>;
    forceNoindex?: InputMaybe<Scalars['Boolean']>;
    handle?: InputMaybe<Scalars['String']>;
+   heroImage?: InputMaybe<Scalars['ID']>;
    image?: InputMaybe<Scalars['ID']>;
    legacyDescription?: InputMaybe<Scalars['String']>;
    legacyPageId?: InputMaybe<Scalars['Int']>;


### PR DESCRIPTION
connects #1170 

This PR adds two strapi fields on product list records for the optional hero image and brand logo 

❗ ❗ ❗ After this PR is merged Strapi should be redeployed in production ❗ ❗ ❗
cc @sterlinghirsh @danielbeardsley 

## QA

1. Login into [Strapi](https://implement-hero-with-background-backend-changes.govinor.com/admin/)
2. Check that the productList model includes the new optional heroImage and brandImage fields
3. Visit [Vercel preview](https://react-commerce-git-implement-hero-with-background-94d831-ifixit.vercel.app/Parts)
4. Verify that everything renders correctly