### PR TITLE
Working on badge and product price responsiveness

### DIFF
--- a/frontend/components/common/ProductGridItem.tsx
+++ b/frontend/components/common/ProductGridItem.tsx
@@ -50,20 +50,36 @@ export function ProductGridItem({ product, onClick }: ProductGridItemProps) {
             }}
          >
             {product.oemPartnership && (
-               <IconBadge colorScheme="green">
+               <IconBadge
+                  colorScheme="green"
+                  size={{ base: 'small', md: 'base' }}
+               >
                   {product.oemPartnership}
                </IconBadge>
             )}
             {product.isPro && (
-               <IconBadge colorScheme="orange">iFixit Pro</IconBadge>
+               <IconBadge
+                  colorScheme="orange"
+                  size={{ base: 'small', md: 'base' }}
+               >
+                  iFixit Pro
+               </IconBadge>
             )}
             {discountPercentage > 0 && (
-               <IconBadge colorScheme={userPrice.isProPrice ? 'orange' : 'red'}>
+               <IconBadge
+                  colorScheme={userPrice.isProPrice ? 'orange' : 'red'}
+                  size={{ base: 'small', md: 'base' }}
+               >
                   {discountPercentage}% Off
                </IconBadge>
             )}
             {product.hasLifetimeWarranty && (
-               <IconBadge colorScheme="blue">Lifetime Guarantee</IconBadge>
+               <IconBadge
+                  colorScheme="blue"
+                  size={{ base: 'small', md: 'base' }}
+               >
+                  Lifetime Guarantee
+               </IconBadge>
             )}
          </ProductCardBadgeList>
          <ProductCard h="full">
