### PR TITLE
Switch from mobile to desktop header at lg size

### DIFF
--- a/packages/ui/header/NavigationDrawer.tsx
+++ b/packages/ui/header/NavigationDrawer.tsx
@@ -72,7 +72,7 @@ export const HeaderNavigationToggleButton = forwardRef<
          }}
          display={{
             base: 'block',
-            xl: 'none',
+            lg: 'none',
          }}
          icon={
             <Icon

--- a/packages/ui/header/NavigationMenu.tsx
+++ b/packages/ui/header/NavigationMenu.tsx
@@ -16,7 +16,7 @@ export const NavigationMenu = forwardRef<BoxProps, 'nav'>(
             as="nav"
             h="full"
             ml="6"
-            display={{ base: 'none', xl: 'block' }}
+            display={{ base: 'none', lg: 'block' }}
             {...otherProps}
          >
             <Flex as="ul" role="menubar" h="full" position="relative">


### PR DESCRIPTION
closes #1424 

### QA

1. Visit [Vercel preview](https://react-commerce-git-change-navigation-mobile-deskt-b1a66f-ifixit.vercel.app/Parts)
2. Verify that for screen widths `>= 1028px` the desktop header is shown