### PR TITLE
Playwright: Update `filters` test to use new Algolia Results

### DIFF
--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -31,13 +31,32 @@ async function checkRefinementInSearchResult(
    if (!facetName) {
       throw new Error('Could not find first facet name');
    }
-   // Reduce the search results to a single array of products.
-   const filteredProducts = results.reduce(
-      (products: [], searchResults: { hits: [] }) => {
-         return [...products, ...searchResults.hits];
-      },
-      []
-   );
+
+   let filteredProducts: any = [];
+   let foundAssociatedResults = false;
+
+   results.forEach((result: any) => {
+      const decodedParams = decodeURIComponent(result.params);
+
+      if (decodedParams.includes(facetOptionValue)) {
+         filteredProducts = [...filteredProducts, ...result.hits];
+
+         if (!foundAssociatedResults) {
+            foundAssociatedResults = true;
+         } else {
+            throw new Error(
+               `Found multiple associated results for "${facetOptionValue}".\n\nThe Algolia search results may have changed in a way that is no longer compatible with this test.\nDouble check the search results structure and update the test accordingly if necessary.`
+            );
+         }
+      }
+   });
+
+   if (!foundAssociatedResults) {
+      throw new Error(
+         `Could not find associated results where facet option "${facetOptionValue}" is included in the params.`
+      );
+   }
+
    filteredProducts.forEach((product: any) => {
       expect(resolvePath(product, facetName)).toContain(facetOptionValue);
    });

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -33,25 +33,22 @@ async function checkRefinementInSearchResult(
    }
 
    let filteredProducts: any = [];
-   let foundAssociatedResults = false;
 
    results.forEach((result: any) => {
       const decodedParams = decodeURIComponent(result.params);
 
       if (decodedParams.includes(facetOptionValue)) {
-         filteredProducts = [...filteredProducts, ...result.hits];
-
-         if (!foundAssociatedResults) {
-            foundAssociatedResults = true;
-         } else {
+         if (filteredProducts.length) {
             throw new Error(
                `Found multiple associated results for "${facetOptionValue}".\n\nThe Algolia search results may have changed in a way that is no longer compatible with this test.\nDouble check the search results structure and update the test accordingly if necessary.`
             );
          }
+
+         filteredProducts = result.hits;
       }
    });
 
-   if (!foundAssociatedResults) {
+   if (!filteredProducts.length) {
       throw new Error(
          `Could not find associated results where facet option "${facetOptionValue}" is included in the params.`
       );


### PR DESCRIPTION
## Description

The Algolia `dev_product_group_en` index was updated recently. This may have caused a bug to surface as our assumption of the Algolia results structure was causing the `filters` test to fail. However, we cannot validate this as we cannot go back to a prior state of the Algolia index.

Overall, what we now know is the Algolia results include hits from different filter parameters. We need to search for the filter parameters that include the facet option we selected. This will indicate that the hits are associated with the filter facet option we selected. 

Additionally, there are some guards to ensure that if our current assumption about the Algolia results is no longer valid, we will throw an error to indicate that the test might need to be updated.

### CR

The structure of the Algolia Results are as such:

![image](https://user-images.githubusercontent.com/22064420/222274349-16837453-ce5d-47fa-914a-8e29cd92d114.png)

Where the `params` property is an encoded URL component, as such we need to decode it in order to safely check if the `facet option` is included in the string.

![image](https://user-images.githubusercontent.com/22064420/222274653-a8f11502-84c3-4f45-8b52-1b0fe6e719e0.png)


### QA

qa_req 0, CI should pass.

I confirmed with @masonmcelvain the sad paths for the guards work as expected.

![image](https://user-images.githubusercontent.com/22064420/222273475-4cd1959a-83ad-41c7-bd58-bd87ec63005e.png)

![image](https://user-images.githubusercontent.com/22064420/222273492-1a6da2d9-0d9b-4a93-99b9-3bf18fe65284.png)

**Reference:**
- https://ifixit.slack.com/archives/C01K32B4FPX/p1677682184659919