### PR TITLE
Add react as dependency to new packages

### DIFF
--- a/packages/ifixit-api-client/package.json
+++ b/packages/ifixit-api-client/package.json
@@ -12,7 +12,11 @@
       "@types/react": "18.0.24",
       "@types/react-dom": "18.0.8",
       "@ifixit/tsconfig": "workspace:*",
-      "typescript": "4.8.4"
+      "typescript": "4.8.4",
+      "react": "18.2.0"
+   },
+   "peerDependencies": {
+      "react": "18.2.0"
    },
    "scripts": {
       "build": "",

--- a/packages/newsletter-sdk/package.json
+++ b/packages/newsletter-sdk/package.json
@@ -10,13 +10,15 @@
       "@ifixit/ifixit-api-client": "workspace:*"
    },
    "peerDependencies": {
-      "@tanstack/react-query": "4.x"
+      "@tanstack/react-query": "4.x",
+      "react": "18.2.0"
    },
    "devDependencies": {
       "@types/react": "18.0.24",
       "@types/react-dom": "18.0.8",
       "@ifixit/tsconfig": "workspace:*",
-      "typescript": "4.8.4"
+      "typescript": "4.8.4",
+      "react": "18.2.0"
    },
    "scripts": {
       "build": "",

--- a/packages/tracking-hooks/package.json
+++ b/packages/tracking-hooks/package.json
@@ -15,6 +15,10 @@
    "devDependencies": {
       "@types/react": "18.0.24",
       "@ifixit/tsconfig": "workspace:*",
-      "typescript": "4.8.4"
+      "typescript": "4.8.4",
+      "react": "18.2.0"
+   },
+   "peerDependencies": {
+      "react": "18.2.0"
    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,7 @@ importers:
       '@ifixit/tsconfig': workspace:*
       '@types/react': 18.0.24
       '@types/react-dom': 18.0.8
+      react: 18.2.0
       typescript: 4.8.4
     dependencies:
       '@ifixit/app': link:../app
@@ -441,6 +442,7 @@ importers:
       '@ifixit/tsconfig': link:../tsconfig
       '@types/react': 18.0.24
       '@types/react-dom': 18.0.8
+      react: 18.2.0
       typescript: 4.8.4
 
   packages/menu:
@@ -459,6 +461,7 @@ importers:
       '@ifixit/tsconfig': workspace:*
       '@types/react': 18.0.24
       '@types/react-dom': 18.0.8
+      react: 18.2.0
       typescript: 4.8.4
     dependencies:
       '@ifixit/helpers': link:../helpers
@@ -468,6 +471,7 @@ importers:
       '@ifixit/tsconfig': link:../tsconfig
       '@types/react': 18.0.24
       '@types/react-dom': 18.0.8
+      react: 18.2.0
       typescript: 4.8.4
 
   packages/sentry:
@@ -510,10 +514,12 @@ importers:
     specifiers:
       '@ifixit/tsconfig': workspace:*
       '@types/react': 18.0.24
+      react: 18.2.0
       typescript: 4.8.4
     devDependencies:
       '@ifixit/tsconfig': link:../tsconfig
       '@types/react': 18.0.24
+      react: 18.2.0
       typescript: 4.8.4
 
   packages/tsconfig:


### PR DESCRIPTION
These packages use react, so we need to add the dependency. According to: https://stackoverflow.com/questions/30451556/what-is-the-correct-way-of-adding-a-dependency-to-react-in-your-package-json-for we should add it as a peer dependency and a dev dependency.

We are failing the build-assets on https://github.com/iFixit/ifixit/pull/47270, so this should fix that.

Qa_req 0

Connects to https://github.com/iFixit/ifixit/pull/47270 