### PR TITLE
Add product banners section UI

### DIFF
--- a/frontend/components/sections/BannersSection.tsx
+++ b/frontend/components/sections/BannersSection.tsx
@@ -1,0 +1,97 @@
+import { Box, Button, Flex, Text } from '@chakra-ui/react';
+import { Wrapper } from '@ifixit/ui';
+import type { Banner } from '@models/components/banner';
+import NextImage from 'next/image';
+import NextLink from 'next/link';
+import { SectionDescription } from './SectionDescription';
+import { SectionHeading } from './SectionHeading';
+
+export interface BannersSectionProps {
+   banners: Banner[];
+}
+
+export function BannersSection({ banners }: BannersSectionProps) {
+   if (banners.length === 0) return null;
+
+   if (banners.length === 1) {
+      return <Banner banner={banners[0]} />;
+   }
+
+   return (
+      <Box as="section" position="relative" w="full" py="16">
+         <Wrapper>
+            <Flex justify="space-between" align="center">
+               {banners.map((banner) => (
+                  <Banner key={banner.id} banner={banner} />
+               ))}
+            </Flex>
+         </Wrapper>
+      </Box>
+   );
+}
+
+interface BannerProps {
+   banner: Banner;
+}
+
+function Banner({ banner }: BannerProps) {
+   return (
+      <Box as="section" position="relative" w="full" pt="36" pb="16">
+         <Box
+            position="absolute"
+            bgGradient="linear(to-r, blackAlpha.600 50%, blackAlpha.400)"
+            zIndex={-1}
+            top="0"
+            left="0"
+            bottom="0"
+            right="0"
+         />
+         {banner.image && (
+            <Box
+               position="absolute"
+               zIndex={-2}
+               top="0"
+               left="0"
+               bottom="0"
+               right="0"
+            >
+               <NextImage
+                  src={banner.image.url}
+                  alt=""
+                  layout="fill"
+                  objectFit="cover"
+               />
+            </Box>
+         )}
+         <Wrapper>
+            <Box textAlign="center">
+               {banner.label && (
+                  <Text color="white" mb="3" fontSize="sm">
+                     {banner.label}
+                  </Text>
+               )}
+               {banner.title && (
+                  <SectionHeading color="white" mb="2.5">
+                     {banner.title}
+                  </SectionHeading>
+               )}
+               {banner.description && (
+                  <SectionDescription
+                     richText={banner.description}
+                     color="white"
+                     maxW="750px"
+                     mx="auto"
+                  />
+               )}
+               {banner.callToAction && (
+                  <NextLink href={banner.callToAction.url} passHref>
+                     <Button as="a" colorScheme="brand" mt="10">
+                        {banner.callToAction.title}
+                     </Button>
+                  </NextLink>
+               )}
+            </Box>
+         </Wrapper>
+      </Box>
+   );
+}

--- a/frontend/components/sections/BannersSection/MultipleBanners.tsx
+++ b/frontend/components/sections/BannersSection/MultipleBanners.tsx
@@ -1,0 +1,99 @@
+import {
+   AspectRatio,
+   Box,
+   Flex,
+   Heading,
+   Link,
+   SimpleGrid,
+} from '@chakra-ui/react';
+import { faArrowRight } from '@fortawesome/pro-solid-svg-icons';
+import { FaIcon } from '@ifixit/icons';
+import { ResponsiveImage } from '@ifixit/ui';
+import type { Banner } from '@models/components/banner';
+
+export interface MultipleBannersProps {
+   banners: Banner[];
+}
+
+export function MultipleBanners({ banners }: MultipleBannersProps) {
+   return (
+      <Box as="section" position="relative" w="full">
+         <SimpleGrid
+            columns={{
+               base: 1,
+               md: banners.length,
+            }}
+            pb="10"
+         >
+            {banners.map((banner) => {
+               return <BannerGridItem key={banner.id} banner={banner} />;
+            })}
+         </SimpleGrid>
+      </Box>
+   );
+}
+
+interface BannerProps {
+   banner: Banner;
+}
+
+function BannerGridItem({ banner }: BannerProps) {
+   return (
+      <Flex direction="column">
+         {banner.image && (
+            <AspectRatio ratio={4 / 3}>
+               <ResponsiveImage
+                  src={banner.image.url}
+                  alt="store hero image"
+                  layout="fill"
+                  objectFit="cover"
+               />
+            </AspectRatio>
+         )}
+         <Flex
+            direction="column"
+            align="flex-start"
+            px="6"
+            py={{
+               base: 6,
+               md: 8,
+            }}
+         >
+            {banner.title && (
+               <Heading
+                  as="h3"
+                  fontWeight="medium"
+                  fontSize="24px"
+                  lineHeight="38px"
+                  color="gray.800"
+                  mb="1"
+               >
+                  {banner.title}
+               </Heading>
+            )}
+            {banner.description && (
+               <Box
+                  color="gray.700"
+                  dangerouslySetInnerHTML={{
+                     __html: banner.description,
+                  }}
+               />
+            )}
+            {banner.callToAction && (
+               <Link
+                  href={banner.callToAction.url}
+                  color="brand.500"
+                  fontWeight="bold"
+                  display="flex"
+                  alignItems="center"
+                  mt="2.5"
+               >
+                  {banner.callToAction.title}
+                  <FaIcon icon={faArrowRight} h="4" mt="0.5" ml="1" />
+                  {/* <Icon as={HiChevronRight} boxSize="6" /> */}
+               </Link>
+            )}
+         </Flex>
+      </Flex>
+   );
+}

