### PR TITLE
@ifixit/breadcrumbs: Require types as dev dependency

### DIFF
--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -25,6 +25,7 @@
       "@emotion/styled": "11.10.5",
       "@fortawesome/pro-solid-svg-icons": "6.2.1",
       "@ifixit/tsconfig": "workspace:*",
+      "@types/lodash": "4.14.182",
       "@types/react-dom": "18.0.8",
       "@types/react": "18.0.24",
       "framer-motion": "6.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,7 @@ importers:
       '@fortawesome/pro-solid-svg-icons': 6.2.1
       '@ifixit/icons': workspace:*
       '@ifixit/tsconfig': workspace:*
+      '@types/lodash': 4.14.182
       '@types/react': 18.0.24
       '@types/react-dom': 18.0.8
       framer-motion: 6.2.7
@@ -312,6 +313,7 @@ importers:
       '@emotion/styled': 11.10.5_yiq25o4tea4ifunxnd2gloaxcy
       '@fortawesome/pro-solid-svg-icons': 6.2.1
       '@ifixit/tsconfig': link:../tsconfig
+      '@types/lodash': 4.14.182
       '@types/react': 18.0.24
       '@types/react-dom': 18.0.8
       framer-motion: 6.2.7_biqbaboplfbrettd7655fr4n2y


### PR DESCRIPTION
This adds the lodash types as a dev dependency to `@ifixit/breadcrumbs`

qa_req 0
This is dev-only.