### PR TITLE
Collections: Add admin links

### DIFF
--- a/frontend/components/admin/PageEditMenu.tsx
+++ b/frontend/components/admin/PageEditMenu.tsx
@@ -9,15 +9,23 @@ import {
    MenuList,
 } from '@chakra-ui/react';
 import { FaIcon } from '@ifixit/icons';
-import { faPenToSquare } from '@fortawesome/pro-solid-svg-icons';
+import {
+   faPenToSquare,
+   IconDefinition,
+} from '@fortawesome/pro-solid-svg-icons';
 import NextLink from 'next/link';
-import { ProductEditMenuLink } from '@helpers/product-helpers';
 
-type ProductEditMenuProps = BoxProps & {
-   links: ProductEditMenuLink[];
+export type PageEditMenuLink = {
+   icon: IconDefinition;
+   label: string;
+   url: string;
 };
 
-export function ProductEditMenu({ links, ...props }: ProductEditMenuProps) {
+type PageEditMenuProps = BoxProps & {
+   links: PageEditMenuLink[];
+};
+
+export function PageEditMenu({ links, ...props }: PageEditMenuProps) {
    if (!links.length) return null;
    return (
       <Box px="4" borderLeftWidth="thin" borderColor="gray.200" {...props}>
@@ -45,11 +53,11 @@ export function ProductEditMenu({ links, ...props }: ProductEditMenuProps) {
    );
 }
 
-type ProductEditMenuLinkProps = {
-   link: ProductEditMenuLink;
+type PageEditMenuLinkProps = {
+   link: PageEditMenuLink;
 };
 
-function MenuLink({ link }: ProductEditMenuLinkProps) {
+function MenuLink({ link }: PageEditMenuLinkProps) {
    const { icon, label, url } = link;
    return (
       <NextLink href={url} passHref legacyBehavior>

--- a/frontend/components/admin/ProductEditMenu.tsx
+++ b/frontend/components/admin/ProductEditMenu.tsx
@@ -18,6 +18,7 @@ type ProductEditMenuProps = BoxProps & {
 };
 
 export function ProductEditMenu({ links, ...props }: ProductEditMenuProps) {
+   if (!links.length) return null;
    return (
       <Box px="4" borderLeftWidth="thin" borderColor="gray.200" {...props}>
          <Menu>

--- a/frontend/components/admin/index.ts
+++ b/frontend/components/admin/index.ts
@@ -1,1 +1,1 @@
-export * from './ProductEditMenu';
+export * from './PageEditMenu';

--- a/frontend/helpers/product-helpers.ts
+++ b/frontend/helpers/product-helpers.ts
@@ -1,3 +1,4 @@
+import { PageEditMenuLink } from '@components/admin';
 import { IFIXIT_ORIGIN } from '@config/env';
 import {
    faArrowUpRightFromSquare,
@@ -19,15 +20,6 @@ export function getProductPath(handle: string) {
    }
 }
 
-interface ProductEditMenuOption {
-   icon: IconDefinition;
-   label: string;
-}
-
-export interface ProductEditMenuLink extends ProductEditMenuOption {
-   url: string;
-}
-
 type GetAdminLinksProps = {
    productcode?: string;
    productId: string;
@@ -38,7 +30,7 @@ export function getAdminLinks({
    productcode,
    productId,
    storeCode,
-}: GetAdminLinksProps): ProductEditMenuLink[] {
+}: GetAdminLinksProps): PageEditMenuLink[] {
    const encodedProductcode = encodeURIComponent(productcode ?? '');
    const encodedProductId = encodeProductId(productId);
    const akeneoOrigin = ifixitOriginWithSubdomain('akeneo');

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -1,3 +1,6 @@
+import { PageEditMenuLink } from '@components/admin';
+import { STRAPI_ORIGIN } from '@config/env';
+import { faDatabase, IconDefinition } from '@fortawesome/pro-solid-svg-icons';
 import { FacetWidgetType, ProductListType } from '@models/product-list';
 import { z } from 'zod';
 
@@ -88,4 +91,21 @@ export function isPartsProductList<
       productList.type === ProductListType.AllParts ||
       productList.type === ProductListType.DeviceParts
    );
+}
+
+type GetAdminLinksProps = {
+   productListId: string | null;
+};
+
+export function getAdminLinks({
+   productListId,
+}: GetAdminLinksProps): PageEditMenuLink[] {
+   if (!productListId) return [];
+   return [
+      {
+         icon: faDatabase,
+         label: 'Strapi',
+         url: `${STRAPI_ORIGIN}/admin/content-manager/collectionType/api::product-list.product-list/${productListId}`,
+      },
+   ];
 }

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -57,6 +57,7 @@ export async function findProductList(
       return null;
    }
 
+   const id = result.productLists?.data?.[0]?.id ?? null;
    const deviceTitle =
       deviceWiki?.deviceTitle ?? productList?.deviceTitle ?? null;
    const handle = productList?.handle ?? '';
@@ -84,6 +85,7 @@ export async function findProductList(
       productListType === ProductListType.DeviceParts;
 
    const baseProductList: BaseProductList = {
+      id,
       title,
       h1,
       handle,

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -57,6 +57,7 @@ export type ProductList =
 export type iFixitPage = StorePage;
 
 export interface BaseProductList {
+   id: string | null;
    title: string;
    h1: string | null;
    handle: string;

--- a/frontend/templates/product-list/SecondaryNavigation.tsx
+++ b/frontend/templates/product-list/SecondaryNavigation.tsx
@@ -1,7 +1,11 @@
 import { Flex } from '@chakra-ui/react';
+import { PageEditMenu } from '@components/admin';
 import { SecondaryNavbar } from '@components/common';
+import { getAdminLinks } from '@helpers/product-list-helpers';
+import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { Wrapper } from '@ifixit/ui';
 import { ProductList, ProductListType } from '@models/product-list';
+import { useMemo } from 'react';
 import { ProductListBreadcrumb } from './ProductListBreadcrumb';
 import { ProductListDeviceNavigation } from './ProductListDeviceNavigation';
 
@@ -15,6 +19,14 @@ export function SecondaryNavigation({ productList }: SecondaryNavigationProps) {
       productList.type === ProductListType.ToolsCategory;
    const hasDeviceNavigation =
       productList.type !== ProductListType.AllParts && !isToolsProductList;
+   const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
+   const adminLinks = useMemo(
+      () =>
+         getAdminLinks({
+            productListId: productList.id,
+         }),
+      [productList.id]
+   );
    return (
       <>
          <SecondaryNavbar
@@ -37,7 +49,15 @@ export function SecondaryNavigation({ productList }: SecondaryNavigationProps) {
                      }}
                      productList={productList}
                   />
-                  <ProductListDeviceNavigation productList={productList} />
+                  <Flex
+                     h="full"
+                     w={{ base: 'full', sm: 'min-content' }}
+                     boxSizing="border-box"
+                     justify="space-between"
+                  >
+                     <ProductListDeviceNavigation productList={productList} />
+                     {isAdminUser && <PageEditMenu links={adminLinks} />}
+                  </Flex>
                </Flex>
             </Wrapper>
          </SecondaryNavbar>

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex } from '@chakra-ui/react';
-import { ProductEditMenu } from '@components/admin';
+import { PageEditMenu } from '@components/admin';
 import { PageBreadcrumb } from '@components/common';
 import { FeaturedProductsSection } from '@components/sections/FeaturedProductsSection';
 import { DEFAULT_STORE_CODE } from '@config/env';
@@ -87,7 +87,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                borderBottomWidth="thin"
             >
                <Flex w="full" direction="row-reverse">
-                  <ProductEditMenu links={adminLinks} />
+                  <PageEditMenu links={adminLinks} />
                </Flex>
             </SecondaryNavigation>
          )}
@@ -96,7 +96,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                <Flex w="full" justify="space-between">
                   <PageBreadcrumb items={product.breadcrumbs} w="full" />
                   {isAdminUser && (
-                     <ProductEditMenu
+                     <PageEditMenu
                         links={adminLinks}
                         display={{
                            base: 'none',


### PR DESCRIPTION
Closes https://github.com/iFixit/react-commerce/issues/416

- Makes the existing admin menu more generic.
- Adds the admin menu to the product list page with a Strapi link, if the collection exists in Strapi.

## QA

- Visit a collection page that exists in strapi, and confirm that the new admin menu has a link to the strapi collection page.
- For collection pages that don't exist in strapi, no admin menu should appear (because it would have no links in it).
- Make sure the edit menu matches the [mockup](https://www.figma.com/file/sfj6r7Bn6eREMvuqo0f7Du/iFixit---Components?node-id=118-12832), and is accessible on mobile and desktop.
- Make sure the sub navigation menu (with breadcrumbs and parts/tools/guides links) still matches `main`.
- Make sure the product page admin menu still works as on `main`.

![image](https://user-images.githubusercontent.com/52104630/226062879-157be830-5692-43e1-8f41-135323c5f5c6.png)