### PR TITLE
Browser Caching: enable it!

### DIFF
--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -10,11 +10,11 @@ export const withCacheControl =
    (options: CacheControlOptions): GetServerSidePropsMiddleware =>
    (next) =>
    (context) => {
-      const sMaxAgeSeconds = options.sMaxAge / 1000;
+      const maxAgeSeconds = options.sMaxAge / 1000;
       const staleWhileRevalidateSeconds = options.staleWhileRevalidate / 1000;
       context.res.setHeader(
          'Cache-Control',
-         `public, s-maxage=${sMaxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`
+         `public, s-maxage=${maxAgeSeconds}, max-age=${maxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`
       );
       return next(context);
    };


### PR DESCRIPTION
Problem: we have been using `s-maxage` and vercel listens to that, but strips it off so both downstream caches (Cloudfront and browsers) see the response as uncacheable.

Since we're telling vercel to cache our responses (via s-maxage), we might as well let browsers and cloudfront cache them too (via maxage).

The only reason this isn't the default recommended for vercel is because they auto-invalidate your caches on deploy and they can't do that for downstream caches. Given that our cache times are 1 minute, I'm OK with CF and browsers storing these responses for that amount of time.

Note: max-age is computed relative to the when the response was generated, not when it was received. So, if vercel sends a 40s-old page to CF and CF caches it, it'll only consider it fresh for another 20s, not 40s + 1min.

qa_req 0