--- a/frontend/components/sections/BannersSection/MultipleBanners.tsx
+++ b/frontend/components/sections/BannersSection/MultipleBanners.tsx
@@ -90,7 +90,6 @@ function BannerGridItem({ banner }: BannerProps) {
                >
                   {banner.callToAction.title}
                   <FaIcon icon={faArrowRight} h="4" mt="0.5" ml="1" />
-                  {/* <Icon as={HiChevronRight} boxSize="6" /> */}
                </Link>
             )}
          </Flex>

--- a/frontend/components/sections/BannersSection/SingleBanner.tsx
+++ b/frontend/components/sections/BannersSection/SingleBanner.tsx
@@ -1,40 +1,15 @@
-import { Box, Button, Flex, Text } from '@chakra-ui/react';
-import { Wrapper } from '@ifixit/ui';
+import { Box, Button, Text } from '@chakra-ui/react';
+import { ResponsiveImage, Wrapper } from '@ifixit/ui';
 import type { Banner } from '@models/components/banner';
-import NextImage from 'next/image';
 import NextLink from 'next/link';
-import { SectionDescription } from './SectionDescription';
-import { SectionHeading } from './SectionHeading';
+import { SectionDescription } from '../SectionDescription';
+import { SectionHeading } from '../SectionHeading';
 
