### PR TITLE
ResponsiveImage: let next.js handle strapi images

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -135,6 +135,7 @@ const moduleExports = {
          'guide-images.cdn.ifixit.com',
          process.env.STRAPI_IMAGE_DOMAIN,
       ].filter((domain) => domain),
+      minimumCacheTTL: 3600,
    },
    i18n: {
       locales: ['en-US'],

--- a/packages/ui/misc/ResponsiveImage/index.tsx
+++ b/packages/ui/misc/ResponsiveImage/index.tsx
@@ -23,7 +23,7 @@ export function ResponsiveImage(props: ImageProps) {
       } else if (isGuideImage(props.src)) {
          loader = getIFixitImageLoader(guideImageSizeMap, 'huge', props.width);
       } else if (isStrapiImage(props.src)) {
-         unoptimized = true;
+         unoptimized = false; // let next handle optimization cache resizing
       }
    }
 


### PR DESCRIPTION
We want folks who upload images to strapi to not have to care about making their images web-ready. They should be able to upload high quality, high-res images and we can then lean on next/image to downsample and re-compress them.

Yes, vercel likely clears the image cache more than we'd like, but we have cloudfront sitting in front of them, so I'm not too worried.

I've left this check in here so there's an explicit callout (strapi images should be processed by next) rather than just an absence.

Closes #1560