@@ -94,6 +110,7 @@ export function ProductGridItem({ product, onClick }: ProductGridItemProps) {
                      showDiscountLabel={false}
                      direction="row-reverse"
                      alignSelf="flex-end"
+                     size={{ base: 'small', md: 'medium' }}
                   />
                </HStack>
             </ProductCardBody>

--- a/frontend/components/sections/ReplacementGuidesSection.tsx
+++ b/frontend/components/sections/ReplacementGuidesSection.tsx
@@ -20,7 +20,12 @@ import {
    faGaugeMax,
    faGaugeMin,
 } from '@fortawesome/pro-solid-svg-icons';
-import { IconBadge, ResponsiveImage, Wrapper } from '@ifixit/ui';
+import {
+   IconBadge,
+   IconBadgeProps,
+   ResponsiveImage,
+   Wrapper,
+} from '@ifixit/ui';
 import type { ReplacementGuidePreview } from '@models/components/replacement-guide-preview';
 
 export interface ReplacementGuidesSectionProps {
@@ -184,14 +189,17 @@ function ReplacementGuideCard({ guide }: ReplacementGuideCardProps) {
                >
                   {isPresent(guide.timeRequired) && (
                      <BadgeListItem>
-                        <IconBadge icon={faClock}>
+                        <IconBadge icon={faClock} size="small">
                            {guide.timeRequired}
                         </IconBadge>
                      </BadgeListItem>
                   )}
                   {isPresent(guide.difficulty) && (
                      <BadgeListItem>
-                        <DifficultyBadge difficulty={guide.difficulty} />
+                        <DifficultyBadge
+                           difficulty={guide.difficulty}
+                           size="small"
+                        />
                      </BadgeListItem>
                   )}
                </UnorderedList>
@@ -213,7 +221,7 @@ function isPresent(text: any): text is string {
    return typeof text === 'string' && text.length > 0;
 }
 
-type DifficultyBadgeProps = TagProps & {
+type DifficultyBadgeProps = IconBadgeProps & {
    difficulty: string;
 };
 

--- a/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
@@ -34,13 +34,13 @@ export function CurrentRefinements() {
                            bgColor="brand.100"
                            borderColor="brand.300"
                            borderWidth="1px"
-                           py="1"
+                           py="3px"
                            px="1.5"
                            mr="1.5"
                            mb="1.5"
                            fontWeight="semibold"
-                           fontSize="sm"
-                           lineHeight="1em"
+                           fontSize={{ base: '13px', md: 'sm' }}
+                           lineHeight={{ base: '4', md: '5' }}
                            color="brand.700"
                            alignItems="center"
                            borderRadius="base"

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -162,24 +162,34 @@ export function ProductListItem({ product }: ProductListItemProps) {
                            }}
                         >
                            {showProBadge && (
-                              <IconBadge colorScheme="orange">
+                              <IconBadge
+                                 colorScheme="orange"
+                                 size={{ base: 'small', md: 'base' }}
+                              >
                                  iFixit Pro
                               </IconBadge>
                            )}
                            {showDiscountBadge && (
                               <IconBadge
                                  colorScheme={isProPrice ? 'orange' : 'red'}
+                                 size={{ base: 'small', md: 'base' }}
                               >
                                  {percentage}% Off
                               </IconBadge>
                            )}
                            {showOemPartnershipBadge && (
-                              <IconBadge colorScheme="green">
+                              <IconBadge
+                                 colorScheme="green"
+                                 size={{ base: 'small', md: 'base' }}
+                              >
                                  {product.oem_partnership}
                               </IconBadge>
                            )}
                            {showLifetimeWarrantyBadge && (
-                              <IconBadge colorScheme="blue">
+                              <IconBadge
+                                 colorScheme="blue"
+                                 size={{ base: 'small', md: 'base' }}
+                              >
                                  Lifetime Guarantee
                               </IconBadge>
                            )}
@@ -203,6 +213,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                         showDiscountLabel={false}
                         direction="column"
                         alignSelf="flex-end"
+                        size={{ base: 'small', md: 'medium' }}
                      />
                   )}
                   <Stack

--- a/frontend/templates/product/sections/CrossSellSection/CrossSellVariantCard.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/CrossSellVariantCard.tsx
@@ -187,6 +187,7 @@ export function CrossSellVariantCard({
                      proPricesByTier={proPricesByTier}
                      direction="column-reverse"
                      alignSelf="flex-end"
+                     size="medium"
                   />
                </Flex>
             </Flex>

--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -133,6 +133,7 @@ export function ProductOverviewSection({
                      compareAtPrice={selectedVariant.compareAtPrice}
                      proPricesByTier={selectedVariant.proPricesByTier}
                      data-testid="product-price-section"
+                     size={{ base: 'medium', md: 'large' }}
                   />
                )}
 

--- a/frontend/tests/jest/tests/__snapshots__/ProductListItem.test.tsx.snap
+++ b/frontend/tests/jest/tests/__snapshots__/ProductListItem.test.tsx.snap
@@ -163,7 +163,7 @@ exports[`ProductListItem renders and matches the snapshot 1`] = `
               class="css-1qc3xp7"
             >
               <div
-                class="css-1ah8j8s"
+                class="css-rzte29"
               >
                 <div
                   class="css-zvlevn"
@@ -178,10 +178,10 @@ exports[`ProductListItem renders and matches the snapshot 1`] = `
           class="chakra-stack css-f4fjr9"
         >
           <div
-            class="css-kmjck4"
+            class="css-oazic6"
           >
             <p
-              class="chakra-text css-1kmakxd"
+              class="chakra-text css-wxbpi4"
               data-testid="current-price"
             >
               $5.00

--- a/packages/ui/commerce/ProductPrice.tsx
+++ b/packages/ui/commerce/ProductPrice.tsx
@@ -14,6 +14,7 @@ import {
    forwardRef,
    Text,
    ThemeTypings,
+   useMultiStyleConfig,
 } from '@chakra-ui/react';
 import { faRectanglePro } from '@fortawesome/pro-solid-svg-icons';
 import { computeDiscountPercentage, formatMoney, Money } from '@ifixit/helpers';
@@ -21,13 +22,17 @@ import { FaIcon } from '@ifixit/icons';
 import { IconBadge } from '../misc';
 import { useUserPrice } from './hooks/useUserPrice';
 
+type ProductPriceSize = 'small' | 'medium' | 'large';
+
 export type ProductVariantPriceProps = Omit<BoxProps, 'children'> & {
    price: Money;
    compareAtPrice?: Money | null;
    proPricesByTier?: Record<string, Money> | null;
    showDiscountLabel?: boolean;
    formatDiscountLabel?: (discountPercentage: number) => string;
-   size?: 'large' | 'medium' | 'small';
+   size?:
+      | ProductPriceSize
+      | Partial<Record<ThemeTypings['breakpoints'], ProductPriceSize>>;
    direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
 };
 
@@ -92,7 +97,9 @@ type ProductPriceProps = {
    discountLabel?: string;
    showDiscountLabel?: boolean;
    showProBadge?: boolean;
-   size?: 'large' | 'medium' | 'small';
+   size?:
+      | ProductPriceSize
+      | Partial<Record<ThemeTypings['breakpoints'], ProductPriceSize>>;
    colorScheme?: ThemeTypings['colorSchemes'];
    direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
 };
@@ -113,33 +120,27 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
       },
       ref
    ) => {
-      const priceFontSize =
-         size === 'large' ? 'xl' : size === 'medium' ? 'md' : 'sm';
-      const compareAtPriceFontSize = size === 'large' ? 'md' : 'sm';
+      const styles = useMultiStyleConfig('ProductPrice', { size });
       const isHorizontal = direction === 'row' || direction === 'row-reverse';
 
       return (
          <Box
             ref={ref}
-            display="flex"
+            __css={styles.container}
             flexDir={direction}
-            alignSelf="flex-start"
             alignItems={isHorizontal ? 'center' : 'flex-end'}
             {...other}
          >
             <Text
-               fontSize={priceFontSize}
-               fontWeight="semibold"
+               sx={styles.price}
                color={isDiscounted ? `${colorScheme}.600` : 'gray.900'}
                data-testid="current-price"
             >
                {showProBadge && !isHorizontal && (
                   <FaIcon
+                     __css={styles.proBadgeVertical}
                      icon={faRectanglePro}
-                     h="4"
-                     mr="1.5"
                      color={`${colorScheme}.500`}
-                     display="inline-block"
                   />
                )}
                {formattedPrice}
@@ -147,17 +148,16 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
             {isDiscounted && (
                <>
                   <Text
+                     sx={styles.compareAtPrice}
                      ml={direction === 'row' ? 1 : 0}
                      mr={direction === 'row-reverse' ? 1 : 0}
-                     fontSize={compareAtPriceFontSize}
-                     color="gray.500"
-                     textDecor="line-through"
                      data-testid="compare-at-price"
                   >
                      {formattedCompareAtPrice}
                   </Text>
                   {isDiscounted && showDiscountLabel && isHorizontal && (
                      <IconBadge
+                        sx={styles.proBadgeHorizontal}
                         ml={direction === 'row' ? '10px' : 0}
                         mr={direction === 'row-reverse' ? '10px' : 0}
                         icon={showProBadge ? faRectanglePro : undefined}

--- a/packages/ui/misc/IconBadge.tsx
+++ b/packages/ui/misc/IconBadge.tsx
@@ -4,46 +4,45 @@ import {
    FlexProps,
    forwardRef,
    ThemeTypings,
+   useMultiStyleConfig,
 } from '@chakra-ui/react';
 import { IconDefinition } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon } from '@ifixit/icons';
 
+type IconBadgeSize = 'tiny' | 'small' | 'base';
+
 export type IconBadgeProps = FlexProps & {
+   size?:
+      | IconBadgeSize
+      | Partial<Record<ThemeTypings['breakpoints'] | string, IconBadgeSize>>;
    colorScheme?: ThemeTypings['colorSchemes'];
    icon?: IconDefinition;
 };
 
 export const IconBadge = forwardRef<IconBadgeProps, 'div'>(
-   ({ children, colorScheme = 'gray', icon, ...props }, ref) => {
+   (
+      { children, size = 'small', colorScheme = 'gray', icon, ...props },
+      ref
+   ) => {
+      const styles = useMultiStyleConfig('IconBadge', { size });
+
       return (
          <Flex
             ref={ref}
+            __css={styles.container}
             bgColor={`${colorScheme}.100`}
             borderColor={`${colorScheme}.300`}
-            borderWidth="1px"
-            py="1"
-            px="1.5"
-            fontWeight="semibold"
-            fontSize="sm"
-            lineHeight="1em"
             color={`${colorScheme}.700`}
-            alignItems="center"
-            borderRadius="base"
-            flexShrink={0}
-            maxW="full"
             {...props}
          >
             {icon && (
-               <Box mr="1">
-                  <FaIcon
-                     display="block"
-                     icon={icon}
-                     h="4"
-                     color={`${colorScheme}.500`}
-                  />
-               </Box>
+               <FaIcon
+                  __css={styles.icon}
+                  icon={icon}
+                  color={`${colorScheme}.500`}
+               />
             )}
-            <Box noOfLines={1}>{children}</Box>
+            <Box __css={styles.label}>{children}</Box>
          </Flex>
       );
    }

--- a/packages/ui/theme/components/icon-badge.ts
+++ b/packages/ui/theme/components/icon-badge.ts
@@ -1,0 +1,51 @@
+import { ComponentStyleConfig } from '@chakra-ui/react';
+
+const IconBadge: ComponentStyleConfig = {
+   parts: ['container', 'icon', 'label'],
+   baseStyle: {
+      container: {
+         px: '1.5',
+         borderWidth: '1px',
+         borderRadius: 'base',
+         maxW: 'full',
+         flexShrink: '0',
+         display: 'flex',
+         alignItems: 'center',
+         fontWeight: 'semibold',
+         wordBreak: 'break-all',
+      },
+      icon: {
+         display: 'block',
+         h: '4',
+         mr: '1',
+      },
+      label: {
+         noOfLines: '1',
+      },
+   },
+   sizes: {
+      tiny: {
+         container: {
+            py: '0.5',
+            fontSize: '2xs',
+            lineHeight: '14px',
+         },
+      },
+      small: {
+         container: {
+            py: '3px',
+            fontSize: '13px',
+            lineHeight: '4',
+         },
+      },
+      base: {
+         container: {
+            py: '3px',
+            fontSize: 'sm',
+            lineHeight: '5',
+         },
+      },
+   },
+};
+
+export default IconBadge;

--- a/packages/ui/theme/components/product-price.ts
+++ b/packages/ui/theme/components/product-price.ts
@@ -1,0 +1,83 @@
+import { ComponentStyleConfig } from '@chakra-ui/react';
+
+const ProductPrice: ComponentStyleConfig = {
+   parts: [
+      'container',
+      'price',
+      'compareAtPrice',
+      'proBadgeHorizontal',
+      'proBadgeVertical',
+   ],
+   baseStyle: {
+      container: {
+         display: 'flex',
+         alignSelf: 'flex-start',
+      },
+      price: {
+         fontWeight: 'semibold',
+         display: 'flex',
+         alignItems: 'center',
+      },
+      proBadgeVertical: {
+         h: '4',
+         mr: '1.5',
+         display: 'inline-block',
+      },
+      compareAtPrice: {
+         color: 'gray.500',
+         textDecor: 'line-through',
+      },
+   },
+   sizes: {
+      small: {
+         price: {
+            fontSize: 'sm',
+         },
+         compareAtPrice: {
+            fontSize: 'sm',
+         },
+         proBadgeHorizontal: {
+            py: '3px',
+            fontSize: '13px',
+            lineHeight: '4',
+         },
+         proBadgeVertical: {
+            h: 4,
+         },
+      },
+      medium: {
+         price: {
+            fontSize: 'md',
+         },
+         compareAtPrice: {
+            fontSize: 'sm',
+         },
+         proBadgeHorizontal: {
+            py: '3px',
+            fontSize: '13px',
+            lineHeight: '4',
+         },
+         proBadgeVertical: {
+            h: 4,
+         },
+      },
+      large: {
+         price: {
+            fontSize: 'xl',
+         },
+         compareAtPrice: {
+            fontSize: 'md',
+         },
+         proBadgeHorizontal: {
+            py: '3px',
+            fontSize: 'sm',
+            lineHeight: '5',
+         },
+         proBadgeVertical: {
+            h: 5,
+         },
+      },
+   },
+};
+
+export default ProductPrice;

--- a/packages/ui/theme/index.ts
+++ b/packages/ui/theme/index.ts
@@ -2,7 +2,9 @@ import { ThemeOverride } from '@chakra-ui/react';
 import Alert from './components/alert';
 import Badge from './components/badge';
 import Button from './components/button';
+import IconBadge from './components/icon-badge';
 import Pagination from './components/pagination';
+import ProductPrice from './components/product-price';
 import { breakpoints } from './foundations/breakpoints';
 import { colors } from './foundations/colors';
 import { fonts } from './foundations/fonts';
@@ -22,5 +24,7 @@ export const theme: ThemeOverride = {
       Badge,
       Alert,
       Button,
+      IconBadge,
+      ProductPrice,
    },
 };


### PR DESCRIPTION
closes #1493 

Apart from fixing #1493, I took the opportunity to work on icon badges and product prices responsiveness.

[Icon badges](https://www.figma.com/file/sfj6r7Bn6eREMvuqo0f7Du/iFixit---Components?node-id=105-5772&t=8OduiF3pdPkIZJqs-0) as well as [product prices](https://www.figma.com/file/sfj6r7Bn6eREMvuqo0f7Du/iFixit---Components?node-id=104-7133&t=jrRjObNfi3KpE3O3-0) have been designed in 3 sizes and often mockups instructed to change the size of these two components at some specific breakpoints.
Up until now, however, those components allowed only to configure a specific size for all the possible screen sizes.

This PR allows to pass to those components a `ResponsiveObject` that allows to vary their sizes at specific breakpoint values.

### QA

1. Visit Vercel preview
2. Verify that icon badges and product prices are now resizing as in the mockups 