### PR TITLE
Product Page: Add OEM partner shipping restriction

### DIFF
--- a/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
+++ b/frontend/templates/product/sections/ProductSection/AddToCart/index.tsx
@@ -176,6 +176,10 @@ const shippingRestrictionsInfo: ShippingRestrictionsInfo = {
       notice: 'Partner fulfilled',
       text: 'This product will be packed and shipped by one of our fulfillment partners.',
    },
+   is_oem_partner_restricted: {
+      notice: 'Shipping restrictions apply',
+      text: 'This product ships to the United States, Japan, South Korea, Hong Kong, and Taiwan only.',
+   },
 };
 
 type ShippingRestrictionsProps = StackProps & {


### PR DESCRIPTION
Adds an OEM Partnership shipping restriction message to the product page.

## QA

Visit a product page for a variant whose shipping restriction metafield includes `is_oem_partner_restricted`. The product page should include the notice specified in the parent issue.

Backend change: https://github.com/iFixit/ifixit/pull/46793
Closes #1418 