### PR TITLE
Add fortawesome/solid-icons to footer package

### DIFF
--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -32,6 +32,7 @@
       "react": ">=18.2.0",
       "@emotion/react": ">=11.0.0 <12.0.0",
       "framer-motion": ">=3.0.0 <4.0.0 || >=4.0.0 <5.0.0 || >=5.0.0 <6.0.0 || >=6.0.0 <7.0.0",
+      "@fortawesome/pro-solid-svg-icons": "6.2.1",
       "@emotion/styled": ">=11.0.0 <12.0.0",
       "react-dom": ">=18.2.0",
       "@babel/core": ">=7.0.0 <8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,7 @@ importers:
       '@babel/core': '>=7.0.0 <8.0.0'
       '@emotion/react': '>=11.0.0 <12.0.0'
       '@emotion/styled': '>=11.0.0 <12.0.0'
+      '@fortawesome/pro-solid-svg-icons': 6.2.1
       '@ifixit/icons': workspace:*
       '@ifixit/menu': workspace:*
       '@ifixit/newsletter-sdk': workspace:*
@@ -383,6 +384,7 @@ importers:
       '@babel/core': 7.18.6
       '@emotion/react': 11.7.1_sxwbo4xt7gk63ri5mq3agqslqm
       '@emotion/styled': 11.6.0_wqfmtoa4qqw2uo45wgyguljgsu
+      '@fortawesome/pro-solid-svg-icons': 6.2.1
       '@ifixit/tsconfig': link:../tsconfig
       '@types/react': 18.0.24
       '@types/react-dom': 18.0.8


### PR DESCRIPTION
We are running into typechecker errors on the iFixit side when trying to update the react-commerce submodule because this package was not added to the footer package. This should fix it.

Qa_req 0 - The icons still render in the footer.


Connects to https://github.com/iFixit/ifixit/pull/47233