### PR TITLE
Playwright: Ignore Upsell Product for Cross Sell Test

### DIFF
--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -30,9 +30,11 @@ test.describe('Cross-sell test', () => {
          }
 
          // Deselect other cross-sell products
-         otherProductTitles.push(
-            await product.getByTestId('cross-sell-item-title').textContent()
-         );
+         const productTitle = await product
+            .getByTestId('cross-sell-item-title')
+            .textContent();
+         expect(productTitle).not.toBeNull();
+         otherProductTitles.push(productTitle!);
          await product.getByTestId('cross-sell-item-select').click();
       }
 
@@ -52,7 +54,8 @@ test.describe('Cross-sell test', () => {
       otherProductTitles.forEach((otherProductTitle) => {
          expect(cartDrawerItems).not.toContainText(otherProductTitle);
       });
-      expect(cartDrawerItems).toContainText(currentProductTitle);
+      expect(currentProductTitle).not.toBeNull();
+      expect(cartDrawerItems).toContainText(currentProductTitle!);
    });
 
    test('Cross-sell products can be added to cart', async ({ page }) => {
@@ -84,7 +87,7 @@ test.describe('Cross-sell test', () => {
          .locator('li');
 
       allProductTitles.forEach((productTitle) => {
-         expect(cartDrawerItems).toContainText(productTitle);
+         expect(cartDrawerItems).toContainText(productTitle!);
       });
    });
 });

--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -8,7 +8,7 @@ test.describe('Cross-sell test', () => {
    test('Current item from cross-sell can be added to cart', async ({
       page,
    }) => {
-      const products = await page.getByTestId('cross-sell-item');
+      const products = page.getByTestId('cross-sell-item');
 
       let currentProductTitle = null;
       let currentProductPrice = null;
@@ -22,7 +22,7 @@ test.describe('Cross-sell test', () => {
             currentProductPrice = await product
                .getByTestId('current-price')
                .textContent();
-            await expect(currentProductPrice).toMatch(/^\$[0-9]+(\.[0-9]{2})/);
+            expect(currentProductPrice).toMatch(/^\$[0-9]+(\.[0-9]{2})/);
             currentProductTitle = await product
                .getByTestId('cross-sell-item-title')
                .textContent();
@@ -47,7 +47,7 @@ test.describe('Cross-sell test', () => {
       // Assert adding to cart only adds current product
       await page.getByTestId('cross-sell-add-to-cart-button').click();
 
-      const cartDrawerItems = await page
+      const cartDrawerItems = page
          .getByTestId('cart-drawer-body')
          .locator('li');
 
@@ -59,7 +59,7 @@ test.describe('Cross-sell test', () => {
    });
 
    test('Cross-sell products can be added to cart', async ({ page }) => {
-      const products = await page.getByTestId('cross-sell-item');
+      const products = page.getByTestId('cross-sell-item');
 
       const allProductTitles = [];
       let expectedTotalPrice = 0;

--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -15,7 +15,7 @@ test.describe('Cross-sell test', () => {
       const otherProductTitles = [];
 
       for (const product of await products.all()) {
-         await product.scrollIntoViewIfNeeded()
+         await product.scrollIntoViewIfNeeded();
 
          const isCurrent = await product
             .locator('span', { hasText: 'Current item' })
@@ -67,7 +67,7 @@ test.describe('Cross-sell test', () => {
       let expectedTotalPrice = 0;
 
       for (const product of await products.all()) {
-         await product.scrollIntoViewIfNeeded()
+         await product.scrollIntoViewIfNeeded();
 
          allProductTitles.push(
             await product.getByTestId('cross-sell-item-title').textContent()

--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -15,6 +15,8 @@ test.describe('Cross-sell test', () => {
       const otherProductTitles = [];
 
       for (const product of await products.all()) {
+         await product.scrollIntoViewIfNeeded()
+
          const isCurrent = await product
             .locator('span', { hasText: 'Current item' })
             .isVisible();
@@ -65,6 +67,8 @@ test.describe('Cross-sell test', () => {
       let expectedTotalPrice = 0;
 
       for (const product of await products.all()) {
+         await product.scrollIntoViewIfNeeded()
+
          allProductTitles.push(
             await product.getByTestId('cross-sell-item-title').textContent()
          );

--- a/frontend/tests/playwright/product/cross_sell.spec.ts
+++ b/frontend/tests/playwright/product/cross_sell.spec.ts
@@ -45,14 +45,14 @@ test.describe('Cross-sell test', () => {
       // Assert adding to cart only adds current product
       await page.getByTestId('cross-sell-add-to-cart-button').click();
 
-      const cartDrawerText = await page
+      const cartDrawerItems = await page
          .getByTestId('cart-drawer-body')
-         .textContent();
+         .locator('li');
 
       otherProductTitles.forEach((otherProductTitle) => {
-         expect(cartDrawerText).not.toContain(otherProductTitle);
+         expect(cartDrawerItems).not.toContainText(otherProductTitle);
       });
-      expect(cartDrawerText).toContain(currentProductTitle);
+      expect(cartDrawerItems).toContainText(currentProductTitle);
    });
 
    test('Cross-sell products can be added to cart', async ({ page }) => {
@@ -79,12 +79,12 @@ test.describe('Cross-sell test', () => {
       // Assert adding to cart adds all products
       await page.getByTestId('cross-sell-add-to-cart-button').click();
 
-      const cartDrawerText = await page
+      const cartDrawerItems = await page
          .getByTestId('cart-drawer-body')
-         .textContent();
+         .locator('li');
 
       allProductTitles.forEach((productTitle) => {
-         expect(cartDrawerText).toContain(productTitle);
+         expect(cartDrawerItems).toContainText(productTitle);
       });
    });
 });


### PR DESCRIPTION
## Description

We were grabbing the text of the entire cart drawer body which includes the text of the upsell product component. This became a problem when the upsell product was one of the products of the cross-sells. As such, when we were validating that the cross-sell product title was not in the cart drawer body we would find it as part of the upsell product and fail the test.

By narrowing down the selector to only grab the `li` elements we will avoid grabbing the text of the upsell product component. In doing so, we need to update the `cartDrawerText` variable name to `cartDrawerItems` to better reflect what it is. Furthermore, we need to update the assertion to  `toContainText` instead of `toContain` as the latter only works with a single string and the former can work with an array of strings.

### QA

qa_req 0
- [ ] CI should now pass

**cc:** @mlahargou 

Connects: #1386 