### PR TITLE
Improve code organization for page sections

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2049,66 +2049,6 @@ export type CallToActionFieldsFragment = {
    url: string;
 };
 
-export type CategoryFieldsFragment = {
-   __typename?: 'ComponentPageCategory';
-   id: string;
-   productList?: {
-      __typename?: 'ProductListEntityResponse';
-      data?: {
-         __typename?: 'ProductListEntity';
-         attributes?: {
-            __typename?: 'ProductList';
-            type?: Enum_Productlist_Type | null;
-            handle: string;
-            deviceTitle?: string | null;
-            title: string;
-            metaDescription?: string | null;
-            image?: {
-               __typename?: 'UploadFileEntityResponse';
-               data?: {
-                  __typename?: 'UploadFileEntity';
-                  attributes?: {
-                     __typename?: 'UploadFile';
-                     alternativeText?: string | null;
-                     url: string;
-                     formats?: any | null;
-                  } | null;
-               } | null;
-            } | null;
-         } | null;
-      } | null;
-   } | null;
-};
-
-export type PressQuoteFieldsFragment = {
-   __typename?: 'ComponentPagePressQuote';
-   id: string;
-   text: string;
-   company?: {
-      __typename?: 'CompanyEntityResponse';
-      data?: {
-         __typename?: 'CompanyEntity';
-         id?: string | null;
-         attributes?: {
-            __typename?: 'Company';
-            name: string;
-            logo?: {
-               __typename?: 'UploadFileEntityResponse';
-               data?: {
-                  __typename?: 'UploadFileEntity';
-                  attributes?: {
-                     __typename?: 'UploadFile';
-                     alternativeText?: string | null;
-                     url: string;
-                     formats?: any | null;
-                  } | null;
-               } | null;
-            } | null;
-         } | null;
-      } | null;
-   } | null;
-};
-
 export type FindStoreQueryVariables = Exact<{
    filters?: InputMaybe<StoreFiltersInput>;
 }>;
@@ -3215,6 +3155,110 @@ export type GetStoreListQuery = {
    } | null;
 };
 
+export type BrowseSectionFieldsFragment = {
+   __typename?: 'ComponentPageBrowse';
+   id: string;
+   title?: string | null;
+   description?: string | null;
+   image?: {
+      __typename?: 'UploadFileEntityResponse';
+      data?: {
+         __typename?: 'UploadFileEntity';
+         attributes?: {
+            __typename?: 'UploadFile';
+            alternativeText?: string | null;
+            url: string;
+            formats?: any | null;
+         } | null;
+      } | null;
+   } | null;
+   categories?: Array<{
+      __typename?: 'ComponentPageCategory';
+      id: string;
+      productList?: {
+         __typename?: 'ProductListEntityResponse';
+         data?: {
+            __typename?: 'ProductListEntity';
+            attributes?: {
+               __typename?: 'ProductList';
+               type?: Enum_Productlist_Type | null;
+               handle: string;
+               deviceTitle?: string | null;
+               title: string;
+               metaDescription?: string | null;
+               image?: {
+                  __typename?: 'UploadFileEntityResponse';
+                  data?: {
+                     __typename?: 'UploadFileEntity';
+                     attributes?: {
+                        __typename?: 'UploadFile';
+                        alternativeText?: string | null;
+                        url: string;
+                        formats?: any | null;
+                     } | null;
+                  } | null;
+               } | null;
+            } | null;
+         } | null;
+      } | null;
+   } | null> | null;
+};
+
+export type CategoryFieldsFragment = {
+   __typename?: 'ComponentPageCategory';
+   id: string;
+   productList?: {
+      __typename?: 'ProductListEntityResponse';
+      data?: {
+         __typename?: 'ProductListEntity';
+         attributes?: {
+            __typename?: 'ProductList';
+            type?: Enum_Productlist_Type | null;
+            handle: string;
+            deviceTitle?: string | null;
+            title: string;
+            metaDescription?: string | null;
+            image?: {
+               __typename?: 'UploadFileEntityResponse';
+               data?: {
+                  __typename?: 'UploadFileEntity';
+                  attributes?: {
+                     __typename?: 'UploadFile';
+                     alternativeText?: string | null;
+                     url: string;
+                     formats?: any | null;
+                  } | null;
+               } | null;
+            } | null;
+         } | null;
+      } | null;
+   } | null;
+};
+
+export type HeroSectionFieldsFragment = {
+   __typename?: 'ComponentPageHero';
+   id: string;
+   title?: string | null;
+   description?: string | null;
+   callToAction?: {
+      __typename?: 'ComponentPageCallToAction';
+      title: string;
+      url: string;
+   } | null;
+   image?: {
+      __typename?: 'UploadFileEntityResponse';
+      data?: {
+         __typename?: 'UploadFileEntity';
+         attributes?: {
+            __typename?: 'UploadFile';
+            alternativeText?: string | null;
+            url: string;
+            formats?: any | null;
+         } | null;
+      } | null;
+   } | null;
+};
+
 export type PressQuotesSectionFieldsFragment = {
    __typename?: 'ComponentPagePress';
    id: string;
@@ -3255,41 +3299,71 @@ export type PressQuotesSectionFieldsFragment = {
    } | null;
 };
 
