### PR TITLE
Refactor product page replacement guides section

### DIFF
--- a/frontend/components/sections/ReplacementGuidesSection.tsx
+++ b/frontend/components/sections/ReplacementGuidesSection.tsx
@@ -21,18 +21,18 @@ import {
    faGaugeMin,
 } from '@fortawesome/pro-solid-svg-icons';
 import { IconBadge, ResponsiveImage, Wrapper } from '@ifixit/ui';
-import type { Product } from '@pages/api/nextjs/cache/product';
+import type { ReplacementGuidePreview } from '@models/components/replacement-guide-preview';
 
-export type ReplacementGuidesSectionProps = {
-   product: Product;
-};
-
-type ReplacementGuide = Product['replacementGuides'][0];
+export interface ReplacementGuidesSectionProps {
+   title?: string | null;
+   guides: ReplacementGuidePreview[];
+}
 
 export function ReplacementGuidesSection({
-   product,
+   title,
+   guides,
 }: ReplacementGuidesSectionProps) {
-   if (product.replacementGuides.length === 0) {
+   if (guides.length === 0) {
       return null;
    }
 
@@ -51,7 +51,7 @@ export function ReplacementGuidesSection({
                fontSize={{ base: '2xl', md: '3xl' }}
                fontWeight="medium"
             >
-               Replacement Guides
+               {title ?? 'Replacement Guides'}
             </Heading>
             <SimpleGrid
                columns={{
@@ -60,7 +60,7 @@ export function ReplacementGuidesSection({
                }}
                spacing="3"
             >
-               {product.replacementGuides.map((guide) => {
+               {guides.map((guide) => {
                   return <ReplacementGuideCard key={guide.id} guide={guide} />;
                })}
             </SimpleGrid>
@@ -70,7 +70,7 @@ export function ReplacementGuidesSection({
 }
 
 type ReplacementGuideCardProps = {
-   guide: ReplacementGuide;
+   guide: ReplacementGuidePreview;
 };
 
 function ReplacementGuideCard({ guide }: ReplacementGuideCardProps) {

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -16,10 +16,6 @@ import {
    productReviewsFromMetafields,
    ProductReviewsSchema,
 } from '@models/components/product-reviews';
-import {
-   replacementGuidePreviewFromMetafield,
-   ReplacementGuidePreviewSchema,
-} from '@models/components/replacement-guide-preview';
 import shuffle from 'lodash/shuffle';
 import { z } from 'zod';
 import {
@@ -79,7 +75,6 @@ export const ProductSchema = z.object({
    productVideos: z.string().nullable(),
    productVideosJson: ProductVideosSchema.nullable(),
    faqs: z.array(FAQSchema),
-   replacementGuides: z.array(ReplacementGuidePreviewSchema),
    featuredProductVariants: z.array(ProductPreviewSchema),
    compatibility: ProductDeviceCompatibilitySchema.nullable(),
    metaTitle: z.string().nullable(),
@@ -139,9 +134,6 @@ export function productFromQueryProduct(
          queryProduct.productVideos?.value
       ),
       faqs: faqsFromMetafield(queryProduct.faqs?.value),
-      replacementGuides: replacementGuidePreviewFromMetafield(
-         queryProduct.replacementGuides?.value
-      ),
       featuredProductVariants: getFeaturedProductPreviews(queryProduct),
       compatibility: productDeviceCompatibilityFromMetafield(
          queryProduct.compatibility?.value
@@ -161,7 +153,7 @@ export function productFromQueryProduct(
       redirectUrl: queryProduct.redirectUrl?.value ?? null,
       vendor: queryProduct.vendor ?? null,
       crossSellVariants: getAllCrossSellProductVariant(queryProduct),
-      sections: getDefaultProductSections(),
+      sections: getDefaultProductSections({ queryProduct }),
    };
 }
 

--- a/frontend/models/product/sections/index.ts
+++ b/frontend/models/product/sections/index.ts
@@ -1,4 +1,7 @@
 import { createSectionId } from '@helpers/strapi-helpers';
+import type { FindProductQuery } from '@lib/shopify-storefront-sdk';
+import { replacementGuidePreviewFromMetafield } from '@models/components/replacement-guide-preview';
+import { ReplacementGuidesSectionSchema } from '@models/sections/replacement-guides-section';
 import { SplitWithImageSectionSchema } from '@models/sections/split-with-image-section';
 import { z } from 'zod';
 import { ProductOverviewSectionSchema } from './product-overview-section';
@@ -8,15 +11,35 @@ export type ProductSection = z.infer<typeof ProductSectionSchema>;
 export const ProductSectionSchema = z.union([
    ProductOverviewSectionSchema,
    SplitWithImageSectionSchema,
+   ReplacementGuidesSectionSchema,
 ]);
 
-export function getDefaultProductSections(): ProductSection[] {
+type QueryProduct = NonNullable<FindProductQuery['product']>;
+
+interface GetDefaultProductSectionsArgs {
+   queryProduct: QueryProduct;
+}
+
+export function getDefaultProductSections({
+   queryProduct,
+}: GetDefaultProductSectionsArgs): ProductSection[] {
    const sections: ProductSection[] = [];
    sections.push({
       type: 'ProductOverview',
       id: createSectionId(
          { __typename: 'ProductOverviewSection' },
          sections.length
+      ),
+   });
+   sections.push({
+      type: 'ReplacementGuides',
+      id: createSectionId(
+         { __typename: 'ReplacementGuidesSection' },
+         sections.length
+      ),
+      title: null,
+      guides: replacementGuidePreviewFromMetafield(
+         queryProduct.replacementGuides?.value
       ),
    });
    return sections;

--- a/frontend/models/sections/replacement-guides-section.ts
+++ b/frontend/models/sections/replacement-guides-section.ts
@@ -1,0 +1,13 @@
+import { ReplacementGuidePreviewSchema } from '@models/components/replacement-guide-preview';
+import { z } from 'zod';
+
+export type ReplacementGuidesSection = z.infer<
+   typeof ReplacementGuidesSectionSchema
+>;
+
+export const ReplacementGuidesSectionSchema = z.object({
+   type: z.literal('ReplacementGuides'),
+   id: z.string(),
+   title: z.string().nullable(),
+   guides: z.array(ReplacementGuidePreviewSchema),
+});

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -29,7 +29,7 @@ import { CompatibilitySection } from './sections/CompatibilitySection';
 import { CrossSellSection } from './sections/CrossSellSection';
 import { LifetimeWarrantySection } from './sections/LifetimeWarrantySection';
 import { ProductOverviewSection } from './sections/ProductOverviewSection';
-import { ReplacementGuidesSection } from './sections/ReplacementGuidesSection';
+import { ReplacementGuidesSection } from '../../components/sections/ReplacementGuidesSection';
 import { ReviewsSection } from './sections/ReviewsSection';
 import { ServiceValuePropositionSection } from './sections/ServiceValuePropositionSection';
 
@@ -121,6 +121,14 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                            internationalBuyBox={internationalBuyBox}
                         />
                      );
+                  case 'ReplacementGuides':
+                     return (
+                        <ReplacementGuidesSection
+                           key={section.id}
+                           title={section.title}
+                           guides={section.guides}
+                        />
+                     );
                   case 'SplitWithImage':
                      return (
                         <SplitWithImageContentSection
@@ -132,7 +140,6 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                      return assertNever(section);
                }
             })}
-            <ReplacementGuidesSection product={product} />
             {product.isEnabled && (
                <ServiceValuePropositionSection
                   selectedVariant={selectedVariant}

--- a/frontend/tests/jest/__mocks__/products.ts
+++ b/frontend/tests/jest/__mocks__/products.ts
@@ -250,18 +250,6 @@ export const mockedProduct: Product = {
    prop65Chemicals: 'lead',
    productVideos:
       'https://www.youtube-nocookie.com/embed/4Kskal4s1sU?wmode=opaque',
-   replacementGuides: [
-      {
-         id: '0',
-         title: 'iPhone 6s Plus Battery Replacement',
-         url: '/Guide/iPhone+6s+Plus+Battery+Replacement/51380',
-         imageUrl:
-            'https://mmcelvain.cominor.com/igi/LVQpdSdCEY1YxPkM.thumbnail',
-         summary: 'Use this guide to bring life back to your...',
-         difficulty: 'Moderate',
-         timeRequired: '15 - 45 minutes',
-      },
-   ],
    featuredProductVariants: [
       {
          id: 'gid://shopify/ProductVariant/32965720178778',
@@ -690,7 +678,29 @@ export const mockedProduct: Product = {
          enabled: true,
       },
    ],
-   sections: getDefaultProductSections(),
+   sections: [
+      {
+         type: 'ProductOverview',
+         id: 'ProductOverviewSection-0',
+      },
+      {
+         type: 'ReplacementGuides',
+         id: 'ReplacementGuidesSection-1',
+         title: null,
+         guides: [
+            {
+               id: '0',
+               title: 'iPhone 6s Plus Battery Replacement',
+               url: '/Guide/iPhone+6s+Plus+Battery+Replacement/51380',
+               imageUrl:
+                  'https://mmcelvain.cominor.com/igi/LVQpdSdCEY1YxPkM.thumbnail',
+               summary: 'Use this guide to bring life back to your...',
+               difficulty: 'Moderate',
+               timeRequired: '15 - 45 minutes',
+            },
+         ],
+      },
+   ],
 };
 
 export const mockedProductVariant: ProductVariant = {
@@ -1173,17 +1183,6 @@ export const mockedBatteryProduct: Product = {
    prop65Chemicals: 'lead',
    productVideos: null,
    productVideosJson: null,
-   replacementGuides: [
-      {
-         id: '0',
-         title: 'Motorola Moto G7 Play Battery Replacement',
-         url: '/Guide/Motorola+Moto+G7+Play+Battery+Replacement/131323',
-         imageUrl: 'https://www.cominor.com/igi/VccIYuMpooQRd6Od.thumbnail',
-         summary: 'This guide will show each detailed step to...',
-         difficulty: 'Moderate',
-         timeRequired: '45 - 50 minutes',
-      },
-   ],
    featuredProductVariants: [
       {
          id: 'gid://shopify/ProductVariant/32965709037658',
@@ -1386,7 +1385,29 @@ export const mockedBatteryProduct: Product = {
    redirectUrl: null,
    vendor: '',
    crossSellVariants: [],
-   sections: getDefaultProductSections(),
+   sections: [
+      {
+         type: 'ProductOverview',
+         id: 'ProductOverviewSection-0',
+      },
+      {
+         type: 'ReplacementGuides',
+         id: 'ReplacementGuidesSection-1',
+         title: null,
+         guides: [
+            {
+               id: '0',
+               title: 'Motorola Moto G7 Play Battery Replacement',
+               url: '/Guide/Motorola+Moto+G7+Play+Battery+Replacement/131323',
+               imageUrl:
+                  'https://www.cominor.com/igi/VccIYuMpooQRd6Od.thumbnail',
+               summary: 'This guide will show each detailed step to...',
+               difficulty: 'Moderate',
+               timeRequired: '45 - 50 minutes',
+            },
+         ],
+      },
+   ],
 };
 
 const toolProductImages: ProductVariantImage[] = [
@@ -1494,7 +1515,6 @@ export const mockedToolProduct: Product = {
    prop65Chemicals: 'none',
    productVideos: null,
    productVideosJson: null,
-   replacementGuides: [],
    featuredProductVariants: [
       {
          id: 'gid://shopify/ProductVariant/39443942670426',
@@ -1728,7 +1748,29 @@ export const mockedToolProduct: Product = {
          enabled: true,
       },
    ],
-   sections: getDefaultProductSections(),
+   sections: [
+      {
+         type: 'ProductOverview',
+         id: 'ProductOverviewSection-0',
+      },
+      {
+         type: 'ReplacementGuides',
+         id: 'ReplacementGuidesSection-1',
+         title: null,
+         guides: [
+            {
+               id: '0',
+               title: 'Motorola Moto G7 Play Battery Replacement',
+               url: '/Guide/Motorola+Moto+G7+Play+Battery+Replacement/131323',
+               imageUrl:
+                  'https://www.cominor.com/igi/VccIYuMpooQRd6Od.thumbnail',
+               summary: 'This guide will show each detailed step to...',
+               difficulty: 'Moderate',
+               timeRequired: '45 - 50 minutes',
+            },
+         ],
+      },
+   ],
 };
 
 const partProductImages: ProductVariantImage[] = [
@@ -1880,17 +1922,6 @@ export const mockedPartProduct: Product = {
    prop65Chemicals: 'lead',
    productVideos: null,
    productVideosJson: null,
-   replacementGuides: [
-      {
-         id: '0',
-         title: 'Samsung Galaxy A51 Screen Replacement',
-         url: '/Guide/Samsung+Galaxy+A51+Screen+Replacement/135277',
-         imageUrl: 'https://www.cominor.com/igi/RH2mIEknySwiMw5Z.thumbnail',
-         summary: 'Use this guide to replace a cracked or broken...',
-         difficulty: 'Moderate',
-         timeRequired: '1 - 2 hours',
-      },
-   ],
    featuredProductVariants: [
       {
          id: 'gid://shopify/ProductVariant/39443942670426',
@@ -2101,7 +2132,29 @@ export const mockedPartProduct: Product = {
    redirectUrl: null,
    vendor: '',
    crossSellVariants: [],
-   sections: getDefaultProductSections(),
+   sections: [
+      {
+         type: 'ProductOverview',
+         id: 'ProductOverviewSection-0',
+      },
+      {
+         type: 'ReplacementGuides',
+         id: 'ReplacementGuidesSection-1',
+         title: null,
+         guides: [
+            {
+               id: '0',
+               title: 'Samsung Galaxy A51 Screen Replacement',
+               url: '/Guide/Samsung+Galaxy+A51+Screen+Replacement/135277',
+               imageUrl:
+                  'https://www.cominor.com/igi/RH2mIEknySwiMw5Z.thumbnail',
+               summary: 'Use this guide to replace a cracked or broken...',
+               difficulty: 'Moderate',
+               timeRequired: '1 - 2 hours',
+            },
+         ],
+      },
+   ],
 };
 
 export const mockedLayoutProps: Pick<ProductTemplateProps, 'layoutProps'> = {

--- a/frontend/tests/jest/tests/ProductReplacementGuide.test.tsx
+++ b/frontend/tests/jest/tests/ProductReplacementGuide.test.tsx
@@ -1,43 +1,48 @@
-import { ReplacementGuidesSection } from '@templates/product/sections/ReplacementGuidesSection';
+import type { ReplacementGuidePreview } from '@models/components/replacement-guide-preview';
+import { ReplacementGuidesSection } from '@components/sections/ReplacementGuidesSection';
 import { screen } from '@testing-library/react';
-import { getMockProduct, renderWithAppContext } from '../utils';
+import { renderWithAppContext } from '../utils';
+
+const replacementGuide: ReplacementGuidePreview = {
+   id: '0',
+   title: 'iPhone 6s Plus Battery Replacement',
+   url: '/Guide/iPhone+6s+Plus+Battery+Replacement/51380',
+   imageUrl: 'https://mmcelvain.cominor.com/igi/LVQpdSdCEY1YxPkM.thumbnail',
+   summary: 'Use this guide to bring life back to your...',
+   difficulty: 'Moderate',
+   timeRequired: '15 - 45 minutes',
+};
 
 describe('Product Replacement Guides Section Tests', () => {
    test('renders Replacement Guides Section for a product with a replacement guide', async () => {
-      const mockedProduct = getMockProduct();
       renderWithAppContext(
-         <ReplacementGuidesSection product={mockedProduct} />
+         <ReplacementGuidesSection guides={[replacementGuide]} />
       );
 
       const replacementGuidesSectionText = await screen.findByText(
          /Replacement Guides/i
       );
-      (expect(replacementGuidesSectionText) as any).toBeVisible();
+      expect(replacementGuidesSectionText).toBeVisible();
 
-      const expectedGuideTitle = mockedProduct.replacementGuides[0].title;
       const guideTitle = await screen.findByText(
-         new RegExp(expectedGuideTitle, 'i')
+         new RegExp(replacementGuide.title, 'i')
       );
-      (expect(guideTitle) as any).toBeVisible();
+      expect(guideTitle).toBeVisible();
 
-      const expectedGuideUrl = mockedProduct.replacementGuides[0].url;
-      (
-         expect(screen.getByRole('link', { name: expectedGuideTitle })) as any
-      ).toHaveAttribute('href', expectedGuideUrl);
+      expect(
+         screen.getByRole('link', { name: replacementGuide.title })
+      ).toHaveAttribute('href', replacementGuide.url);
    });
 
    test('does not render Replacement Guides Section for a product with no replacement guides', async () => {
       const { container } = renderWithAppContext(
-         <ReplacementGuidesSection
-            product={getMockProduct({ replacementGuides: [] })}
-         />
+         <ReplacementGuidesSection guides={[]} />
       );
 
-      const replacementGuidesHeading = await screen.queryByText(
-         /Replacement Guides/i
-      );
-      (expect(replacementGuidesHeading) as any).not.toBeInTheDocument();
+      const replacementGuidesHeading =
+         screen.queryByText(/Replacement Guides/i);
+      expect(replacementGuidesHeading).not.toBeInTheDocument();
 
-      (expect(container.firstChild) as any).toBeEmptyDOMElement();
+      expect(container.firstChild).toBeEmptyDOMElement();
    });
 });


### PR DESCRIPTION
closes #1505 

## QA

1. Open [product page preview](https://react-commerce-git-add-replacement-guides-to-sections-ifixit.vercel.app/products/iphone-6s-screen)
2. Verify that the replacement guides section is still rendered