### PR TITLE
Fix company content type public permission

### DIFF
--- a/backend/src/bootstrap/permissions/config.json
+++ b/backend/src/bootstrap/permissions/config.json
@@ -8,6 +8,8 @@
       "api::product-list.product-list.findOne",
       "api::product-list.product-list.find",
       "api::page.page.findOne",
-      "api::page.page.find"
+      "api::page.page.find",
+      "api::company.company.findOne",
+      "api::company.company.find"
    ]
 }


### PR DESCRIPTION
closes #1411 

❕ CI cannot pass because without the change this PR is introducing, the remote instance of Strapi returns a forbidden request error to seeding requests (i.e. `main.govinor` will not be able to provide seed data for other instances until this is merged)

❗❗❗After this PR is merged Strapi should be redeployed in production ❗❗❗

cc @sterlinghirsh @danielbeardsley @masonmcelvain 

## QA

This PR enables permissions for public reading of `company` content type. To verify this, visit this url:
https://fix-company-strapi-public-permission.govinor.com/api/companies?populate[logo][fields]=%2A&pagination[page]=1&pagination[pageSize]=100
and verify that you receive a `200` response (you can check this from the browser dev tools network tab