-export const ImageFieldsFragmentDoc = `
-    fragment ImageFields on UploadFileEntityResponse {
-  data {
-    attributes {
-      alternativeText
-      url
-      formats
-    }
-  }
-}
-    `;
-export const ProductListFieldsFragmentDoc = `
-    fragment ProductListFields on ProductListEntity {
-  attributes {
-    type
-    handle
-    deviceTitle
-    title
-    metaDescription
-    image {
-      ...ImageFields
-    }
-  }
-}
-    `;
-export const CategoryFieldsFragmentDoc = `
-    fragment CategoryFields on ComponentPageCategory {
-  id
-  productList {
-    data {
-      ...ProductListFields
-    }
-  }
-}
-    `;
+export type PressQuoteFieldsFragment = {
+   __typename?: 'ComponentPagePressQuote';
+   id: string;
+   text: string;
+   company?: {
+      __typename?: 'CompanyEntityResponse';
+      data?: {
+         __typename?: 'CompanyEntity';
+         id?: string | null;
+         attributes?: {
+            __typename?: 'Company';
+            name: string;
+            logo?: {
+               __typename?: 'UploadFileEntityResponse';
+               data?: {
+                  __typename?: 'UploadFileEntity';
+                  attributes?: {
+                     __typename?: 'UploadFile';
+                     alternativeText?: string | null;
+                     url: string;
+                     formats?: any | null;
+                  } | null;
+               } | null;
+            } | null;
+         } | null;
+      } | null;
+   } | null;
+};
+
+export type SplitWithImageSectionFieldsFragment = {
+   __typename?: 'ComponentPageSplitWithImage';
+   id: string;
+   title?: string | null;
+   description?: string | null;
+   imagePosition?: Enum_Componentpagesplitwithimage_Imageposition | null;
+   callToAction?: {
+      __typename?: 'ComponentPageCallToAction';
+      title: string;
+      url: string;
+   } | null;
+   image?: {
+      __typename?: 'UploadFileEntityResponse';
+      data?: {
+         __typename?: 'UploadFileEntity';
+         attributes?: {
+            __typename?: 'UploadFile';
+            alternativeText?: string | null;
+            url: string;
+            formats?: any | null;
+         } | null;
+      } | null;
+   } | null;
+};
+
+export type StatsSectionFieldsFragment = {
+   __typename?: 'ComponentPageStats';
+   id: string;
+   stats: Array<{
+      __typename?: 'ComponentPageStatItem';
+      id: string;
+      label: string;
+      value: string;
+   } | null>;
+};
+
 export const MenuPropsFragmentDoc = `
     fragment MenuProps on Menu {
   title
@@ -3379,6 +3453,73 @@ export const MenuEntityResponsePropsFragmentDoc = `
   }
 }
     `;
+export const ImageFieldsFragmentDoc = `
+    fragment ImageFields on UploadFileEntityResponse {
+  data {
+    attributes {
+      alternativeText
+      url
+      formats
+    }
+  }
+}
+    `;
+export const ProductListFieldsFragmentDoc = `
+    fragment ProductListFields on ProductListEntity {
+  attributes {
+    type
+    handle
+    deviceTitle
+    title
+    metaDescription
+    image {
+      ...ImageFields
+    }
+  }
+}
+    `;
+export const CategoryFieldsFragmentDoc = `
+    fragment CategoryFields on ComponentPageCategory {
+  id
+  productList {
+    data {
+      ...ProductListFields
+    }
+  }
+}
+    `;
+export const BrowseSectionFieldsFragmentDoc = `
+    fragment BrowseSectionFields on ComponentPageBrowse {
+  id
+  title
+  description
+  image {
+    ...ImageFields
+  }
+  categories(pagination: {limit: 100}) {
+    ...CategoryFields
+  }
+}
+    `;
+export const CallToActionFieldsFragmentDoc = `
+    fragment CallToActionFields on ComponentPageCallToAction {
+  title
+  url
+}
+    `;
+export const HeroSectionFieldsFragmentDoc = `
+    fragment HeroSectionFields on ComponentPageHero {
+  id
+  title
+  description
+  callToAction {
+    ...CallToActionFields
+  }
+  image {
+    ...ImageFields
+  }
+}
+    `;
 export const CompanyFieldsFragmentDoc = `
     fragment CompanyFields on CompanyEntity {
   id
@@ -3401,12 +3542,6 @@ export const PressQuoteFieldsFragmentDoc = `
   text
 }
     `;
-export const CallToActionFieldsFragmentDoc = `
-    fragment CallToActionFields on ComponentPageCallToAction {
-  title
-  url
-}
-    `;
 export const PressQuotesSectionFieldsFragmentDoc = `
     fragment PressQuotesSectionFields on ComponentPagePress {
   id
@@ -3417,6 +3552,30 @@ export const PressQuotesSectionFieldsFragmentDoc = `
   }
   callToAction {
     ...CallToActionFields
+  }
+}
+    `;
+export const SplitWithImageSectionFieldsFragmentDoc = `
+    fragment SplitWithImageSectionFields on ComponentPageSplitWithImage {
+  id
+  title
+  description
+  callToAction {
+    ...CallToActionFields
+  }
+  imagePosition
+  image {
+    ...ImageFields
+  }
+}
+    `;
+export const StatsSectionFieldsFragmentDoc = `
+    fragment StatsSectionFields on ComponentPageStats {
+  id
+  stats {
+    id
+    label
+    value
   }
 }
     `;
@@ -3434,60 +3593,24 @@ export const FindPageDocument = `
         title
         sections {
           __typename
-          ... on ComponentPageHero {
-            id
-            title
-            description
-            callToAction {
-              ...CallToActionFields
-            }
-            image {
-              ...ImageFields
-            }
-          }
-          ... on ComponentPageBrowse {
-            id
-            title
-            description
-            image {
-              ...ImageFields
-            }
-            categories(pagination: {limit: 100}) {
-              ...CategoryFields
-            }
-          }
-          ... on ComponentPageStats {
-            id
-            stats {
-              id
-              label
-              value
-            }
-          }
-          ... on ComponentPageSplitWithImage {
-            id
-            title
-            description
-            callToAction {
-              ...CallToActionFields
-            }
-            imagePosition
-            image {
-              ...ImageFields
-            }
-          }
-          ... on ComponentPagePress {
-            ...PressQuotesSectionFields
-          }
+          ...HeroSectionFields
+          ...BrowseSectionFields
+          ...StatsSectionFields
+          ...SplitWithImageSectionFields
+          ...PressQuotesSectionFields
         }
       }
     }
   }
 }
