### PR TITLE
Update related post section style

### DIFF
--- a/frontend/templates/product-list/sections/RelatedPostsSection/PostCard.tsx
+++ b/frontend/templates/product-list/sections/RelatedPostsSection/PostCard.tsx
@@ -6,7 +6,8 @@ import {
    Text,
    VStack,
 } from '@chakra-ui/react';
-import { Card } from '@components/ui';
+import { FaIcon } from '@ifixit/icons';
+import { faImage } from '@fortawesome/pro-duotone-svg-icons';
 import { ResponsiveImage } from '@ifixit/ui';
 import dayjs from 'dayjs';
 import NextLink from 'next/link';
@@ -32,16 +33,17 @@ export function PostCard({
    return (
       <LinkBox
          bg="white"
-         as={Card}
+         borderWidth="1px"
+         borderStyle="solid"
+         borderColor="gray.300"
+         borderRadius="base"
+         _hover={{ borderColor: 'brand.300', borderWidth: '1px' }}
          overflow="hidden"
-         _hover={{
-            boxShadow: 'md',
-         }}
          transition="all 300ms"
       >
          <Flex direction="column">
-            {imageSrc && (
-               <Box position="relative" h="140px">
+            {imageSrc ? (
+               <Box position="relative" h={{ base: '36', md: '40' }}>
                   <ResponsiveImage
                      src={imageSrc}
                      alt={imageAlt}
@@ -50,33 +52,34 @@ export function PostCard({
                      sizes="50vw"
                   />
                </Box>
+            ) : (
+               <Flex
+                  bgColor="brand.100"
+                  h={{ base: '36', md: '40' }}
+                  alignItems="center"
+                  justifyContent="center"
+               >
+                  <FaIcon icon={faImage} h="12" color="brand.200" />
+               </Flex>
             )}
-            <VStack spacing="2" p="4" align="flex-start">
+            <VStack spacing="3" p="4" align="flex-start">
                {category && category.length > 0 && (
-                  <Text
-                     color="brand.500"
-                     fontSize="xs"
-                     fontWeight="bold"
-                     textTransform="uppercase"
-                  >
+                  <Text color="brand.500" fontWeight="medium">
                      {category}
                   </Text>
                )}
-               <NextLink href={link} passHref>
-                  <LinkOverlay>
-                     <Text
-                        as="h3"
-                        fontSize="lg"
-                        fontWeight="bold"
-                        lineHeight="shorter"
-                     >
-                        {title}
-                     </Text>
-                  </LinkOverlay>
-               </NextLink>
-               <Text fontFamily="mono" fontSize="sm" color="gray.600">
-                  {dayjs(date).format('MMMM D, YYYY')}
-               </Text>
+               <VStack spacing="1" align="flex-start">
+                  <NextLink href={link} passHref>
+                     <LinkOverlay>
+                        <Text as="h3" fontWeight="medium" lineHeight="shorter">
+                           {title}
+                        </Text>
+                     </LinkOverlay>
+                  </NextLink>
+                  <Text fontSize="sm" color="gray.600">
+                     {dayjs(date).format('MMMM D, YYYY')}
+                  </Text>
+               </VStack>
             </VStack>
          </Flex>
       </LinkBox>

--- a/frontend/templates/product-list/sections/RelatedPostsSection/index.tsx
+++ b/frontend/templates/product-list/sections/RelatedPostsSection/index.tsx
@@ -23,7 +23,7 @@ export function RelatedPostsSection({ tags = [] }: RelatedPostsSectionProps) {
       <VStack align="stretch" spacing="4">
          <Heading
             as="h2"
-            color="gray.700"
+            color="gray.900"
             fontSize={{ base: '2xl', md: '3xl' }}
             fontWeight="medium"
          >

--- a/frontend/templates/product/sections/CompatibilitySection/index.tsx
+++ b/frontend/templates/product/sections/CompatibilitySection/index.tsx
@@ -16,7 +16,7 @@ export function CompatibilitySection({
          <Wrapper>
             <Heading
                as="h2"
-               color="gray.700"
+               color="gray.900"
                textAlign="center"
                mb="12"
                fontSize={{ base: '2xl', md: '3xl' }}

--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -181,7 +181,7 @@ export function CrossSellSection({
          <Wrapper>
             <Heading
                as="h2"
-               color="gray.700"
+               color="gray.900"
                textAlign="center"
                mb={{
                   base: 6,

--- a/frontend/templates/product/sections/ReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ReviewsSection/index.tsx
@@ -82,7 +82,7 @@ export function ReviewsSection({
          <Wrapper>
             <Heading
                as="h2"
-               color="gray.700"
+               color="gray.900"
                textAlign="center"
                mb={{
                   base: 8,


### PR DESCRIPTION
closes #1453 

<img width="918" alt="Screenshot 2023-03-16 at 16 29 44" src="https://user-images.githubusercontent.com/7805759/225666807-ea456652-8641-4ba7-8449-41e591963d72.png">

### QA

1. Visit Vercel preview
2. Verify that the related post section adheres to the new mockup