### PR TITLE
Playwright: Make tests a bit more resilient

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -189,6 +189,7 @@ const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
                px="2"
                textAlign="center"
                {...otherProps}
+               data-testid="product-list-no-results"
             >
                <Icon
                   as={SearchEmptyStateIllustration}

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -262,6 +262,7 @@ export function CrossSellSection({
                            base: 6,
                            sm: 0,
                         }}
+                        data-testid="cross-sell-total-price"
                      >
                         Total price:{' '}
                         <Box as="span" fontWeight="semibold">

--- a/frontend/templates/product/sections/ProductSection/AddToCart/NotifyMeForm.tsx
+++ b/frontend/templates/product/sections/ProductSection/AddToCart/NotifyMeForm.tsx
@@ -62,7 +62,7 @@ export function NotifyMeForm({ sku }: NotifyMeFormProps) {
 
    if (status === NotifyMeStatus.Submitted) {
       return (
-         <Alert status="success">
+         <Alert status="success" data-testid="notify-me-form-successful">
             <FaIcon icon={faCheckCircle} h="5" mr="2" color="green.700" />
             You will be notified when this product is back in stock.
          </Alert>
@@ -78,6 +78,7 @@ export function NotifyMeForm({ sku }: NotifyMeFormProps) {
          w="full"
          px="3"
          py="4"
+         data-testid="notify-me-form"
       >
          <form onSubmit={handleFormSubmit}>
             <Text fontWeight="semibold" mb="1.5">

--- a/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
@@ -115,7 +115,7 @@ export function AddToCart({ product, selectedVariant }: AddToCartProps) {
                      align="flex-start"
                   />
                )}
-               <Alert status="warning" mb="3">
+               <Alert status="warning" mb="3" data-testid='out-of-stock-alert'>
                   <FaIcon
                      icon={faExclamationCircle}
                      h="5"

--- a/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
@@ -115,7 +115,7 @@ export function AddToCart({ product, selectedVariant }: AddToCartProps) {
                      align="flex-start"
                   />
                )}
-               <Alert status="warning" mb="3" data-testid='out-of-stock-alert'>
+               <Alert status="warning" mb="3" data-testid="out-of-stock-alert">
                   <FaIcon
                      icon={faExclamationCircle}
                      h="5"

--- a/frontend/templates/product/sections/ProductSection/InternationalBuyBox.tsx
+++ b/frontend/templates/product/sections/ProductSection/InternationalBuyBox.tsx
@@ -26,7 +26,7 @@ export function InternationalBuyBox({
       });
    }, [selectedVariant, store]);
    return (
-      <Box textAlign="center">
+      <Box textAlign="center" data-testid="international-buy-box">
          <Button
             mt={3}
             variant="outline"

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -116,6 +116,7 @@ export function ProductSection({
                }}
                fontSize="sm"
                position="relative"
+               data-testid="product-info-section"
             >
                {selectedVariant.sku && (
                   <Text color="gray.500" data-testid="product-sku">
@@ -368,7 +369,7 @@ function ProOnlyAlert(props: AlertProps) {
 
 function NotForSaleAlert(props: AlertProps) {
    return (
-      <Alert status="warning" {...props}>
+      <Alert status="warning" {...props} data-testid="not-for-sale-alert">
          <FaIcon icon={faCircleExclamation} h="5" mr="2" color="amber.600" />
          <span>Not for Sale.</span>
       </Alert>

--- a/frontend/tests/playwright/fixtures/product-page.ts
+++ b/frontend/tests/playwright/fixtures/product-page.ts
@@ -103,7 +103,9 @@ export class ProductPage {
     * If no message is given, it will assert that the inventory message is
     * not visible.
     */
-   async assertInventoryMessage(message: string | null = null): Promise<void> {
+   async assertInventoryMessage(
+      message: string | RegExp | null = null
+   ): Promise<void> {
       if (message === null) {
          await expect(
             this.page.getByTestId('product-inventory-message')

--- a/frontend/tests/playwright/fixtures/product-page.ts
+++ b/frontend/tests/playwright/fixtures/product-page.ts
@@ -111,7 +111,7 @@ export class ProductPage {
       } else {
          await expect(
             this.page.getByTestId('product-inventory-message')
-         ).toHaveText(message);
+         ).toContainText(message);
       }
    }
 }

--- a/frontend/tests/playwright/product-list/newsletter_subscribe.spec.ts
+++ b/frontend/tests/playwright/product-list/newsletter_subscribe.spec.ts
@@ -22,14 +22,20 @@ test.describe('Subscribe to newsletter', () => {
    });
 
    test('Prevents invalid email', async ({ page }) => {
+      const footerNewsletterForm = page.getByTestId('footer-newsletter-form');
+
       await expect(
-         page.getByText(/please insert a valid email/i)
+         footerNewsletterForm.getByText(/please insert a valid email/i)
       ).not.toBeVisible();
 
-      await page.getByLabel(/enter your email/i).fill('test@example');
-      await page.getByRole('button', { name: /subscribe|join/i }).click();
+      await footerNewsletterForm
+         .getByLabel(/enter your email/i)
+         .fill('test@example');
+      await footerNewsletterForm
+         .getByRole('button', { name: /subscribe|join/i })
+         .click();
       await expect(
-         page.getByText(/please insert a valid email/i)
+         footerNewsletterForm.getByText(/please insert a valid email/i)
       ).toBeVisible();
    });
 
@@ -44,14 +50,20 @@ test.describe('Subscribe to newsletter', () => {
          })
       );
 
-      await page.getByLabel(/enter your email/i).fill('test@example.com');
-      await page.getByRole('button', { name: /subscribe|join/i }).click();
-      await expect(page.getByText('Subscribed!')).toBeVisible();
+      const footerNewsletterForm = page.getByTestId('footer-newsletter-form');
+
+      await footerNewsletterForm
+         .getByLabel(/enter your email/i)
+         .fill('test@example.com');
+      await footerNewsletterForm
+         .getByRole('button', { name: /subscribe|join/i })
+         .click();
+      await expect(footerNewsletterForm.getByText('Subscribed!')).toBeVisible();
       await expect(
-         page.getByTestId('footer-newsletter-subscribe-button')
+         footerNewsletterForm.getByTestId('footer-newsletter-subscribe-button')
       ).not.toBeVisible();
       await expect(
-         page.getByText(/please insert a valid email/i)
+         footerNewsletterForm.getByText(/please insert a valid email/i)
       ).not.toBeVisible();
    });
 
@@ -66,12 +78,20 @@ test.describe('Subscribe to newsletter', () => {
          })
       );
 
-      await page.getByLabel(/enter your email/i).fill('test@example.com');
+      const footerNewsletterForm = page.getByTestId('footer-newsletter-form');
 
-      await page.getByRole('button', { name: /subscribe|join/i }).click();
+      await footerNewsletterForm
+         .getByLabel(/enter your email/i)
+         .fill('test@example.com');
+
+      await footerNewsletterForm
+         .getByRole('button', { name: /subscribe|join/i })
+         .click();
 
       await expect(
-         page.getByText(/error trying to subscribe to newsletter/i)
+         footerNewsletterForm.getByText(
+            /error trying to subscribe to newsletter/i
+         )
       ).toBeVisible();
    });
 });

