### PR TITLE
Github Actions: build strapi image and push to ECR

### DIFF
--- a/.github/workflows/deploy-strapi.yml
+++ b/.github/workflows/deploy-strapi.yml
@@ -1,0 +1,42 @@
+name: Build Strapi on Deploy
+
+on:
+   workflow_dispatch:
+   push:
+      branches:
+         - main
+         - deploy-strapi-test*
+      paths:
+         - 'backend/**'
+
+# @see https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-permissions-settings
+permissions:
+   id-token: write # Required to allow the JWT to be requested from GitHub's OIDC provider
+   contents: read # Required for actions/checkout
+
+jobs:
+   build-strapi:
+      runs-on: ubuntu-latest
+      steps:
+         - name: Checkout
+           uses: actions/checkout@v3
+
+         - name: Configure AWS credentials
+           uses: aws-actions/configure-aws-credentials@v1
+           with:
+              role-to-assume: 'arn:aws:iam::884681002735:role/github_actions/github-actions-role'
+              aws-region: us-east-1
+
+         - name: Login to Amazon ECR
+           id: login-ecr
+           uses: aws-actions/amazon-ecr-login@v1
+
+         - name: Build, Tag, and Push Base Image to Amazon ECR Private
+           env:
+              REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+              DOCKER_TAG: strapi:${{ github.sha }}
+           run: |
+              cd backend
+              docker build -t "$DOCKER_TAG" .
+              docker tag "$DOCKER_TAG" "$REGISTRY/$DOCKER_TAG"
+              docker push "$REGISTRY/$DOCKER_TAG"

--- a/.github/workflows/deploy-strapi.yml
+++ b/.github/workflows/deploy-strapi.yml
@@ -22,7 +22,7 @@ jobs:
            uses: actions/checkout@v3
 
          - name: Configure AWS credentials
-           uses: aws-actions/configure-aws-credentials@v1
+           uses: aws-actions/configure-aws-credentials@v2
            with:
               role-to-assume: 'arn:aws:iam::884681002735:role/github_actions/github-actions-role'
               aws-region: us-east-1

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -112,5 +112,4 @@ exports
 *.cache
 build
 .strapi-updater.json
-
 dist


### PR DESCRIPTION
Add a github action to build the strapi docker image and push it to aws ecr.

This is dependent on the IAM setup that's in a separate pull request. It has already been run, so this now succeeds (see the workflow runs on this pull!)