### PR TITLE
Vulcan: Add `canonical` tag

### DIFF
--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -14,6 +14,7 @@ export type TroubleshootingData = {
    conclusion: Section[];
    editUrl: string;
    historyUrl: string;
+   canonicalUrl: string;
 };
 
 type TroubleshootingPageProps = {

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -40,6 +40,7 @@ const Wiki: NextPageWithLayout<{
          >
             <Head>
                <meta name="robots" content="noindex" />
+               <link rel="canonical" href={wikiData.canonicalUrl} />
             </Head>
             <Heading as="h1">{wikiData.title}</Heading>
             {wikiData.introduction.map((intro) => (

--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -12,4 +12,13 @@ test.describe('Vulcan page', () => {
       const meta = page.locator('meta[name="robots"]');
       await expect(meta).toHaveAttribute('content', 'noindex');
    });
+
+   test('it should include the canonical link', async ({ page }) => {
+      await page.goto('/Vulcan/Dryer_Not_Spinning');
+      // check that the canonical link is a resonable URL
+      const canonical = page.locator('link[rel="canonical"]');
+      await expect(canonical).toHaveAttribute('href', /Dryer.*Not.*Spinning/);
+      // Check that the canonical link is an absolute URL
+      await expect(canonical).toHaveAttribute('href', /^http/);
+   });
 });


### PR DESCRIPTION
This adds a `link` tag with the canonical URL for each Vulcan page.

## QA Notes
There's a test that should be validating the main point here.

qa_req 0

Closes iFixit/ifixit#46644