### PR TITLE
Collection page style refinements

### DIFF
--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -33,7 +33,7 @@ export function ProductListView({
          <Wrapper py={{ base: 4, md: 6 }}>
             <VStack align="stretch" spacing={{ base: 4, md: 6 }}>
                <Index indexName={indexName} indexId="main-product-list-index">
-                  <Configure filters={filters} hitsPerPage={18} />
+                  <Configure filters={filters} hitsPerPage={24} />
                   <MetaTags productList={productList} />
                   {productList.heroImage ? (
                      <HeroWithBackgroundSection productList={productList} />

--- a/frontend/templates/product-list/sections/BannerSection/index.tsx
+++ b/frontend/templates/product-list/sections/BannerSection/index.tsx
@@ -20,10 +20,7 @@ export function BannerSection({
    return (
       <Box
          as="section"
-         borderRadius={{
-            base: 'none',
-            sm: '2xl',
-         }}
+         borderRadius="base"
          overflow="hidden"
          position="relative"
       >

--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -77,7 +77,7 @@ export function FilterableProductsSection({ productList }: SectionProps) {
          </Heading>
 
          <SearchQueryProvider>
-            <Flex mt="4" align="flex-start">
+            <Flex align="flex-start">
                <Flex
                   bg="white"
                   borderWidth="1px"

--- a/frontend/templates/product-list/sections/HeroWithBackgroundSection.tsx
+++ b/frontend/templates/product-list/sections/HeroWithBackgroundSection.tsx
@@ -41,13 +41,7 @@ export function HeroWithBackgroundSection({ productList }: HeroSectionProps) {
 
    const title = getProductListTitle(productList, itemType);
    return (
-      <Flex
-         pos="relative"
-         mx={{ base: 6, sm: 0 }}
-         minH="96"
-         borderRadius="base"
-         overflow="hidden"
-      >
+      <Flex pos="relative" minH="96" borderRadius="base" overflow="hidden">
          <ResponsiveImage
             priority
             layout="fill"

--- a/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
@@ -43,7 +43,6 @@ export function ProductListChildrenSection({
                xl: 5,
             }}
             spacing="2"
-            pt={1}
          >
             {productListChildren.map((child, index) => {
                return (

--- a/frontend/templates/product-list/sections/RelatedPostsSection/index.tsx
+++ b/frontend/templates/product-list/sections/RelatedPostsSection/index.tsx
@@ -20,8 +20,15 @@ export function RelatedPostsSection({ tags = [] }: RelatedPostsSectionProps) {
    }
 
    return (
-      <VStack align="stretch" spacing="6">
-         <Heading size="lg">Related News Stories</Heading>
+      <VStack align="stretch" spacing="4">
+         <Heading
+            as="h2"
+            color="gray.700"
+            fontSize={{ base: '2xl', md: '3xl' }}
+            fontWeight="medium"
+         >
+            Related News Stories
+         </Heading>
          <SimpleGrid columns={{ base: 1, sm: 2, md: 3 }} spacing="6">
             {posts.map((post) => (
                <PostCard

--- a/frontend/tests/jest/tests/__snapshots__/ProductListItem.test.tsx.snap
+++ b/frontend/tests/jest/tests/__snapshots__/ProductListItem.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`ProductListItem renders and matches the snapshot 1`] = `
               class="css-1qc3xp7"
             >
               <div
-                class="css-1nqx83v"
+                class="css-1ah8j8s"
               >
                 <div
                   class="css-zvlevn"

--- a/packages/ui/misc/IconBadge.tsx
+++ b/packages/ui/misc/IconBadge.tsx
@@ -28,7 +28,7 @@ export const IconBadge = forwardRef<IconBadgeProps, 'div'>(
             lineHeight="1em"
             color={`${colorScheme}.700`}
             alignItems="center"
-            borderRadius="md"
+            borderRadius="base"
             flexShrink={0}
             maxW="full"
             {...props}


### PR DESCRIPTION
closes #1428
closes #1422

This PR is a follow-up of #1369 #1373 #1375 and #1376

It fixes a couple of details like the border-radius of product-list items or the margin on top of the filterableListItem which were not yet correct.

In addition to this, the `HeroWithBackground` component needed to be adapted to the new wrapper, since it was introduced in parallel with it.

qa_req 0