-    ${CallToActionFieldsFragmentDoc}
+    ${HeroSectionFieldsFragmentDoc}
+${CallToActionFieldsFragmentDoc}
 ${ImageFieldsFragmentDoc}
+${BrowseSectionFieldsFragmentDoc}
 ${CategoryFieldsFragmentDoc}
 ${ProductListFieldsFragmentDoc}
+${StatsSectionFieldsFragmentDoc}
+${SplitWithImageSectionFieldsFragmentDoc}
 ${PressQuotesSectionFieldsFragmentDoc}
 ${PressQuoteFieldsFragmentDoc}
 ${CompanyFieldsFragmentDoc}`;

--- a/frontend/lib/strapi-sdk/operations/findPage.graphql
+++ b/frontend/lib/strapi-sdk/operations/findPage.graphql
@@ -14,51 +14,11 @@ query findPage(
             title
             sections {
                __typename
-               ... on ComponentPageHero {
-                  id
-                  title
-                  description
-                  callToAction {
-                     ...CallToActionFields
-                  }
-                  image {
-                     ...ImageFields
-                  }
-               }
-               ... on ComponentPageBrowse {
-                  id
-                  title
-                  description
-                  image {
-                     ...ImageFields
-                  }
-                  categories(pagination: { limit: 100 }) {
-                     ...CategoryFields
-                  }
-               }
-               ... on ComponentPageStats {
-                  id
-                  stats {
-                     id
-                     label
-                     value
-                  }
-               }
-               ... on ComponentPageSplitWithImage {
-                  id
-                  title
-                  description
-                  callToAction {
-                     ...CallToActionFields
-                  }
-                  imagePosition
-                  image {
-                     ...ImageFields
-                  }
-               }
-               ... on ComponentPagePress {
-                  ...PressQuotesSectionFields
-               }
+               ...HeroSectionFields
+               ...BrowseSectionFields
+               ...StatsSectionFields
+               ...SplitWithImageSectionFields
+               ...PressQuotesSectionFields
             }
          }
       }
@@ -68,23 +28,4 @@ query findPage(
 fragment CallToActionFields on ComponentPageCallToAction {
    title
    url
-}
-
-fragment CategoryFields on ComponentPageCategory {
-   id
-   productList {
-      data {
-         ...ProductListFields
-      }
-   }
-}
-
-fragment PressQuoteFields on ComponentPagePressQuote {
-   id
-   company {
-      data {
-         ...CompanyFields
-      }
-   }
-   text
 }

--- a/frontend/lib/strapi-sdk/operations/sections/BrowseSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/BrowseSectionFields.fragment.graphql
@@ -1,0 +1,20 @@
+fragment BrowseSectionFields on ComponentPageBrowse {
+   id
+   title
+   description
+   image {
+      ...ImageFields
+   }
+   categories(pagination: { limit: 100 }) {
+      ...CategoryFields
+   }
+}
+
+fragment CategoryFields on ComponentPageCategory {
+   id
+   productList {
+      data {
+         ...ProductListFields
+      }
+   }
+}

--- a/frontend/lib/strapi-sdk/operations/sections/HeroSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/HeroSectionFields.fragment.graphql
@@ -1,0 +1,11 @@
+fragment HeroSectionFields on ComponentPageHero {
+   id
+   title
+   description
+   callToAction {
+      ...CallToActionFields
+   }
+   image {
+      ...ImageFields
+   }
+}

--- a/frontend/lib/strapi-sdk/operations/sections/PressQuotesSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/PressQuotesSectionFields.fragment.graphql
@@ -9,3 +9,13 @@ fragment PressQuotesSectionFields on ComponentPagePress {
       ...CallToActionFields
    }
 }
+
+fragment PressQuoteFields on ComponentPagePressQuote {
+   id
+   company {
+      data {
+         ...CompanyFields
+      }
+   }
+   text
+}

--- a/frontend/lib/strapi-sdk/operations/sections/SplitWithImageSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/SplitWithImageSectionFields.fragment.graphql
@@ -1,0 +1,12 @@
+fragment SplitWithImageSectionFields on ComponentPageSplitWithImage {
+   id
+   title
+   description
+   callToAction {
+      ...CallToActionFields
+   }
+   imagePosition
+   image {
+      ...ImageFields
+   }
+}

--- a/frontend/lib/strapi-sdk/operations/sections/StatsSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/StatsSectionFields.fragment.graphql
@@ -1,0 +1,8 @@
+fragment StatsSectionFields on ComponentPageStats {
+   id
+   stats {
+      id
+      label
+      value
+   }
+}

--- a/frontend/models/page/components/browse-category.ts
+++ b/frontend/models/page/components/browse-category.ts
@@ -1,0 +1,36 @@
+import { CategoryFieldsFragment } from '@lib/strapi-sdk';
+import { ProductListType } from '@models/product-list';
+import { getProductListType } from '@models/product-list/server';
+import { ImageSchema, imageFromStrapi } from '@models/shared/components/image';
+import { z } from 'zod';
+
+export const BrowseCategorySchema = z.object({
+   id: z.string(),
+   type: z.nativeEnum(ProductListType),
+   handle: z.string(),
+   title: z.string(),
+   deviceTitle: z.string().nullable(),
+   metaDescription: z.string().nullable(),
+   image: ImageSchema.nullable(),
+});
+
+export type BrowseCategory = z.infer<typeof BrowseCategorySchema>;
+
+export function browseCategoryFromStrapi(
+   fragment: CategoryFieldsFragment | null | undefined
+): BrowseCategory | null {
+   const id = fragment?.id;
+   const attributes = fragment?.productList?.data?.attributes;
+   if (id == null || attributes == null) {
+      return null;
+   }
+   return {
+      id,
+      type: getProductListType(attributes.type),
+      handle: attributes.handle,
+      title: attributes.title,
+      deviceTitle: attributes.deviceTitle ?? null,
+      metaDescription: attributes.metaDescription ?? null,
+      image: imageFromStrapi(attributes.image),
+   };
+}

--- a/frontend/models/page/sections/browse-section.ts
+++ b/frontend/models/page/sections/browse-section.ts
@@ -1,20 +1,15 @@
-import { ProductListType } from '@models/product-list';
-import { ImageSchema } from '@models/shared/components/image';
+import { filterFalsyItems } from '@helpers/application-helpers';
+import { createSectionId } from '@helpers/strapi-helpers';
+import { BrowseSectionFieldsFragment } from '@lib/strapi-sdk';
+import { imageFromStrapi, ImageSchema } from '@models/shared/components/image';
 import { z } from 'zod';
+import {
+   BrowseCategory,
+   browseCategoryFromStrapi,
+   BrowseCategorySchema,
+} from '../components/browse-category';
 
 export type BrowseSection = z.infer<typeof BrowseSectionSchema>;
-
-export const BrowseCategorySchema = z.object({
-   id: z.string(),
-   type: z.nativeEnum(ProductListType),
-   handle: z.string(),
-   title: z.string(),
-   deviceTitle: z.string().nullable(),
-   metaDescription: z.string().nullable(),
-   image: ImageSchema.nullable(),
-});
-
-export type BrowseCategory = z.infer<typeof BrowseCategorySchema>;
 
 export const BrowseSectionSchema = z.object({
    type: z.literal('Browse'),
@@ -24,3 +19,26 @@ export const BrowseSectionSchema = z.object({
    image: ImageSchema.nullable(),
    categories: z.array(BrowseCategorySchema),
 });
+
+export function browseSectionFromStrapi(
+   fragment: BrowseSectionFieldsFragment | null | undefined,
+   index: number
+): BrowseSection | null {
+   const id = createSectionId(fragment, index);
+   const title = fragment?.title ?? null;
+   const description = fragment?.description ?? null;
+   const categories: BrowseCategory[] = filterFalsyItems(
+      fragment?.categories?.map(browseCategoryFromStrapi)
+   );
+
+   if (id == null) return null;
+
+   return {
+      type: 'Browse',
+      id,
+      title,
+      description,
+      image: imageFromStrapi(fragment?.image),
+      categories,
+   };
+}

--- a/frontend/models/page/sections/hero-section.ts
+++ b/frontend/models/page/sections/hero-section.ts
@@ -1,5 +1,10 @@
-import { CallToActionSchema } from '@models/shared/components/call-to-action';
-import { ImageSchema } from '@models/shared/components/image';
+import { createSectionId } from '@helpers/strapi-helpers';
+import type { HeroSectionFieldsFragment } from '@lib/strapi-sdk';
+import {
+   callToActionFromStrapi,
+   CallToActionSchema,
+} from '@models/shared/components/call-to-action';
+import { imageFromStrapi, ImageSchema } from '@models/shared/components/image';
 import { z } from 'zod';
 
 export type HeroSection = z.infer<typeof HeroSectionSchema>;
@@ -12,3 +17,23 @@ export const HeroSectionSchema = z.object({
    image: ImageSchema.nullable(),
    callToAction: CallToActionSchema.nullable(),
 });
+
+export function heroSectionFromStrapi(
+   fragment: HeroSectionFieldsFragment | null | undefined,
+   index: number
+): HeroSection | null {
+   const id = createSectionId(fragment, index);
+   const title = fragment?.title ?? null;
+   const description = fragment?.description ?? null;
+
+   if (id == null) return null;
+
+   return {
+      type: 'Hero',
+      id,
+      title,
+      description,
+      image: imageFromStrapi(fragment?.image),
+      callToAction: callToActionFromStrapi(fragment?.callToAction),
+   };
+}

--- a/frontend/models/page/server.ts
+++ b/frontend/models/page/server.ts
@@ -1,16 +1,11 @@
-import {
-   filterFalsyItems,
-   filterNullableItems,
-} from '@helpers/application-helpers';
-import { createSectionId } from '@helpers/strapi-helpers';
+import { filterNullableItems } from '@helpers/application-helpers';
 import { assertNever } from '@ifixit/helpers';
-import { CategoryFieldsFragment, strapi } from '@lib/strapi-sdk';
-import { callToActionFromStrapi } from '@models/shared/components/call-to-action';
-import { imageFromStrapi } from '@models/shared/components/image';
-import { imagePositionFromStrapi } from '@models/shared/sections/split-with-image-section';
+import { FindPageQuery, strapi } from '@lib/strapi-sdk';
+import { iFixitStatsSectionFromStrapi } from '@models/shared/sections/ifixit-stats-section';
+import { splitWithImageSectionFromStrapi } from '@models/shared/sections/split-with-image-section';
 import type { Page, PageSection } from '.';
-import { getProductListType } from '../product-list/server';
-import type { BrowseCategory } from './sections/browse-section';
+import { browseSectionFromStrapi } from './sections/browse-section';
+import { heroSectionFromStrapi } from './sections/hero-section';
 import { pressQuotesSectionFromStrapi } from './sections/press-quotes-section';
 
 interface FindPageArgs {
@@ -25,77 +20,38 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
          },
       },
    });
-   const page = response.pages?.data[0]?.attributes;
+   const page = pageFromStrapi(response);
+
    if (page == null) {
       return null;
    }
 
-   const sections = filterNullableItems(
-      page.sections?.map((section, index): PageSection | null => {
-         if (section == null) {
+   const sections = sectionsFromStrapi(page.sections, (section, index) => {
+      switch (section.__typename) {
+         case 'ComponentPageHero': {
+            return heroSectionFromStrapi(section, index);
+         }
+         case 'ComponentPageBrowse': {
+            return browseSectionFromStrapi(section, index);
+         }
+         case 'ComponentPageStats': {
+            return iFixitStatsSectionFromStrapi(section, index);
+         }
+         case 'ComponentPageSplitWithImage': {
+            return splitWithImageSectionFromStrapi(section, index);
+         }
+         case 'ComponentPagePress': {
+            return pressQuotesSectionFromStrapi(section, index);
+         }
+         case 'Error': {
+            console.error('Failed to parse page section:', section);
             return null;
          }
-         switch (section?.__typename) {
-            case 'ComponentPageHero': {
-               return {
-                  type: 'Hero',
-                  id: createSectionId(section, index),
-                  title: section.title ?? null,
-                  description: section.description ?? null,
-                  callToAction: callToActionFromStrapi(section.callToAction),
-                  image: imageFromStrapi(section.image),
-               };
-            }
-            case 'ComponentPageBrowse': {
-               const categories: BrowseCategory[] = filterFalsyItems(
-                  section.categories?.map(processStrapiProductList)
-               );
-               return {
-                  type: 'Browse',
-                  id: createSectionId(section, index),
-                  title: section.title ?? null,
-                  description: section.description ?? null,
-                  image: imageFromStrapi(section.image),
-                  categories,
-               };
-            }
-            case 'ComponentPageStats': {
-               const stats = filterFalsyItems(section.stats).map(
-                  ({ id, label, value }) => {
-                     return { id, label, value };
-                  }
-               );
-               return {
-                  type: 'IFixitStats',
-                  id: createSectionId(section, index),
-                  stats,
-               };
-            }
-            case 'ComponentPageSplitWithImage': {
-               return {
-                  type: 'SplitWithImage',
-                  id: `${section.__typename}-${index}`,
-                  title: section.title ?? null,
-                  description: section.description ?? null,
-                  image: imageFromStrapi(section.image),
-                  imagePosition:
-                     imagePositionFromStrapi(section.imagePosition) ?? 'right',
-                  callToAction: section.callToAction ?? null,
-               };
-            }
-            case 'ComponentPagePress': {
-               return pressQuotesSectionFromStrapi(section, index);
-            }
-            case 'Error': {
-               console.error('Failed to parse page section:', section);
-               return null;
-            }
-            default: {
-               return assertNever(section);
-            }
+         default: {
+            return assertNever(section);
          }
-      }) ?? []
-   );
+      }
+   });
 
    return {
       path: page.path,
@@ -104,21 +60,21 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
    };
 }
 
-function processStrapiProductList(
-   categoryFragment: CategoryFieldsFragment | null | undefined
-): BrowseCategory | null {
-   const id = categoryFragment?.id;
-   const attributes = categoryFragment?.productList?.data?.attributes;
-   if (id == null || attributes == null) {
-      return null;
-   }
-   return {
-      id,
-      type: getProductListType(attributes.type),
-      handle: attributes.handle,
-      title: attributes.title,
-      deviceTitle: attributes.deviceTitle ?? null,
-      metaDescription: attributes.metaDescription ?? null,
-      image: imageFromStrapi(attributes.image),
-   };
+type StrapiPage = NonNullable<ReturnType<typeof pageFromStrapi>>;
+
+function pageFromStrapi(response: FindPageQuery) {
+   return response.pages?.data[0]?.attributes ?? null;
+}
+
+type StrapiSection = NonNullable<StrapiPage['sections'][0]>;
+
+function sectionsFromStrapi(
+   sections: StrapiPage['sections'],
+   fn: (section: StrapiSection, index: number) => PageSection | null
+) {
+   return filterNullableItems(
+      sections?.map((section, index) =>
+         section == null ? null : fn(section, index)
+      ) ?? []
+   );
 }

--- a/frontend/models/shared/sections/ifixit-stats-section.ts
+++ b/frontend/models/shared/sections/ifixit-stats-section.ts
@@ -1,3 +1,6 @@
+import { filterFalsyItems } from '@helpers/application-helpers';
+import { createSectionId } from '@helpers/strapi-helpers';
+import { StatsSectionFieldsFragment } from '@lib/strapi-sdk';
 import { z } from 'zod';
 
 export type IFixitStat = z.infer<typeof IFixitStatSchema>;
@@ -15,3 +18,21 @@ export const IFixitStatsSectionSchema = z.object({
    id: z.string(),
    stats: z.array(IFixitStatSchema),
 });
+
+export function iFixitStatsSectionFromStrapi(
+   fragment: StatsSectionFieldsFragment | null | undefined,
+   index: number
+): IFixitStatsSection | null {
+   const id = createSectionId(fragment, index);
+   const stats = filterFalsyItems(fragment?.stats).map(
+      ({ id, label, value }) => ({ id, label, value })
+   );
+
+   if (id == null || stats == null) return null;
+
+   return {
+      type: 'IFixitStats',
+      id,
+      stats,
+   };
+}

--- a/frontend/models/shared/sections/split-with-image-section.ts
+++ b/frontend/models/shared/sections/split-with-image-section.ts
@@ -1,8 +1,15 @@
+import { createSectionId } from '@helpers/strapi-helpers';
 import { assertNever } from '@ifixit/helpers';
-import { Enum_Componentpagesplitwithimage_Imageposition } from '@lib/strapi-sdk';
+import {
+   Enum_Componentpagesplitwithimage_Imageposition,
+   SplitWithImageSectionFieldsFragment,
+} from '@lib/strapi-sdk';
 import { z } from 'zod';
-import { CallToActionSchema } from '../components/call-to-action';
-import { ImageSchema } from '../components/image';
+import {
+   callToActionFromStrapi,
+   CallToActionSchema,
+} from '../components/call-to-action';
+import { imageFromStrapi, ImageSchema } from '../components/image';
 
 export type SplitWithImageSection = z.infer<typeof SplitWithImageSectionSchema>;
 
@@ -16,7 +23,29 @@ export const SplitWithImageSectionSchema = z.object({
    callToAction: CallToActionSchema.nullable(),
 });
 
-export function imagePositionFromStrapi(
+export function splitWithImageSectionFromStrapi(
+   fragment: SplitWithImageSectionFieldsFragment | null | undefined,
+   index: number
+): SplitWithImageSection | null {
+   const id = createSectionId(fragment, index);
+   const title = fragment?.title ?? null;
+   const description = fragment?.description ?? null;
+
+   if (id == null) return null;
+
+   return {
+      type: 'SplitWithImage',
+      id,
+      title,
+      description,
+      image: imageFromStrapi(fragment?.image),
+      imagePosition:
+         imagePositionFromStrapi(fragment?.imagePosition) ?? 'right',
+      callToAction: callToActionFromStrapi(fragment?.callToAction),
+   };
+}
+
+function imagePositionFromStrapi(
    position: Enum_Componentpagesplitwithimage_Imageposition | null | undefined
 ): SplitWithImageSection['imagePosition'] | null {
    if (position == null) return null;


### PR DESCRIPTION
Extracted this while working on #1409 

## QA

This is just a small refactor, let's just check that the store home page still renders:

1. Visit preview [store home page](https://react-commerce-git-refactor-page-model-sections-ifixit.vercel.app/store)
2. Verify that the page renders (don't worry about the sections, it's just dummy data from Strapi)