### PR TITLE
Playwright: Deflake Parts Page Search Test

### DIFF
--- a/frontend/tests/playwright/product-list/parts_page_search.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_search.spec.ts
@@ -1,4 +1,3 @@
-import { waitForAlgoliaSearch } from './../utils';
 import { test, expect } from '../test-fixtures';
 
 test.describe('parts page search', () => {
@@ -10,13 +9,9 @@ test.describe('parts page search', () => {
       expect(page.getByTestId('collections-search-box')).toBeVisible();
       expect(page.getByTestId('collections-search-box')).not.toBeDisabled();
 
-      // Start listening for algolia search request
-      const queryResponse = waitForAlgoliaSearch(page);
-
       await page.getByTestId('collections-search-box').fill('iphone');
-
-      // Wait for search request to finish
-      await queryResponse;
+      // Wait for url to update after search
+      await page.waitForURL('**/Parts?q=*');
 
       // Check that url parameter contains ?q after searching
       expect(page.url()).toContain('?q=iphone');
@@ -39,13 +34,9 @@ test.describe('parts page search', () => {
       expect(page.getByTestId('collections-search-box')).toBeVisible();
       expect(page.getByTestId('collections-search-box')).not.toBeDisabled();
 
-      // Start listening for algolia search request
-      const queryResponse = waitForAlgoliaSearch(page);
-
       await page.getByTestId('collections-search-box').fill('asdasasdadasd');
-
-      // Wait for search request to finish
-      await queryResponse;
+      // Wait for url to update after search
+      await page.waitForURL('**/Parts?q=*');
 
       // Check that url parameter contains ?q after searching
       expect(page.url()).toContain('?q=');


### PR DESCRIPTION
## Description

This test is flaky as we wait for the algolia query to finish but this event does not mean that the page has fully been updated. As a result, we sometimes fail since we have not updated the url after the query has finished.

This flakiness became more of an issue in https://github.com/iFixit/react-commerce/pull/1375. Locally the test passes for the branch. However, when we run the entire test-suite the flakiness of the test increases. This means when the machine is under higher loads the test begins to fail more often. 

To fix this, we will instead wait for the url to be updated with a query parameter after we enter the search text but before the assertion is made. This will give the page enough time to update the URL. 

### QA

qa_req 0 CI should continue to pass.

I confirmed this helped to deflake the test by running the following command to overload the playwright workers:

```
pnpm playwright:run parts_page_search --repeat-each=5 --workers=5
```

|Before|After|
|:---:|:---:|
|  ![image](https://user-images.githubusercontent.com/22064420/221963602-a46d3fab-684c-41dd-8379-c9cd1ef2b5c0.png)  | ![image](https://user-images.githubusercontent.com/22064420/221963630-d00811fe-22e8-45ea-8caa-879638cb3409.png) |

**cc:** @federicobadini 

Closes: #1416 