### PR TITLE
Memory Cache: don't clear on vercel_no_cache

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -2,7 +2,6 @@ import { PROD_USER_AGENT } from '@config/constants';
 import { CACHE_DISABLED } from '@config/env';
 import { setSentryPageContext } from '@ifixit/sentry';
 import { withTiming } from '@ifixit/helpers';
-import { clearCache } from '@lib/cache';
 import type { GetServerSidePropsMiddleware } from '@lib/next-middleware';
 import * as Sentry from '@sentry/nextjs';
 import { GetServerSidePropsContext } from 'next';
@@ -21,9 +20,6 @@ export const withLogging: GetServerSidePropsMiddleware = (next) => {
       });
       const isCacheDisabled =
          CACHE_DISABLED || context.query._vercel_no_cache === '1';
-      if (isCacheDisabled) {
-         clearCache();
-      }
       return next(context)
          .then((result) => {
             if (isCacheDisabled) {
@@ -31,7 +27,6 @@ export const withLogging: GetServerSidePropsMiddleware = (next) => {
                   'Cache-Control',
                   'no-store, no-cache, must-revalidate, stale-if-error=0'
                );
-               clearCache();
             }
             return result;
          })

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -16,7 +16,3 @@ export function cache<T>(
    cacheStore.set(key, result, { ttl: ttl * 1000 });
    return result;
 }
-
-export function clearCache(): void {
-   cacheStore.clear();
-}


### PR DESCRIPTION
We are using Alertra to monitor uptime and we add a _vercel_no_cache=1 query param to ensure we actually run app code. We don't want this to constantly clear the in-memory cache because we have alerta checking twice a minute.

The in-memory cache only stores a few global settings and it expires every hour.

See comment here: https://github.com/iFixit/ifixit/issues/46312#issuecomment-1442379352

qa_req 0