### PR TITLE
Hot Fix: Make Runners Explicitly use Node Version 16

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,6 +13,12 @@ jobs:
            uses: actions/checkout@v2
            with:
               token: ${{ secrets.ACTION_PAT }}
+
+         - name: Install Node.js
+           uses: actions/setup-node@v3
+           with:
+              node-version: 16
+
          - name: Setup and cache pnpm
            uses: ./.github/actions/pnpm-setup
          - name: Install workspaces

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -8,9 +8,11 @@ jobs:
       steps:
          - name: Checkout
            uses: actions/checkout@v2
+
          - uses: actions/setup-node@v3
            with:
               node-version: 16
+
          - name: Setup and cache pnpm
            uses: ./.github/actions/pnpm-setup
          - name: Install workspaces

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,12 @@ jobs:
            uses: actions/checkout@v2
            with:
               token: ${{ secrets.ACTION_PAT }}
+
+         - name: Install Node.js
+           uses: actions/setup-node@v3
+           with:
+              node-version: 16
+
          - name: Setup and cache pnpm
            uses: ./.github/actions/pnpm-setup
          - name: Install workspaces

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,12 @@ jobs:
       steps:
          - name: Checkout
            uses: actions/checkout@v3
+
+         - name: Install Node.js
+           uses: actions/setup-node@v3
+           with:
+              node-version: 16
+
          - name: Start strapi server
            run: cd backend && docker-compose up -d
            env:

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -19,6 +19,11 @@ jobs:
          - name: Checkout
            uses: actions/checkout@v2
 
+         - name: Install Node.js
+           uses: actions/setup-node@v3
+           with:
+              node-version: 16
+
          - name: Setup and cache pnpm
            uses: ./.github/actions/pnpm-setup
 

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -8,6 +8,12 @@ jobs:
       steps:
          - name: Checkout
            uses: actions/checkout@v2
+
+         - name: Install Node.js
+           uses: actions/setup-node@v3
+           with:
+              node-version: 16
+
          - name: Setup and cache pnpm
            uses: ./.github/actions/pnpm-setup
          - name: Install workspaces


### PR DESCRIPTION
## Description

The default node version for the runners was changed to 18, which is not compatible with our current setup. Unfortunately, this change was only tracked as an issue and was not announced on GitHub's blog (https://github.blog/changelog/label/actions/), which is why we did not notice it. 

In order to fix this, we need to explicitly set the node version to 16 for all our workflows that use node/pnpm.

## QA Notes:

qa_req 0 CI should pass

References:
https://github.com/actions/runner-images/issues/7002
https://ifixit.slack.com/archives/C02SMF0AZPF/p1676677777249139