### PR TITLE
Hero with background: add brandLogoWidth field

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -87,6 +87,14 @@
             }
          }
       },
+      "brandLogoWidth": {
+         "pluginOptions": {
+            "i18n": {
+               "localized": false
+            }
+         },
+         "type": "integer"
+      },
       "filters": {
          "pluginOptions": {
             "i18n": {

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -972,6 +972,7 @@ export type PaginationArg = {
 export type ProductList = {
    __typename?: 'ProductList';
    brandLogo?: Maybe<UploadFileEntityResponse>;
+   brandLogoWidth?: Maybe<Scalars['Int']>;
    children?: Maybe<ProductListRelationResponseCollection>;
    childrenHeading?: Maybe<Scalars['String']>;
    createdAt?: Maybe<Scalars['DateTime']>;
@@ -1033,6 +1034,7 @@ export type ProductListEntityResponseCollection = {
 
 export type ProductListFiltersInput = {
    and?: InputMaybe<Array<InputMaybe<ProductListFiltersInput>>>;
+   brandLogoWidth?: InputMaybe<IntFilterInput>;
    children?: InputMaybe<ProductListFiltersInput>;
    childrenHeading?: InputMaybe<StringFilterInput>;
    createdAt?: InputMaybe<DateTimeFilterInput>;
@@ -1063,6 +1065,7 @@ export type ProductListFiltersInput = {
 
 export type ProductListInput = {
    brandLogo?: InputMaybe<Scalars['ID']>;
+   brandLogoWidth?: InputMaybe<Scalars['Int']>;
    children?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
    childrenHeading?: InputMaybe<Scalars['String']>;
    defaultShowAllChildrenOnLgSizes?: InputMaybe<Scalars['Boolean']>;


### PR DESCRIPTION
connects #1170 

This PR is an addition to #1352: an additional `brandLogoWidth` image has been added to simplify the sizing of logos with different aspect ratios

<img width="851" alt="Screenshot" src="https://user-images.githubusercontent.com/7805759/219323815-39ee0d32-4048-4dfc-9468-156962846e49.png">


❗ ❗ ❗ After this PR is merged Strapi should be redeployed in production ❗ ❗ ❗
cc @sterlinghirsh @danielbeardsley 

## QA

1. Login into [Strapi](https://implement-hero-with-background-backend-changes.govinor.com/admin/)
2. Check that the productList model includes the new optional brandLogoWidth field
3. Visit [Vercel preview](https://react-commerce-git-implement-hero-with-background-94d831-ifixit.vercel.app/Parts)
4. Verify that everything renders correctly