--- a/frontend/tests/playwright/product-list/parts_page_search.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_search.spec.ts
@@ -1,10 +1,6 @@
 import { waitForAlgoliaSearch } from './../utils';
 import { test, expect } from '../test-fixtures';
 
-const NO_SEARCH_RESULT = 'No matching products found';
-const NO_SEARCH_RESULTS_DESC =
-   "Try adjusting your search or filter to find what you're looking for";
-
 test.describe('parts page search', () => {
    test.beforeEach(async ({ page }) => {
       await page.goto('/Parts');
@@ -55,7 +51,6 @@ test.describe('parts page search', () => {
       expect(page.url()).toContain('?q=');
 
       await expect(page.getByTestId('list-view-products')).not.toBeVisible();
-      await expect(page.getByText(NO_SEARCH_RESULT)).toBeVisible();
-      await expect(page.getByText(NO_SEARCH_RESULTS_DESC)).toBeVisible();
+      await expect(page.getByTestId('product-list-no-results')).toBeVisible();
    });
 });

--- a/frontend/tests/playwright/product/add_to_cart.spec.ts
+++ b/frontend/tests/playwright/product/add_to_cart.spec.ts
@@ -205,15 +205,16 @@ test.describe('product page add to cart', () => {
          await productPage.assertInventoryMessage();
 
          await expect(
-            page.getByText(/This item is currently Out of Stock./i)
+            page.getByTestId('out-of-stock-alert')
          ).toBeVisible();
 
-         await page.getByLabel('Email address').fill('test@example.com');
-         await page.getByRole('button', { name: 'Notify me' }).click();
+         const notifyMeForm = page.getByTestId('notify-me-form');
+         await expect(notifyMeForm).toBeVisible();
+
+         await notifyMeForm.getByLabel('Email address').fill('test@example.com');
+         await notifyMeForm.getByRole('button', { name: 'Notify me' }).click();
          await expect(
-            page.getByText(
-               'You will be notified when this product is back in stock.'
-            )
+            page.getByTestId('notify-me-form-successful')
          ).toBeVisible();
 
          await productPage.switchSelectedVariant();

--- a/frontend/tests/playwright/product/add_to_cart.spec.ts
+++ b/frontend/tests/playwright/product/add_to_cart.spec.ts
@@ -204,14 +204,14 @@ test.describe('product page add to cart', () => {
          await expect(productPage.addToCartButton).not.toBeVisible();
          await productPage.assertInventoryMessage();
 
-         await expect(
-            page.getByTestId('out-of-stock-alert')
-         ).toBeVisible();
+         await expect(page.getByTestId('out-of-stock-alert')).toBeVisible();
 
          const notifyMeForm = page.getByTestId('notify-me-form');
          await expect(notifyMeForm).toBeVisible();
 
-         await notifyMeForm.getByLabel('Email address').fill('test@example.com');
+         await notifyMeForm
+            .getByLabel('Email address')
+            .fill('test@example.com');
          await notifyMeForm.getByRole('button', { name: 'Notify me' }).click();
          await expect(
             page.getByTestId('notify-me-form-successful')

--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -37,9 +37,10 @@ test.describe('Cross-sell test', () => {
       }
 
       // Assert total price matches price of product as it's the only one selected
-      await expect(
-         page.getByText('Total Price: ' + currentProductPrice)
-      ).toBeVisible();
+      expect(currentProductPrice).not.toBeNull();
+      expect(
+         await page.getByTestId('cross-sell-total-price').textContent()
+      ).toContain(currentProductPrice!);
 
       // Assert adding to cart only adds current product
       await page.getByTestId('cross-sell-add-to-cart-button').click();
@@ -71,9 +72,9 @@ test.describe('Cross-sell test', () => {
       }
 
       // Assert total price matches the sum of all products
-      await expect(
-         page.getByText('Total Price: $' + expectedTotalPrice.toFixed(2))
-      ).toBeVisible();
+      expect(
+         await page.getByTestId('cross-sell-total-price').textContent()
+      ).toContain(expectedTotalPrice.toFixed(2));
 
       // Assert adding to cart adds all products
       await page.getByTestId('cross-sell-add-to-cart-button').click();

--- a/frontend/tests/playwright/product/disabled_product.spec.ts
+++ b/frontend/tests/playwright/product/disabled_product.spec.ts
@@ -25,24 +25,33 @@ test.describe('Disabled Product Test', () => {
          `http://localhost:${port}/products/iphone-6s-plus-replacement-battery-disabled`
       );
 
-      await expect(page.getByText('Not for Sale')).toBeVisible();
-      await expect(page.getByText('Description')).toBeVisible();
+      await expect(page.getByTestId('not-for-sale-alert')).toBeVisible();
+
+      const productInfoSection = page.getByTestId('product-info-section');
+      await expect(productInfoSection.getByText('Description')).toBeVisible();
       await expect(
-         page.getByRole('link', { name: 'One year warranty' })
+         productInfoSection.getByRole('link', { name: 'One year warranty' })
       ).toHaveAttribute('href', 'https://www.cominor.com/Info/Warranty');
 
       // Assert the following to be not visible
-      await expect(page.getByText('Add to Cart')).not.toBeVisible();
-      await expect(page.getByText(/Only \d left/i)).not.toBeVisible();
-      await expect(page.getByText('Notify me')).not.toBeVisible();
       await expect(
-         page.getByText('Shipping restrictions apply')
+         productInfoSection.getByTestId('product-add-to-cart-button')
       ).not.toBeVisible();
       await expect(
-         page.getByTestId('product-variants-selector')
+         productInfoSection.getByTestId('product-inventory-message')
       ).not.toBeVisible();
-      await expect(page.getByText(/Buy from our Store in/i)).not.toBeVisible();
-      await expect(page.getByText(/Buy from our US Store/i)).not.toBeVisible();
+      await expect(
+         productInfoSection.getByTestId('notify-me-form')
+      ).not.toBeVisible();
+      await expect(
+         productInfoSection.getByText('Shipping restrictions apply')
+      ).not.toBeVisible();
+      await expect(
+         productInfoSection.getByTestId('product-variants-selector')
+      ).not.toBeVisible();
+      await expect(
+         productInfoSection.getByTestId('international-buy-box')
+      ).not.toBeVisible();
 
       // Assert that we noindex disabled product pages
       const metaRobots = page.locator('meta[name="robots"]');

--- a/frontend/tests/playwright/product/fix_kit.spec.ts
+++ b/frontend/tests/playwright/product/fix_kit.spec.ts
@@ -6,7 +6,9 @@ test.describe('Fix Kit and Part Only test', () => {
    });
 
    test('Kit contents and product skus', async ({ page, productPage }) => {
-      await expect(await productPage.getActiveVariant()).toHaveText('Fix Kit');
+      await expect(await productPage.getActiveVariant()).toContainText(
+         'Fix Kit'
+      );
       await expect(page.getByText('Kit contents')).toBeVisible();
       await expect(page.getByText('Assembly contents')).not.toBeVisible();
 
@@ -22,7 +24,9 @@ test.describe('Fix Kit and Part Only test', () => {
    });
 
    test('Product image changes', async ({ page, productPage }) => {
-      await expect(await productPage.getActiveVariant()).toHaveText('Fix Kit');
+      await expect(await productPage.getActiveVariant()).toContainText(
+         'Fix Kit'
+      );
       await expect(page.getByRole('img', { name: 'Fix Kit' })).toBeVisible();
       await expect(
          page.getByRole('img', { name: 'Part Only' }).first()

--- a/frontend/tests/playwright/product/fix_kit.spec.ts
+++ b/frontend/tests/playwright/product/fix_kit.spec.ts
@@ -9,14 +9,23 @@ test.describe('Fix Kit and Part Only test', () => {
       await expect(await productPage.getActiveVariant()).toContainText(
          'Fix Kit'
       );
-      await expect(page.getByText('Kit contents')).toBeVisible();
-      await expect(page.getByText('Assembly contents')).not.toBeVisible();
+
+      const productInfoSection = page.getByTestId('product-info-section');
+
+      await expect(productInfoSection.getByText('Kit contents')).toBeVisible();
+      await expect(
+         productInfoSection.getByText('Assembly contents')
+      ).not.toBeVisible();
 
       const fixKitSku = await productPage.getSku();
 
       await productPage.switchSelectedVariant();
-      await expect(page.getByText('Assembly contents')).toBeVisible();
-      await expect(page.getByText('Kit contents')).not.toBeVisible();
+      await expect(
+         productInfoSection.getByText('Assembly contents')
+      ).toBeVisible();
+      await expect(
+         productInfoSection.getByText('Kit contents')
+      ).not.toBeVisible();
 
       const partOnlySku = await productPage.getSku();
 

--- a/frontend/tests/playwright/product/product_option.spec.ts
+++ b/frontend/tests/playwright/product/product_option.spec.ts
@@ -44,10 +44,10 @@ test.describe('Product option test', () => {
       await cartDrawer.assertItemIsPresent(secondOptionSku);
 
       // Assert that the cart drawer contains the prices of the added products
-      expect(await cartDrawer.getItem(firstOptionSku)).toHaveText(
+      expect(await cartDrawer.getItem(firstOptionSku)).toContainText(
          firstOptionPrice.toFixed(2)
       );
-      expect(await cartDrawer.getItem(secondOptionSku)).toHaveText(
+      expect(await cartDrawer.getItem(secondOptionSku)).toContainText(
          secondOptionPrice.toFixed(2)
       );
    });

--- a/frontend/tests/playwright/product/product_option.spec.ts
+++ b/frontend/tests/playwright/product/product_option.spec.ts
@@ -3,8 +3,9 @@ import { test, expect } from '../test-fixtures';
 test.describe('Product option test', () => {
    test('Different styles', async ({ page, productPage, cartDrawer }) => {
       await productPage.gotoProduct('repair-business-toolkit');
+      const productInfoSection = page.getByTestId('product-info-section');
 
-      await expect(page.getByText('Style')).toBeVisible();
+      await expect(productInfoSection.getByText('Style')).toBeVisible();
 
       // Get the price, sku, and name for the first product option
       const firstOptionPrice = await productPage.getCurrentPrice();

--- a/frontend/tests/playwright/product/product_page.spec.ts
+++ b/frontend/tests/playwright/product/product_page.spec.ts
@@ -9,18 +9,20 @@ test.describe('Product page test', () => {
 
       // Assert product title is visible
       await expect(page.getByTestId('product-title')).toBeVisible();
-      await expect(page.getByTestId('product-title')).toHaveText(
+      await expect(page.getByTestId('product-title')).toContainText(
          'Repair Business Toolkit'
       );
 
       // Assert product sku is visible
       await expect(page.getByTestId('product-sku')).toBeVisible();
       /* eslint-disable no-useless-escape */
-      await expect(page.getByTestId('product-sku')).toHaveText(/IF\d*\-\d*/g);
+      await expect(page.getByTestId('product-sku')).toContainText(
+         /IF\d*\-\d*/g
+      );
 
       // Get price from page
       await expect(page.getByTestId('current-price').first()).toBeVisible();
-      await expect(page.getByTestId('current-price').first()).toHaveText(
+      await expect(page.getByTestId('current-price').first()).toContainText(
          /\$\d*\.\d*/g
       );
    });

--- a/frontend/tests/playwright/product/product_reviews.spec.ts
+++ b/frontend/tests/playwright/product/product_reviews.spec.ts
@@ -11,7 +11,7 @@ test.describe('Product Page Reviews test', () => {
          .getByTestId('product-review-line-item')
          .count();
 
-      await page.getByText('see more reviews').click();
+      await page.getByRole('button', { name: /see more reviews/gi }).click();
 
       const reviewsAfter = page.getByTestId('product-review-line-item');
       const reviewsCountAfter = await reviewsAfter.count();


### PR DESCRIPTION
## Description

In https://github.com/iFixit/react-commerce/pull/1317 there was a small grammatical change that caused the tests to fail. https://github.com/iFixit/react-commerce/commit/4031350862efa7ef883f2a133e2af4ebbae51aa4

The main two reasons why this occurred are:
1. We use `toHaveText` instead of `toContainText`[^1] for asserting the text in an element. 
	- `toHaveText` will do an explicit match while `toContainText` will match if the string is included. Therefore, we should use the latter for validating that some text is within the element. For explicit assertions, we can still use `toContainText` but pass in a `RegExp` instead. 
2. We search for elements based on text content
	- By searching for elements based on text, we might end up nabbing a different element than expected if our text is too vague. On the other hand, if our text is too specific, then we risk our assertions failing if we add a minor change-- like a `period`.   

This pull tries to address these issues to make our tests more resilient to text changes.

### CR Notes:

In order to make our tests more resilient I made a few changes to our tests.

- I replaced all uses of `toHaveText` with `toContainText`
- I added `data-testid`s to certain components in order to replace some usages of `getByText`.
- To avoid adding multiple `data-testid`s I narrowed down the searching for an element by scoping it down from the `page` to a closer `parent` element. This allows us to ensure we do not reference a different element with similar text.

### QA Notes:

qa_req 0 CI continues to pass

Closes: #1326 

[^1]: https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-contain-text