### PR TITLE
Enable zoom only when image is larger than gallery container by 1.5 factor

### DIFF
--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -59,7 +59,7 @@ export function ProductGallery({
                ({ width, height }) =>
                   !width ||
                   !height ||
-                  width * height < containerWidth * containerHeight
+                  width * height < containerWidth * containerHeight * 1.5
             )
          );
       };


### PR DESCRIPTION
closes #1097 

### QA

1. Visit Vercel preview
2. Verify that images with `inner_width * inner_height` only slightly larger than the gallery container are not zoomed
3. Only images with an `inner_width * inner_height >= container_width * container_height * 1.5` should have zoom enabled