### PR TITLE
Fix `og:image` meta in product page

### DIFF
--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -33,21 +33,15 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
 
    const genericImages = React.useMemo(() => {
       return product.images.filter((image) => {
-         return (
-            image.altText == null ||
-            !product.variants.find((variant) => variant.sku === image.altText)
-         );
+         return image.variantId === null;
       });
-   }, [product.images, product.variants]);
+   }, [product.images]);
 
    const selectedVariantImages = React.useMemo(() => {
       return product.images.filter((image) => {
-         const variant = product.variants.find(
-            (variant) => variant.sku === image.altText
-         );
-         return image.altText != null && variant?.id === selectedVariant.id;
+         return image.variantId === selectedVariant.id;
       });
-   }, [product.images, product.variants, selectedVariant.id]);
+   }, [product.images, selectedVariant.id]);
 
    const priceValidUntil = new Date();
    priceValidUntil.setFullYear(priceValidUntil.getFullYear() + 1);


### PR DESCRIPTION
closes #1440 
connects [#1092](https://github.com/iFixit/react-commerce/pull/1092#issuecomment-1455270179)

The code that was in charge of separating generic and variant specific product images was still using the old logic that exploited the image `altText` attribute. 
After the execution of the [formatImage](https://github.com/iFixit/react-commerce/blob/b40d56b2bba9f2f4f8dde57df19bc759cbecbb29/frontend/models/product/server.ts#L186-L195) function though, this is not anymore true.
We have to rely on the `variantId` attribute on the image to assert if an image is generic or variant specific.

### QA

1. Visit [Vercel preview](https://react-commerce-git-fix-product-page-og-image-ifixit.vercel.app/products/ifixit-precision-4-mm-screwdriver-bit)
2. Assert that `og:image` tags are generated only for generic images + selected variant images