### PR TITLE
Add product collection type permissions

### DIFF
--- a/backend/src/bootstrap/permissions/config.json
+++ b/backend/src/bootstrap/permissions/config.json
@@ -10,6 +10,8 @@
       "api::page.page.findOne",
       "api::page.page.find",
       "api::company.company.findOne",
-      "api::company.company.find"
+      "api::company.company.find",
+      "api::product.product.findOne",
+      "api::product.product.find"
    ]
 }


### PR DESCRIPTION
closes #1461 

⚠️ 👁️ CI is broken because the seed process is broken. This PR fixes that.

## QA

1. Verify that the following link returns `200` response (you can use the network tab in the browser dev tools)
    https://fix-strapi-product-permissions.govinor.com/api/products?populate[sections][populate]=%2A&pagination[page]=1&pagination[pageSize]=100


❗❗❗After this PR is merged Strapi should be redeployed in production ❗❗❗

cc @sterlinghirsh @danielbeardsley @masonmcelvain 
