### PR TITLE
Add split with image section

### DIFF
--- a/backend/src/api/page/content-types/page/schema.json
+++ b/backend/src/api/page/content-types/page/schema.json
@@ -42,7 +42,12 @@
             }
          },
          "type": "dynamiczone",
-         "components": ["page.hero", "page.browse", "page.stats"],
+         "components": [
+            "page.hero",
+            "page.browse",
+            "page.stats",
+            "page.split-with-image"
+         ],
          "required": true
       }
    }

--- a/backend/src/components/page/split-with-image.json
+++ b/backend/src/components/page/split-with-image.json
@@ -1,0 +1,32 @@
+{
+   "collectionName": "components_page_split_with_images",
+   "info": {
+      "displayName": "Split with Image",
+      "description": ""
+   },
+   "options": {},
+   "attributes": {
+      "title": {
+         "type": "string"
+      },
+      "description": {
+         "type": "richtext"
+      },
+      "callToAction": {
+         "type": "component",
+         "repeatable": false,
+         "component": "page.call-to-action"
+      },
+      "imagePosition": {
+         "type": "enumeration",
+         "enum": ["Left", "Right"],
+         "default": "Right"
+      },
+      "image": {
+         "type": "media",
+         "multiple": false,
+         "required": false,
+         "allowedTypes": ["images"]
+      }
+   }
+}

--- a/frontend/components/sections/SplitWithImageSection.tsx
+++ b/frontend/components/sections/SplitWithImageSection.tsx
@@ -1,0 +1,72 @@
+import { Box, Button, Flex, VStack } from '@chakra-ui/react';
+import { ResponsiveImage, Wrapper } from '@ifixit/ui';
+import type { SplitWithImageSection } from '@models/shared/sections/split-with-image-section';
+import NextLink from 'next/link';
+import { SectionDescription } from './SectionDescription';
+import { SectionHeading } from './SectionHeading';
+
+export interface SplitWithImageContentSectionProps {
+   data: SplitWithImageSection;
+}
+
+export function SplitWithImageContentSection({
+   data: { title, description, image, imagePosition, callToAction },
+}: SplitWithImageContentSectionProps) {
+   const isImageLeft = imagePosition === 'left';
+   return (
+      <Box as="section" position="relative" w="full">
+         {image && (
+            <Box
+               w={{
+                  base: 'full',
+                  md: '50%',
+               }}
+               position={{
+                  base: 'relative',
+                  md: 'absolute',
+               }}
+               h={{
+                  base: '340px',
+                  md: 'full',
+               }}
+               right={isImageLeft ? undefined : '0'}
+            >
+               <ResponsiveImage
+                  src={image.url}
+                  alt={image.altText ?? ''}
+                  objectFit="cover"
+                  layout="fill"
+               />
+            </Box>
+         )}
+         <Wrapper>
+            <Flex justify={isImageLeft ? 'flex-end' : 'flex-start'}>
+               <VStack
+                  align="flex-start"
+                  py={{
+                     base: '10',
+                     md: '36',
+                  }}
+                  spacing="7"
+                  w={{
+                     base: 'full',
+                     md: '50%',
+                  }}
+                  pl={{ base: 0, md: isImageLeft ? '32' : undefined }}
+                  pr={{ base: 0, md: isImageLeft ? undefined : '32' }}
+               >
+                  {title && <SectionHeading>{title}</SectionHeading>}
+                  {description && <SectionDescription richText={description} />}
+                  {callToAction && (
+                     <NextLink href={callToAction.url} passHref>
+                        <Button as="a" colorScheme="brand">
+                           {callToAction.title}
+                        </Button>
+                     </NextLink>
+                  )}
+               </VStack>
+            </Flex>
+         </Wrapper>
+      </Box>
+   );
+}

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -144,6 +144,16 @@ export type ComponentPageHero = {
    title?: Maybe<Scalars['String']>;
 };
 
