### PR TITLE
Correct zoom container size

### DIFF
--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -95,8 +95,8 @@ export function ProductSection({
                   top="0"
                   w={{
                      md: '320px',
-                     lg: 'calc(400px + 16px + ((100vw - 960px) / 2 - 24px))',
-                     xl: 'calc(400px + 16px + ((100vw - 1100px) / 2 - 24px))',
+                     lg: 'calc(16px + 400px + 32px - 24px)',
+                     xl: 'calc(16px + 400px + 32px + (100vw - 1280px) / 2 - 24px)',
                   }}
                   left="calc(100% + 24px)"
                   boxShadow="md"

--- a/frontend/templates/product/sections/ProductSection/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/index.tsx
@@ -93,6 +93,7 @@ export function ProductSection({
                   id="zoom-container"
                   position="absolute"
                   top="0"
+                  // Calculation description: https://github.com/iFixit/react-commerce/pull/1398#issuecomment-1440432678
                   w={{
                      md: '320px',
                      lg: 'calc(16px + 400px + 32px - 24px)',

--- a/packages/ui/theme/foundations/breakpoints.ts
+++ b/packages/ui/theme/foundations/breakpoints.ts
@@ -3,9 +3,9 @@ import primitives from '@core-ds/primitives';
 
 export const breakpoints: ThemeOverride['breakpoints'] = {
    base: '0px',
-   sm: primitives.breakpoint.sm, // 576px
-   md: primitives.breakpoint.md, // 768px
-   lg: primitives.breakpoint.lg, // 1000px
-   xl: primitives.breakpoint.xl, // 1200px
-   '2xl': '1536px',
+   sm: primitives.breakpoint.sm,
+   md: primitives.breakpoint.md,
+   lg: primitives.breakpoint.lg,
+   xl: primitives.breakpoint.xl,
+   '2xl': primitives.breakpoint['2xl'],
 };


### PR DESCRIPTION
close #1397 

### QA

1. Visit [Vercel preview](https://react-commerce-git-fix-zoom-wrapper-regression-ifixit.vercel.app/products/iphone-7-plus-screen)
2. Verify that the zoom container is now sized correctly and is not overflowing anymore outside of the viewport