### PR TITLE
Include current itemcode in Frequently Bought Together event

### DIFF
--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -42,8 +42,10 @@ export function trackAddToCart(
    const itemcodes =
       addToCartInput.type === 'product'
          ? addToCartInput.product.itemcode
-         : `${addToCartInput.bundle.currentItemCode}/`
-         + `${addToCartInput.bundle.items.map((item) => item.itemcode).join(', ')}`;
+         : `${addToCartInput.bundle.currentItemCode}/` +
+           `${addToCartInput.bundle.items
+              .map((item) => item.itemcode)
+              .join(', ')}`;
    trackInMatomoAndGA({
       eventCategory: event,
       eventAction: `${event} - ${itemcodes}`,

--- a/packages/analytics/index.tsx
+++ b/packages/analytics/index.tsx
@@ -42,7 +42,8 @@ export function trackAddToCart(
    const itemcodes =
       addToCartInput.type === 'product'
          ? addToCartInput.product.itemcode
-         : addToCartInput.bundle.items.map((item) => item.itemcode).join(', ');
+         : `${addToCartInput.bundle.currentItemCode}/`
+         + `${addToCartInput.bundle.items.map((item) => item.itemcode).join(', ')}`;
    trackInMatomoAndGA({
       eventCategory: event,
       eventAction: `${event} - ${itemcodes}`,


### PR DESCRIPTION
This allows the E-Commerce team to see what variant "Frequently Bought Together" items are associated with. Currently in Matomo, you can see the URL, but that doesn't include the variant.

See row 223 of [iFixit EVENTS Spreadsheet (updated 03-08-2023)
](https://docs.google.com/spreadsheets/d/16Xas1pHf_K7FmfOX3yX2mYgeYr2DIENr8cyQp19FZkA/edit?pli=1#gid=1839136207&fvid=1843464925) for spec details.

A little discussion in the comments of this PR around the spec: https://github.com/iFixit/react-commerce/pull/1452#discussion_r1130094635

Closes https://github.com/iFixit/react-commerce/issues/1414