### PR TITLE
Reorganize the Directory Structure of the Trace files

### DIFF
--- a/frontend/tests/playwright/fixtures/index.ts
+++ b/frontend/tests/playwright/fixtures/index.ts
@@ -3,11 +3,20 @@ import { CartDrawer } from './cart-drawer';
 import Server from './custom-nextjs-server';
 export type { CustomNextjsServer } from './custom-nextjs-server';
 import { findProductQueryMock } from './shopify-mocked-queries';
+import { traceOutputDirTemplate } from './trace-override';
+import type { TestInfo } from '@playwright/test';
 
 export type ProductFixtures = {
    productPage: ProductPage;
    cartDrawer: CartDrawer;
    findProductQueryMock: typeof findProductQueryMock;
+   testInfo: TestInfo;
 };
 
-export { ProductPage, CartDrawer, Server, findProductQueryMock };
+export {
+   ProductPage,
+   CartDrawer,
+   Server,
+   findProductQueryMock,
+   traceOutputDirTemplate,
+};

--- a/frontend/tests/playwright/fixtures/trace-override.ts
+++ b/frontend/tests/playwright/fixtures/trace-override.ts
@@ -19,10 +19,7 @@ export function traceOutputDirTemplate(testInfo: TestInfo) {
 }
 
 function formatTestNameForDirectory(testName: string) {
-   // Replace any special characters and spaces with a hyphen
    const formattedName = testName.replace(/[^a-zA-Z0-9]+/g, '-');
-
-   // Ensure the directory name is in lowercase
    const directoryName = formattedName.toLowerCase();
 
    return directoryName;

--- a/frontend/tests/playwright/fixtures/trace-override.ts
+++ b/frontend/tests/playwright/fixtures/trace-override.ts
@@ -1,0 +1,29 @@
+import { TestInfo } from '@playwright/test';
+import path from 'node:path';
+
+export function traceOutputDirTemplate(testInfo: TestInfo) {
+   // The path to where all the trace files will be outputted as defined
+   // in the Playwright config
+   const globalOutputDir = testInfo.project.outputDir;
+
+   // titlePath houses the path to the test file relevant to the test directory
+   // e.g. 'product/add_to_cart.spec.ts' -> 'product/add_to_cart'
+   const testFile = testInfo.titlePath[0].replace(/\.spec\.ts$/, '');
+
+   const testName = formatTestNameForDirectory(testInfo.title);
+
+   // The 'device' the test was ran on
+   const projectName = testInfo.project.name.replace(/\s/g, '-').toLowerCase();
+
+   return path.join(globalOutputDir, testFile, testName, projectName);
+}
+
+function formatTestNameForDirectory(testName: string) {
+   // Replace any special characters and spaces with a hyphen
+   const formattedName = testName.replace(/[^a-zA-Z0-9]+/g, '-');
+
+   // Ensure the directory name is in lowercase
+   const directoryName = formattedName.toLowerCase();
+
+   return directoryName;
+}

--- a/frontend/tests/playwright/test-fixtures.ts
+++ b/frontend/tests/playwright/test-fixtures.ts
@@ -22,6 +22,7 @@ import {
    CartDrawer,
    Server,
    findProductQueryMock,
+   traceOutputDirTemplate,
 } from './fixtures';
 import type { MockServiceWorker } from 'playwright-msw';
 import { createWorkerFixture } from 'playwright-msw';
@@ -67,6 +68,14 @@ export const test = base.extend<
    cartDrawer: async ({ page }, use) => {
       await use(new CartDrawer(page));
    },
+   testInfo: [
+      // eslint-disable-next-line no-empty-pattern
+      async ({}, use, testInfo) => {
+         testInfo.outputDir = traceOutputDirTemplate(testInfo);
+         await use(testInfo);
+      },
+      { scope: 'test', auto: true },
+   ],
    findProductQueryMock,
    clientRequestHandler: createWorkerFixture(handlers),
    /**


### PR DESCRIPTION
## Description

This pull request adds a new formatting fixture for trace file output paths in Playwright tests. It modifies the `testInfo.outputDir` property to create a nested directory structure that makes it easier to locate trace files for specific tests.

The new directory structure for trace files will look like this:
```bash
[subtest-directory]/test-file-name/test-name/device-name/
```

For example:
```bash
product/add_to_cart/back-to-shopping-button-works/desktop-chrome/
```

This nested directory structure will allow us to easily find the trace files for a given test as the original trace files were underneath a single directory where the directory name was a flattened version of the new directory structure.

|Before|After|
|:---:|:---:|
|  ![image](https://user-images.githubusercontent.com/22064420/231305905-1b66b28d-0fb0-4d71-9ac6-80b876fba2d1.png)  | ![image](https://user-images.githubusercontent.com/22064420/231305922-fcd7a32a-6f03-4d1b-b277-ef28758c028b.png)     |


### QA Notes

- [ ] Verify that a trace file is created in the expected folder path for a test file in the playwright directory.
	- Check if a `.spec.ts` file lives in the `playwright` folder so that the `[subtest-directory]` path will be omitted and the trace file will still successfully be outputted
- [ ] Test the proper formatting of directory names when special characters are used in test names.
	- Basically check `'` and other special characters that would be used in a test case name will be properly formatted for the use of a directory name

Connects: #1496