+export type ComponentPageSplitWithImage = {
+   __typename?: 'ComponentPageSplitWithImage';
+   callToAction?: Maybe<ComponentPageCallToAction>;
+   description?: Maybe<Scalars['String']>;
+   id: Scalars['ID'];
+   image?: Maybe<UploadFileEntityResponse>;
+   imagePosition?: Maybe<Enum_Componentpagesplitwithimage_Imageposition>;
+   title?: Maybe<Scalars['String']>;
+};
+
 export type ComponentPageStatItem = {
    __typename?: 'ComponentPageStatItem';
    id: Scalars['ID'];
@@ -340,6 +350,11 @@ export type DateTimeFilterInput = {
    startsWith?: InputMaybe<Scalars['DateTime']>;
 };
 
+export enum Enum_Componentpagesplitwithimage_Imageposition {
+   Left = 'Left',
+   Right = 'Right',
+}
+
 export enum Enum_Productlist_Type {
    AllParts = 'all_parts',
    AllTools = 'all_tools',
@@ -402,6 +417,7 @@ export type GenericMorph =
    | ComponentPageCallToAction
    | ComponentPageCategory
    | ComponentPageHero
+   | ComponentPageSplitWithImage
    | ComponentPageStatItem
    | ComponentPageStats
    | ComponentProductListBanner
@@ -951,6 +967,7 @@ export type PageRelationResponseCollection = {
 export type PageSectionsDynamicZone =
    | ComponentPageBrowse
    | ComponentPageHero
+   | ComponentPageSplitWithImage
    | ComponentPageStats
    | Error;
 
@@ -1800,6 +1817,30 @@ export type FindPageQuery = {
                     id: string;
                     title?: string | null;
                     description?: string | null;
+                    callToAction?: {
+                       __typename?: 'ComponentPageCallToAction';
+                       title: string;
+                       url: string;
+                    } | null;
+                    image?: {
+                       __typename?: 'UploadFileEntityResponse';
+                       data?: {
+                          __typename?: 'UploadFileEntity';
+                          attributes?: {
+                             __typename?: 'UploadFile';
+                             alternativeText?: string | null;
+                             url: string;
+                             formats?: any | null;
+                          } | null;
+                       } | null;
+                    } | null;
+                 }
+               | {
+                    __typename: 'ComponentPageSplitWithImage';
+                    id: string;
+                    title?: string | null;
+                    description?: string | null;
+                    imagePosition?: Enum_Componentpagesplitwithimage_Imageposition | null;
                     callToAction?: {
                        __typename?: 'ComponentPageCallToAction';
                        title: string;
@@ -3151,6 +3192,18 @@ export const FindPageDocument = `
               id
               label
               value
+            }
+          }
+          ... on ComponentPageSplitWithImage {
+            id
+            title
+            description
+            callToAction {
+              ...CallToActionFields
+            }
+            imagePosition
+            image {
+              ...ImageFields
             }
           }
         }

--- a/frontend/lib/strapi-sdk/operations/findPage.graphql
+++ b/frontend/lib/strapi-sdk/operations/findPage.graphql
@@ -44,6 +44,18 @@ query findPage(
                      value
                   }
                }
+               ... on ComponentPageSplitWithImage {
+                  id
+                  title
+                  description
+                  callToAction {
+                     ...CallToActionFields
+                  }
+                  imagePosition
+                  image {
+                     ...ImageFields
+                  }
+               }
             }
          }
       }

--- a/frontend/models/page/index.ts
+++ b/frontend/models/page/index.ts
@@ -1,4 +1,5 @@
 import { IFixitStatsSectionSchema } from '@models/shared/sections/ifixit-stats-section';
+import { SplitWithImageSectionSchema } from '@models/shared/sections/split-with-image-section';
 import { z } from 'zod';
 import { BrowseSectionSchema } from './sections/browse-section';
 import { HeroSectionSchema } from './sections/hero-section';
@@ -9,6 +10,7 @@ export const PageSectionSchema = z.union([
    HeroSectionSchema,
    BrowseSectionSchema,
    IFixitStatsSectionSchema,
+   SplitWithImageSectionSchema,
 ]);
 
 export type Page = z.infer<typeof PageSchema>;

--- a/frontend/models/page/server.ts
+++ b/frontend/models/page/server.ts
@@ -5,8 +5,9 @@ import {
 import { assertNever } from '@ifixit/helpers';
 import { CategoryFieldsFragment, strapi } from '@lib/strapi-sdk';
 import { imageFromStrapi } from '@models/shared/components/image';
-import type { Page, PageSection } from '.';
+import { imagePositionFromStrapi } from '@models/shared/sections/split-with-image-section';
 import { getProductListType } from '../product-list/server';
+import type { Page, PageSection } from '.';
 import type { BrowseCategory } from './sections/browse-section';
 
 interface FindPageArgs {
@@ -65,6 +66,18 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
                   type: 'IFixitStats',
                   id: `${section.__typename}-${index}`,
                   stats,
+               };
+            }
+            case 'ComponentPageSplitWithImage': {
+               return {
+                  type: 'SplitWithImage',
+                  id: `${section.__typename}-${index}`,
+                  title: section.title ?? null,
+                  description: section.description ?? null,
+                  image: imageFromStrapi(section.image),
+                  imagePosition:
+                     imagePositionFromStrapi(section.imagePosition) ?? 'right',
+                  callToAction: section.callToAction ?? null,
                };
             }
             case 'Error': {

--- a/frontend/models/shared/sections/split-with-image-section.ts
+++ b/frontend/models/shared/sections/split-with-image-section.ts
@@ -1,0 +1,32 @@
+import { assertNever } from '@ifixit/helpers';
+import { Enum_Componentpagesplitwithimage_Imageposition } from '@lib/strapi-sdk';
+import { z } from 'zod';
+import { CallToActionSchema } from '../components/call-to-action';
+import { ImageSchema } from '../components/image';
+
+export type SplitWithImageSection = z.infer<typeof SplitWithImageSectionSchema>;
+
+export const SplitWithImageSectionSchema = z.object({
+   type: z.literal('SplitWithImage'),
+   id: z.string(),
+   title: z.string().nullable(),
+   description: z.string().nullable(),
+   image: ImageSchema.nullable(),
+   imagePosition: z.enum(['left', 'right']),
+   callToAction: CallToActionSchema.nullable(),
+});
+
+export function imagePositionFromStrapi(
+   position: Enum_Componentpagesplitwithimage_Imageposition | null | undefined
+): SplitWithImageSection['imagePosition'] | null {
+   if (position == null) return null;
+
+   switch (position) {
+      case Enum_Componentpagesplitwithimage_Imageposition.Left:
+         return 'left';
+      case Enum_Componentpagesplitwithimage_Imageposition.Right:
+         return 'right';
+      default:
+         return assertNever(position);
+   }
+}

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import { IFixitStatsSection } from '@components/sections/IFixitStatsSection';
+import { SplitWithImageContentSection } from '@components/sections/SplitWithImageSection';
 import { assertNever } from '@ifixit/helpers';
 import { DefaultLayout } from '@layouts/default';
 import {
@@ -23,6 +24,14 @@ const PageTemplate: NextPageWithLayout<PageTemplateProps> = () => {
                }
                case 'IFixitStats': {
                   return <IFixitStatsSection key={section.id} data={section} />;
+               }
+               case 'SplitWithImage': {
+                  return (
+                     <SplitWithImageContentSection
+                        key={section.id}
+                        data={section}
+                     />
+                  );
                }
                default:
                   return assertNever(section);


### PR DESCRIPTION
closes #1383 

## QA

1. Visit preview [store home page](https://react-commerce-git-add-split-with-image-section-ifixit.vercel.app/store)
2. Verify that the split with image section is visible and implemented according to [mockup](https://www.figma.com/file/jRG4EyQXRDMGfyLqut08KP/iFixit---Working-files?node-id=6315%3A69164&t=eCepNFgQfxNde2XK-4)

    ![Screenshot 2023-02-22 at 11 04 46](https://user-images.githubusercontent.com/4640135/220587913-3e5d5a41-d5cc-4a2d-9b60-b61cfa50607f.png)


3. Verify that the split with image section is responsive

---

❗ ❗ ❗ This PR requires a Strapi redeploy ❗ ❗ ❗ 

I didn't split backend and frontend changes into separate PRs because this stuff is still behind a feature flag

cc @sterlinghirsh @danielbeardsley 