### PR TITLE
Instantsearch: Handle typos in Strapi productlist filters

### DIFF
--- a/frontend/components/common/AppProviders.tsx
+++ b/frontend/components/common/AppProviders.tsx
@@ -51,19 +51,24 @@ export type WithProvidersProps<T> = T & { appProps: AppProvidersProps };
 export type AppProvidersProps = {
    algolia?: AlgoliaProps;
    ifixitOrigin?: string;
+   adminMessage?: string;
 };
 
 export function AppProviders({
    children,
    algolia,
    ifixitOrigin,
+   adminMessage,
 }: React.PropsWithChildren<AppProvidersProps>) {
    const markup = (
       <ChakraProvider theme={customTheme}>{children}</ChakraProvider>
    );
 
    return (
-      <AppProvider ifixitOrigin={ifixitOrigin ?? IFIXIT_ORIGIN}>
+      <AppProvider
+         ifixitOrigin={ifixitOrigin ?? IFIXIT_ORIGIN}
+         adminMessage={adminMessage}
+      >
          <CartDrawerProvider>
             <QueryClientProvider client={queryClient}>
                {algolia ? (

--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -1,4 +1,7 @@
 import {
+   Alert,
+   AlertIcon,
+   AlertTitle,
    Box,
    DrawerCloseButton,
    Flex,
@@ -70,6 +73,8 @@ export function DefaultLayout({
 }: React.PropsWithChildren<DefaultLayoutProps>) {
    const { menu } = currentStore.header;
    const mobileSearchInputRef = React.useRef<HTMLInputElement>(null);
+   const { adminMessage } = useAppContext();
+   const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
 
    return (
       <ShopifyStorefrontProvider
@@ -279,6 +284,12 @@ export function DefaultLayout({
                   </HeaderBar>
                   {menu && <LayoutNavigationDrawer menu={menu} />}
                </Header>
+               {isAdminUser && adminMessage && (
+                  <Alert status="error">
+                     <AlertIcon />
+                     <AlertTitle>{adminMessage}</AlertTitle>
+                  </Alert>
+               )}
                {children}
                <CartFooter
                   partners={currentStore.footer.partners}

--- a/packages/app/index.tsx
+++ b/packages/app/index.tsx
@@ -2,18 +2,24 @@ import * as React from 'react';
 
 export type AppContext = {
    ifixitOrigin: string;
+   adminMessage?: string;
 };
 
 const AppContext = React.createContext<AppContext | null>(null);
 
 type AppProviderProps = React.PropsWithChildren<{
    ifixitOrigin: string;
+   adminMessage?: string;
 }>;
 
-export function AppProvider({ ifixitOrigin, children }: AppProviderProps) {
+export function AppProvider({
+   ifixitOrigin,
+   adminMessage,
+   children,
+}: AppProviderProps) {
    const value = React.useMemo(
-      (): AppContext => ({ ifixitOrigin }),
-      [ifixitOrigin]
+      (): AppContext => ({ ifixitOrigin, adminMessage }),
+      [ifixitOrigin, adminMessage]
    );
 
    return <AppContext.Provider value={value}>{children}</AppContext.Provider>;


### PR DESCRIPTION
Closes #1399

Renders productlist pages with typos in their Strapi instantsearch filter instead of 500ing. The misconfiguration in Strapi is reported to Sentry.

## QA
- Add an invalid filter to a productlist on this branch's [strapi instance](https://handle-productlist-filter-typos.govinor.com/admin).
  - For example, on add the following filter to this [productlist](https://handle-productlist-filter-typos.govinor.com/admin/content-manager/collectionType/api::product-list.product-list/461?plugins[i18n][locale]=en).
```
(identifiers: 'IF145-472' OR 
identifiers: 'IF145-348' OR 
identifiers: 'IF145-335' OR 
(identifiers: 'IF145-077' OR 
identifiers: 'IF145-523' OR 
identifiers: 'IF145-307' OR 
identifiers: 'IF145-364' OR 
identifiers: 'IF317-092' OR 
identifiers: 'IF145-106' OR 
identifiers: 'IF145-238' OR 
identifiers: 'IF145-002' OR 
identifiers: 'IF145-027' OR 
identifiers: 'IF145-020') 
```
- Visit the affected productlist page (`/Tools/Xbox_Series_X_Wireless_Controller`), and note that the page renders just fine. The error will get logged in the vercel logs, and should get reported to the react-commerce-dev sentry project.

CC @sterlinghirsh 