### PR TITLE
Remove flex gap property from footer

### DIFF
--- a/packages/footer/components/Newsletter.tsx
+++ b/packages/footer/components/Newsletter.tsx
@@ -153,7 +153,6 @@ const NewsletterSubscribed = ({ isSubscribed }: { isSubscribed: boolean }) => {
          flexDirection="row"
          alignItems="center"
          padding="3"
-         gap="2"
          w="100%"
          mt="3"
          bg="brand.100"
@@ -163,7 +162,9 @@ const NewsletterSubscribed = ({ isSubscribed }: { isSubscribed: boolean }) => {
          borderRadius="base"
       >
          <FaIcon icon={faCircleCheck} color="brand.500" />
-         <Text color="gray.900">Subscribed!</Text>
+         <Text color="gray.900" ml="2">
+            Subscribed!
+         </Text>
       </Flex>
    );
 };

--- a/packages/footer/components/Partners.tsx
+++ b/packages/footer/components/Partners.tsx
@@ -11,7 +11,8 @@ export const FooterPartners = forwardRef<BoxProps, 'div'>(
             alignItems="center"
             justifyContent="center"
             flexWrap="wrap"
-            gap="3"
+            ml="-3"
+            mb="-3"
             {...otherProps}
          >
             {children}
@@ -35,6 +36,8 @@ export const FooterPartnerLink = forwardRef<BoxProps, 'a'>(
             opacity="0.5"
             h="62px"
             w="92px"
+            ml="3"
+            mb="3"
             p="4"
             borderRadius="base"
             boxSizing="border-box"


### PR DESCRIPTION
References https://github.com/iFixit/react-commerce/pull/1465#discussion_r1135888653

This PR removes any references to the flex `gap` property from the footer.
All the usages were easily substituted with margins.

cc @aburke07 

### QA

1. Visit Vercel preview
2. Check that this change does not introduce any visible change to the footer wrt production