-export interface BannersSectionProps {
-   banners: Banner[];
-}
-
-export function BannersSection({ banners }: BannersSectionProps) {
-   if (banners.length === 0) return null;
-
-   if (banners.length === 1) {
-      return <Banner banner={banners[0]} />;
-   }
-
-   return (
-      <Box as="section" position="relative" w="full" py="16">
-         <Wrapper>
-            <Flex justify="space-between" align="center">
-               {banners.map((banner) => (
-                  <Banner key={banner.id} banner={banner} />
-               ))}
-            </Flex>
-         </Wrapper>
-      </Box>
-   );
-}
-
-interface BannerProps {
+interface SingleBannerProps {
    banner: Banner;
 }
 
-function Banner({ banner }: BannerProps) {
+export function SingleBanner({ banner }: SingleBannerProps) {
    return (
       <Box as="section" position="relative" w="full" pt="36" pb="16">
          <Box
@@ -55,7 +30,7 @@ function Banner({ banner }: BannerProps) {
                bottom="0"
                right="0"
             >
-               <NextImage
+               <ResponsiveImage
                   src={banner.image.url}
                   alt=""
                   layout="fill"

--- a/frontend/components/sections/BannersSection/index.tsx
+++ b/frontend/components/sections/BannersSection/index.tsx
@@ -1,0 +1,17 @@
+import type { Banner as SingleBannerSection } from '@models/components/banner';
+import { MultipleBanners } from './MultipleBanners';
+import { SingleBanner } from './SingleBanner';
+
+export interface BannersSectionProps {
+   banners: SingleBannerSection[];
+}
+
+export function BannersSection({ banners }: BannersSectionProps) {
+   if (banners.length === 0) return null;
+
+   if (banners.length === 1) {
+      return <SingleBanner banner={banners[0]} />;
+   }
+
+   return <MultipleBanners banners={banners} />;
+}

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2223,6 +2223,40 @@ export type UsersPermissionsUserRelationResponseCollection = {
    data: Array<UsersPermissionsUserEntity>;
 };
 
+export type BannerFieldsFragment = {
+   __typename?: 'BannerEntity';
+   id?: string | null;
+   attributes?: {
+      __typename?: 'Banner';
+      title?: string | null;
+      label?: string | null;
+      description?: string | null;
+      image?: {
+         __typename?: 'UploadFileEntityResponse';
+         data?: {
+            __typename?: 'UploadFileEntity';
+            attributes?: {
+               __typename?: 'UploadFile';
+               alternativeText?: string | null;
+               url: string;
+               formats?: any | null;
+            } | null;
+         } | null;
+      } | null;
+      callToAction?: {
+         __typename?: 'ComponentPageCallToAction';
+         title: string;
+         url: string;
+      } | null;
+   } | null;
+};
+
+export type CallToActionFieldsFragment = {
+   __typename?: 'ComponentPageCallToAction';
+   title: string;
+   url: string;
+};
+
 export type CompanyFieldsFragment = {
    __typename?: 'CompanyEntity';
    id?: string | null;
@@ -2499,12 +2533,6 @@ export type FindPageQuery = {
    } | null;
 };
 
-export type CallToActionFieldsFragment = {
-   __typename?: 'ComponentPageCallToAction';
-   title: string;
-   url: string;
-};
-
 export type FindProductQueryVariables = Exact<{
    handle?: InputMaybe<Scalars['String']>;
 }>;
@@ -2562,6 +2590,40 @@ export type FindProductQuery = {
                     title?: string | null;
                  }
                | { __typename: 'ComponentSectionBanner' }
+               | {
+                    __typename: 'ComponentSectionBanner';
+                    id: string;
+                    banners?: {
+                       __typename?: 'BannerRelationResponseCollection';
+                       data: Array<{
+                          __typename?: 'BannerEntity';
+                          id?: string | null;
+                          attributes?: {
+                             __typename?: 'Banner';
+                             title?: string | null;
+                             label?: string | null;
+                             description?: string | null;
+                             image?: {
+                                __typename?: 'UploadFileEntityResponse';
+                                data?: {
+                                   __typename?: 'UploadFileEntity';
+                                   attributes?: {
+                                      __typename?: 'UploadFile';
+                                      alternativeText?: string | null;
+                                      url: string;
+                                      formats?: any | null;
+                                   } | null;
+                                } | null;
+                             } | null;
+                             callToAction?: {
+                                __typename?: 'ComponentPageCallToAction';
+                                title: string;
+                                url: string;
+                             } | null;
+                          } | null;
+                       }>;
+                    } | null;
+                 }
                | {
                     __typename: 'ComponentSectionFeaturedProducts';
                     id: string;
@@ -3789,6 +3851,41 @@ export type GetStoreListQuery = {
    } | null;
 };
 
+export type BannersSectionFieldsFragment = {
+   __typename?: 'ComponentSectionBanner';
+   id: string;
+   banners?: {
+      __typename?: 'BannerRelationResponseCollection';
+      data: Array<{
+         __typename?: 'BannerEntity';
+         id?: string | null;
+         attributes?: {
+            __typename?: 'Banner';
+            title?: string | null;
+            label?: string | null;
+            description?: string | null;
+            image?: {
+               __typename?: 'UploadFileEntityResponse';
+               data?: {
+                  __typename?: 'UploadFileEntity';
+                  attributes?: {
+                     __typename?: 'UploadFile';
+                     alternativeText?: string | null;
+                     url: string;
+                     formats?: any | null;
+                  } | null;
+               } | null;
+            } | null;
+            callToAction?: {
+               __typename?: 'ComponentPageCallToAction';
+               title: string;
+               url: string;
+            } | null;
+         } | null;
+      }>;
+   } | null;
+};
+
 export type BrowseSectionFieldsFragment = {
    __typename?: 'ComponentPageBrowse';
    id: string;
@@ -4206,6 +4303,38 @@ export const ImageFieldsFragmentDoc = `
   }
 }
     `;
+export const CallToActionFieldsFragmentDoc = `
+    fragment CallToActionFields on ComponentPageCallToAction {
+  title
+  url
+}
+    `;
+export const BannerFieldsFragmentDoc = `
+    fragment BannerFields on BannerEntity {
+  id
+  attributes {
+    title
+    label
+    description
+    image {
+      ...ImageFields
+    }
+    callToAction {
+      ...CallToActionFields
+    }
+  }
+}
+    `;
+export const BannersSectionFieldsFragmentDoc = `
+    fragment BannersSectionFields on ComponentSectionBanner {
+  id
+  banners {
+    data {
+      ...BannerFields
+    }
+  }
+}
+    `;
 export const ProductListFieldsFragmentDoc = `
     fragment ProductListFields on ProductListEntity {
   attributes {
@@ -4258,12 +4387,6 @@ export const FeaturedProductsSectionFieldsFragmentDoc = `
       }
     }
   }
-}
-    `;
-export const CallToActionFieldsFragmentDoc = `
-    fragment CallToActionFields on ComponentPageCallToAction {
-  title
-  url
 }
     `;
 export const HeroSectionFieldsFragmentDoc = `
@@ -4454,6 +4577,7 @@ export const FindProductDocument = `
           ...FeaturedProductsSectionFields
           ...LifetimeWarrantySectionFields
           ...SplitWithImageSectionFields
+          ...BannersSectionFields
         }
       }
     }
@@ -4468,7 +4592,9 @@ ${FeaturedProductsSectionFieldsFragmentDoc}
 ${LifetimeWarrantySectionFieldsFragmentDoc}
 ${SplitWithImageSectionFieldsFragmentDoc}
 ${CallToActionFieldsFragmentDoc}
-${ImageFieldsFragmentDoc}`;
+${ImageFieldsFragmentDoc}
+${BannersSectionFieldsFragmentDoc}
+${BannerFieldsFragmentDoc}`;
 export const FindStoreDocument = `
     query findStore($filters: StoreFiltersInput) {
   store: stores(filters: $filters) {

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2589,7 +2589,6 @@ export type FindProductQuery = {
                     id: string;
                     title?: string | null;
                  }
-               | { __typename: 'ComponentSectionBanner' }
                | {
                     __typename: 'ComponentSectionBanner';
                     id: string;

--- a/frontend/lib/strapi-sdk/operations/BannersFields.graphql
+++ b/frontend/lib/strapi-sdk/operations/BannersFields.graphql
@@ -1,0 +1,14 @@
+fragment BannerFields on BannerEntity {
+   id
+   attributes {
+      title
+      label
+      description
+      image {
+         ...ImageFields
+      }
+      callToAction {
+         ...CallToActionFields
+      }
+   }
+}

--- a/frontend/lib/strapi-sdk/operations/CallToActionFields.graphql
+++ b/frontend/lib/strapi-sdk/operations/CallToActionFields.graphql
@@ -1,0 +1,4 @@
+fragment CallToActionFields on ComponentPageCallToAction {
+   title
+   url
+}

--- a/frontend/lib/strapi-sdk/operations/findPage.graphql
+++ b/frontend/lib/strapi-sdk/operations/findPage.graphql
@@ -26,8 +26,3 @@ query findPage(
       }
    }
 }
-
-fragment CallToActionFields on ComponentPageCallToAction {
-   title
-   url
-}

--- a/frontend/lib/strapi-sdk/operations/findProduct.graphql
+++ b/frontend/lib/strapi-sdk/operations/findProduct.graphql
@@ -14,6 +14,7 @@ query findProduct($handle: String) {
                ...FeaturedProductsSectionFields
                ...LifetimeWarrantySectionFields
                ...SplitWithImageSectionFields
+               ...BannersSectionFields
             }
          }
       }

--- a/frontend/lib/strapi-sdk/operations/sections/BannersSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/BannersSectionFields.fragment.graphql
@@ -1,0 +1,8 @@
+fragment BannersSectionFields on ComponentSectionBanner {
+   id
+   banners {
+      data {
+         ...BannerFields
+      }
+   }
+}

--- a/frontend/models/components/banner.ts
+++ b/frontend/models/components/banner.ts
@@ -1,0 +1,33 @@
+import type { BannerFieldsFragment } from '@lib/strapi-sdk';
+import { z } from 'zod';
+import { callToActionFromStrapi, CallToActionSchema } from './call-to-action';
+import { imageFromStrapi, ImageSchema } from './image';
+
+export type Banner = z.infer<typeof BannerSchema>;
+
+export const BannerSchema = z.object({
+   id: z.string(),
+   label: z.string().nullable(),
+   title: z.string().nullable(),
+   description: z.string().nullable(),
+   image: ImageSchema.nullable(),
+   callToAction: CallToActionSchema.nullable(),
+});
+
+export function bannerFromStrapiFragment(
+   fragment: BannerFieldsFragment | null | undefined
+): Banner | null {
+   const id = fragment?.id;
+   const attributes = fragment?.attributes;
+
+   if (id == null || attributes == null) return null;
+
+   return {
+      id,
+      label: attributes.label ?? null,
+      title: attributes.title ?? null,
+      description: attributes.description ?? null,
+      image: imageFromStrapi(attributes?.image),
+      callToAction: callToActionFromStrapi(attributes?.callToAction),
+   };
+}

--- a/frontend/models/product/sections/index.ts
+++ b/frontend/models/product/sections/index.ts
@@ -4,6 +4,10 @@ import type { FindProductQuery as ShopifyFindProductQuery } from '@lib/shopify-s
 import type { FindProductQuery as StrapiFindProductQuery } from '@lib/strapi-sdk';
 import { replacementGuidePreviewFromMetafield } from '@models/components/replacement-guide-preview';
 import {
+   bannersSectionFromStrapi,
+   BannersSectionSchema,
+} from '@models/sections/banners-section';
+import {
    featuredProductPreviewsFromShopifyProduct,
    featuredProductsSectionFromStrapi,
    FeaturedProductsSectionSchema,
@@ -33,6 +37,7 @@ export const ProductSectionSchema = z.union([
    FeaturedProductsSectionSchema,
    LifetimeWarrantySectionSchema,
    ServiceValuePropositionSectionSchema,
+   BannersSectionSchema,
 ]);
 
 interface GetProductSectionsArgs {
@@ -108,6 +113,9 @@ export async function getProductSections({
                   };
                case 'ComponentPageSplitWithImage':
                   return splitWithImageSectionFromStrapi(section, sectionId);
+
+               case 'ComponentSectionBanner':
+                  return bannersSectionFromStrapi(section, sectionId);
 
                default:
                   return null;

--- a/frontend/models/sections/banners-section.ts
+++ b/frontend/models/sections/banners-section.ts
@@ -1,0 +1,33 @@
+import { filterFalsyItems } from '@helpers/application-helpers';
+import type { BannersSectionFieldsFragment } from '@lib/strapi-sdk';
+import {
+   bannerFromStrapiFragment,
+   BannerSchema,
+} from '@models/components/banner';
+import { z } from 'zod';
+
+export type BannersSection = z.infer<typeof BannersSectionSchema>;
+
+export const BannersSectionSchema = z.object({
+   type: z.literal('Banners'),
+   id: z.string(),
+   banners: z.array(BannerSchema),
+});
+
+export function bannersSectionFromStrapi(
+   fragment: BannersSectionFieldsFragment | null | undefined,
+   sectionId: string
+): BannersSection | null {
+   const strapiBanners = fragment?.banners?.data ?? [];
+   const banners = filterFalsyItems(
+      strapiBanners.map(bannerFromStrapiFragment)
+   );
+
+   if (banners == null) return null;
+
+   return {
+      type: 'Banners',
+      id: sectionId,
+      banners,
+   };
+}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -211,10 +211,6 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                      );
                   }
                   case 'Banners': {
-                     if (section.banners.length === 0) return null;
-
-                     // return null;
-                     // return <p key={section.id}>Banners</p>;
                      return (
                         <BannersSection
                            key={section.id}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex } from '@chakra-ui/react';
 import { PageEditMenu } from '@components/admin';
 import { PageBreadcrumb } from '@components/common';
+import { BannersSection } from '@components/sections/BannersSection';
 import { FeaturedProductsSection } from '@components/sections/FeaturedProductsSection';
 import { ReplacementGuidesSection } from '@components/sections/ReplacementGuidesSection';
 import { ServiceValuePropositionSection } from '@components/sections/ServiceValuePropositionSection';
@@ -113,7 +114,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                </Flex>
             </SecondaryNavigation>
          )}
-         <Box pt="6">
+         <Box>
             {product.sections.map((section) => {
                switch (section.type) {
                   case 'ProductOverview':
@@ -206,6 +207,18 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                            key={section.id}
                            title={section.title}
                            description={section.description}
+                        />
+                     );
+                  }
+                  case 'Banners': {
+                     if (section.banners.length === 0) return null;
+
+                     // return null;
+                     // return <p key={section.id}>Banners</p>;
+                     return (
+                        <BannersSection
+                           key={section.id}
+                           banners={section.banners}
                         />
                      );
                   }

--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -66,7 +66,7 @@ export function ProductOverviewSection({
    const isForSale = useIsProductForSale(product);
 
    return (
-      <Wrapper as="section" id="product" mb="16">
+      <Wrapper as="section" id="product" mb="16" pt="6">
          <Flex>
             <Flex
                position="sticky"


### PR DESCRIPTION
closes #1532 

## QA

1. Visit a [product preview](https://react-commerce-git-add-product-banners-section-ui-ifixit.vercel.app/products/repair-business-toolkit)
2. Verify that the two types of banners are rendered according to #1532 (note that the single banner call to action button will not show an icon at this time)
3. Verify that banners sections are responsive
4. Verify you can change banners content from [Strapi](https://add-product-banners-section-ui.govinor.com/admin/content-manager/collectionType/api::banner.banner?page=1&pageSize=10&sort=title:ASC&plugins[i18n][locale]=en)