### PR TITLE
Add collection displayTitle backend

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -45,6 +45,15 @@
          "type": "string",
          "required": true
       },
+      "h1": {
+         "pluginOptions": {
+            "i18n": {
+               "localized": true
+            }
+         },
+         "type": "string",
+         "required": false
+      },
       "description": {
          "pluginOptions": {
             "i18n": {

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -1091,6 +1091,7 @@ export type ProductList = {
    excludeFromHierarchyDisplay: Scalars['Boolean'];
    filters?: Maybe<Scalars['String']>;
    forceNoindex?: Maybe<Scalars['Boolean']>;
+   h1?: Maybe<Scalars['String']>;
    handle: Scalars['String'];
    heroImage?: Maybe<UploadFileEntityResponse>;
    image?: Maybe<UploadFileEntityResponse>;
@@ -1152,6 +1153,7 @@ export type ProductListFiltersInput = {
    excludeFromHierarchyDisplay?: InputMaybe<BooleanFilterInput>;
    filters?: InputMaybe<StringFilterInput>;
    forceNoindex?: InputMaybe<BooleanFilterInput>;
+   h1?: InputMaybe<StringFilterInput>;
    handle?: InputMaybe<StringFilterInput>;
    id?: InputMaybe<IdFilterInput>;
    legacyDescription?: InputMaybe<StringFilterInput>;
@@ -1181,6 +1183,7 @@ export type ProductListInput = {
    excludeFromHierarchyDisplay?: InputMaybe<Scalars['Boolean']>;
    filters?: InputMaybe<Scalars['String']>;
    forceNoindex?: InputMaybe<Scalars['Boolean']>;
+   h1?: InputMaybe<Scalars['String']>;
    handle?: InputMaybe<Scalars['String']>;
    heroImage?: InputMaybe<Scalars['ID']>;
    image?: InputMaybe<Scalars['ID']>;


### PR DESCRIPTION
connects #898 

This pr add a ~`displayTitle`~ `h1` field to the Strapi backend

❗ ❗ ❗ After this PR is merged Strapi should be redeployed in production ❗ ❗ ❗
cc @sterlinghirsh @danielbeardsley 

### QA

1. Navigate to [Strapi](https://add-collection-display-title-backend.govinor.com/admin)
2. Verify that the ~`displayTitle`~ `h1` field is present in the `productList` model
3. Visit [Vercel preview](https://react-commerce-git-add-collection-display-title-backend-ifixit.vercel.app/Parts)
4. Verify that the product list page still renders correctly

