### PR TITLE
Github Actions: Add stress-test workflow

### DIFF
--- a/.github/actions/build-test-frontend/action.yml
+++ b/.github/actions/build-test-frontend/action.yml
@@ -10,14 +10,14 @@ runs:
       - name: Cache Next.js cache directory
         uses: actions/cache@v3
         with:
-          path: frontend/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          restore-keys: |
+           path: frontend/.next/cache
+           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+           restore-keys: |
               ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 
       - name: Build Next.js
         env:
-          NODE_ENV: test
-          NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
-          ALGOLIA_API_KEY: ${{ inputs.ALGOLIA_API_KEY }}
+           NODE_ENV: test
+           NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
+           ALGOLIA_API_KEY: ${{ inputs.ALGOLIA_API_KEY }}
         run: cd frontend && pnpm build

--- a/.github/actions/build-test-frontend/action.yml
+++ b/.github/actions/build-test-frontend/action.yml
@@ -1,0 +1,23 @@
+name: Build test frontend
+description: Builds the test frontend, and caches the next.js cache directory
+inputs:
+   algolia-api-key:
+      description: 'Algolia api key'
+      required: true
+runs:
+   using: 'composite'
+   steps:
+      - name: Cache Next.js cache directory
+        uses: actions/cache@v3
+        with:
+          path: frontend/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+              ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+
+      - name: Build Next.js
+        env:
+          NODE_ENV: test
+          NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
+          ALGOLIA_API_KEY: ${{ inputs.ALGOLIA_API_KEY }}
+        run: cd frontend && pnpm build

--- a/.github/actions/build-test-frontend/action.yml
+++ b/.github/actions/build-test-frontend/action.yml
@@ -21,3 +21,4 @@ runs:
            NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
            ALGOLIA_API_KEY: ${{ inputs.ALGOLIA_API_KEY }}
         run: cd frontend && pnpm build
+        shell: bash

--- a/.github/actions/playwright-setup/action.yml
+++ b/.github/actions/playwright-setup/action.yml
@@ -6,6 +6,7 @@ runs:
       - name: Get installed Playwright version
         id: playwright-version
         run: echo "PLAYWRIGHT_VERSION=$(pnpm list -r "@playwright/test" | grep "@playwright/test" | tr -dc 1-9.)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Cache playwright binaries
         uses: actions/cache@v3
@@ -17,3 +18,4 @@ runs:
       - name: Install Playwright Dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: cd frontend && npx playwright install
+        shell: bash

--- a/.github/actions/playwright-setup/action.yml
+++ b/.github/actions/playwright-setup/action.yml
@@ -1,0 +1,19 @@
+name: Setup playwright
+description: Installs playwright dependencies, and caches the binaries
+runs:
+   using: 'composite'
+   steps:
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "PLAYWRIGHT_VERSION=$(pnpm list -r "@playwright/test" | grep "@playwright/test" | tr -dc 1-9.)" >> $GITHUB_ENV
+
+      - name: Cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: Install Playwright Dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: cd frontend && npx playwright install

--- a/.github/actions/playwright-setup/action.yml
+++ b/.github/actions/playwright-setup/action.yml
@@ -11,8 +11,8 @@ runs:
         uses: actions/cache@v3
         id: playwright-cache
         with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+           path: ~/.cache/ms-playwright
+           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
 
       - name: Install Playwright Dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,20 +38,8 @@ jobs:
               FONT_AWESOME_NPM_TOKEN: ${{ secrets.FONT_AWESOME_NPM_TOKEN }}
            run: pnpm install
 
-         - name: Get installed Playwright version
-           id: playwright-version
-           run: echo "PLAYWRIGHT_VERSION=$(pnpm list -r "@playwright/test" | grep "@playwright/test" | tr -dc 1-9.)" >> $GITHUB_ENV
-
-         - name: Cache playwright binaries
-           uses: actions/cache@v3
-           id: playwright-cache
-           with:
-              path: ~/.cache/ms-playwright
-              key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-
-         - name: Install Playwright Dependencies
-           if: steps.playwright-cache.outputs.cache-hit != 'true'
-           run: cd frontend && npx playwright install
+         - name: Setup and cache playwright dependencies
+           uses: ./.github/actions/playwright-setup
 
          - name: Cache Next.js cache directory
            uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,22 +41,10 @@ jobs:
          - name: Setup and cache playwright dependencies
            uses: ./.github/actions/playwright-setup
 
-         - name: Cache Next.js cache directory
-           uses: actions/cache@v3
+         - name: Build and cache frontend for with test setup
+           uses: ./.github/actions/build-test-frontend
            with:
