### PR TITLE
Troubleshooting: Add hreflang links to page head

### DIFF
--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -26,6 +26,7 @@ export type TroubleshootingData = {
    canonicalUrl: string;
    lastUpdatedDate: number;
    authors: Author[];
+   hreflangUrls: Record<string, string>;
 };
 
 type TroubleshootingPageProps = {

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -56,6 +56,7 @@ const Wiki: NextPageWithLayout<{
             <Head>
                <meta name="robots" content="noindex" />
                <link rel="canonical" href={wikiData.canonicalUrl} />
+               <HreflangUrls urls={wikiData.hreflangUrls} />
             </Head>
             <Heading as="h1">{wikiData.title}</Heading>
             <AuthorInformation
@@ -283,6 +284,17 @@ function NavTabs({ devicePartsUrl, deviceGuideUrl }: NavTabsProps) {
             </Link>
             <Box {...selectedStyleProps}>Answers</Box>
          </Flex>
+      </>
+   );
+}
+
+function HreflangUrls({ urls }: { urls: Record<string, string> }) {
+   const hreflangs = Object.entries(urls);
+   return (
+      <>
+         {hreflangs.map(([lang, url]) => (
+            <link rel="alternate" key={lang} hrefLang={lang} href={url} />
+         ))}
       </>
    );
 }


### PR DESCRIPTION
Does what it says on the tin.

## QA Notes
Please view-source on https://react-commerce-git-troubleshooting-add-hreflangs-ifixit.vercel.app/Vulcan/troubleshooting-test and check that we end up with a `<link rel="alternate" hreflang="en" href="some reasonable URL for Vulcan">` tag and one for `x-default` on the page.

Then also check that a translated wiki, such as https://react-commerce-git-troubleshooting-add-hreflangs-ifixit.vercel.app/Vulcan/KitchenAid_KSM150PSER_Troubleshooting, ends up with some non-English values.

Closes https://github.com/iFixit/ifixit/issues/46809