### PR TITLE
Update Test Section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ After running the dev server, you can access the Strapi admin panel at `http://l
 
 The local Strapi dev server will allow you to make changes to the schema of content types. When you're satisfied with the changes, you can push into a new branch to get a preview url from [govinor](https://govinor.com/).
 
-### Project structure
+## Project structure
 
 The project contains a `backend` folder with Strapi config and a `frontend` with Next.js.
 You can run the backend both using SQLite and using Postgres with docker compose. For now the recommended approach for local dev is to just use SQLite.
@@ -93,7 +93,7 @@ Here's an overview of the production setup (the focus is on Next.js, therefore d
 
 ![image](https://user-images.githubusercontent.com/4640135/203581627-82ab19ca-7de7-4343-ae05-2a4f6330f38a.png)
 
-### Tests
+## Tests
 
 We use Jest and Playwright (with MSW) to run our tests.
 
@@ -131,7 +131,7 @@ pnpm test
 
 > ⚠️ We don't need to have the dev server running before we run the Jest tests.
 
-### Using SVG
+## Using SVG
 
 If you want to use an svg as a React component, add it to `frontend/assets/svg/files` and run
 
@@ -147,16 +147,16 @@ import { LifetimeWarrantyIcon } from '@assets/svg';
 
 > :warning: SVGR uses the name of the file to name the component (it converts it to camel case), so name the svg accordingly.
 
-### Miscellaenous
+## Miscellaenous
 
-#### Update Storefront graphql schema
+### Update Storefront graphql schema
 
 When you need to update the Shopify storefront GraphQL schema version, follow these steps:
 
 1. Update `NEXT_PUBLIC_SHOPIFY_STOREFRONT_VERSION` in `frontend/.env.development` and `frontend/.env.production`
 2. Run `pnpm codegen:download-shopify-storefront-schema`
 
-#### Generate Shopify storefront delegate access token
+### Generate Shopify storefront delegate access token
 
 The public Shopify storefront API is rate limited by user IP. To avoid hitting the rate limit when making requests from the server, we use Shopify storefront API with a [delegate access token](https://shopify.dev/apps/auth/oauth/delegate-access-tokens). To generate a token for a shop, use the automation bot:
 
@@ -166,9 +166,9 @@ pnpm bot shopify create delegate-token
 
 > :information_source: You can use the **Admin API Password** of the app that you use to generate the Storefront access token.
 
-### Troubleshooting
+## Troubleshooting
 
-#### Backend folder dependencies errors
+### Backend folder dependencies errors
 
 Since [OSX 12.3](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes), python(2) is no longer available by default.
 If no prebuilt image is available for some dependencies like sqlite3, it may be necessary to install python(2) to build the image locally.
@@ -181,7 +181,7 @@ pyenv global 2.7.18
 echo 'PATH=$(pyenv root)/shims:$PATH' >> ~/.zshrc
 ```
 
-#### Local Strapi missing iFixit Test Store
+### Local Strapi missing iFixit Test Store
 
 With the latest changes, we might run into a situation where the local strapi does not have the ifixit test store in it. In order to fix this add the folowing to `backend/.env`
 
@@ -193,6 +193,6 @@ With the latest version of main, go to your local strapi at http://localhost:133
 
 If this page does not appear, then delete `backend/.cache` and `backend/dist` and re-start the dev server.
 
