### PR TITLE
Add page template press section

### DIFF
--- a/backend/src/api/company/content-types/company/schema.json
+++ b/backend/src/api/company/content-types/company/schema.json
@@ -1,0 +1,24 @@
+{
+   "kind": "collectionType",
+   "collectionName": "companies",
+   "info": {
+      "singularName": "company",
+      "pluralName": "companies",
+      "displayName": "Company"
+   },
+   "options": {
+      "draftAndPublish": true
+   },
+   "pluginOptions": {},
+   "attributes": {
+      "name": {
+         "type": "string",
+         "required": true
+      },
+      "logo": {
+         "allowedTypes": ["images"],
+         "type": "media",
+         "multiple": false
+      }
+   }
+}

--- a/backend/src/api/company/controllers/company.ts
+++ b/backend/src/api/company/controllers/company.ts
@@ -1,0 +1,7 @@
+/**
+ * company controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::company.company');

--- a/backend/src/api/company/routes/company.ts
+++ b/backend/src/api/company/routes/company.ts
@@ -1,0 +1,7 @@
+/**
+ * company router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::company.company');

--- a/backend/src/api/company/services/company.ts
+++ b/backend/src/api/company/services/company.ts
@@ -1,0 +1,7 @@
+/**
+ * company service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::company.company');

--- a/backend/src/api/page/content-types/page/schema.json
+++ b/backend/src/api/page/content-types/page/schema.json
@@ -46,7 +46,8 @@
             "page.hero",
             "page.browse",
             "page.stats",
-            "page.split-with-image"
+            "page.split-with-image",
+            "page.press"
          ],
          "required": true
       }

--- a/backend/src/components/page/press-quote.json
+++ b/backend/src/components/page/press-quote.json
@@ -1,0 +1,18 @@
+{
+   "collectionName": "components_page_press_quotes",
+   "info": {
+      "displayName": "Press Quote"
+   },
+   "options": {},
+   "attributes": {
+      "company": {
+         "type": "relation",
+         "relation": "oneToOne",
+         "target": "api::company.company"
+      },
+      "text": {
+         "type": "richtext",
+         "required": true
+      }
+   }
+}

--- a/backend/src/components/page/press.json
+++ b/backend/src/components/page/press.json
@@ -1,0 +1,25 @@
+{
+   "collectionName": "components_page_presses",
+   "info": {
+      "displayName": "press"
+   },
+   "options": {},
+   "attributes": {
+      "title": {
+         "type": "string"
+      },
+      "description": {
+         "type": "richtext"
+      },
+      "quotes": {
+         "type": "component",
+         "repeatable": true,
+         "component": "page.press-quote"
+      },
+      "callToAction": {
+         "type": "component",
+         "repeatable": false,
+         "component": "page.call-to-action"
+      }
+   }
+}

--- a/backend/src/components/page/press.json
+++ b/backend/src/components/page/press.json
@@ -1,7 +1,7 @@
 {
    "collectionName": "components_page_presses",
    "info": {
-      "displayName": "press"
+      "displayName": "press quotes"
    },
    "options": {},
    "attributes": {

--- a/backend/src/components/page/split-with-image.json
+++ b/backend/src/components/page/split-with-image.json
@@ -1,7 +1,7 @@
 {
    "collectionName": "components_page_split_with_images",
    "info": {
-      "displayName": "Split with Image",
+      "displayName": "split with image",
       "description": ""
    },
    "options": {},

--- a/frontend/components/sections/SectionDescription.tsx
+++ b/frontend/components/sections/SectionDescription.tsx
@@ -9,7 +9,7 @@ export function SectionDescription({
 }: SectionDescriptionProps) {
    return (
       <Box
-         color="gray.600"
+         color="gray.700"
          {...otherProps}
          dangerouslySetInnerHTML={{
             __html: richText,

--- a/frontend/components/sections/SectionHeading.tsx
+++ b/frontend/components/sections/SectionHeading.tsx
@@ -1,5 +1,7 @@
 import { Heading, HeadingProps } from '@chakra-ui/react';
 
 export function SectionHeading(props: HeadingProps) {
-   return <Heading as="h2" color="gray.700" size="lg" {...props} />;
+   return (
+      <Heading as="h2" color="black" size="lg" fontWeight="medium" {...props} />
+   );
 }

--- a/frontend/helpers/strapi-helpers.ts
+++ b/frontend/helpers/strapi-helpers.ts
@@ -27,3 +27,20 @@ export function getImageFromStrapiImage(
 
    return result;
 }
+
+export function createSectionId<T extends { __typename: string }>(
+   section: T,
+   index: number
+): string;
+export function createSectionId<T extends { __typename?: string | null }>(
+   section: T | null | undefined,
+   index: number
+): string | null;
+export function createSectionId<T extends { __typename?: string | null }>(
+   section: T | null | undefined,
+   index: number
+): string | null {
+   if (section == null) return null;
+
+   return `${section.__typename}-${index}`;
+}

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -1995,6 +1995,11 @@ export type FindPageQuery = {
                           } | null;
                        } | null;
                     } | null> | null;
+                    callToAction?: {
+                       __typename?: 'ComponentPageCallToAction';
+                       title: string;
+                       url: string;
+                    } | null;
                  }
                | {
                     __typename: 'ComponentPageSplitWithImage';
@@ -3243,14 +3248,13 @@ export type PressQuotesSectionFieldsFragment = {
          } | null;
       } | null;
    } | null> | null;
+   callToAction?: {
+      __typename?: 'ComponentPageCallToAction';
+      title: string;
+      url: string;
+   } | null;
 };
 
-export const CallToActionFieldsFragmentDoc = `
-    fragment CallToActionFields on ComponentPageCallToAction {
-  title
-  url
-}
-    `;
 export const ImageFieldsFragmentDoc = `
     fragment ImageFields on UploadFileEntityResponse {
   data {
@@ -3397,6 +3401,12 @@ export const PressQuoteFieldsFragmentDoc = `
   text
 }
     `;
+export const CallToActionFieldsFragmentDoc = `
+    fragment CallToActionFields on ComponentPageCallToAction {
+  title
+  url
+}
+    `;
 export const PressQuotesSectionFieldsFragmentDoc = `
     fragment PressQuotesSectionFields on ComponentPagePress {
   id
@@ -3404,6 +3414,9 @@ export const PressQuotesSectionFieldsFragmentDoc = `
   description
   quotes {
     ...PressQuoteFields
+  }
+  callToAction {
+    ...CallToActionFields
   }
 }
     `;

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -53,6 +53,49 @@ export type BooleanFilterInput = {
    startsWith?: InputMaybe<Scalars['Boolean']>;
 };
 
+export type Company = {
+   __typename?: 'Company';
+   createdAt?: Maybe<Scalars['DateTime']>;
+   logo?: Maybe<UploadFileEntityResponse>;
+   name: Scalars['String'];
+   publishedAt?: Maybe<Scalars['DateTime']>;
+   updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type CompanyEntity = {
+   __typename?: 'CompanyEntity';
+   attributes?: Maybe<Company>;
+   id?: Maybe<Scalars['ID']>;
+};
+
+export type CompanyEntityResponse = {
+   __typename?: 'CompanyEntityResponse';
+   data?: Maybe<CompanyEntity>;
+};
+
+export type CompanyEntityResponseCollection = {
+   __typename?: 'CompanyEntityResponseCollection';
+   data: Array<CompanyEntity>;
+   meta: ResponseCollectionMeta;
+};
+
+export type CompanyFiltersInput = {
+   and?: InputMaybe<Array<InputMaybe<CompanyFiltersInput>>>;
+   createdAt?: InputMaybe<DateTimeFilterInput>;
+   id?: InputMaybe<IdFilterInput>;
+   name?: InputMaybe<StringFilterInput>;
+   not?: InputMaybe<CompanyFiltersInput>;
+   or?: InputMaybe<Array<InputMaybe<CompanyFiltersInput>>>;
+   publishedAt?: InputMaybe<DateTimeFilterInput>;
+   updatedAt?: InputMaybe<DateTimeFilterInput>;
+};
+
+export type CompanyInput = {
+   logo?: InputMaybe<Scalars['ID']>;
+   name?: InputMaybe<Scalars['String']>;
+   publishedAt?: InputMaybe<Scalars['DateTime']>;
+};
+
 export type ComponentGlobalNewsletterForm = {
    __typename?: 'ComponentGlobalNewsletterForm';
    callToActionButtonTitle: Scalars['String'];
@@ -142,6 +185,36 @@ export type ComponentPageHero = {
    id: Scalars['ID'];
    image?: Maybe<UploadFileEntityResponse>;
    title?: Maybe<Scalars['String']>;
+};
+
+export type ComponentPagePress = {
+   __typename?: 'ComponentPagePress';
+   callToAction?: Maybe<ComponentPageCallToAction>;
+   description?: Maybe<Scalars['String']>;
+   id: Scalars['ID'];
+   quotes?: Maybe<Array<Maybe<ComponentPagePressQuote>>>;
+   title?: Maybe<Scalars['String']>;
+};
+
+export type ComponentPagePressQuotesArgs = {
+   filters?: InputMaybe<ComponentPagePressQuoteFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type ComponentPagePressQuote = {
+   __typename?: 'ComponentPagePressQuote';
+   company?: Maybe<CompanyEntityResponse>;
+   id: Scalars['ID'];
+   text: Scalars['String'];
+};
+
+export type ComponentPagePressQuoteFiltersInput = {
+   and?: InputMaybe<Array<InputMaybe<ComponentPagePressQuoteFiltersInput>>>;
+   company?: InputMaybe<CompanyFiltersInput>;
+   not?: InputMaybe<ComponentPagePressQuoteFiltersInput>;
+   or?: InputMaybe<Array<InputMaybe<ComponentPagePressQuoteFiltersInput>>>;
+   text?: InputMaybe<StringFilterInput>;
 };
 
 export type ComponentPageSplitWithImage = {
@@ -408,6 +481,7 @@ export type FloatFilterInput = {
 };
 
 export type GenericMorph =
+   | Company
    | ComponentGlobalNewsletterForm
    | ComponentMenuLink
    | ComponentMenuLinkWithImage
@@ -417,6 +491,8 @@ export type GenericMorph =
    | ComponentPageCallToAction
    | ComponentPageCategory
    | ComponentPageHero
+   | ComponentPagePress
+   | ComponentPagePressQuote
    | ComponentPageSplitWithImage
    | ComponentPageStatItem
    | ComponentPageStats
@@ -653,6 +729,7 @@ export type Mutation = {
    __typename?: 'Mutation';
    /** Change user password. Confirm with the current password. */
    changePassword?: Maybe<UsersPermissionsLoginPayload>;
