### PR TITLE
Playwright: Only cache the nextjs cache dir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,18 +53,17 @@ jobs:
            if: steps.playwright-cache.outputs.cache-hit != 'true'
            run: cd frontend && npx playwright install
 
-         - name: Cache Next.js build
+         - name: Cache Next.js cache directory
            uses: actions/cache@v3
-           id: nextjs-cache
            with:
-              path: frontend/.next
-              key: ${{ github.ref_name }}-nextjs-${{github.sha}}
+              path: frontend/.next/cache
+              # Generate a new cache whenever packages or source files change.
+              key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+              # If source files changed but packages didn't, rebuild from a prior cache.
               restore-keys: |
-                 ${{ github.ref_name }}-nextjs-${{github.event.before}}
-                 ${{ github.ref_name }}-nextjs-
+                 ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
          - name: Build Next.js
-           if: steps.nextjs-cache.outputs.cache-hit != 'true'
            env:
               NODE_ENV: test
               NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337


### PR DESCRIPTION
All reruns were failing b/c we were not building the nextjs app (`pnpm build`) on reruns:
- First run (successful): https://github.com/iFixit/react-commerce/actions/runs/4257656032/jobs/7408032866
- Second run (failure): https://github.com/iFixit/react-commerce/actions/runs/4257656032/jobs/7408197758

That lead me to think that there was some state that gets transferred from the first job that causes the second to fail. After digging into the workflow, I noticed that we are caching the entire `frontend/.nex`t directory. The second run drops the entire `frontend/.next` directory in from the first run and does not run `pnpm build`.

I did a little research and noticed that most other workflows [only cache the .next/cache directory](https://nextjs.org/docs/advanced-features/ci-build-caching#github-actions) but will still build the app. I did that and things behaved like normal on both runs. We do get a bit of a slowdown because we call `pnpm build` every time, but I think that's worth it.

QA:
--
Once CI finishes, rerun a playwright test. We shouldn't see any of the `FetchError: request to http://localhost:1337/graphql failed` errors that we saw in the issue.

cc @ardelato 

Closes: #1392 