### PR TITLE
Add split with image label

### DIFF
--- a/frontend/components/sections/SplitWithImageSection.tsx
+++ b/frontend/components/sections/SplitWithImageSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, VStack } from '@chakra-ui/react';
+import { Box, Button, Flex, Text } from '@chakra-ui/react';
 import { ResponsiveImage, Wrapper } from '@ifixit/ui';
 import type { CallToAction } from '@models/components/call-to-action';
 import type { Image } from '@models/components/image';
@@ -10,6 +10,7 @@ import { SectionHeading } from './SectionHeading';
 export interface SplitWithImageContentSectionProps {
    id: string;
    title?: string | null;
+   label?: string | null;
    description?: string | null;
    image?: Image | null;
    imagePosition?: SplitWithImageSection['imagePosition'];
@@ -19,6 +20,7 @@ export interface SplitWithImageContentSectionProps {
 export function SplitWithImageContentSection({
    id,
    title,
+   label,
    description,
    image,
    imagePosition,
@@ -53,13 +55,11 @@ export function SplitWithImageContentSection({
          )}
          <Wrapper>
             <Flex justify={isImageLeft ? 'flex-end' : 'flex-start'}>
-               <VStack
-                  align="flex-start"
+               <Box
                   py={{
                      base: '10',
                      md: '36',
                   }}
-                  spacing="7"
                   w={{
                      base: 'full',
                      md: '50%',
@@ -67,16 +67,21 @@ export function SplitWithImageContentSection({
                   pl={{ base: 0, md: isImageLeft ? '32' : undefined }}
                   pr={{ base: 0, md: isImageLeft ? undefined : '32' }}
                >
-                  {title && <SectionHeading>{title}</SectionHeading>}
+                  {label && (
+                     <Text color="brand.500" fontSize="sm" fontFamily="mono">
+                        {label}
+                     </Text>
+                  )}
+                  {title && <SectionHeading mb="4">{title}</SectionHeading>}
                   {description && <SectionDescription richText={description} />}
                   {callToAction && (
                      <NextLink href={callToAction.url} passHref>
-                        <Button as="a" colorScheme="brand">
+                        <Button as="a" colorScheme="brand" mt="6">
                            {callToAction.title}
                         </Button>
                      </NextLink>
                   )}
-               </VStack>
+               </Box>
             </Flex>
          </Wrapper>
       </Box>

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2550,6 +2550,7 @@ export type FindPageQuery = {
                     __typename: 'ComponentPageSplitWithImage';
                     id: string;
                     title?: string | null;
+                    label?: string | null;
                     description?: string | null;
                     imagePosition?: Enum_Componentpagesplitwithimage_Imageposition | null;
                     callToAction?: {
@@ -2656,6 +2657,7 @@ export type FindProductQuery = {
                     __typename: 'ComponentPageSplitWithImage';
                     id: string;
                     title?: string | null;
+                    label?: string | null;
                     description?: string | null;
                     imagePosition?: Enum_Componentpagesplitwithimage_Imageposition | null;
                     callToAction?: {
@@ -4359,6 +4361,7 @@ export type SplitWithImageSectionFieldsFragment = {
    __typename?: 'ComponentPageSplitWithImage';
    id: string;
    title?: string | null;
+   label?: string | null;
    description?: string | null;
    imagePosition?: Enum_Componentpagesplitwithimage_Imageposition | null;
    callToAction?: {
@@ -4726,6 +4729,7 @@ export const SplitWithImageSectionFieldsFragmentDoc = `
     fragment SplitWithImageSectionFields on ComponentPageSplitWithImage {
   id
   title
+  label
   description
   callToAction {
     ...CallToActionFields

--- a/frontend/lib/strapi-sdk/operations/sections/SplitWithImageSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/SplitWithImageSectionFields.fragment.graphql
@@ -1,6 +1,7 @@
 fragment SplitWithImageSectionFields on ComponentPageSplitWithImage {
    id
    title
+   label
    description
    callToAction {
       ...CallToActionFields

--- a/frontend/models/sections/split-with-image-section.ts
+++ b/frontend/models/sections/split-with-image-section.ts
@@ -16,6 +16,7 @@ export const SplitWithImageSectionSchema = z.object({
    type: z.literal('SplitWithImage'),
    id: z.string(),
    title: z.string().nullable(),
+   label: z.string().nullable(),
    description: z.string().nullable(),
    image: ImageSchema.nullable(),
    imagePosition: z.enum(['left', 'right']),
@@ -27,12 +28,14 @@ export function splitWithImageSectionFromStrapi(
    sectionId: string
 ): SplitWithImageSection | null {
    const title = fragment?.title ?? null;
+   const label = fragment?.label ?? null;
    const description = fragment?.description ?? null;
 
    return {
       type: 'SplitWithImage',
       id: sectionId,
       title,
+      label,
       description,
       image: imageFromStrapi(fragment?.image),
       imagePosition:

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -144,6 +144,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                            key={section.id}
                            id={section.id}
                            title={section.title}
+                           label={section.label}
                            description={section.description}
                            image={section.image}
                            imagePosition={section.imagePosition}


### PR DESCRIPTION
closes #1553 
~~blocked by #1554~~

## QA

1. Open [featured product preview](https://react-commerce-git-add-split-with-image-label-ifixit.vercel.app/products/repair-business-toolkit)
2. Verify that the split with image label is present (see #1553) as specified in Strapi
3. Verify that you can change the label from [Strapi](https://add-split-with-image-label.govinor.com/admin/content-manager/collectionType/api::product.product/1) 
