### PR TITLE
Correct cross sell test

### DIFF
--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -46,7 +46,7 @@ test.describe('Cross-sell test', () => {
       await page.getByTestId('cross-sell-add-to-cart-button').click();
 
       const cartDrawerText = await page
-         .getByTestId('cart-drawer-body')
+         .getByTestId('cart-drawer-line-items')
          .textContent();
 
       otherProductTitles.forEach((otherProductTitle) => {
@@ -80,7 +80,7 @@ test.describe('Cross-sell test', () => {
       await page.getByTestId('cross-sell-add-to-cart-button').click();
 
       const cartDrawerText = await page
-         .getByTestId('cart-drawer-body')
+         .getByTestId('cart-drawer-line-items')
          .textContent();
 
       allProductTitles.forEach((productTitle) => {

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -141,7 +141,7 @@ export function CartDrawer() {
                      <ScaleFade
                         in={cart.data != null && cart.data.hasItemsInCart}
                      >
-                        <Box as="ul">
+                        <Box as="ul" data-testid="cart-drawer-line-items">
                            <AnimatePresence>
                               {cart.data?.lineItems.map((lineItem) => {
                                  return (
@@ -152,8 +152,8 @@ export function CartDrawer() {
                                  );
                               })}
                            </AnimatePresence>
-                           {upsellItem && <Upsell item={upsellItem} />}
                         </Box>
+                        {upsellItem && <Upsell item={upsellItem} />}
                      </ScaleFade>
                      <Collapse
                         animateOpacity


### PR DESCRIPTION
closes #1384 

This PR introduces a new `data-testid` that targets the line items container.
The upsell component was also moved outside the line-items `ul`.

### QA

1. Visit Vercel preview
2. Verify that there is no visual changes to the upsell banner inside the cart drawer
3. Verify that the cross sell tests are now running correctly