-              path: frontend/.next/cache
-              # Generate a new cache whenever packages or source files change.
-              key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-              # If source files changed but packages didn't, rebuild from a prior cache.
-              restore-keys: |
-                 ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
-         - name: Build Next.js
-           env:
-              NODE_ENV: test
-              NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
-              ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-           run: cd frontend && pnpm build
+              algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
 
          - name: Run Playwright Tests
            env:

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -114,3 +114,30 @@ jobs:
               name: playwright-artifacts
               path: frontend/tests/playwright/test-results/artifacts
               retention-days: 7
+
+   jest:
+      name: jest-stress-test
+      runs-on: ubuntu-latest
+      needs: check-diff
+      if: needs.check-diff.outputs.modified-jest-tests != ''
+      steps:
+         - name: Checkout
+           uses: actions/checkout@v2
+
+         - uses: actions/setup-node@v3
+           with:
+              node-version: 16
+
+         - name: Setup and cache pnpm
+           uses: ./.github/actions/pnpm-setup
+
+         - name: Install workspaces
+           env:
+              FONT_AWESOME_NPM_TOKEN: ${{ secrets.FONT_AWESOME_NPM_TOKEN }}
+           run: pnpm install:all
+
+         - name: Run Jest tests
+           run: for i in {1..5}; do jest -- ${{ needs.check-diff.outputs.modified-jest-tests }}; done
+           env:
+              NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
+              ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -70,20 +70,10 @@ jobs:
          - name: Setup and cache playwright dependencies
            uses: ./.github/actions/playwright-setup
 
-         - name: Cache Next.js cache directory
-           uses: actions/cache@v3
+         - name: Build and cache frontend for with test setup
+           uses: ./.github/actions/build-test-frontend
            with:
-              path: frontend/.next/cache
-              key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-              restore-keys: |
-                 ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-
-         - name: Build Next.js
-           env:
-              NODE_ENV: test
-              NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
-              ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
-           run: cd frontend && pnpm build
+              algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
 
          - name: Run Playwright Tests
            env:

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -1,0 +1,36 @@
+name: Stress-test
+
+on: [pull_request]
+env:
+   npm_config_userconfig: './.npmrc'
+jobs:
+   check-diff:
+      name: check-diff
+      runs-on: ubuntu-latest
+      steps:
+         - name: Checkout ifixit
+           uses: actions/checkout@v3
+           with:
+              fetch-depth: 0
+
+         - name: Get head commit message
+           run: |
+              echo "headCommitMsg=$(git log -s -1 --format=%B ${{ github.event.pull_request.head.sha }} | tr '\n' ' ')" >> $GITHUB_ENV
+
+         - name: Get base branch commit sha when the pull request was created
+           run: |
+              BASE_COMMIT_SHA=$(gh api repos/iFixit/react-commerce/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --jq '.merge_base_commit.sha')
+              echo "The base branch commit sha: $BASE_COMMIT_SHA"
+              echo "baseCommitSha=$BASE_COMMIT_SHA" >> $GITHUB_ENV
+           env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+         - name: Get and log modified test names
+           if: "!contains(env.headCommitMsg, '[skip stress-test]')"
+           run: |
+              MODIFIED_PLAYWRIGHT_TESTS=$(git diff ${{ env.baseCommitSha }}...${{ github.event.pull_request.head.sha }} --name-only --diff-filter=d -- 'frontend/tests/playwright/*.spec.ts' | tr '\n' ' ')
+              MODIFIED_JEST_TESTS=$(git diff ${{ env.baseCommitSha }}...${{ github.event.pull_request.head.sha }} --name-only --diff-filter=d -- 'frontend/tests/jest/tests/*.test.tsx' | tr '\n' ' ')
+              echo "modified-playwright-tests=$(echo $MODIFIED_PLAYWRIGHT_TESTS)" >> $GITHUB_OUTPUT
+              echo "modified-jest-tests=$(echo $MODIFIED_JEST_TESTS)" >> $GITHUB_OUTPUT
+              echo "Modified playwright tests: $MODIFIED_PLAYWRIGHT_TESTS"
+              echo "Modified jest tests: $MODIFIED_JEST_TESTS"

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -44,11 +44,7 @@ jobs:
       strategy:
          fail-fast: false
          matrix:
-            project:
-               [
-                  'Desktop Chrome',
-                  'Mobile Chrome',
-               ]
+            project: ['Desktop Chrome', 'Mobile Chrome']
       steps:
          - name: Checkout
            uses: actions/checkout@v3

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -67,20 +67,8 @@ jobs:
               FONT_AWESOME_NPM_TOKEN: ${{ secrets.FONT_AWESOME_NPM_TOKEN }}
            run: pnpm install
 
