### PR TITLE
Update Test Docs to Include Working with Mocks

### DIFF
--- a/frontend/tests/jest/README.md
+++ b/frontend/tests/jest/README.md
@@ -3,7 +3,7 @@
 This document contains extra information for writing `Jest` tests within the context of our application.
 
 -  [Updating Jest Snapshots](#updating-jest-snapshots)
--  [Woring with Mock Data](#woring-with-mock-data)
+-  [Working with Mock Data](#working-with-mock-data)
    -  [`products` Mock Data](#products-mock-data)
       -  [Updating Mock Data with `TypeScript`](#updating-mock-data-with-typescript)
       -  [Updating Mock Data with `console`](#updating-mock-data-with-console)
@@ -59,6 +59,6 @@ When adding new mock data, ensure:
 2. The mock data is assigned a type matching the type of data being mocked. For example, if mocking a `Product`, the mock data should be of type `Product`.
 3. Snapshot the mock data.
 
-   To mock data from the `pageProps` object, follow the instructions in [Update Mock Data](#using-console-to-update-mock-data). Otherwise, manually add a `console.log` statement to obtain the data you want to mock.
+   To mock data from the `pageProps` object, follow the instructions in [ Updating Mock Data with `console`](#updating-mock-data-with-console). Otherwise, manually add a `console.log` statement to obtain the data you want to mock.
 
 4. Add the mock data to the `__mocks__` directory.

--- a/frontend/tests/jest/README.md
+++ b/frontend/tests/jest/README.md
@@ -1,0 +1,64 @@
+# Jest Testing Documentation
+
+This document contains extra information for writing `Jest` tests within the context of our application.
+
+-  [Updating Jest Snapshots](#updating-jest-snapshots)
+-  [Woring with Mock Data](#woring-with-mock-data)
+   -  [`products` Mock Data](#products-mock-data)
+      -  [Updating Mock Data with `TypeScript`](#updating-mock-data-with-typescript)
+      -  [Updating Mock Data with `console`](#updating-mock-data-with-console)
+   -  [Adding New Mock Data](#adding-new-mock-data)
+
+## Updating Jest Snapshots
+
+To update a Jest snapshot, follow these steps:
+
+1. Ensure the changes are intentional.
+2. Run the command below, where `[test-name]` is an optional parameter to update a specific test's snapshot. If no test name is provided, all snapshots will be updated.
+
+```sh
+pnpm test -- [test-name] --updateSnapshot
+```
+
+## Woring with Mock Data
+
+Unlike `Playwright`, we don't use `MSW` for mocking. We use static mock data passed to our components. The mock data is located in the `__mocks__` directory, containing both `ts` and `tsx` files.
+
+⚠ **Important**: Match the file extension with the type of data being mocked to avoid confusion. See https://github.com/iFixit/react-commerce/issues/1400 for context.
+
+### `products` Mock Data
+
+The `products` subdirectory stores the mock data for the [`Product` model](../../models/product/index.ts#L55). Each file contains a snapshot of a specific product type, such as `battery`, `tool`, or `part`. All these products are of the `Product` model type.
+
+Using `TypeScript`, the `Product` type helps ensure the mock data's validity. If the mock data is invalid, tests will fail, requiring an update to the mock data.
+
+#### Updating Mock Data with `TypeScript`
+
+For minor changes, like adding a new scalar field, update the mock data by adding the missing field with a default value. Tests should pass after this change.
+
+For significant changes, like adding a new field referencing a custom type, a re-snapshot of the mock data may be needed. See the next section for more details.
+
+#### Updating Mock Data with `console`
+
+To easily update the mock data:
+
+1. Start the dev server.
+2. Navigate to a product page for the desired product type.
+3. Open the console.
+4. Run the command:
+   ```js
+   copy(window.__NEXT_DATA__.props.pageProps.product);
+   ```
+5. Paste the copied product data into the mock data file and update the snapshot accordingly.
+
+### Adding New Mock Data
+
+When adding new mock data, ensure:
+
+1. The file extension is correct.
+2. The mock data is assigned a type matching the type of data being mocked. For example, if mocking a `Product`, the mock data should be of type `Product`.
+3. Snapshot the mock data.
+
+   To mock data from the `pageProps` object, follow the instructions in [Update Mock Data](#using-console-to-update-mock-data). Otherwise, manually add a `console.log` statement to obtain the data you want to mock.
+
+4. Add the mock data to the `__mocks__` directory.

--- a/frontend/tests/jest/README.md
+++ b/frontend/tests/jest/README.md
@@ -20,7 +20,7 @@ To update a Jest snapshot, follow these steps:
 pnpm test -- [test-name] --updateSnapshot
 ```
 
-## Woring with Mock Data
+## Working with Mock Data
 
 Unlike `Playwright`, we don't use `MSW` for mocking. We use static mock data passed to our components. The mock data is located in the `__mocks__` directory, containing both `ts` and `tsx` files.
 

--- a/frontend/tests/playwright/README.md
+++ b/frontend/tests/playwright/README.md
@@ -8,6 +8,7 @@ This document contains extra information for writing Playwright tests within the
       -  [Practical Usage: Developing Components](#practical-usage-developing-components)
       -  [Practical Usage: Global Test Mock](#practical-usage-global-test-mock)
    -  [Dynamic Handlers](#dynamic-handlers)
+   -  [Working with Mock Data](#working-with-mock-data)
 -  [Debugging Playwright Tests](#debugging-playwright-tests)
    -  [`pnpm playwright:debug`](#pnpm-playwrightdebug)
       -  [`--debug` flag](#--debug-flag)
@@ -141,6 +142,27 @@ Likewise, if you want to mock an API request for a **client-side request**, you 
             })
          );
 ```
+
+### Working with Mock Data
+
+We are currently only mocking the `findProduct` GraphQL query from `shopify` -- [mocked queries](./fixtures/shopify-mocked-queries.ts).
+
+If we ever change the fields we request or the schema changes, we will need to do the following to update the mock data:
+
+1. Copy the `graphql` query from [`findProduct` query](../../lib/shopify-storefront-sdk/operations/findProduct.graphql)
+2. Grab a `shopify` storefront access token
+3. Send a curl request to `https://store.cominor.com/api/<latest>/graphql.json` where `latest` is the most recently generate graphql schema date. For example `2022-10`
+
+```bash
+curl --location 'https://store.cominor.com/api/2022-10/graphql.json' \
+--header 'X-Shopify-Storefront-Access-Token: <access-token>' \
+--header 'Content-Type: application/json' \
+--data '{"query":"<graphql-query>", "variables":{"handle": "<product-handle>"}}'
+```
+
+4. Copy the response body and paste it into [`shopify-mocked-queries.ts`](./fixtures/shopify-mocked-queries.ts)
+
+_💡 It can be easier to use `Postman` to send the request and copy the response body._
 
 ## Debugging Playwright Tests
 


### PR DESCRIPTION
## Description

This is a follow-up to https://github.com/ifixit/react-commerce/issues/1400 and https://github.com/iFixit/react-commerce/pull/1470#pullrequestreview-1342102872

This adds a new `README` to the `jest` directory and updates the `playwright` `README` to include information about working with mocks. This includes tips on how to easily update the mocks and how to create new ones.

### QA

- [ ] A simple grammar check
- [ ] Links point to the correct information

Closes: #1400 