### PR TITLE
Add menu3 to strapi store

### DIFF
--- a/backend/src/components/store/footer.json
+++ b/backend/src/components/store/footer.json
@@ -2,10 +2,21 @@
    "collectionName": "components_store_footers",
    "info": {
       "displayName": "footer",
-      "icon": "shoe-prints"
+      "icon": "shoe-prints",
+      "description": ""
    },
    "options": {},
    "attributes": {
+      "bottomMenu": {
+         "type": "relation",
+         "relation": "oneToOne",
+         "target": "api::menu.menu"
+      },
+      "partners": {
+         "type": "relation",
+         "relation": "oneToOne",
+         "target": "api::menu.menu"
+      },
       "menu1": {
          "type": "relation",
          "relation": "oneToOne",
@@ -16,12 +27,7 @@
          "relation": "oneToOne",
          "target": "api::menu.menu"
       },
-      "bottomMenu": {
-         "type": "relation",
-         "relation": "oneToOne",
-         "target": "api::menu.menu"
-      },
-      "partners": {
+      "menu3": {
          "type": "relation",
          "relation": "oneToOne",
          "target": "api::menu.menu"

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -304,6 +304,7 @@ export type ComponentStoreFooter = {
    id: Scalars['ID'];
    menu1?: Maybe<MenuEntityResponse>;
    menu2?: Maybe<MenuEntityResponse>;
+   menu3?: Maybe<MenuEntityResponse>;
    partners?: Maybe<MenuEntityResponse>;
 };
 
@@ -312,6 +313,7 @@ export type ComponentStoreFooterFiltersInput = {
    bottomMenu?: InputMaybe<MenuFiltersInput>;
    menu1?: InputMaybe<MenuFiltersInput>;
    menu2?: InputMaybe<MenuFiltersInput>;
+   menu3?: InputMaybe<MenuFiltersInput>;
    not?: InputMaybe<ComponentStoreFooterFiltersInput>;
    or?: InputMaybe<Array<InputMaybe<ComponentStoreFooterFiltersInput>>>;
    partners?: InputMaybe<MenuFiltersInput>;
@@ -322,6 +324,7 @@ export type ComponentStoreFooterInput = {
    id?: InputMaybe<Scalars['ID']>;
    menu1?: InputMaybe<Scalars['ID']>;
    menu2?: InputMaybe<Scalars['ID']>;
+   menu3?: InputMaybe<Scalars['ID']>;
    partners?: InputMaybe<Scalars['ID']>;
 };
 
@@ -2216,6 +2219,230 @@ export type FindStoreQuery = {
             };
             footer: {
                __typename?: 'ComponentStoreFooter';
+               partners?: {
+                  __typename?: 'MenuEntityResponse';
+                  data?: {
+                     __typename?: 'MenuEntity';
+                     attributes?: {
+                        __typename?: 'Menu';
+                        title: string;
+                        items: Array<
+                           | {
+                                __typename: 'ComponentMenuLink';
+                                name: string;
+                                url: string;
+                                description?: string | null;
+                             }
+                           | {
+                                __typename: 'ComponentMenuLinkWithImage';
+                                name: string;
+                                url: string;
+                                image: {
+                                   __typename?: 'UploadFileEntityResponse';
+                                   data?: {
+                                      __typename?: 'UploadFileEntity';
+                                      attributes?: {
+                                         __typename?: 'UploadFile';
+                                         alternativeText?: string | null;
+                                         url: string;
+                                         formats?: any | null;
+                                      } | null;
+                                   } | null;
+                                };
+                             }
+                           | {
+                                __typename: 'ComponentMenuProductListLink';
+                                name: string;
+                                productList?: {
+                                   __typename?: 'ProductListEntityResponse';
+                                   data?: {
+                                      __typename?: 'ProductListEntity';
+                                      attributes?: {
+                                         __typename?: 'ProductList';
+                                         handle: string;
+                                      } | null;
+                                   } | null;
+                                } | null;
+                             }
+                           | {
+                                __typename: 'ComponentMenuSubmenu';
+                                name: string;
+                                submenu?: {
+                                   __typename?: 'MenuEntityResponse';
+                                   data?: {
+                                      __typename?: 'MenuEntity';
+                                      attributes?: {
+                                         __typename?: 'Menu';
+                                         title: string;
+                                         items: Array<
+                                            | {
+                                                 __typename: 'ComponentMenuLink';
+                                                 name: string;
+                                                 url: string;
+                                                 description?: string | null;
+                                              }
+                                            | {
+                                                 __typename: 'ComponentMenuLinkWithImage';
+                                                 name: string;
+                                                 url: string;
+                                                 image: {
+                                                    __typename?: 'UploadFileEntityResponse';
+                                                    data?: {
+                                                       __typename?: 'UploadFileEntity';
+                                                       attributes?: {
+                                                          __typename?: 'UploadFile';
+                                                          alternativeText?:
+                                                             | string
+                                                             | null;
+                                                          url: string;
+                                                          formats?: any | null;
+                                                       } | null;
+                                                    } | null;
+                                                 };
+                                              }
+                                            | {
+                                                 __typename: 'ComponentMenuProductListLink';
+                                                 name: string;
+                                                 productList?: {
+                                                    __typename?: 'ProductListEntityResponse';
+                                                    data?: {
+                                                       __typename?: 'ProductListEntity';
+                                                       attributes?: {
+                                                          __typename?: 'ProductList';
+                                                          handle: string;
+                                                       } | null;
+                                                    } | null;
+                                                 } | null;
+                                              }
+                                            | {
+                                                 __typename: 'ComponentMenuSubmenu';
+                                                 name: string;
+                                              }
+                                            | { __typename: 'Error' }
+                                            | null
+                                         >;
+                                      } | null;
+                                   } | null;
+                                } | null;
+                             }
+                           | { __typename: 'Error' }
+                           | null
+                        >;
+                     } | null;
+                  } | null;
+               } | null;
+               bottomMenu?: {
+                  __typename?: 'MenuEntityResponse';
+                  data?: {
+                     __typename?: 'MenuEntity';
+                     attributes?: {
+                        __typename?: 'Menu';
+                        title: string;
+                        items: Array<
+                           | {
+                                __typename: 'ComponentMenuLink';
+                                name: string;
+                                url: string;
+                                description?: string | null;
+                             }
+                           | {
+                                __typename: 'ComponentMenuLinkWithImage';
+                                name: string;
+                                url: string;
+                                image: {
+                                   __typename?: 'UploadFileEntityResponse';
+                                   data?: {
+                                      __typename?: 'UploadFileEntity';
+                                      attributes?: {
+                                         __typename?: 'UploadFile';
+                                         alternativeText?: string | null;
+                                         url: string;
+                                         formats?: any | null;
+                                      } | null;
+                                   } | null;
+                                };
+                             }
+                           | {
+                                __typename: 'ComponentMenuProductListLink';
+                                name: string;
+                                productList?: {
+                                   __typename?: 'ProductListEntityResponse';
+                                   data?: {
+                                      __typename?: 'ProductListEntity';
+                                      attributes?: {
+                                         __typename?: 'ProductList';
+                                         handle: string;
+                                      } | null;
+                                   } | null;
+                                } | null;
+                             }
+                           | {
+                                __typename: 'ComponentMenuSubmenu';
+                                name: string;
+                                submenu?: {
+                                   __typename?: 'MenuEntityResponse';
+                                   data?: {
+                                      __typename?: 'MenuEntity';
+                                      attributes?: {
+                                         __typename?: 'Menu';
+                                         title: string;
+                                         items: Array<
+                                            | {
+                                                 __typename: 'ComponentMenuLink';
+                                                 name: string;
+                                                 url: string;
+                                                 description?: string | null;
+                                              }
+                                            | {
+                                                 __typename: 'ComponentMenuLinkWithImage';
+                                                 name: string;
+                                                 url: string;
+                                                 image: {
+                                                    __typename?: 'UploadFileEntityResponse';
+                                                    data?: {
+                                                       __typename?: 'UploadFileEntity';
+                                                       attributes?: {
+                                                          __typename?: 'UploadFile';
+                                                          alternativeText?:
+                                                             | string
+                                                             | null;
+                                                          url: string;
+                                                          formats?: any | null;
+                                                       } | null;
+                                                    } | null;
+                                                 };
+                                              }
+                                            | {
+                                                 __typename: 'ComponentMenuProductListLink';
+                                                 name: string;
+                                                 productList?: {
+                                                    __typename?: 'ProductListEntityResponse';
+                                                    data?: {
+                                                       __typename?: 'ProductListEntity';
+                                                       attributes?: {
+                                                          __typename?: 'ProductList';
+                                                          handle: string;
+                                                       } | null;
+                                                    } | null;
+                                                 } | null;
+                                              }
+                                            | {
+                                                 __typename: 'ComponentMenuSubmenu';
+                                                 name: string;
+                                              }
+                                            | { __typename: 'Error' }
+                                            | null
+                                         >;
+                                      } | null;
+                                   } | null;
+                                } | null;
+                             }
+                           | { __typename: 'Error' }
+                           | null
+                        >;
+                     } | null;
+                  } | null;
+               } | null;
                menu1?: {
                   __typename?: 'MenuEntityResponse';
                   data?: {
@@ -2440,119 +2667,7 @@ export type FindStoreQuery = {
                      } | null;
                   } | null;
                } | null;
-               partners?: {
-                  __typename?: 'MenuEntityResponse';
-                  data?: {
-                     __typename?: 'MenuEntity';
-                     attributes?: {
-                        __typename?: 'Menu';
-                        title: string;
-                        items: Array<
-                           | {
-                                __typename: 'ComponentMenuLink';
-                                name: string;
-                                url: string;
-                                description?: string | null;
-                             }
-                           | {
-                                __typename: 'ComponentMenuLinkWithImage';
-                                name: string;
-                                url: string;
-                                image: {
-                                   __typename?: 'UploadFileEntityResponse';
-                                   data?: {
-                                      __typename?: 'UploadFileEntity';
-                                      attributes?: {
-                                         __typename?: 'UploadFile';
-                                         alternativeText?: string | null;
-                                         url: string;
-                                         formats?: any | null;
-                                      } | null;
-                                   } | null;
-                                };
-                             }
-                           | {
-                                __typename: 'ComponentMenuProductListLink';
-                                name: string;
-                                productList?: {
-                                   __typename?: 'ProductListEntityResponse';
-                                   data?: {
-                                      __typename?: 'ProductListEntity';
-                                      attributes?: {
-                                         __typename?: 'ProductList';
-                                         handle: string;
-                                      } | null;
-                                   } | null;
-                                } | null;
-                             }
-                           | {
-                                __typename: 'ComponentMenuSubmenu';
-                                name: string;
-                                submenu?: {
-                                   __typename?: 'MenuEntityResponse';
-                                   data?: {
-                                      __typename?: 'MenuEntity';
-                                      attributes?: {
-                                         __typename?: 'Menu';
-                                         title: string;
-                                         items: Array<
-                                            | {
-                                                 __typename: 'ComponentMenuLink';
-                                                 name: string;
-                                                 url: string;
-                                                 description?: string | null;
-                                              }
-                                            | {
-                                                 __typename: 'ComponentMenuLinkWithImage';
-                                                 name: string;
-                                                 url: string;
-                                                 image: {
-                                                    __typename?: 'UploadFileEntityResponse';
-                                                    data?: {
-                                                       __typename?: 'UploadFileEntity';
-                                                       attributes?: {
-                                                          __typename?: 'UploadFile';
-                                                          alternativeText?:
-                                                             | string
-                                                             | null;
-                                                          url: string;
-                                                          formats?: any | null;
-                                                       } | null;
-                                                    } | null;
-                                                 };
-                                              }
-                                            | {
-                                                 __typename: 'ComponentMenuProductListLink';
-                                                 name: string;
-                                                 productList?: {
-                                                    __typename?: 'ProductListEntityResponse';
-                                                    data?: {
-                                                       __typename?: 'ProductListEntity';
-                                                       attributes?: {
-                                                          __typename?: 'ProductList';
-                                                          handle: string;
-                                                       } | null;
-                                                    } | null;
-                                                 } | null;
-                                              }
-                                            | {
-                                                 __typename: 'ComponentMenuSubmenu';
-                                                 name: string;
-                                              }
-                                            | { __typename: 'Error' }
-                                            | null
-                                         >;
-                                      } | null;
-                                   } | null;
-                                } | null;
-                             }
-                           | { __typename: 'Error' }
-                           | null
-                        >;
-                     } | null;
-                  } | null;
-               } | null;
-               bottomMenu?: {
+               menu3?: {
                   __typename?: 'MenuEntityResponse';
                   data?: {
                      __typename?: 'MenuEntity';
@@ -3703,19 +3818,22 @@ export const FindStoreDocument = `
           }
         }
         footer {
-          menu1 {
-            ...MenuEntityResponseProps
-          }
-          menu2 {
-            ...MenuEntityResponseProps
-          }
-          partners {
-            ...MenuEntityResponseProps
-          }
-          bottomMenu {
-            ...MenuEntityResponseProps
-          }
-        }
+         partners {
+           ...MenuEntityResponseProps
+         }
+         bottomMenu {
+           ...MenuEntityResponseProps
+         }
+         menu1 {
+           ...MenuEntityResponseProps
+         }
+         menu2 {
+           ...MenuEntityResponseProps
+         }
+         menu3 {
+           ...MenuEntityResponseProps
+         }
+       }
         socialMediaAccounts {
           twitter
           tiktok

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -3830,9 +3830,6 @@ export const FindStoreDocument = `
          menu2 {
            ...MenuEntityResponseProps
          }
-         menu3 {
-           ...MenuEntityResponseProps
-         }
        }
         socialMediaAccounts {
           twitter

--- a/frontend/lib/strapi-sdk/operations/findStore.graphql
+++ b/frontend/lib/strapi-sdk/operations/findStore.graphql
@@ -8,16 +8,19 @@ query findStore($filters: StoreFiltersInput) {
                }
             }
             footer {
+               partners {
+                  ...MenuEntityResponseProps
+               }
+               bottomMenu {
+                  ...MenuEntityResponseProps
+               }
                menu1 {
                   ...MenuEntityResponseProps
                }
                menu2 {
                   ...MenuEntityResponseProps
                }
-               partners {
-                  ...MenuEntityResponseProps
-               }
-               bottomMenu {
+               menu3 {
                   ...MenuEntityResponseProps
                }
             }

--- a/frontend/lib/strapi-sdk/operations/findStore.graphql
+++ b/frontend/lib/strapi-sdk/operations/findStore.graphql
@@ -20,9 +20,6 @@ query findStore($filters: StoreFiltersInput) {
                menu2 {
                   ...MenuEntityResponseProps
                }
-               menu3 {
-                  ...MenuEntityResponseProps
-               }
             }
             socialMediaAccounts {
                twitter

--- a/frontend/models/store.ts
+++ b/frontend/models/store.ts
@@ -50,7 +50,6 @@ async function findStoreByCodeFromStrapi(code: string) {
          bottomMenu: createMenu(store.footer.bottomMenu),
          menu1: createMenu(store.footer.menu1),
          menu2: createMenu(store.footer.menu2),
-         menu3: createMenu(store.footer.menu3),
       },
       socialMediaAccounts: {
          twitter: store.socialMediaAccounts.twitter || null,

--- a/frontend/models/store.ts
+++ b/frontend/models/store.ts
@@ -46,10 +46,11 @@ async function findStoreByCodeFromStrapi(code: string) {
          menu: createMenu(store.header.menu),
       },
       footer: {
-         menu1: createMenu(store.footer.menu1),
-         menu2: createMenu(store.footer.menu2),
          partners: createMenu(store.footer.partners),
          bottomMenu: createMenu(store.footer.bottomMenu),
+         menu1: createMenu(store.footer.menu1),
+         menu2: createMenu(store.footer.menu2),
+         menu3: createMenu(store.footer.menu3),
       },
       socialMediaAccounts: {
          twitter: store.socialMediaAccounts.twitter || null,


### PR DESCRIPTION
1. This copies over the autogenerated changes from https://github.com/iFixit/react-commerce/pull/1342.
2. We need to add menu3 to strapi before trying to access it in the frontend.

## QA
Qa_req 0 - Tests should cover any regressions.

Connects to https://github.com/iFixit/ifixit/issues/45964