-         - name: Get installed Playwright version
-           id: playwright-version
-           run: echo "PLAYWRIGHT_VERSION=$(pnpm list -r "@playwright/test" | grep "@playwright/test" | tr -dc 1-9.)" >> $GITHUB_ENV
-
-         - name: Cache playwright binaries
-           uses: actions/cache@v3
-           id: playwright-cache
-           with:
-              path: ~/.cache/ms-playwright
-              key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-
-         - name: Install Playwright Dependencies
-           if: steps.playwright-cache.outputs.cache-hit != 'true'
-           run: cd frontend && npx playwright install
+         - name: Setup and cache playwright dependencies
+           uses: ./.github/actions/playwright-setup
 
          - name: Cache Next.js cache directory
            uses: actions/cache@v3

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -34,3 +34,83 @@ jobs:
               echo "modified-jest-tests=$(echo $MODIFIED_JEST_TESTS)" >> $GITHUB_OUTPUT
               echo "Modified playwright tests: $MODIFIED_PLAYWRIGHT_TESTS"
               echo "Modified jest tests: $MODIFIED_JEST_TESTS"
+
+   playwright-run:
+      name: playwright-stress-test
+      runs-on: ubuntu-latest
+      needs: check-diff
+      if: needs.check-diff.outputs.modified-playwright-tests != ''
+      timeout-minutes: 15
+      strategy:
+         fail-fast: false
+         matrix:
+            project:
+               [
+                  'Desktop Chrome',
+                  'Mobile Chrome',
+               ]
+      steps:
+         - name: Checkout
+           uses: actions/checkout@v3
+
+         - name: Install Node.js
+           uses: actions/setup-node@v3
+           with:
+              node-version: 16
+
+         - name: Start strapi server
+           run: cd backend && docker-compose up -d
+           env:
+              JWT_SECRET: 'ci-secret'
+              API_TOKEN_SALT: 'Not_A-s3Cr3t-/Qr5iGP0g=='
+
+         - name: Setup and cache pnpm
+           uses: ./.github/actions/pnpm-setup
+         - name: Install workspaces
+           env:
+              FONT_AWESOME_NPM_TOKEN: ${{ secrets.FONT_AWESOME_NPM_TOKEN }}
+           run: pnpm install
+
+         - name: Get installed Playwright version
+           id: playwright-version
+           run: echo "PLAYWRIGHT_VERSION=$(pnpm list -r "@playwright/test" | grep "@playwright/test" | tr -dc 1-9.)" >> $GITHUB_ENV
+
+         - name: Cache playwright binaries
+           uses: actions/cache@v3
+           id: playwright-cache
+           with:
+              path: ~/.cache/ms-playwright
+              key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+
+         - name: Install Playwright Dependencies
+           if: steps.playwright-cache.outputs.cache-hit != 'true'
+           run: cd frontend && npx playwright install
+
+         - name: Cache Next.js cache directory
+           uses: actions/cache@v3
+           with:
+              path: frontend/.next/cache
+              key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+              restore-keys: |
+                 ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+
+         - name: Build Next.js
+           env:
+              NODE_ENV: test
+              NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
+              ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+           run: cd frontend && pnpm build
+
+         - name: Run Playwright Tests
+           env:
+              NODE_ENV: test
+              NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
+              ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+           run: cd frontend && pnpm playwright:run --project="${{ matrix.project }}" ${{ needs.check-diff.outputs.modified-playwright-tests }} --repeat-each=5
+
+         - uses: actions/upload-artifact@v2
+           if: failure()
+           with:
+              name: playwright-artifacts
+              path: frontend/tests/playwright/test-results/artifacts
+              retention-days: 7


### PR DESCRIPTION
## Summary
Added stress-test ci for playwright and jest tests.

The new workflow has 3 jobs:
- The first job checks for the test changes and the logic for skipping the stress-test check.
  - It looks for modified jest test files in `frontend/tests/playwright/` folder with `*.spec.ts` file extension and jest tests in `frontend/tests/jest/tests/` with `*.test.tsx`. If changes were found, it will trigger the corresponding jobs to run the stress-test.
   - Also, if the last commit message has [skip stress-test] commit message, then it will not run stress tests (copy from `ifixit`).
- The second job runs `playwright` stress-test if there were test changes. It runs stress-test for `Desktop Chrome` and `Mobile Chrome` projects (we can add `Firefox` and `Tablet` but seems a bit too many). It uses `--repeat-each` option to run each test method `5` times.
- The third job runs `jest` stress-test and uses regular bash for loop to run jest test-suite `5` times (unfortunately `--repeat-each` doesn't exist for jest).

The only difference from the `iFixit/ifixit`'s stress-test workflow is that in `react-commerce`, we can't easily get the modified individual testMethod so we end up running the whole test class (which I think is fine). 

## QA
Check the following cases:
1. Make sure it doesn't run the stress-test when no test changes were made. 
2. Make sure it does run the stress-test when test changes were made.  

closes #1431 