### PR TITLE
Troubleshooting: Add html5 video styling

### DIFF
--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -134,13 +134,13 @@ const renderStyles: SystemStyleObject = {
       height: 0,
       paddingBottom: '56.25%',
 
-      'video': {
+      video: {
          position: 'absolute',
          top: 0,
          left: 0,
          width: '100%',
          height: '100%',
-      }
+      },
    },
 
    '.imageBox_left': {

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -97,6 +97,52 @@ const renderStyles: SystemStyleObject = {
       },
    },
 
+   '.videoFrame': {
+      maxWidth: '100%',
+      border: '1px solid #e5e7eb',
+      marginTop: '8px',
+      marginBottom: '8px',
+      padding: '1px',
+      borderRadius: 0,
+      height: 'auto',
+
+      '&.videoBox_left': {
+         float: 'left',
+         clear: 'left',
+         marginRight: '30px',
+         position: 'relative',
+         width: 'fit-content',
+      },
+      '&.videoBox_center': {
+         marginLeft: 'auto',
+         marginRight: 'auto',
+         clear: 'both',
+         display: 'block',
+      },
+      '&.videoBox_right': {
+         float: 'right',
+         clear: 'right',
+         marginLeft: '30px',
+      },
+   },
+
+   '.videoBox': {
+      position: 'relative',
+      width: 'auto !important',
+      overflow: 'hidden',
+      maxWidth: '100%',
+      height: 0,
+      paddingBottom: '56.25%',
+
+      'video': {
+         position: 'absolute',
+         top: 0,
+         left: 0,
+         width: '100%',
+         height: '100%',
+      }
+   },
+
    '.imageBox_left': {
       clear: 'left',
       float: 'left',

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -106,12 +106,20 @@ const renderStyles: SystemStyleObject = {
       borderRadius: 0,
       height: 'auto',
 
+      '@media only screen and (max-width: 575px)': {
+         width: 'auto !important',
+      },
+
       '&.videoBox_left': {
          float: 'left',
          clear: 'left',
          marginRight: '30px',
          position: 'relative',
          width: 'fit-content',
+
+         '@media only screen and (max-width: 575px)': {
+            float: 'none',
+         },
       },
       '&.videoBox_center': {
          marginLeft: 'auto',
@@ -123,6 +131,10 @@ const renderStyles: SystemStyleObject = {
          float: 'right',
          clear: 'right',
          marginLeft: '30px',
+
+         '@media only screen and (max-width: 575px)': {
+            float: 'none',
+         },
       },
    },
 

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -84,6 +84,8 @@ const renderStyles: SystemStyleObject = {
       borderWidth: '1px',
       borderStyle: 'solid',
       padding: '1px',
+      maxWidth: '100%',
+      height: 'auto !important',
 
       '&.float-left': {
          float: 'left',


### PR DESCRIPTION
Add styles for non-YouTube videos and add styles for videos on mobile to prevent horizontal overflow.

QA
---
Check both YouTube and non-YouTube video styling at desktop and mobile.

Closes: https://github.com/iFixit/ifixit/issues/46894