+   createCompany?: Maybe<CompanyEntityResponse>;
    createGlobalLocalization?: Maybe<GlobalEntityResponse>;
    createMenu?: Maybe<MenuEntityResponse>;
    createMenuLocalization?: Maybe<MenuEntityResponse>;
@@ -667,6 +744,7 @@ export type Mutation = {
    createUsersPermissionsRole?: Maybe<UsersPermissionsCreateRolePayload>;
    /** Create a new user */
    createUsersPermissionsUser: UsersPermissionsUserEntityResponse;
+   deleteCompany?: Maybe<CompanyEntityResponse>;
    deleteGlobal?: Maybe<GlobalEntityResponse>;
    deleteMenu?: Maybe<MenuEntityResponse>;
    deletePage?: Maybe<PageEntityResponse>;
@@ -689,6 +767,7 @@ export type Mutation = {
    removeFile?: Maybe<UploadFileEntityResponse>;
    /** Reset user password. Confirm with a code (resetToken from forgotPassword) */
    resetPassword?: Maybe<UsersPermissionsLoginPayload>;
+   updateCompany?: Maybe<CompanyEntityResponse>;
    updateFileInfo: UploadFileEntityResponse;
    updateGlobal?: Maybe<GlobalEntityResponse>;
    updateMenu?: Maybe<MenuEntityResponse>;
@@ -708,6 +787,10 @@ export type MutationChangePasswordArgs = {
    currentPassword: Scalars['String'];
    password: Scalars['String'];
    passwordConfirmation: Scalars['String'];
+};
+
+export type MutationCreateCompanyArgs = {
+   data: CompanyInput;
 };
 
 export type MutationCreateGlobalLocalizationArgs = {
@@ -767,6 +850,10 @@ export type MutationCreateUsersPermissionsRoleArgs = {
 
 export type MutationCreateUsersPermissionsUserArgs = {
    data: UsersPermissionsUserInput;
+};
+
+export type MutationDeleteCompanyArgs = {
+   id: Scalars['ID'];
 };
 
 export type MutationDeleteGlobalArgs = {
@@ -839,6 +926,11 @@ export type MutationResetPasswordArgs = {
    code: Scalars['String'];
    password: Scalars['String'];
    passwordConfirmation: Scalars['String'];
+};
+
+export type MutationUpdateCompanyArgs = {
+   data: CompanyInput;
+   id: Scalars['ID'];
 };
 
 export type MutationUpdateFileInfoArgs = {
@@ -967,6 +1059,7 @@ export type PageRelationResponseCollection = {
 export type PageSectionsDynamicZone =
    | ComponentPageBrowse
    | ComponentPageHero
+   | ComponentPagePress
    | ComponentPageSplitWithImage
    | ComponentPageStats
    | Error;
@@ -1123,6 +1216,8 @@ export enum PublicationState {
 
 export type Query = {
    __typename?: 'Query';
+   companies?: Maybe<CompanyEntityResponseCollection>;
+   company?: Maybe<CompanyEntityResponse>;
    global?: Maybe<GlobalEntityResponse>;
    i18NLocale?: Maybe<I18NLocaleEntityResponse>;
    i18NLocales?: Maybe<I18NLocaleEntityResponseCollection>;
@@ -1143,6 +1238,17 @@ export type Query = {
    usersPermissionsRoles?: Maybe<UsersPermissionsRoleEntityResponseCollection>;
    usersPermissionsUser?: Maybe<UsersPermissionsUserEntityResponse>;
    usersPermissionsUsers?: Maybe<UsersPermissionsUserEntityResponseCollection>;
+};
+
+export type QueryCompaniesArgs = {
+   filters?: InputMaybe<CompanyFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
+   publicationState?: InputMaybe<PublicationState>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type QueryCompanyArgs = {
+   id?: InputMaybe<Scalars['ID']>;
 };
 
 export type QueryGlobalArgs = {
@@ -1835,6 +1941,7 @@ export type FindPageQuery = {
                        } | null;
                     } | null;
                  }
+               | { __typename: 'ComponentPagePress' }
                | {
                     __typename: 'ComponentPageSplitWithImage';
                     id: string;

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -1816,6 +1816,27 @@ export type UsersPermissionsUserRelationResponseCollection = {
    data: Array<UsersPermissionsUserEntity>;
 };
 
+export type CompanyFieldsFragment = {
+   __typename?: 'CompanyEntity';
+   id?: string | null;
+   attributes?: {
+      __typename?: 'Company';
+      name: string;
+      logo?: {
+         __typename?: 'UploadFileEntityResponse';
+         data?: {
+            __typename?: 'UploadFileEntity';
+            attributes?: {
+               __typename?: 'UploadFile';
+               alternativeText?: string | null;
+               url: string;
+               formats?: any | null;
+            } | null;
+         } | null;
+      } | null;
+   } | null;
+};
+
 export type ImageFieldsFragment = {
    __typename?: 'UploadFileEntityResponse';
    data?: {
@@ -1941,7 +1962,40 @@ export type FindPageQuery = {
                        } | null;
                     } | null;
                  }
-               | { __typename: 'ComponentPagePress' }
+               | {
+                    __typename: 'ComponentPagePress';
+                    id: string;
+                    title?: string | null;
+                    description?: string | null;
+                    quotes?: Array<{
+                       __typename?: 'ComponentPagePressQuote';
+                       id: string;
+                       text: string;
+                       company?: {
+                          __typename?: 'CompanyEntityResponse';
+                          data?: {
+                             __typename?: 'CompanyEntity';
+                             id?: string | null;
+                             attributes?: {
+                                __typename?: 'Company';
+                                name: string;
+                                logo?: {
+                                   __typename?: 'UploadFileEntityResponse';
+                                   data?: {
+                                      __typename?: 'UploadFileEntity';
+                                      attributes?: {
+                                         __typename?: 'UploadFile';
+                                         alternativeText?: string | null;
+                                         url: string;
+                                         formats?: any | null;
+                                      } | null;
+                                   } | null;
+                                } | null;
+                             } | null;
+                          } | null;
+                       } | null;
+                    } | null> | null;
+                 }
                | {
                     __typename: 'ComponentPageSplitWithImage';
                     id: string;
@@ -2005,6 +2059,35 @@ export type CategoryFieldsFragment = {
             title: string;
             metaDescription?: string | null;
             image?: {
+               __typename?: 'UploadFileEntityResponse';
+               data?: {
+                  __typename?: 'UploadFileEntity';
+                  attributes?: {
+                     __typename?: 'UploadFile';
+                     alternativeText?: string | null;
+                     url: string;
+                     formats?: any | null;
+                  } | null;
+               } | null;
+            } | null;
+         } | null;
+      } | null;
+   } | null;
+};
+
+export type PressQuoteFieldsFragment = {
+   __typename?: 'ComponentPagePressQuote';
+   id: string;
+   text: string;
+   company?: {
+      __typename?: 'CompanyEntityResponse';
+      data?: {
+         __typename?: 'CompanyEntity';
+         id?: string | null;
+         attributes?: {
+            __typename?: 'Company';
+            name: string;
+            logo?: {
                __typename?: 'UploadFileEntityResponse';
                data?: {
                   __typename?: 'UploadFileEntity';
@@ -3127,6 +3210,41 @@ export type GetStoreListQuery = {
    } | null;
 };
 
+export type PressQuotesSectionFieldsFragment = {
+   __typename?: 'ComponentPagePress';
+   id: string;
+   title?: string | null;
+   description?: string | null;
+   quotes?: Array<{
+      __typename?: 'ComponentPagePressQuote';
+      id: string;
+      text: string;
+      company?: {
+         __typename?: 'CompanyEntityResponse';
+         data?: {
+            __typename?: 'CompanyEntity';
+            id?: string | null;
+            attributes?: {
+               __typename?: 'Company';
+               name: string;
+               logo?: {
+                  __typename?: 'UploadFileEntityResponse';
+                  data?: {
+                     __typename?: 'UploadFileEntity';
+                     attributes?: {
+                        __typename?: 'UploadFile';
+                        alternativeText?: string | null;
+                        url: string;
+                        formats?: any | null;
+                     } | null;
+                  } | null;
+               } | null;
+            } | null;
+         } | null;
+      } | null;
+   } | null> | null;
+};
+
 export const CallToActionFieldsFragmentDoc = `
     fragment CallToActionFields on ComponentPageCallToAction {
   title
@@ -3257,6 +3375,38 @@ export const MenuEntityResponsePropsFragmentDoc = `
   }
 }
     `;
+export const CompanyFieldsFragmentDoc = `
+    fragment CompanyFields on CompanyEntity {
+  id
+  attributes {
+    name
+    logo {
+      ...ImageFields
+    }
+  }
+}
+    `;
+export const PressQuoteFieldsFragmentDoc = `
+    fragment PressQuoteFields on ComponentPagePressQuote {
+  id
+  company {
+    data {
+      ...CompanyFields
+    }
+  }
+  text
+}
+    `;
+export const PressQuotesSectionFieldsFragmentDoc = `
+    fragment PressQuotesSectionFields on ComponentPagePress {
+  id
+  title
+  description
+  quotes {
+    ...PressQuoteFields
+  }
+}
+    `;
 export const FindPageDocument = `
     query findPage($filters: PageFiltersInput, $publicationState: PublicationState) {
   pages(
@@ -3313,6 +3463,9 @@ export const FindPageDocument = `
               ...ImageFields
             }
           }
+          ... on ComponentPagePress {
+            ...PressQuotesSectionFields
+          }
         }
       }
     }
@@ -3321,7 +3474,10 @@ export const FindPageDocument = `
     ${CallToActionFieldsFragmentDoc}
 ${ImageFieldsFragmentDoc}
 ${CategoryFieldsFragmentDoc}
-${ProductListFieldsFragmentDoc}`;
+${ProductListFieldsFragmentDoc}
+${PressQuotesSectionFieldsFragmentDoc}
+${PressQuoteFieldsFragmentDoc}
+${CompanyFieldsFragmentDoc}`;
 export const FindStoreDocument = `
     query findStore($filters: StoreFiltersInput) {
   store: stores(filters: $filters) {

--- a/frontend/lib/strapi-sdk/operations/CompanyFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/CompanyFields.fragment.graphql
@@ -1,0 +1,9 @@
+fragment CompanyFields on CompanyEntity {
+   id
+   attributes {
+      name
+      logo {
+         ...ImageFields
+      }
+   }
+}

--- a/frontend/lib/strapi-sdk/operations/findPage.graphql
+++ b/frontend/lib/strapi-sdk/operations/findPage.graphql
@@ -56,6 +56,9 @@ query findPage(
                      ...ImageFields
                   }
                }
+               ... on ComponentPagePress {
+                  ...PressQuotesSectionFields
+               }
             }
          }
       }
@@ -74,4 +77,14 @@ fragment CategoryFields on ComponentPageCategory {
          ...ProductListFields
       }
    }
+}
+
+fragment PressQuoteFields on ComponentPagePressQuote {
+   id
+   company {
+      data {
+         ...CompanyFields
+      }
+   }
+   text
 }

--- a/frontend/lib/strapi-sdk/operations/sections/PressQuotesSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/PressQuotesSectionFields.fragment.graphql
@@ -5,4 +5,7 @@ fragment PressQuotesSectionFields on ComponentPagePress {
    quotes {
       ...PressQuoteFields
    }
+   callToAction {
+      ...CallToActionFields
+   }
 }

--- a/frontend/lib/strapi-sdk/operations/sections/PressQuotesSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/PressQuotesSectionFields.fragment.graphql
@@ -1,0 +1,8 @@
+fragment PressQuotesSectionFields on ComponentPagePress {
+   id
+   title
+   description
+   quotes {
+      ...PressQuoteFields
+   }
+}

--- a/frontend/models/page/components/press-quote.ts
+++ b/frontend/models/page/components/press-quote.ts
@@ -1,0 +1,26 @@
+import type { PressQuoteFieldsFragment } from '@lib/strapi-sdk';
+import {
+   companyFromStrapi,
+   CompanySchema,
+} from '@models/shared/components/company';
+import { z } from 'zod';
+
+export type PressQuote = z.infer<typeof PressQuoteSchema>;
+
+export const PressQuoteSchema = z.object({
+   id: z.string(),
+   company: CompanySchema,
+   text: z.string(),
+});
+
+export function pressQuoteFromStrapi(
+   fragment: PressQuoteFieldsFragment | null | undefined
+): PressQuote | null {
+   const id = fragment?.id;
+   const company = companyFromStrapi(fragment?.company?.data);
+   const text = fragment?.text;
+
+   if (id == null || company == null || text == null) return null;
+
+   return { id, company, text };
+}

--- a/frontend/models/page/index.ts
+++ b/frontend/models/page/index.ts
@@ -3,6 +3,7 @@ import { SplitWithImageSectionSchema } from '@models/shared/sections/split-with-
 import { z } from 'zod';
 import { BrowseSectionSchema } from './sections/browse-section';
 import { HeroSectionSchema } from './sections/hero-section';
+import { PressQuotesSectionSchema } from './sections/press-quotes-section';
 
 export type PageSection = z.infer<typeof PageSectionSchema>;
 
@@ -11,6 +12,7 @@ export const PageSectionSchema = z.union([
    BrowseSectionSchema,
    IFixitStatsSectionSchema,
    SplitWithImageSectionSchema,
+   PressQuotesSectionSchema,
 ]);
 
 export type Page = z.infer<typeof PageSchema>;

--- a/frontend/models/page/sections/press-quotes-section.ts
+++ b/frontend/models/page/sections/press-quotes-section.ts
@@ -1,6 +1,10 @@
 import { filterFalsyItems } from '@helpers/application-helpers';
 import { createSectionId } from '@helpers/strapi-helpers';
 import type { PressQuotesSectionFieldsFragment } from '@lib/strapi-sdk';
+import {
+   callToActionFromStrapi,
+   CallToActionSchema,
+} from '@models/shared/components/call-to-action';
 import { z } from 'zod';
 import {
    pressQuoteFromStrapi,
@@ -15,6 +19,7 @@ export const PressQuotesSectionSchema = z.object({
    title: z.string().nullable(),
    description: z.string().nullable(),
    quotes: z.array(PressQuoteSchema),
+   callToAction: CallToActionSchema.nullable(),
 });
 
 export function pressQuotesSectionFromStrapi(
@@ -25,9 +30,10 @@ export function pressQuotesSectionFromStrapi(
    const title = fragment?.title;
    const description = fragment?.description;
    const quotes = filterFalsyItems(fragment?.quotes?.map(pressQuoteFromStrapi));
+   const callToAction = callToActionFromStrapi(fragment?.callToAction);
 
    if (id == null || title == null || description == null || quotes == null)
       return null;
 
-   return { type: 'PressQuotes', id, title, description, quotes };
+   return { type: 'PressQuotes', id, title, description, quotes, callToAction };
 }

--- a/frontend/models/page/sections/press-quotes-section.ts
+++ b/frontend/models/page/sections/press-quotes-section.ts
@@ -1,0 +1,33 @@
+import { filterFalsyItems } from '@helpers/application-helpers';
+import { createSectionId } from '@helpers/strapi-helpers';
+import type { PressQuotesSectionFieldsFragment } from '@lib/strapi-sdk';
+import { z } from 'zod';
+import {
+   pressQuoteFromStrapi,
+   PressQuoteSchema,
+} from '../components/press-quote';
+
+export type PressQuotesSection = z.infer<typeof PressQuotesSectionSchema>;
+
+export const PressQuotesSectionSchema = z.object({
+   type: z.literal('PressQuotes'),
+   id: z.string(),
+   title: z.string().nullable(),
+   description: z.string().nullable(),
+   quotes: z.array(PressQuoteSchema),
+});
+
+export function pressQuotesSectionFromStrapi(
+   fragment: PressQuotesSectionFieldsFragment | null | undefined,
+   index: number
+): PressQuotesSection | null {
+   const id = createSectionId(fragment, index);
+   const title = fragment?.title;
+   const description = fragment?.description;
+   const quotes = filterFalsyItems(fragment?.quotes?.map(pressQuoteFromStrapi));
+
+   if (id == null || title == null || description == null || quotes == null)
+      return null;
+
+   return { type: 'PressQuotes', id, title, description, quotes };
+}

--- a/frontend/models/page/server.ts
+++ b/frontend/models/page/server.ts
@@ -5,6 +5,7 @@ import {
 import { createSectionId } from '@helpers/strapi-helpers';
 import { assertNever } from '@ifixit/helpers';
 import { CategoryFieldsFragment, strapi } from '@lib/strapi-sdk';
+import { callToActionFromStrapi } from '@models/shared/components/call-to-action';
 import { imageFromStrapi } from '@models/shared/components/image';
 import { imagePositionFromStrapi } from '@models/shared/sections/split-with-image-section';
 import type { Page, PageSection } from '.';
@@ -41,7 +42,7 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
                   id: createSectionId(section, index),
                   title: section.title ?? null,
                   description: section.description ?? null,
-                  callToAction: section.callToAction ?? null,
+                  callToAction: callToActionFromStrapi(section.callToAction),
                   image: imageFromStrapi(section.image),
                };
             }

--- a/frontend/models/page/server.ts
+++ b/frontend/models/page/server.ts
@@ -2,13 +2,15 @@ import {
    filterFalsyItems,
    filterNullableItems,
 } from '@helpers/application-helpers';
+import { createSectionId } from '@helpers/strapi-helpers';
 import { assertNever } from '@ifixit/helpers';
 import { CategoryFieldsFragment, strapi } from '@lib/strapi-sdk';
 import { imageFromStrapi } from '@models/shared/components/image';
 import { imagePositionFromStrapi } from '@models/shared/sections/split-with-image-section';
-import { getProductListType } from '../product-list/server';
 import type { Page, PageSection } from '.';
+import { getProductListType } from '../product-list/server';
 import type { BrowseCategory } from './sections/browse-section';
+import { pressQuotesSectionFromStrapi } from './sections/press-quotes-section';
 
 interface FindPageArgs {
    path: string;
@@ -36,7 +38,7 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
             case 'ComponentPageHero': {
                return {
                   type: 'Hero',
-                  id: `${section.__typename}-${index}`,
+                  id: createSectionId(section, index),
                   title: section.title ?? null,
                   description: section.description ?? null,
                   callToAction: section.callToAction ?? null,
@@ -49,7 +51,7 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
                );
                return {
                   type: 'Browse',
-                  id: `${section.__typename}-${index}`,
+                  id: createSectionId(section, index),
                   title: section.title ?? null,
                   description: section.description ?? null,
                   image: imageFromStrapi(section.image),
@@ -64,7 +66,7 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
                );
                return {
                   type: 'IFixitStats',
-                  id: `${section.__typename}-${index}`,
+                  id: createSectionId(section, index),
                   stats,
                };
             }
@@ -79,6 +81,9 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
                      imagePositionFromStrapi(section.imagePosition) ?? 'right',
                   callToAction: section.callToAction ?? null,
                };
+            }
+            case 'ComponentPagePress': {
+               return pressQuotesSectionFromStrapi(section, index);
             }
             case 'Error': {
                console.error('Failed to parse page section:', section);

--- a/frontend/models/shared/components/call-to-action.ts
+++ b/frontend/models/shared/components/call-to-action.ts
@@ -1,3 +1,4 @@
+import type { CallToActionFieldsFragment } from '@lib/strapi-sdk';
 import { z } from 'zod';
 
 export const CallToActionSchema = z.object({
@@ -6,3 +7,14 @@ export const CallToActionSchema = z.object({
 });
 
 export type CallToAction = z.infer<typeof CallToActionSchema>;
+
+export function callToActionFromStrapi(
+   fragment: CallToActionFieldsFragment | null | undefined
+): CallToAction | null {
+   const title = fragment?.title;
+   const url = fragment?.url;
+
+   if (title == null || url == null) return null;
+
+   return { title, url };
+}

--- a/frontend/models/shared/components/company.ts
+++ b/frontend/models/shared/components/company.ts
@@ -1,0 +1,21 @@
+import type { CompanyFieldsFragment } from '@lib/strapi-sdk';
+import { z } from 'zod';
+import { imageFromStrapi, ImageSchema } from './image';
+
+export const CompanySchema = z.object({
+   name: z.string(),
+   logo: ImageSchema,
+});
+
+export type Company = z.infer<typeof CompanySchema>;
+
+export function companyFromStrapi(
+   fragment: CompanyFieldsFragment | null | undefined
+): Company | null {
+   const name = fragment?.attributes?.name;
+   const logo = imageFromStrapi(fragment?.attributes?.logo);
+
+   if (name == null || logo == null) return null;
+
+   return { name, logo };
+}

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -9,6 +9,7 @@ import {
 } from './hooks/usePageTemplateProps';
 import { BrowseSection } from './sections/BrowseSection';
 import { HeroSection } from './sections/HeroSection';
+import { PressQuotesSection } from './sections/PressQuotesSection';
 
 const PageTemplate: NextPageWithLayout<PageTemplateProps> = () => {
    const { page } = usePageTemplateProps();
@@ -34,7 +35,7 @@ const PageTemplate: NextPageWithLayout<PageTemplateProps> = () => {
                   );
                }
                case 'PressQuotes': {
-                  return <div key={section.id}>press quotes</div>;
+                  return <PressQuotesSection key={section.id} data={section} />;
                }
                default:
                   return assertNever(section);

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -33,6 +33,9 @@ const PageTemplate: NextPageWithLayout<PageTemplateProps> = () => {
                      />
                   );
                }
+               case 'PressQuotes': {
+                  return <div key={section.id}>press quotes</div>;
+               }
                default:
                   return assertNever(section);
             }

--- a/frontend/templates/page/sections/PressQuotesSection.tsx
+++ b/frontend/templates/page/sections/PressQuotesSection.tsx
@@ -1,0 +1,138 @@
+import { Box, chakra, Flex, Link } from '@chakra-ui/react';
+import { SectionDescription } from '@components/sections/SectionDescription';
+import { SectionHeading } from '@components/sections/SectionHeading';
+import { ResponsiveImage, Wrapper } from '@ifixit/ui';
+import type { PressQuote } from '@models/page/components/press-quote';
+import type { PressQuotesSection } from '@models/page/sections/press-quotes-section';
+import NextLink from 'next/link';
+import 'swiper/css';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+export interface PressQuotesSectionProps {
+   data: PressQuotesSection;
+}
+
+export function PressQuotesSection({
+   data: { title, description, callToAction, quotes },
+}: PressQuotesSectionProps) {
+   return (
+      <Box as="section" position="relative" w="full" bg="gray.200">
+         <Flex direction="column" py="16" alignItems="center">
+            <Wrapper textAlign="center">
+               {title && <SectionHeading mb="4">{title}</SectionHeading>}
+               {description && <SectionDescription richText={description} />}
+            </Wrapper>
+            <Box
+               w="full"
+               my={{
+                  base: '6',
+                  md: '8',
+               }}
+            >
+               <QuotesGallery quotes={quotes} />
+            </Box>
+            {callToAction && (
+               <NextLink href={callToAction.url} passHref>
+                  <Link
+                     color="brand.500"
+                     fontWeight="bold"
+                     display="block"
+                     py="2"
+                     px="3"
+                  >
+                     {callToAction.title}
+                  </Link>
+               </NextLink>
+            )}
+         </Flex>
+      </Box>
+   );
+}
+
+interface QuotesGalleryProps {
+   quotes: PressQuote[];
+}
+
+function QuotesGallery({ quotes }: QuotesGalleryProps) {
+   return (
+      <Slider
+         loop
+         spaceBetween={20}
+         slidesPerView="auto"
+         slideToClickedSlide
+         centeredSlides
+         breakpoints={{
+            768: {
+               spaceBetween: 48,
+            },
+         }}
+         sx={{
+            '& .swiper-slide': {
+               cursor: 'pointer',
+               maxW: {
+                  base: '256px',
+                  md: '320px',
+               },
+               opacity: 0.2,
+               transition: 'opacity 300ms',
+               '&.swiper-slide-prev, &.swiper-slide-next': {
+                  opacity: 0.4,
+               },
+               '&.swiper-slide-active': {
+                  opacity: 1,
+               },
+               '&:not(.swiper-slide-active):hover': {
+                  opacity: 0.6,
+               },
+            },
+         }}
+      >
+         {quotes.map((quote) => {
+            return (
+               <SwiperSlide key={quote.id}>
+                  <Quote quote={quote} />
+               </SwiperSlide>
+            );
+         })}
+      </Slider>
+   );
+}
+
+interface QuoteProps {
+   quote: PressQuote;
+}
+
+function Quote({ quote }: QuoteProps) {
+   return (
+      <Flex direction="column" alignItems="center">
+         <Box
+            position="relative"
+            w={{
+               base: '120px',
+               md: '200px',
+            }}
+            h={{
+               base: '30px',
+               md: '40px',
+            }}
+            my="30px"
+         >
+            <ResponsiveImage
+               src={quote.company.logo.url}
+               alt={quote.company.logo.altText ?? ''}
+               objectFit="contain"
+               layout="fill"
+            />
+         </Box>
+         <Box
+            color="gray.800"
+            textAlign="center"
+            dangerouslySetInnerHTML={{
+               __html: quote.text,
+            }}
+         />
+      </Flex>
+   );
+}
+
+const Slider = chakra(Swiper);


### PR DESCRIPTION
closes #1396 

> 🔍 The additional 29kb added to the `/store` bundle are due to the use of swiper.js, the same library that we're using to handle the product page gallery.

## QA

1. Visit preview [store home page](https://react-commerce-git-add-page-template-press-section-ifixit.vercel.app/store)
2. Verify that the press quotes section is visible and implemented according to [mockup](https://www.figma.com/file/jRG4EyQXRDMGfyLqut08KP/iFixit---Working-files?node-id=6315%3A68822&t=BgbMfgqro1NEnYVQ-4)

    ![Screenshot 2023-02-23 at 14 56 53](https://user-images.githubusercontent.com/4640135/220928246-ca410f36-7d6a-422c-99f1-d0cd0e80b03a.png)

3. Verify that the section is responsive

---

❗ ❗ ❗ This PR requires a Strapi redeploy ❗ ❗ ❗ 

I didn't split backend and frontend changes into separate PRs because this stuff is still behind a feature flag

cc @sterlinghirsh @danielbeardsley @masonmcelvain 