-#### I've updated the Shopify Storefront schema version but the graphql codegen script is not working
+### I've updated the Shopify Storefront schema version but the graphql codegen script is not working
 
 Whenever you update the Shopify Storefront schema version, you need to run `pnpm codegen:download-shopify-storefront-schema` to download the new schema.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,29 @@ We use [Jest](https://jestjs.io) and [Playwright](https://playwright.dev/) (with
 
 At the moment, we only have tests for the `frontend`. These tests are located in the `frontend/tests` directory.
 
-You can use any of the following commands to run Playwright tests:
+### Running Jest Tests
+
+You can use the following command to run all the `Jest` tests:
+```sh
+pnpm test
+```
+
+Additionally, you can pass any `Jest` flag to the command by prepending `--` before the flags:
+```sh
+pnpm test -- --watch
+pnpm test -- ProductListItem --updateSnapshot
+```
+
+⚠️ **Note:** You will not be able to interact with the Jest CLI prompt if the tests were ran from the `root` directory. To be able to interact with the Jest CLI prompt, you will need to run the tests from the `frontend` directory.
+
+|Root Dir Execution| Frontend Execution|
+|:---:|:---:|
+| ![image](https://user-images.githubusercontent.com/22064420/225107750-2e161321-dc48-424a-880c-9d10ba1b12c3.png) |  ![image](https://user-images.githubusercontent.com/22064420/225106631-9d459540-4659-4f40-9070-40f25a5ac979.png) |
+
+**For more information on Jest flags, click on the link to read the docs: [Jest CLI](https://jestjs.io/docs/cli)**
+
+<br/>
+
 
 ```sh
 pnpm run playwright:run       // Runs all tests for all projects

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ pnpm playwright:run --project="Mobile Chrome" --headed fix_kit
 ```
 **For more information on Playwright flags, click on the link to read the docs: [Playwright CLI](https://playwright.dev/docs/test-cli#reference)**
 
+⚠️ **For more Playwright specific information such as Mocking API Requests and
+debugging tips, check out the [testing-doc](frontend/tests/playwright/testing-doc.md)**
+
 ## Using SVG
 
 If you want to use an svg as a React component, add it to `frontend/assets/svg/files` and run

--- a/README.md
+++ b/README.md
@@ -122,30 +122,35 @@ pnpm test -- ProductListItem --updateSnapshot
 
 <br/>
 
+### Running Playwright Tests
 
+You can use the following command to run all `Playwright` tests:
+- **Run all tests for all devices _(a.k.a projects)_**
+   ```sh
+   pnpm playwright:run
+   ```
+
+<br/>
+
+If you want to **debug** all the tests, or a single test, you can use the following command:
+
+- **Run all tests for Desktop Chrome**
+   ```sh
+   pnpm playwright:debug [test_name]
+   ```
+   - This will make Playwright do the following:
+     - Launch the browser in **headed** mode
+     - Disables parallelization
+     - Sets the `timeout` to `0` (_no timeout_)
+     - Configures a `playwright` object in the browser to allow you to interact with Playwright's Locator API right from the browser's console
+     - Enables verbose logging of Playwright's API calls
+
+Additionally, you can directly add any `Playwright` flag to the command:
 ```sh
-pnpm run playwright:run       // Runs all tests for all projects
-pnpm run playwright:debug     // Runs all tests for desktop chrome in debug mode (see frontend/package.json for details)
+pnpm playwright:run --project="Desktop Chrome" fix_kit
+pnpm playwright:run --project="Mobile Chrome" --headed fix_kit
 ```
-
-Also you can provide additional flags/options to run single/multiple tests and with different devices/projects:
-
-```sh
-pnpm run playwright:run --project="Desktop Chrome" fix_kit         // Runs fix_kit test for desktop chrome headless
-pnpm run playwright:run --project="Mobile Chrome" --headed fix_kit // Runs fix_kit test for mobile chrome headed
-```
-
-> ⚠️ We need to have the dev server running before we run the Playwright tests.
-> Luckily, Playwright webserver will start the app automatically if it's not running yet.
-
-If you are trying to experiment with the MSW handlers, you can use the following command to instantiate the Next.js server
-with the MSW handlers integrated. You can then add or remove handlers from
-`frontend/tests/playwright/msw/handlers.ts` and see the changes. If you do make
-any changes, make sure to restart the server.
-
-```sh
-NEXT_PUBLIC_MOCK_API=true pnpm dev
-```
+**For more information on Playwright flags, click on the link to read the docs: [Playwright CLI](https://playwright.dev/docs/test-cli#reference)**
 
 This command will run Jest tests:
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ Here's an overview of the production setup (the focus is on Next.js, therefore d
 
 We use [Jest](https://jestjs.io) and [Playwright](https://playwright.dev/) (with [MSW](https://mswjs.io/)) to run our tests.
 
-At the moment, we only have tests for the `frontend`. These tests are located in the `frontend/tests` directory.
+At the moment, we only have tests for the `frontend`. These tests are located in the [`frontend/tests`](frontend/tests) directory.
 
 ### Running Jest Tests
+> ⚠️ We don't need to have the dev server running before we run the Jest tests.
 
 You can use the following command to run all the `Jest` tests:
 ```sh
@@ -123,6 +124,9 @@ pnpm test -- ProductListItem --updateSnapshot
 <br/>
 
 ### Running Playwright Tests
+> ⚠️ We need the dev server running to run the Playwright tests. You can run the dev server by running `pnpm dev` in the `root` directory.
+>
+> You can also just let Playwright start the dev server automatically when running the tests, but this will make running Playwright tests slower as it will need to start the dev server every time.
 
 You can use the following command to run all `Playwright` tests:
 - **Run all tests for all devices _(a.k.a projects)_**
@@ -151,14 +155,6 @@ pnpm playwright:run --project="Desktop Chrome" fix_kit
 pnpm playwright:run --project="Mobile Chrome" --headed fix_kit
 ```
 **For more information on Playwright flags, click on the link to read the docs: [Playwright CLI](https://playwright.dev/docs/test-cli#reference)**
-
-This command will run Jest tests:
-
-```sh
-pnpm test
-```
-
-> ⚠️ We don't need to have the dev server running before we run the Jest tests.
 
 ## Using SVG
 

--- a/README.md
+++ b/README.md
@@ -100,14 +100,17 @@ We use [Jest](https://jestjs.io) and [Playwright](https://playwright.dev/) (with
 At the moment, we only have tests for the `frontend`. These tests are located in the [`frontend/tests`](frontend/tests) directory.
 
 ### Running Jest Tests
+
 > ⚠️ We don't need to have the dev server running before we run the Jest tests.
 
 You can use the following command to run all the `Jest` tests:
+
 ```sh
 pnpm test
 ```
 
 Additionally, you can pass any `Jest` flag to the command by prepending `--` before the flags:
+
 ```sh
 pnpm test -- --watch
 pnpm test -- ProductListItem --updateSnapshot
@@ -115,21 +118,23 @@ pnpm test -- ProductListItem --updateSnapshot
 
 ⚠️ **Note:** You will not be able to interact with the Jest CLI prompt if the tests were ran from the `root` directory. To be able to interact with the Jest CLI prompt, you will need to run the tests from the `frontend` directory.
 
-|Root Dir Execution| Frontend Execution|
-|:---:|:---:|
-| ![image](https://user-images.githubusercontent.com/22064420/225107750-2e161321-dc48-424a-880c-9d10ba1b12c3.png) |  ![image](https://user-images.githubusercontent.com/22064420/225106631-9d459540-4659-4f40-9070-40f25a5ac979.png) |
+|                                               Root Dir Execution                                                |                                               Frontend Execution                                                |
+| :-------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------: |
+| ![image](https://user-images.githubusercontent.com/22064420/225107750-2e161321-dc48-424a-880c-9d10ba1b12c3.png) | ![image](https://user-images.githubusercontent.com/22064420/225106631-9d459540-4659-4f40-9070-40f25a5ac979.png) |
 
 **For more information on Jest flags, click on the link to read the docs: [Jest CLI](https://jestjs.io/docs/cli)**
 
 <br/>
 
 ### Running Playwright Tests
+
 > ⚠️ We need the dev server running to run the Playwright tests. You can run the dev server by running `pnpm dev` in the `root` directory.
 >
 > You can also just let Playwright start the dev server automatically when running the tests, but this will make running Playwright tests slower as it will need to start the dev server every time.
 
 You can use the following command to run all `Playwright` tests:
-- **Run all tests for all devices _(a.k.a projects)_**
+
+-  **Run all tests for all devices _(a.k.a projects)_**
    ```sh
    pnpm playwright:run
    ```
@@ -138,22 +143,24 @@ You can use the following command to run all `Playwright` tests:
 
 If you want to **debug** all the tests, or a single test, you can use the following command:
 
-- **Run all tests for Desktop Chrome**
+-  **Run all tests for Desktop Chrome**
    ```sh
    pnpm playwright:debug [test_name]
    ```
-   - This will make Playwright do the following:
-     - Launch the browser in **headed** mode
-     - Disables parallelization
-     - Sets the `timeout` to `0` (_no timeout_)
-     - Configures a `playwright` object in the browser to allow you to interact with Playwright's Locator API right from the browser's console
-     - Enables verbose logging of Playwright's API calls
+   -  This will make Playwright do the following:
+      -  Launch the browser in **headed** mode
+      -  Disables parallelization
+      -  Sets the `timeout` to `0` (_no timeout_)
+      -  Configures a `playwright` object in the browser to allow you to interact with Playwright's Locator API right from the browser's console
+      -  Enables verbose logging of Playwright's API calls
 
 Additionally, you can directly add any `Playwright` flag to the command:
+
 ```sh
 pnpm playwright:run --project="Desktop Chrome" fix_kit
 pnpm playwright:run --project="Mobile Chrome" --headed fix_kit
 ```
+
 **For more information on Playwright flags, click on the link to read the docs: [Playwright CLI](https://playwright.dev/docs/test-cli#reference)**
 
 ⚠️ **For more Playwright specific information such as Mocking API Requests and

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ Here's an overview of the production setup (the focus is on Next.js, therefore d
 
 ## Tests
 
-We use Jest and Playwright (with MSW) to run our tests.
+We use [Jest](https://jestjs.io) and [Playwright](https://playwright.dev/) (with [MSW](https://mswjs.io/)) to run our tests.
+
+At the moment, we only have tests for the `frontend`. These tests are located in the `frontend/tests` directory.
 
 You can use any of the following commands to run Playwright tests:
 

--- a/frontend/tests/playwright/testing-doc.md
+++ b/frontend/tests/playwright/testing-doc.md
@@ -1,7 +1,9 @@
 # Playwright Testing Documentation
+
 This document contains extra information for writing Playwright tests within the context of our application.
 
 ## Mocking API Requests
+
 Currently, we only mock API Requests for Playwright tests.
 
 We use [MSW](https://mswjs.io/) to mock API requests. We have the ability to mock either Client-Side or Server-Side API requests using an MSW handler. You can find the default handlers in [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts)
@@ -18,29 +20,29 @@ MSW uses something called a ["request handler"](https://mswjs.io/docs/basics/req
    <tr>
    <td>
 
-   ```ts
-   rest.get(
-      '*/api/2.0/internal/international_store_promotion/buybox',
-      (req, res, ctx) => {
-         return res(ctx.status(200));
-      }
-   ),
-   ```
+```ts
+rest.get(
+   '*/api/2.0/internal/international_store_promotion/buybox',
+   (req, res, ctx) => {
+      return res(ctx.status(200));
+   }
+),
+```
 
    </td>
    <td>
 
-   ```ts
-      createRestHandler({
-         request: {
-            endpoint: '*/api/2.0/internal/international_store_promotion/buybox',
-            method: 'get',
-         },
-         response: {
-            status: 200,
-         },
-      }),
-   ```
+```ts
+   createRestHandler({
+      request: {
+         endpoint: '*/api/2.0/internal/international_store_promotion/buybox',
+         method: 'get',
+      },
+      response: {
+         status: 200,
+      },
+   }),
+```
 
    </td>
    </tr>
@@ -50,12 +52,15 @@ MSW uses something called a ["request handler"](https://mswjs.io/docs/basics/req
 We can use these handlers to statically mock API requests or dynamically mock API requests.
 
 ### Static Handlers
+
 Static handlers are defined in [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts). These handlers can be considered the default handlers that will be used by both the MSW client-side service worker (_a.k.a. browser side_) and server-side service worker.
 
 #### Practical Usage: Developing Components
-These handlers are more useful when you want to mock API requests without having to run Playwright. For example, if you are working on a component that requires a Product to be in a certain state, you can define a handler in the  [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file to mock the API request for such a product. This way, you can develop the component without having to manually alter the state of the product in the database.
+
+These handlers are more useful when you want to mock API requests without having to run Playwright. For example, if you are working on a component that requires a Product to be in a certain state, you can define a handler in the [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file to mock the API request for such a product. This way, you can develop the component without having to manually alter the state of the product in the database.
 
 To do this, you will need to do the following:
+
 1. Append a new handler to the array in the [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file
 2. Run the application with the `NEXT_PUBLIC_MOCK_API` environment variable set to `true`
    ```sh
@@ -64,9 +69,11 @@ To do this, you will need to do the following:
 3. Use and develop the application as you normally would. The API requests will be mocked according to the handlers you defined in the [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file.
 
 #### Practical Usage: Global Test Mock
+
 If you want to mock an API request for all tests, you can define a handler in the [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file. This way, you can mock an API request without having to define it in every test.
 
 ### Dynamic Handlers
+
 Dynamic handlers are meant to be used in tests. These handlers are defined within the tests themsevles as opposed to the handlers defined in [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts). These handlers are useful when you want to mock API requests for a specific test.
 
 To enable these handlers, you will need to import the respective MSW worker as part of the Playwright fixtures we have defined in [`frontend/tests/playwright/test-fixtures.ts`](test-fixtures.ts).
@@ -124,7 +131,6 @@ Likewise, if you want to mock an API request for a **client-side request**, you 
 
 The Playwright docs are very extensive and contain a lot of information on how to [debug tests](https://playwright.dev/docs/debug), however it can be difficult to find the information you need. This section contains some useful information that we have found useful when debugging Playwright tests.
 
-
 ### `pnpm playwright:debug`
 
 As mentioned in the [`README`](../../../README.md#running-playwright-tests), you can run the Playwright tests in a custom debug mode by running the following command, where `test_name` is an optional argument if you want to debug a specific test.
@@ -136,41 +142,49 @@ pnpm playwright:debug [test_name]
 <br/>
 
 Overall, this `pnpm` script will execute the following command:
+
 ```sh
 DEBUG=pw:api playwright test --project="Desktop Chrome" --debug
 ```
 
 #### `--debug` flag
+
 The `--debug` flag will run Playwright in [debug mode](https://playwright.dev/docs/debug#pwdebug) which is the same as setting the `PWDEBUG` environment variable to `console`. In this mode, Playwright will do the following:
-   - Runs a headed browser
-   - disables parallelization
-   - Sets the `timeout` to `0` _(i.e. no timeout)_
-   - Adds a `playwright` object to the browser to allow you to interact with the Playwright Locator api via the console
-     - What this means is that you can use the `playwright` object to interact with the DOM and debug your tests in the browser console. For example, you can use the `playwright` object to help you find the correct selector for a specific element. For more information on how to use the `playwright` object, see the [playwright debug object docs](https://playwright.dev/docs/debug-selectors#using-devtools).
-   ![image](https://user-images.githubusercontent.com/22064420/225163397-ea4409ca-0cf4-4a1c-96ae-c3307c0d1e0f.png)
+
+-  Runs a headed browser
+-  disables parallelization
+-  Sets the `timeout` to `0` _(i.e. no timeout)_
+-  Adds a `playwright` object to the browser to allow you to interact with the Playwright Locator api via the console
+   -  What this means is that you can use the `playwright` object to interact with the DOM and debug your tests in the browser console. For example, you can use the `playwright` object to help you find the correct selector for a specific element. For more information on how to use the `playwright` object, see the [playwright debug object docs](https://playwright.dev/docs/debug-selectors#using-devtools).
+      ![image](https://user-images.githubusercontent.com/22064420/225163397-ea4409ca-0cf4-4a1c-96ae-c3307c0d1e0f.png)
 
 #### `--project="Desktop Chrome"` flag
+
 The `--project="Desktop Chrome"` flag will run the tests using a Chromium instance and the presets for a Desktop browser. This is to narrow down the scope of the tests to be ran. It is possible to
 change this to run the tests in a different browser or device preset by using one of the project names defined within the `projects` array in the [`playwright.config.ts`](../../playwright.config.ts) file.
 
 #### `DEBUG=pw:api` flag
+
 Lastly, the [`DEBUG=pw:api`](https://playwright.dev/docs/debug-selectors#verbose-api-logs) flag will enable verbose logging of Playwright's API. This will log all the Playwright API calls to the console. This is useful when you want to see what Playwright is doing under the hood. Ideally it would be used to ensure that certain events are being triggered or gain more insight into the order of events.
-   - For example, if you want to use `page.waitForLoadState('networkidle')` to wait for a page to no longer have any network requests, but you are not sure if the page is actually waiting for the network to be idle, you can enable this flag to see if the `networkidle` event is being triggered.
+
+-  For example, if you want to use `page.waitForLoadState('networkidle')` to wait for a page to no longer have any network requests, but you are not sure if the page is actually waiting for the network to be idle, you can enable this flag to see if the `networkidle` event is being triggered.
    ![image](https://user-images.githubusercontent.com/22064420/225164688-0f2a8df7-12f1-4cdc-9e4b-a3e2d2a341bc.png)
 
 ### Playwright Trace Viewer
 
 Playwright has a built-in [trace viewer](https://playwright.dev/docs/trace-viewer) that can be used to debug tests that have already ran. This is useful when you want to see what happened during a test run while having access to the following runtime information:
-   - Browser Console
-   - Network Requests
-   - The DOM
-   - Associated Playwright actions and source code
-   - Metadata
-   - Screenshots
+
+-  Browser Console
+-  Network Requests
+-  The DOM
+-  Associated Playwright actions and source code
+-  Metadata
+-  Screenshots
 
 This is a lot more useful than just looking at the failure log and trying to reproduce the failure. In order to use the trace viewer, you will need to record a trace log of a test run to obtain a `trace.zip` file.
 
 #### Recording a Trace Log
+
 We have already enabled trace viewer in CI, and have uploaded the `trace.zip` files as an artifact. More information on this can be found in [Viewing Trace Logs](#viewing-trace-logs).
 
 To enable trace viewer locally, you will need to add the `--trace on` flag to the Playwright commands. This will create a `trace.zip` file in the `frontend/tests/playwright/test-results` directory.

--- a/frontend/tests/playwright/testing-doc.md
+++ b/frontend/tests/playwright/testing-doc.md
@@ -119,3 +119,41 @@ Likewise, if you want to mock an API request for a **client-side request**, you 
             })
          );
 ```
+
+## Debugging Playwright Tests
+
+The Playwright docs are very extensive and contain a lot of information on how to [debug tests](https://playwright.dev/docs/debug), however it can be difficult to find the information you need. This section contains some useful information that we have found useful when debugging Playwright tests.
+
+
+### `pnpm playwright:debug`
+
+As mentioned in the [`README`](../../../README.md#running-playwright-tests), you can run the Playwright tests in a custom debug mode by running the following command, where `test_name` is an optional argument if you want to debug a specific test.
+
+```sh
+pnpm playwright:debug [test_name]
+```
+
+<br/>
+
+Overall, this `pnpm` script will execute the following command:
+```sh
+DEBUG=pw:api playwright test --project="Desktop Chrome" --debug
+```
+
+#### `--debug` flag
+The `--debug` flag will run Playwright in [debug mode](https://playwright.dev/docs/debug#pwdebug) which is the same as setting the `PWDEBUG` environment variable to `console`. In this mode, Playwright will do the following:
+   - Runs a headed browser
+   - disables parallelization
+   - Sets the `timeout` to `0` _(i.e. no timeout)_
+   - Adds a `playwright` object to the browser to allow you to interact with the Playwright Locator api via the console
+     - What this means is that you can use the `playwright` object to interact with the DOM and debug your tests in the browser console. For example, you can use the `playwright` object to help you find the correct selector for a specific element. For more information on how to use the `playwright` object, see the [playwright debug object docs](https://playwright.dev/docs/debug-selectors#using-devtools).
+   ![image](https://user-images.githubusercontent.com/22064420/225163397-ea4409ca-0cf4-4a1c-96ae-c3307c0d1e0f.png)
+
+#### `--project="Desktop Chrome"` flag
+The `--project="Desktop Chrome"` flag will run the tests using a Chromium instance and the presets for a Desktop browser. This is to narrow down the scope of the tests to be ran. It is possible to
+change this to run the tests in a different browser or device preset by using one of the project names defined within the `projects` array in the [`playwright.config.ts`](../../playwright.config.ts) file.
+
+#### `DEBUG=pw:api` flag
+Lastly, the [`DEBUG=pw:api`](https://playwright.dev/docs/debug-selectors#verbose-api-logs) flag will enable verbose logging of Playwright's API. This will log all the Playwright API calls to the console. This is useful when you want to see what Playwright is doing under the hood. Ideally it would be used to ensure that certain events are being triggered or gain more insight into the order of events.
+   - For example, if you want to use `page.waitForLoadState('networkidle')` to wait for a page to no longer have any network requests, but you are not sure if the page is actually waiting for the network to be idle, you can enable this flag to see if the `networkidle` event is being triggered.
+   ![image](https://user-images.githubusercontent.com/22064420/225164688-0f2a8df7-12f1-4cdc-9e4b-a3e2d2a341bc.png)

--- a/frontend/tests/playwright/testing-doc.md
+++ b/frontend/tests/playwright/testing-doc.md
@@ -157,3 +157,55 @@ change this to run the tests in a different browser or device preset by using on
 Lastly, the [`DEBUG=pw:api`](https://playwright.dev/docs/debug-selectors#verbose-api-logs) flag will enable verbose logging of Playwright's API. This will log all the Playwright API calls to the console. This is useful when you want to see what Playwright is doing under the hood. Ideally it would be used to ensure that certain events are being triggered or gain more insight into the order of events.
    - For example, if you want to use `page.waitForLoadState('networkidle')` to wait for a page to no longer have any network requests, but you are not sure if the page is actually waiting for the network to be idle, you can enable this flag to see if the `networkidle` event is being triggered.
    ![image](https://user-images.githubusercontent.com/22064420/225164688-0f2a8df7-12f1-4cdc-9e4b-a3e2d2a341bc.png)
+
+### Playwright Trace Viewer
+
+Playwright has a built-in [trace viewer](https://playwright.dev/docs/trace-viewer) that can be used to debug tests that have already ran. This is useful when you want to see what happened during a test run while having access to the following runtime information:
+   - Browser Console
+   - Network Requests
+   - The DOM
+   - Associated Playwright actions and source code
+   - Metadata
+   - Screenshots
+
+This is a lot more useful than just looking at the failure log and trying to reproduce the failure. In order to use the trace viewer, you will need to record a trace log of a test run to obtain a `trace.zip` file.
+
+#### Recording a Trace Log
+We have already enabled trace viewer in CI, and have uploaded the `trace.zip` files as an artifact. More information on this can be found in [Viewing Trace Logs](#viewing-trace-logs).
+
+To enable trace viewer locally, you will need to add the `--trace on` flag to the Playwright commands. This will create a `trace.zip` file in the `frontend/tests/playwright/test-results` directory.
+
+Note, this won't really be that useful if you are running debug mode.
+
+```bash
+pnpm playwright:run --trace on
+
+pnpm playwright:debug --trace on # Not really useful for debug mode
+```
+
+#### Viewing Trace Logs
+
+In order to view a trace log, you will need a `trace.zip` file. If you
+have already enabled trace viewer locally, you can find the `trace.zip` file in the `frontend/tests/playwright/test-results` directory after a test run.
+
+If you are trying to view a trace log from CI, you can download the `playwright-artifacts.zip` file from the `Summary` tab of the `E2E` workflow run. Then you can unzip the `artifacts.zip` file which will contain a `trace.zip` file for each `device-test` failure.
+
+<details>
+<summary>Location of the <code>playwright-artifacts.zip</code> file</summary>
+
+![image](https://user-images.githubusercontent.com/22064420/225168783-470c1337-4894-4371-a205-251e31a33846.png)
+
+</details>
+
+**View the Trace Log Locally**
+
+To view the trace logs locally, you can run the following command:
+
+```bash
+npx playwright show-trace <path-to-trace.zip>
+```
+
+**View the Trace Log in the Browser**
+Otherwise, you can upload the `trace.zip` file to [Playwright Trace Viewer](https://trace.playwright.dev/).
+
+![image](https://user-images.githubusercontent.com/22064420/225170856-ac20e320-83cf-4cbd-967f-b858a1bf773a.png)

--- a/frontend/tests/playwright/testing-doc.md
+++ b/frontend/tests/playwright/testing-doc.md
@@ -2,6 +2,21 @@
 
 This document contains extra information for writing Playwright tests within the context of our application.
 
+-  [Mocking API Requests](#mocking-api-requests)
+   -  [Mock Handlers](#mock-handlers)
+   -  [Static Handlers](#static-handlers)
+      -  [Practical Usage: Developing Components](#practical-usage-developing-components)
+      -  [Practical Usage: Global Test Mock](#practical-usage-global-test-mock)
+   -  [Dynamic Handlers](#dynamic-handlers)
+-  [Debugging Playwright Tests](#debugging-playwright-tests)
+   -  [`pnpm playwright:debug`](#pnpm-playwrightdebug)
+      -  [`--debug` flag](#--debug-flag)
+      -  [`--project="Desktop Chrome"` flag](#--projectdesktop-chrome-flag)
+      -  [`DEBUG=pw:api` flag](#debugpwapi-flag)
+   -  [Playwright Trace Viewer](#playwright-trace-viewer)
+      -  [Recording a Trace Log](#recording-a-trace-log)
+      -  [Viewing Trace Logs](#viewing-trace-logs)
+
 ## Mocking API Requests
 
 Currently, we only mock API Requests for Playwright tests.

--- a/frontend/tests/playwright/testing-doc.md
+++ b/frontend/tests/playwright/testing-doc.md
@@ -1,0 +1,121 @@
+# Playwright Testing Documentation
+This document contains extra information for writing Playwright tests within the context of our application.
+
+## Mocking API Requests
+Currently, we only mock API Requests for Playwright tests.
+
+We use [MSW](https://mswjs.io/) to mock API requests. We have the ability to mock either Client-Side or Server-Side API requests using an MSW handler. You can find the default handlers in [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts)
+
+### Mock Handlers
+
+MSW uses something called a ["request handler"](https://mswjs.io/docs/basics/request-handler) to define how matching requests should be mocked according to the API type _(i.e. `graphql` or `rest`)_. We have built a wrapper around these handlers to make it easier to create such handlers. The wrapper logic can be in [`frontend/tests/playwright/msw/request-handler.ts`](./msw/request-handler.ts)
+
+<table>
+   <tr>
+      <th>MSW Handler Interface</th>
+      <th>Wrapper Handler Interface</th>
+   </tr>
+   <tr>
+   <td>
+
+   ```ts
+   rest.get(
+      '*/api/2.0/internal/international_store_promotion/buybox',
+      (req, res, ctx) => {
+         return res(ctx.status(200));
+      }
+   ),
+   ```
+
+   </td>
+   <td>
+
+   ```ts
+      createRestHandler({
+         request: {
+            endpoint: '*/api/2.0/internal/international_store_promotion/buybox',
+            method: 'get',
+         },
+         response: {
+            status: 200,
+         },
+      }),
+   ```
+
+   </td>
+   </tr>
+
+</table>
+
+We can use these handlers to statically mock API requests or dynamically mock API requests.
+
+### Static Handlers
+Static handlers are defined in [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts). These handlers can be considered the default handlers that will be used by both the MSW client-side service worker (_a.k.a. browser side_) and server-side service worker.
+
+#### Practical Usage: Developing Components
+These handlers are more useful when you want to mock API requests without having to run Playwright. For example, if you are working on a component that requires a Product to be in a certain state, you can define a handler in the  [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file to mock the API request for such a product. This way, you can develop the component without having to manually alter the state of the product in the database.
+
+To do this, you will need to do the following:
+1. Append a new handler to the array in the [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file
+2. Run the application with the `NEXT_PUBLIC_MOCK_API` environment variable set to `true`
+   ```sh
+   NEXT_PUBLIC_MOCK_API=true pnpm dev
+   ```
+3. Use and develop the application as you normally would. The API requests will be mocked according to the handlers you defined in the [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file.
+
+#### Practical Usage: Global Test Mock
+If you want to mock an API request for all tests, you can define a handler in the [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts) file. This way, you can mock an API request without having to define it in every test.
+
+### Dynamic Handlers
+Dynamic handlers are meant to be used in tests. These handlers are defined within the tests themsevles as opposed to the handlers defined in [`frontend/tests/playwright/msw/handlers.ts`](./msw/handlers.ts). These handlers are useful when you want to mock API requests for a specific test.
+
+To enable these handlers, you will need to import the respective MSW worker as part of the Playwright fixtures we have defined in [`frontend/tests/playwright/test-fixtures.ts`](test-fixtures.ts).
+
+For example, if you want to mock an API request for a **server-side request**, you will need to import the `serverRequestInterceptor` fixture. This fixture will provide a reference to the MSW **server-side** worker. You can define a handler(s) for this worker to use.
+
+```ts
+  test('Low stocked product changes quantity', async ({
+         productPage,
+         cartDrawer,
+         serverRequestInterceptor,
+      }) => {
+         const lowStockedProduct = cloneDeep(mockedProductQuery);
+         if (lowStockedProduct.product) {
+            lowStockedProduct.product.variants.nodes[0].quantityAvailable = 3;
+         }
+
+         serverRequestInterceptor.use(
+            createGraphQLHandler({
+               request: {
+                  endpoint: 'findProduct',
+                  method: 'query',
+               },
+               response: {
+                  status: 200,
+                  body: lowStockedProduct,
+               },
+            })
+         );
+```
+
+Likewise, if you want to mock an API request for a **client-side request**, you will need to import the `clientRequestHandler` fixture. This fixture will provide a reference to the MSW **client-side** worker.
+
+```ts
+ test('Out of stock product cannot be added to cart', async ({
+         productPage,
+         cartDrawer,
+         serverRequestInterceptor,
+         clientRequestHandler,
+      }) => {
+         clientRequestHandler.use(
+            createRestHandler({
+               request: {
+                  endpoint: '/api/2.0/cart/product/notifyWhenSkuInStock',
+                  method: 'post',
+               },
+               response: {
+                  status: 200,
+               },
+            })
+         );
+```


### PR DESCRIPTION
## Description

There is some tribal knowledge surrounding how to run and debug tests that makes the `Tests` section out-of-date in the `README`.

This cleans up the `Tests` section and adds an additional document. This additional document elaborates on how to mock API requests and how to debug `Playwright` tests.

### CR

Ensure the information is understandable and is correct.

### QA

- [ ] Grammar check

Closes: https://github.com/ifixit/react-commerce/issues/1417