### PR TITLE
Tests: Add search for empty query test

### DIFF
--- a/frontend/tests/playwright/product-list/parts_page_search.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_search.spec.ts
@@ -45,24 +45,22 @@ test.describe('parts page search', () => {
       await expect(page.getByTestId('product-list-no-results')).toBeVisible();
    });
 
-   test.only("Should update url on empty search query", async ({
-    page,
- }) => {
-    expect(page.getByTestId('collections-search-box')).toBeVisible();
-    expect(page.getByTestId('collections-search-box')).not.toBeDisabled();
+   test.only('Should update url on empty search query', async ({ page }) => {
+      expect(page.getByTestId('collections-search-box')).toBeVisible();
+      expect(page.getByTestId('collections-search-box')).not.toBeDisabled();
 
-    const searchText = "vive";
-    await page.getByTestId('collections-search-box').fill(searchText);
-    // Wait for url to update after search
-    await page.waitForURL(`**/Parts?q=${searchText}`);
-    expect(page.url()).toContain(`?q=${searchText}`);
+      const searchText = 'vive';
+      await page.getByTestId('collections-search-box').fill(searchText);
+      // Wait for url to update after search
+      await page.waitForURL(`**/Parts?q=${searchText}`);
+      expect(page.url()).toContain(`?q=${searchText}`);
 
-    // Empty the search-box
-    await page.getByTestId('collections-search-box').fill('');
+      // Empty the search-box
+      await page.getByTestId('collections-search-box').fill('');
 
-    // Check that url doesn't have the query parameter containing ?q
-    await page.waitForURL('**/Parts');
-    expect(page.url()).not.toContain('?q=');
-    expect(page.url()).not.toContain(`?q=${searchText}`);
- });
+      // Check that url doesn't have the query parameter containing ?q
+      await page.waitForURL('**/Parts');
+      expect(page.url()).not.toContain('?q=');
+      expect(page.url()).not.toContain(`?q=${searchText}`);
+   });
 });

--- a/frontend/tests/playwright/product-list/parts_page_search.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_search.spec.ts
@@ -45,7 +45,7 @@ test.describe('parts page search', () => {
       await expect(page.getByTestId('product-list-no-results')).toBeVisible();
    });
 
-   test.only('Should update url on empty search query', async ({ page }) => {
+   test('Should update url on empty search query', async ({ page }) => {
       expect(page.getByTestId('collections-search-box')).toBeVisible();
       expect(page.getByTestId('collections-search-box')).not.toBeDisabled();
 

--- a/frontend/tests/playwright/product-list/parts_page_search.spec.ts
+++ b/frontend/tests/playwright/product-list/parts_page_search.spec.ts
@@ -44,4 +44,25 @@ test.describe('parts page search', () => {
       await expect(page.getByTestId('list-view-products')).not.toBeVisible();
       await expect(page.getByTestId('product-list-no-results')).toBeVisible();
    });
+
+   test.only("Should update url on empty search query", async ({
+    page,
+ }) => {
+    expect(page.getByTestId('collections-search-box')).toBeVisible();
+    expect(page.getByTestId('collections-search-box')).not.toBeDisabled();
+
+    const searchText = "vive";
+    await page.getByTestId('collections-search-box').fill(searchText);
+    // Wait for url to update after search
+    await page.waitForURL(`**/Parts?q=${searchText}`);
+    expect(page.url()).toContain(`?q=${searchText}`);
+
+    // Empty the search-box
+    await page.getByTestId('collections-search-box').fill('');
+
+    // Check that url doesn't have the query parameter containing ?q
+    await page.waitForURL('**/Parts');
+    expect(page.url()).not.toContain('?q=');
+    expect(page.url()).not.toContain(`?q=${searchText}`);
+ });
 });


### PR DESCRIPTION
## Summary
Added a test that checks if the URL is updated after clearing the search text.
It makes sure the URL is updated and has no query parameters such as `?q=...`.

## QA notes
Passing CI is enough.

closes https://github.com/iFixit/react-commerce/issues/1276
qa_req 0
