### PR TITLE
Add strapi image loader

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -134,6 +134,7 @@ const moduleExports = {
          'www.cominor.com',
          'guide-images.cdn.ifixit.com',
          process.env.STRAPI_IMAGE_DOMAIN,
+         new URL(strapiOrigin).hostname,
       ].filter((domain) => domain),
    },
    i18n: {


### PR DESCRIPTION
Closes #1550 

Adds a loader to correctly resolve images hosted on Strapi. We get urls like "/uploads/newproducts_v1_89907dd0d2.jpg" from Strapi's API, but the images are hosted on Strapi's origin, not the same origin as the page.

## QA

Make sure the section images on `/products/repair-business-toolkit` load correctly.

CC @sterlinghirsh 