### PR TITLE
Force wrapper to fill all available space

### DIFF
--- a/frontend/templates/product-list/sections/HeroSection.tsx
+++ b/frontend/templates/product-list/sections/HeroSection.tsx
@@ -8,7 +8,6 @@ import {
    Heading,
    Text,
    useDisclosure,
-   VStack,
 } from '@chakra-ui/react';
 import { DEFAULT_ANIMATION_DURATION_MS } from '@config/constants';
 import { getProductListTitle } from '@helpers/product-list-helpers';

--- a/packages/ui/misc/Wrapper.tsx
+++ b/packages/ui/misc/Wrapper.tsx
@@ -5,6 +5,7 @@ export type WrapperProps = BoxProps;
 export function Wrapper({ ...props }: WrapperProps) {
    return (
       <Box
+         w="full"
          maxW="80rem"
          mx="auto"
          px={{


### PR DESCRIPTION
closes #1482

This issue was due to the wrapper not expanding to fill all the available space.
It was by chance that it was noted only on `HeroWithImage`.

The length of the description field contained in the Hero components was often enough to push the container to fill all the available space.

### QA

1. Visit Vercel preview
2. Verify that the issue described in #1482 is not present anymore