### PR TITLE
Restructure product page next data

### DIFF
--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -11,7 +11,7 @@ export function CompatibleDevice({
    device,
    maxModelLines = 0,
 }: CompatibleDeviceProps) {
-   const variants = React.useMemo(() => device.variants, [device.variants]);
+   const variants = device.variants;
    const [visibleVariants, hiddenVariantCount] = React.useMemo(
       () =>
          maxModelLines > 0 && variants.length > maxModelLines

--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -11,10 +11,7 @@ export function CompatibleDevice({
    device,
    maxModelLines = 0,
 }: CompatibleDeviceProps) {
-   const variants = React.useMemo(
-      () => device.variants.filter(Boolean),
-      [device.variants]
-   );
+   const variants = React.useMemo(() => device.variants, [device.variants]);
    const [visibleVariants, hiddenVariantCount] = React.useMemo(
       () =>
          maxModelLines > 0 && variants.length > maxModelLines

--- a/frontend/models/product/schema.ts
+++ b/frontend/models/product/schema.ts
@@ -80,7 +80,6 @@ export const ProductVariantSchema = z.object({
    internalDisplayName: z.string().nullable(),
    selectedOptions: z.array(SelectedOptionSchema),
    title: z.string(),
-   isActive: z.boolean().optional(),
 });
 
 export type ProductVariant = z.infer<typeof ProductVariantSchema>;

--- a/frontend/models/product/schema.ts
+++ b/frontend/models/product/schema.ts
@@ -69,7 +69,7 @@ export const ProductVariantSchema = z.object({
    warning: z.string().nullable(),
    specifications: z.string().nullable(),
    warranty: z.string().nullable(),
-   crossSellVariants: z.array(ProductVariantCardSchema),
+   crossSellVariantIds: z.array(z.string()),
    enabled: z.boolean(),
    disableWhenOOS: z.boolean(),
    shippingRestrictions: z.array(z.string()).nullable(),
@@ -80,6 +80,7 @@ export const ProductVariantSchema = z.object({
    internalDisplayName: z.string().nullable(),
    selectedOptions: z.array(SelectedOptionSchema),
    title: z.string(),
+   isActive: z.boolean().optional(),
 });
 
 export type ProductVariant = z.infer<typeof ProductVariantSchema>;
@@ -147,10 +148,8 @@ export const ProductSchema = z.object({
    tags: z.array(z.string()),
    breadcrumbs: z.array(BreadcrumbSchema).nullable(),
    images: z.array(ProductVariantImageSchema),
-   allImages: z.array(ProductVariantImageSchema),
    options: z.array(ProductOptionSchema),
    variants: z.array(ProductVariantSchema),
-   allVariants: z.array(ProductVariantSchema),
    isEnabled: z.boolean(),
    prop65WarningType: z.string().nullable(),
    prop65Chemicals: z.string().nullable(),
@@ -178,6 +177,7 @@ export const ProductSchema = z.object({
    enabledDomains: EnabledDomainsSchema,
    redirectUrl: z.string().nullable(),
    vendor: z.string().nullable(),
+   crossSellVariants: z.array(ProductVariantCardSchema),
 });
 
 export type Product = z.infer<typeof ProductSchema>;

--- a/frontend/models/product/server.ts
+++ b/frontend/models/product/server.ts
@@ -101,6 +101,15 @@ export async function findProduct({
       response.product.title
    );
 
+   const compatibility = parseCompatibility(
+      response.product.compatibility?.value
+   );
+   if (compatibility) {
+      compatibility.devices.forEach((device) => {
+         device.variants = device.variants.filter(Boolean);
+      });
+   }
+
    return {
       ...response.product,
       breadcrumbs,
@@ -121,7 +130,7 @@ export async function findProduct({
          response.product.replacementGuides?.value
       ),
       featuredProductVariants: getFeaturedProductPreviews(response.product),
-      compatibility: parseCompatibility(response.product.compatibility?.value),
+      compatibility,
       metaTitle: response.product.metaTitle?.value ?? null,
       shortDescription: response.product.shortDescription?.value ?? null,
       rating: parseRating(response.product.rating?.value),

--- a/frontend/templates/product/hooks/useSelectedVariant.ts
+++ b/frontend/templates/product/hooks/useSelectedVariant.ts
@@ -17,7 +17,7 @@ export function useSelectedVariant(
 
    let variant = product.variants.find((v) => v.id === currentVariantId);
    if (variant == null) {
-      variant = product.allVariants.find((v) => v.id === defaultVariantId);
+      variant = product.variants.find((v) => v.id === defaultVariantId);
    }
 
    invariant(
@@ -49,9 +49,7 @@ export function useDefaultVariantId(product: Product): string {
    const variant =
       product.variants.find(
          (variant) => variant.quantityAvailable && variant.quantityAvailable > 0
-      ) ??
-      product.variants[0] ??
-      product.allVariants[0];
+      ) ?? product.variants[0];
    return variant.id;
 }
 

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -29,6 +29,7 @@ import {
    useCartDrawer,
    useGetUserPrice,
 } from '@ifixit/ui';
+import { ProductVariantCard } from '@models/product/schema';
 import type { Product, ProductVariant } from '@pages/api/nextjs/cache/product';
 import NextLink from 'next/link';
 import React from 'react';
@@ -46,8 +47,10 @@ export function CrossSellSection({
    const getUserPrice = useGetUserPrice();
    const { onOpen } = useCartDrawer();
 
-   const crossSellVariantsForSale =
-      useCrossSellVariantsForSale(selectedVariant);
+   const crossSellVariantsForSale = useCrossSellVariantsForSale(
+      selectedVariant,
+      product.crossSellVariants
+   );
 
    const [selectedCrossSellVariantIds, setSelectedCrossSellVariantIds] =
       useSelectCrossSellVariantIds(selectedVariant, crossSellVariantsForSale);
@@ -522,15 +525,22 @@ export const CardImage = ({ src, alt }: CardImageProps) => {
    );
 };
 
-function useCrossSellVariantsForSale(variant: ProductVariant) {
+function useCrossSellVariantsForSale(
+   variant: ProductVariant,
+   crossSellVariants: ProductVariantCard[]
+) {
    const getIsProductForSale = useGetIsProductForSale();
 
    const crossSellVariantsForSale = React.useMemo(() => {
-      return variant.crossSellVariants.filter((v) => {
-         const isProductForSale = getIsProductForSale(v.product);
-         return isProductForSale;
-      });
-   }, [getIsProductForSale, variant.crossSellVariants]);
+      return crossSellVariants
+         .filter((crossSellVariant) =>
+            variant.crossSellVariantIds.includes(crossSellVariant.id)
+         )
+         .filter((v) => {
+            const isProductForSale = getIsProductForSale(v.product);
+            return isProductForSale;
+         });
+   }, [getIsProductForSale, variant.crossSellVariantIds, crossSellVariants]);
 
    return crossSellVariantsForSale;
 }

--- a/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductSection/ProductGallery.tsx
@@ -224,12 +224,9 @@ export function ProductGallery({
 
 function useVariantImages(product: Product, variantId: string) {
    return React.useMemo(() => {
-      return product.allImages.filter((image) => {
-         const linkedVariant = product.allVariants.find(
-            (variant) => variant.id === image.variantId
-         );
-         return linkedVariant == null || linkedVariant.id === variantId;
-      });
+      return product.images.filter(
+         (image) => image.variantId == null || image.variantId === variantId
+      );
    }, [product, variantId]);
 }
 

--- a/frontend/tests/jest/__mocks__/products.ts
+++ b/frontend/tests/jest/__mocks__/products.ts
@@ -107,136 +107,9 @@ const productVariants: ProductVariant[] = [
       isDiscounted: true,
       discountPercentage: 20,
       title: 'New / Fix Kit',
-      crossSellVariants: [
-         {
-            id: 'gid://shopify/ProductVariant/32965720473690',
-            sku: 'IF145-257-1',
-            quantityAvailable: 186,
-            product: {
-               handle: 'anti-static-project-tray',
-               title: 'Anti-Static Project Tray',
-               tags: [
-                  'Condition:New',
-                  'ESD-safe:ESD-safe',
-                  'iFixit Exclusive:iFixit Exclusive',
-                  'Item Type:SIM',
-                  'Main Category=Tools',
-                  'Product Manufacturer=iFixit',
-                  'Tool',
-                  'Tool Category (Legacy):ESD Safe',
-                  'Tool Type=Organization Tools',
-               ],
-               rating: 4.8,
-               reviewsCount: 273,
-               oemPartnership: null,
-            },
-            image: {
-               id: 'gid://shopify/ProductImage/30908161917018',
-               altText: '*',
-               height: 2000,
-               width: 2000,
-               url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/xe2tWdmD14WfKdFS.jpg?v=1642620899',
-            },
-            price: {
-               amount: 4.99,
-               currencyCode: 'USD',
-            },
-            compareAtPrice: null,
-            proPricesByTier: {
-               pro_1: {
-                  amount: 3.99,
-                  currencyCode: 'USD',
-               },
-               pro_2: {
-                  amount: 3.99,
-                  currencyCode: 'USD',
-               },
-               pro_3: {
-                  amount: 3.99,
-                  currencyCode: 'USD',
-               },
-               pro_4: {
-                  amount: 3.99,
-                  currencyCode: 'USD',
-               },
-            },
-            warranty: 'Lifetime Guarantee',
-            enabled: true,
-         },
-         {
-            id: 'gid://shopify/ProductVariant/32965720178778',
-            sku: 'IF145-307-4',
-            quantityAvailable: 607,
-            product: {
-               handle: 'pro-tech-toolkit',
-               title: 'Pro Tech Toolkit',
-               tags: [
-                  'Condition:New',
-                  'iFixit Exclusive:iFixit Exclusive',
-                  'Item Type:Kits',
-                  'Item Type:SIM',
-                  'Main Category=Tools',
-                  'Product Manufacturer=iFixit',
-                  'Profile=Adapter',
-                  'Profile=Flathead',
-                  'Profile=Gamebit',
-                  'Profile=Hex',
-                  'Profile=iPhone Standoff',
-                  'Profile=JIS',
-                  'Profile=Magnetic Pickup',
-                  'Profile=Nut Driver',
-                  'Profile=Oval Bit',
-                  'Profile=Pentalobe',
-                  'Profile=Phillips',
-                  'Profile=SIM Eject',
-                  'Profile=Spanner',
-                  'Profile=Square',
-                  'Profile=Torx',
-                  'Profile=Torx Security',
-                  'Profile=Tri-point',
-                  'Profile=Triangle',
-                  'Screwdriver Type:Interchangeable Bits',
-                  'Tool',
-                  'Tool Category (Legacy):Drivers & Wrenches',
-                  'Tool Type=Toolkits',
-               ],
-               rating: 4.9,
-               reviewsCount: 1381,
-               oemPartnership: null,
-            },
-            image: {
-               id: 'gid://shopify/ProductImage/31392629260378',
-               altText: 'IF145-307-4',
-               height: 2000,
-               width: 2000,
-               url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/p1IwUWSyQKngOgFn_0b395d12-94a4-40b6-932e-3cbc60cef003.jpg?v=1660832943',
-            },
-            price: {
-               amount: 74.99,
-               currencyCode: 'USD',
-            },
-            compareAtPrice: null,
-            proPricesByTier: {
-               pro_1: {
-                  amount: 59.99,
-                  currencyCode: 'USD',
-               },
-               pro_2: {
-                  amount: 59.99,
-                  currencyCode: 'USD',
-               },
-               pro_3: {
-                  amount: 59.99,
-                  currencyCode: 'USD',
-               },
-               pro_4: {
-                  amount: 59.99,
-                  currencyCode: 'USD',
-               },
-            },
-            warranty: 'Lifetime Guarantee',
-            enabled: true,
-         },
+      crossSellVariantIds: [
+         'gid://shopify/ProductVariant/32965720473690',
+         'gid://shopify/ProductVariant/32965720178778',
       ],
    },
    {
@@ -305,135 +178,9 @@ const productVariants: ProductVariant[] = [
       isDiscounted: false,
       discountPercentage: 0,
       title: 'New / Part Only',
-      crossSellVariants: [
-         {
-            id: 'gid://shopify/ProductVariant/39333786746970',
-            sku: 'IF315-038-1',
-            quantityAvailable: 25,
-            product: {
-               handle: 'iphone-6s-plus-screen',
-               title: 'iPhone 6s Plus Screen',
-               tags: [
-                  'Apple Device=iPhone',
-                  'Condition:New',
-                  'Device Brand:Apple',
-                  'Device Category:Phone',
-                  'Device Manufacturer=Apple',
-                  'Device Type:iPhone',
-                  'Device Type=Smartphones',
-                  'Item Type:Screens',
-                  'Main Category=Parts',
-                  'Model Number=A1634',
-                  'Model Number=A1687',
-                  'Model=iPhone 6s Plus',
-                  'OS:iOS',
-                  'Part',
-                  'Part or Kit:Fix Kit',
-                  'Part or Kit:Part Only',
-                  'Spare Part=Screens',
-                  'Version=iPhone Repair Kits',
-                  'worksin:1059',
-               ],
-               rating: 4.7,
-               reviewsCount: 27,
-               oemPartnership: null,
-            },
-            image: {
-               id: 'gid://shopify/ProductImage/31268982194266',
-               altText: 'IF315-038-1',
-               height: 2000,
-               width: 2000,
-               url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/5VOJlrQqeBjCF3nF.jpg?v=1656622264',
-            },
-            price: {
-               amount: 59.99,
-               currencyCode: 'USD',
-            },
-            compareAtPrice: null,
-            proPricesByTier: {
-               pro_1: {
-                  amount: 59.99,
-                  currencyCode: 'USD',
-               },
-               pro_2: {
-                  amount: 59.99,
-                  currencyCode: 'USD',
-               },
-               pro_3: {
-                  amount: 44.82,
-                  currencyCode: 'USD',
-               },
-               pro_4: {
-                  amount: 37.92,
-                  currencyCode: 'USD',
-               },
-            },
-            warranty: 'Lifetime Warranty',
-            enabled: true,
-         },
-         {
-            id: 'gid://shopify/ProductVariant/39333786583130',
-            sku: 'IF315-049-2',
-            quantityAvailable: 46,
-            product: {
-               handle: 'iphone-6s-plus-display-assembly-adhesive',
-               title: 'iPhone 6s Plus Display Assembly Adhesive',
-               tags: [
-                  'Apple Device=iPhone',
-                  'Condition:New',
-                  'Device Brand:Apple',
-                  'Device Category:Phone',
-                  'Device Manufacturer=Apple',
-                  'Device Type:iPhone',
-                  'Device Type=Smartphones',
-                  'Item Type:Adhesives',
-                  'Main Category=Parts',
-                  'Model Number=A1634',
-                  'Model Number=A1687',
-                  'Model=iPhone 6s Plus',
-                  'OS:iOS',
-                  'Part',
-                  'Part or Kit:Part Only',
-                  'Spare Part=Adhesives',
-                  'worksin:1059',
-               ],
-               rating: 4.7,
-               reviewsCount: 20,
-               oemPartnership: null,
-            },
-            image: {
-               id: 'gid://shopify/ProductImage/30908245409882',
-               altText: 'IF315-049-2',
-               height: 2000,
-               width: 2000,
-               url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/BBYFChBH3BMOwJvp_6d0c34d9-eb5f-49e8-8c43-3a443b66fa14.jpg?v=1642621670',
-            },
-            price: {
-               amount: 4.99,
-               currencyCode: 'USD',
-            },
-            compareAtPrice: null,
-            proPricesByTier: {
-               pro_1: {
-                  amount: 4.49,
-                  currencyCode: 'USD',
-               },
-               pro_2: {
-                  amount: 3.99,
-                  currencyCode: 'USD',
-               },
-               pro_3: {
-                  amount: 1.5,
-                  currencyCode: 'USD',
-               },
-               pro_4: {
-                  amount: 0.9,
-                  currencyCode: 'USD',
-               },
-            },
-            warranty: 'Sold as-is; no refunds or returns',
-            enabled: true,
-         },
+      crossSellVariantIds: [
+         'gid://shopify/ProductVariant/39333786746970',
+         'gid://shopify/ProductVariant/39333786583130',
       ],
    },
 ];
@@ -736,7 +483,6 @@ export const mockedProduct: Product = {
       'A new replacement 2750 mAh battery compatible with the iPhone 6s Plus. 3.80 Volts (V), 10.45 Watt Hours (Wh). This replacement does not require soldering and is compatible with all iPhone 6s Plus models (not iPhone 6, 6 Plus, or 6s).',
    oemPartnership: null,
    images: productImages,
-   allImages: productImages,
    options: [
       {
          id: 'gid://shopify/ProductOption/5958025085018',
@@ -750,7 +496,6 @@ export const mockedProduct: Product = {
       },
    ],
    variants: productVariants,
-   allVariants: productVariants,
    isEnabled: true,
    iFixitProductId: 'IF315-007',
    productcode: '315007',
@@ -758,78 +503,6 @@ export const mockedProduct: Product = {
    enabledDomains: undefined,
    redirectUrl: null,
    vendor: '',
-};
-
-export const mockedProductVariant: ProductVariant = {
-   id: 'gid://shopify/ProductVariant/32965718147162',
-   sku: 'IF315-007-10',
-   quantityAvailable: 63,
-   image: {
-      id: 'gid://shopify/ProductImage/31263941197914',
-      altText: 'iPhone 6s Plus Battery New Fix Kit',
-      height: 2000,
-      width: 2000,
-      url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/WNVDn4lvaMJpK33F.jpg?v=1656545132',
-      variantId: 'gid://shopify/ProductVariant/32965718147162',
-   },
-   price: {
-      amount: 23.99,
-      currencyCode: 'USD',
-   },
-   compareAtPrice: {
-      amount: 29.99,
-      currencyCode: 'USD',
-   },
-   proPricesByTier: {
-      pro_1: {
-         amount: 29.99,
-         currencyCode: 'USD',
-      },
-      pro_2: {
-         amount: 29.99,
-         currencyCode: 'USD',
-      },
-      pro_3: {
-         amount: 29.99,
-         currencyCode: 'USD',
-      },
-      pro_4: {
-         amount: 29.99,
-         currencyCode: 'USD',
-      },
-   },
-   selectedOptions: [
-      {
-         name: 'Condition',
-         value: 'New',
-      },
-      {
-         name: 'Part or Kit',
-         value: 'Fix Kit',
-      },
-   ],
-   description:
-      '<p>This replacement battery is what you need to bring that dead smartphone back to life. The Fix Kit includes everything you need to swap in a new replacement battery.</p>\n\n<ul><li>This battery is brand new! Each one has been tested to confirm that there are no cycles on the cell and that the capacity is 95% or higher.</li><li>Make disassembly for future repairs easier, replace your pentalobe bottom screws with the Phillips screws included in the kit.</li></ul>',
-   kitContents:
-      '<ul><li>New Replacement Battery Compatible with iPhone 6s Plus with Adhesive Strips Preinstalled</li><li><a href="/products/iphone-6s-plus-display-assembly-adhesive">iPhone 6s Plus Display Assembly Adhesive</a></li><li><a href="/products/spudger">Spudger</a></li><li><a href="/products/suction-handle">Suction Handle</a></li><li><a href="/products/tweezers">Tweezers / Angled / Pro / ESD</a></li><li><a href="/products/ifixit-opening-tool">iFixit Opening Tool</a></li><li>Replacement Phillips Bottom Screws</li><li><a href="/products/ifixit-precision-bit-driver">Precision Bit Driver</a></li><li><a href="/products/ifixit-precision-4-mm-screwdriver-bit">4 mm Precision Bits</a>:<ul><li>Phillips #000</li><li>Pentalobe P2</li><li>Tri-point Y000</li></ul></li></ul>',
-   assemblyContents: null,
-   note: '<p>For optimal performance, calibrate your newly installed battery: Charge it to 100% and keep charging it for at least 2 more hours. Then use your device until it shuts off due to low battery. Finally, charge it uninterrupted to 100%.</p>',
-   disclaimer:
-      '<p>While not necessary, some fixers prefer to use additional tools to accomplish this repair: <a href="/products/iopener">iOpener</a> and <a href="/products/plastic-cards">Plastic Card</a>.</p>',
-   warning:
-      '<p><a href="https://mmcelvain.cominor.com/Wiki/What_to_do_with_a_swollen_battery" target="_blank">Learn more</a> about safe lithium-ion battery handling and proper disposal.</p>',
-   specifications:
-      "<table class='specifications'><tr><th>Part #</th><td>616-00045</td></tr>\n<tr><th>Watt Hours</th><td>10.45 Wh</td></tr>\n<tr><th>Voltage</th><td>3.8 V</td></tr>\n<tr><th>Milliamp Hours</th><td>2750 mAh</td></tr>\n<tr><th>Manufacturer</th><td>Aftermarket</td></tr></table>",
-   warranty: 'One year warranty',
-   enabled: true,
-   disableWhenOOS: false,
-   internalDisplayName: 'iPhone 6s Plus Battery / Fix Kit with Adhesive',
-   shippingRestrictions: ['is_battery'],
-   productcode: '315007',
-   optionid: '10',
-   isDiscounted: true,
-   discountPercentage: 20,
-   title: 'New / Fix Kit',
    crossSellVariants: [
       {
          id: 'gid://shopify/ProductVariant/32965720473690',
@@ -960,6 +633,210 @@ export const mockedProductVariant: ProductVariant = {
          warranty: 'Lifetime Guarantee',
          enabled: true,
       },
+      {
+         id: 'gid://shopify/ProductVariant/39333786746970',
+         sku: 'IF315-038-1',
+         quantityAvailable: 25,
+         product: {
+            handle: 'iphone-6s-plus-screen',
+            title: 'iPhone 6s Plus Screen',
+            tags: [
+               'Apple Device=iPhone',
+               'Condition:New',
+               'Device Brand:Apple',
+               'Device Category:Phone',
+               'Device Manufacturer=Apple',
+               'Device Type:iPhone',
+               'Device Type=Smartphones',
+               'Item Type:Screens',
+               'Main Category=Parts',
+               'Model Number=A1634',
+               'Model Number=A1687',
+               'Model=iPhone 6s Plus',
+               'OS:iOS',
+               'Part',
+               'Part or Kit:Fix Kit',
+               'Part or Kit:Part Only',
+               'Spare Part=Screens',
+               'Version=iPhone Repair Kits',
+               'worksin:1059',
+            ],
+            rating: 4.7,
+            reviewsCount: 27,
+            oemPartnership: null,
+         },
+         image: {
+            id: 'gid://shopify/ProductImage/31268982194266',
+            altText: 'IF315-038-1',
+            height: 2000,
+            width: 2000,
+            url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/5VOJlrQqeBjCF3nF.jpg?v=1656622264',
+         },
+         price: {
+            amount: 59.99,
+            currencyCode: 'USD',
+         },
+         compareAtPrice: null,
+         proPricesByTier: {
+            pro_1: {
+               amount: 59.99,
+               currencyCode: 'USD',
+            },
+            pro_2: {
+               amount: 59.99,
+               currencyCode: 'USD',
+            },
+            pro_3: {
+               amount: 44.82,
+               currencyCode: 'USD',
+            },
+            pro_4: {
+               amount: 37.92,
+               currencyCode: 'USD',
+            },
+         },
+         warranty: 'Lifetime Warranty',
+         enabled: true,
+      },
+      {
+         id: 'gid://shopify/ProductVariant/39333786583130',
+         sku: 'IF315-049-2',
+         quantityAvailable: 46,
+         product: {
+            handle: 'iphone-6s-plus-display-assembly-adhesive',
+            title: 'iPhone 6s Plus Display Assembly Adhesive',
+            tags: [
+               'Apple Device=iPhone',
+               'Condition:New',
+               'Device Brand:Apple',
+               'Device Category:Phone',
+               'Device Manufacturer=Apple',
+               'Device Type:iPhone',
+               'Device Type=Smartphones',
+               'Item Type:Adhesives',
+               'Main Category=Parts',
+               'Model Number=A1634',
+               'Model Number=A1687',
+               'Model=iPhone 6s Plus',
+               'OS:iOS',
+               'Part',
+               'Part or Kit:Part Only',
+               'Spare Part=Adhesives',
+               'worksin:1059',
+            ],
+            rating: 4.7,
+            reviewsCount: 20,
+            oemPartnership: null,
+         },
+         image: {
+            id: 'gid://shopify/ProductImage/30908245409882',
+            altText: 'IF315-049-2',
+            height: 2000,
+            width: 2000,
+            url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/BBYFChBH3BMOwJvp_6d0c34d9-eb5f-49e8-8c43-3a443b66fa14.jpg?v=1642621670',
+         },
+         price: {
+            amount: 4.99,
+            currencyCode: 'USD',
+         },
+         compareAtPrice: null,
+         proPricesByTier: {
+            pro_1: {
+               amount: 4.49,
+               currencyCode: 'USD',
+            },
+            pro_2: {
+               amount: 3.99,
+               currencyCode: 'USD',
+            },
+            pro_3: {
+               amount: 1.5,
+               currencyCode: 'USD',
+            },
+            pro_4: {
+               amount: 0.9,
+               currencyCode: 'USD',
+            },
+         },
+         warranty: 'Sold as-is; no refunds or returns',
+         enabled: true,
+      },
+   ],
+};
+
+export const mockedProductVariant: ProductVariant = {
+   id: 'gid://shopify/ProductVariant/32965718147162',
+   sku: 'IF315-007-10',
+   quantityAvailable: 63,
+   image: {
+      id: 'gid://shopify/ProductImage/31263941197914',
+      altText: 'iPhone 6s Plus Battery New Fix Kit',
+      height: 2000,
+      width: 2000,
+      url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/WNVDn4lvaMJpK33F.jpg?v=1656545132',
+      variantId: 'gid://shopify/ProductVariant/32965718147162',
+   },
+   price: {
+      amount: 23.99,
+      currencyCode: 'USD',
+   },
+   compareAtPrice: {
+      amount: 29.99,
+      currencyCode: 'USD',
+   },
+   proPricesByTier: {
+      pro_1: {
+         amount: 29.99,
+         currencyCode: 'USD',
+      },
+      pro_2: {
+         amount: 29.99,
+         currencyCode: 'USD',
+      },
+      pro_3: {
+         amount: 29.99,
+         currencyCode: 'USD',
+      },
+      pro_4: {
+         amount: 29.99,
+         currencyCode: 'USD',
+      },
+   },
+   selectedOptions: [
+      {
+         name: 'Condition',
+         value: 'New',
+      },
+      {
+         name: 'Part or Kit',
+         value: 'Fix Kit',
+      },
+   ],
+   description:
+      '<p>This replacement battery is what you need to bring that dead smartphone back to life. The Fix Kit includes everything you need to swap in a new replacement battery.</p>\n\n<ul><li>This battery is brand new! Each one has been tested to confirm that there are no cycles on the cell and that the capacity is 95% or higher.</li><li>Make disassembly for future repairs easier, replace your pentalobe bottom screws with the Phillips screws included in the kit.</li></ul>',
+   kitContents:
+      '<ul><li>New Replacement Battery Compatible with iPhone 6s Plus with Adhesive Strips Preinstalled</li><li><a href="/products/iphone-6s-plus-display-assembly-adhesive">iPhone 6s Plus Display Assembly Adhesive</a></li><li><a href="/products/spudger">Spudger</a></li><li><a href="/products/suction-handle">Suction Handle</a></li><li><a href="/products/tweezers">Tweezers / Angled / Pro / ESD</a></li><li><a href="/products/ifixit-opening-tool">iFixit Opening Tool</a></li><li>Replacement Phillips Bottom Screws</li><li><a href="/products/ifixit-precision-bit-driver">Precision Bit Driver</a></li><li><a href="/products/ifixit-precision-4-mm-screwdriver-bit">4 mm Precision Bits</a>:<ul><li>Phillips #000</li><li>Pentalobe P2</li><li>Tri-point Y000</li></ul></li></ul>',
+   assemblyContents: null,
+   note: '<p>For optimal performance, calibrate your newly installed battery: Charge it to 100% and keep charging it for at least 2 more hours. Then use your device until it shuts off due to low battery. Finally, charge it uninterrupted to 100%.</p>',
+   disclaimer:
+      '<p>While not necessary, some fixers prefer to use additional tools to accomplish this repair: <a href="/products/iopener">iOpener</a> and <a href="/products/plastic-cards">Plastic Card</a>.</p>',
+   warning:
+      '<p><a href="https://mmcelvain.cominor.com/Wiki/What_to_do_with_a_swollen_battery" target="_blank">Learn more</a> about safe lithium-ion battery handling and proper disposal.</p>',
+   specifications:
+      "<table class='specifications'><tr><th>Part #</th><td>616-00045</td></tr>\n<tr><th>Watt Hours</th><td>10.45 Wh</td></tr>\n<tr><th>Voltage</th><td>3.8 V</td></tr>\n<tr><th>Milliamp Hours</th><td>2750 mAh</td></tr>\n<tr><th>Manufacturer</th><td>Aftermarket</td></tr></table>",
+   warranty: 'One year warranty',
+   enabled: true,
+   disableWhenOOS: false,
+   internalDisplayName: 'iPhone 6s Plus Battery / Fix Kit with Adhesive',
+   shippingRestrictions: ['is_battery'],
+   productcode: '315007',
+   optionid: '10',
+   isDiscounted: true,
+   discountPercentage: 20,
+   title: 'New / Fix Kit',
+   crossSellVariantIds: [
+      'gid://shopify/ProductVariant/32965720473690',
+      'gid://shopify/ProductVariant/32965720178778',
    ],
 };
 
@@ -1301,7 +1178,7 @@ const batteryProductVariants: ProductVariant[] = [
       isDiscounted: false,
       discountPercentage: 0,
       title: 'New',
-      crossSellVariants: [],
+      crossSellVariantIds: [],
    },
 ];
 
@@ -1564,7 +1441,6 @@ export const mockedBatteryProduct: Product = {
       },
    ],
    images: batteryProductImages,
-   allImages: batteryProductImages,
    options: [
       {
          id: 'gid://shopify/ProductOption/8434015174746',
@@ -1573,12 +1449,12 @@ export const mockedBatteryProduct: Product = {
       },
    ],
    variants: batteryProductVariants,
-   allVariants: batteryProductVariants,
    isEnabled: true,
    iFixitProductId: 'IF390-042',
    productcode: '390042',
    redirectUrl: null,
    vendor: '',
+   crossSellVariants: [],
 };
 
 const toolProductImages: ProductVariantImage[] = [
@@ -1652,57 +1528,7 @@ const toolProductVariants: ProductVariant[] = [
       isDiscounted: false,
       discountPercentage: 0,
       title: 'New',
-      crossSellVariants: [
-         {
-            id: 'gid://shopify/ProductVariant/39333789794394',
-            sku: 'IF317-047-1',
-            quantityAvailable: 31,
-            product: {
-               handle: 'hakko-3-sa-tweezers',
-               title: 'Hakko 3 SA Tweezers',
-               tags: [
-                  'Condition:New',
-                  'Tool',
-                  'Tool Category (Legacy):Soldering & Wiring',
-               ],
-               rating: 5,
-               reviewsCount: 3,
-               oemPartnership: null,
-            },
-            image: {
-               id: 'gid://shopify/ProductImage/31648429015130',
-               altText: 'IF317-047-1',
-               height: 2000,
-               width: 2000,
-               url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/NHvasuuucgWNLOiK_5fe4cc71-1a6d-4718-b654-3f4cde68dbec.jpg?v=1667585988',
-            },
-            price: {
-               amount: 9.99,
-               currencyCode: 'USD',
-            },
-            compareAtPrice: null,
-            proPricesByTier: {
-               pro_1: {
-                  amount: 9.95,
-                  currencyCode: 'USD',
-               },
-               pro_2: {
-                  amount: 9.95,
-                  currencyCode: 'USD',
-               },
-               pro_3: {
-                  amount: 9.95,
-                  currencyCode: 'USD',
-               },
-               pro_4: {
-                  amount: 9.95,
-                  currencyCode: 'USD',
-               },
-            },
-            warranty: 'One year warranty',
-            enabled: true,
-         },
-      ],
+      crossSellVariantIds: ['gid://shopify/ProductVariant/39333789794394'],
    },
 ];
 
@@ -1908,7 +1734,6 @@ export const mockedToolProduct: Product = {
       },
    ],
    images: toolProductImages,
-   allImages: toolProductImages,
    options: [
       {
          id: 'gid://shopify/ProductOption/8433952227418',
@@ -1917,12 +1742,62 @@ export const mockedToolProduct: Product = {
       },
    ],
    variants: toolProductVariants,
-   allVariants: toolProductVariants,
    isEnabled: true,
    iFixitProductId: 'IF317-048',
    productcode: '317048',
    redirectUrl: null,
    vendor: '',
+   crossSellVariants: [
+      {
+         id: 'gid://shopify/ProductVariant/39333789794394',
+         sku: 'IF317-047-1',
+         quantityAvailable: 31,
+         product: {
+            handle: 'hakko-3-sa-tweezers',
+            title: 'Hakko 3 SA Tweezers',
+            tags: [
+               'Condition:New',
+               'Tool',
+               'Tool Category (Legacy):Soldering & Wiring',
+            ],
+            rating: 5,
+            reviewsCount: 3,
+            oemPartnership: null,
+         },
+         image: {
+            id: 'gid://shopify/ProductImage/31648429015130',
+            altText: 'IF317-047-1',
+            height: 2000,
+            width: 2000,
+            url: 'https://cdn.shopify.com/s/files/1/2429/5121/products/NHvasuuucgWNLOiK_5fe4cc71-1a6d-4718-b654-3f4cde68dbec.jpg?v=1667585988',
+         },
+         price: {
+            amount: 9.99,
+            currencyCode: 'USD',
+         },
+         compareAtPrice: null,
+         proPricesByTier: {
+            pro_1: {
+               amount: 9.95,
+               currencyCode: 'USD',
+            },
+            pro_2: {
+               amount: 9.95,
+               currencyCode: 'USD',
+            },
+            pro_3: {
+               amount: 9.95,
+               currencyCode: 'USD',
+            },
+            pro_4: {
+               amount: 9.95,
+               currencyCode: 'USD',
+            },
+         },
+         warranty: 'One year warranty',
+         enabled: true,
+      },
+   ],
 };
 
 const partProductImages: ProductVariantImage[] = [
@@ -2010,7 +1885,7 @@ const partProductVariants: ProductVariant[] = [
       isDiscounted: false,
       discountPercentage: 0,
       title: 'New / Part Only',
-      crossSellVariants: [],
+      crossSellVariantIds: [],
    },
 ];
 
@@ -2274,7 +2149,6 @@ export const mockedPartProduct: Product = {
       },
    ],
    images: partProductImages,
-   allImages: partProductImages,
    options: [
       {
          id: 'gid://shopify/ProductOption/8466995773530',
@@ -2288,12 +2162,12 @@ export const mockedPartProduct: Product = {
       },
    ],
    variants: partProductVariants,
-   allVariants: partProductVariants,
    isEnabled: true,
    iFixitProductId: 'IF457-000',
    productcode: '457000',
    redirectUrl: null,
    vendor: '',
+   crossSellVariants: [],
 };
 
 export const mockedLayoutProps: Pick<ProductTemplateProps, 'layoutProps'> = {


### PR DESCRIPTION
connects https://github.com/iFixit/react-commerce/pull/1092#issuecomment-1455270179
closes #1443 

Cross sell variants are now grouped at product level and referenced by id.
The duplicated structures were removed - according to how many active variants we have we pass down the data and the images associated to the active elements (`> 0` active variants) or the one associated with the first variant (`= 0` active variants)

### QA

1. Visit [Vercel preview](https://react-commerce-git-restructure-product-page-next-data-ifixit.vercel.app/products/iphone-6s-screen)
2. Check that there is no change in how product pages or cross sell section behave wrt production
3. Check also that products with disabled variants and products with no variants available for sale are still working as they do in production
