### PR TITLE
Refactor Responsive image loader RegExp

### DIFF
--- a/packages/ui/misc/ResponsiveImage/iFixitUtils.ts
+++ b/packages/ui/misc/ResponsiveImage/iFixitUtils.ts
@@ -30,22 +30,25 @@ export const cartImageSizeMap: SizeMap = [
    { name: 'large', width: 3000 },
 ];
 
+const guideImageRegExp = new RegExp(
+   /^https:\/\/(guide-images\.cdn\.ifixit\.com|([^\/]+\.(ubreakit|cominor)\.com\/igi))\//
+);
 export function isGuideImage(src: string) {
-   return src.match(
-      /^https:\/\/(guide-images\.cdn\.ifixit\.com|([^/]+\.(ubreakit|cominor)\.com\/igi))\//
-   );
+   return guideImageRegExp.test(src);
 }
 
+const cartImageRegExp = new RegExp(
+   /^https:\/\/(cart-products\.cdn\.ifixit\.com|([^\/]+\.(ubreakit|cominor)\.com\/cart-products))\//
+);
 export function isCartImage(src: string) {
-   return src.match(
-      /^https:\/\/(cart-products\.cdn\.ifixit\.com|([^/]+\.(ubreakit|cominor)\.com\/cart-products))\//
-   );
+   return cartImageRegExp.test(src);
 }
 
+const strapiImageRegExp = new RegExp(
+   /^https:\/\/ifixit-(dev-)?strapi-uploads\.s3\.amazonaws\.com\/|^\/uploads\//
+);
 export function isStrapiImage(src: string) {
-   return src.match(
-      /^https:\/\/ifixit-(dev-)?strapi-uploads.s3.amazonaws.com\//
-   );
+   return strapiImageRegExp.test(src);
 }
 
 export function getIFixitImageLoader(

--- a/packages/ui/misc/ResponsiveImage/index.tsx
+++ b/packages/ui/misc/ResponsiveImage/index.tsx
@@ -1,4 +1,4 @@
-import Image, { ImageProps } from 'next/image';
+import Image, { ImageLoader, ImageProps } from 'next/image';
 import {
    cartImageSizeMap,
    getIFixitImageLoader,
@@ -11,22 +11,23 @@ import { getShopifyImageLoader, isShopifyImage } from './shopifyUtils';
 
 export function ResponsiveImage(props: ImageProps) {
    const alt = props.alt ?? '';
-   let loader = props.loader;
-   let unoptimized = props.unoptimized;
+
+   let loader: ImageLoader | undefined;
+   let unoptimized: boolean | undefined;
 
    if (typeof props.src === 'string') {
-      if (isGuideImage(props.src)) {
-         loader = getIFixitImageLoader(guideImageSizeMap, 'huge', props.width);
+      if (isShopifyImage(props.src)) {
+         loader = getShopifyImageLoader();
       } else if (isCartImage(props.src)) {
          loader = getIFixitImageLoader(cartImageSizeMap, 'large', props.width);
+      } else if (isGuideImage(props.src)) {
+         loader = getIFixitImageLoader(guideImageSizeMap, 'huge', props.width);
       } else if (isStrapiImage(props.src)) {
          unoptimized = true;
-      } else if (isShopifyImage(props.src)) {
-         loader = getShopifyImageLoader();
       }
    }
 
    return (
-      <Image alt={alt} unoptimized={unoptimized} loader={loader} {...props} />
+      <Image alt={alt} loader={loader} unoptimized={unoptimized} {...props} />
    );
 }

--- a/packages/ui/misc/ResponsiveImage/shopifyUtils.ts
+++ b/packages/ui/misc/ResponsiveImage/shopifyUtils.ts
@@ -1,23 +1,12 @@
 import { ImageLoaderProps } from 'next/image';
 
-const CDN_HOSTNAMES = [
-   'cdn.shopify.com',
-   'cdn.shopifycdn.net',
-   'shopify-assets.shopifycdn.com',
-   'shopify-assets.shopifycdn.net',
-];
-
 const BASE_IMAGE_SIZE = 352;
 
+const shopifyImageRegExp = new RegExp(
+   /cdn\.shopify\.com|cdn\.shopifycdn\.net|shopify-assets\.shopifycdn\.com|shopify-assets\.shopifycdn\.net/
+);
 export function isShopifyImage(src: string) {
-   try {
-      const url = new URL(src);
-      return CDN_HOSTNAMES.some((allowedHostname) =>
-         url.hostname.endsWith(allowedHostname)
-      );
-   } catch (e) {
-      return false;
-   }
+   return shopifyImageRegExp.test(src);
 }
 
 export function getShopifyImageLoader() {


### PR DESCRIPTION
closes #1365 

Fixed a couple of missing escape in RegExp.
RegExp have been moved outside of functions to avoid recreating them on each function iteration.
Added `^\/uploads\/` to the Strapi image RegExp to handle correctly the relative urls associated to images uploaded during development

### QA

1. Visit [Vercel preview](https://react-commerce-git-refactor-responsive-image-load-71418b-ifixit.vercel.app/Parts)
2. Images should load correctly as before - no visual change should be present.