### PR TITLE
Add products anchor

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -75,6 +75,7 @@ export function FilterableProductsSection({ productList }: SectionProps) {
    return (
       <Flex
          ref={productsContainerScrollRef}
+         id="products"
          as="section"
          direction="column"
          align="stretch"


### PR DESCRIPTION
closes #1510 

## QA

Open a product list preview from mobile and verify that by appending `#products` the browser scrolls down to the list of products.
For example check with this link [/Tools?q=Marlin#products](https://react-commerce-git-add-products-anchor-to-product-list-ifixit.vercel.app/Tools?q=Marlin)