### PR TITLE
Stress-test: specify outputs for check-diff job

### DIFF
--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -9,7 +9,7 @@ jobs:
       runs-on: ubuntu-latest
       outputs:
          modified-playwright-tests: ${{ steps.git-diff.outputs.modified-playwright-tests }}
-         modified-jest-tests: ${{ steps.git-diff.outputs.modified-playwright-tests }}
+         modified-jest-tests: ${{ steps.git-diff.outputs.modified-jest-tests }}
       steps:
          - name: Checkout ifixit
            uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
            run: pnpm install:all
 
          - name: Run Jest tests
-           run: for i in {1..5}; do jest -- ${{ needs.check-diff.outputs.modified-jest-tests }}; done
+           run: for i in {1..5}; do pnpm test -- ${{ needs.check-diff.outputs.modified-jest-tests }}; done
            env:
               NEXT_PUBLIC_STRAPI_ORIGIN: http://localhost:1337
               ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}

--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -7,6 +7,9 @@ jobs:
    check-diff:
       name: check-diff
       runs-on: ubuntu-latest
+      outputs:
+         modified-playwright-tests: ${{ steps.git-diff.outputs.modified-playwright-tests }}
+         modified-jest-tests: ${{ steps.git-diff.outputs.modified-playwright-tests }}
       steps:
          - name: Checkout ifixit
            uses: actions/checkout@v3
@@ -26,6 +29,7 @@ jobs:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
          - name: Get and log modified test names
+           id: git-diff
            if: "!contains(env.headCommitMsg, '[skip stress-test]')"
            run: |
               MODIFIED_PLAYWRIGHT_TESTS=$(git diff ${{ env.baseCommitSha }}...${{ github.event.pull_request.head.sha }} --name-only --diff-filter=d -- 'frontend/tests/playwright/*.spec.ts' | tr '\n' ' ')


### PR DESCRIPTION
## Background
Stress-tests workflow wasn't running stress tests even though it found changed test files, discovered by @ardelato in https://github.com/iFixit/react-commerce/pull/1519. 

## Summary
Since we didn't specify outputs for the job at the top level, it wasn't able to get the output from the previous job
so the stress-test didn't run.

Now, playwright-run and jest runs will be able to get the output from the check-diff job.

## QA Notes
Use the following steps to test:
1. Checkout this branch. 
2. Then create a new branch: `git co -b "<testing-branch-name>"`
3. Modify some jest and playwright tests. Add, commit, and push the changes. Create a test pull request.
4. Then make sure `playwright-stress-test` and `jest-stress-test` get triggered. 
5. Confirm the modifed tests get stress-tested.
6. Then close the testing pull request.
