### PR TITLE
Add banners section to page template

### DIFF
--- a/backend/src/api/page/content-types/page/schema.json
+++ b/backend/src/api/page/content-types/page/schema.json
@@ -50,7 +50,8 @@
             "page.press",
             "section.featured-products",
             "section.social-gallery",
-            "section.lifetime-warranty"
+            "section.lifetime-warranty",
+            "section.banner"
          ],
          "required": true
       }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2583,7 +2583,40 @@ export type FindPageQuery = {
                        value: string;
                     } | null>;
                  }
-               | { __typename: 'ComponentSectionBanner' }
+               | {
+                    __typename: 'ComponentSectionBanner';
+                    id: string;
+                    banners?: {
+                       __typename?: 'BannerRelationResponseCollection';
+                       data: Array<{
+                          __typename?: 'BannerEntity';
+                          id?: string | null;
+                          attributes?: {
+                             __typename?: 'Banner';
+                             title?: string | null;
+                             label?: string | null;
+                             description?: string | null;
+                             image?: {
+                                __typename?: 'UploadFileEntityResponse';
+                                data?: {
+                                   __typename?: 'UploadFileEntity';
+                                   attributes?: {
+                                      __typename?: 'UploadFile';
+                                      alternativeText?: string | null;
+                                      url: string;
+                                      formats?: any | null;
+                                   } | null;
+                                } | null;
+                             } | null;
+                             callToAction?: {
+                                __typename?: 'ComponentPageCallToAction';
+                                title: string;
+                                url: string;
+                             } | null;
+                          } | null;
+                       }>;
+                    } | null;
+                 }
                | {
                     __typename: 'ComponentSectionFeaturedProducts';
                     id: string;
@@ -4781,6 +4814,7 @@ export const FindPageDocument = `
           ...FeaturedProductsSectionFields
           ...SocialGallerySectionFields
           ...LifetimeWarrantySectionFields
+          ...BannersSectionFields
         }
       }
     }
@@ -4800,7 +4834,9 @@ ${CompanyFieldsFragmentDoc}
 ${FeaturedProductsSectionFieldsFragmentDoc}
 ${SocialGallerySectionFieldsFragmentDoc}
 ${SocialPostFieldsFragmentDoc}
-${LifetimeWarrantySectionFieldsFragmentDoc}`;
+${LifetimeWarrantySectionFieldsFragmentDoc}
+${BannersSectionFieldsFragmentDoc}
+${BannerFieldsFragmentDoc}`;
 export const FindProductDocument = `
     query findProduct($handle: String) {
   products(filters: {handle: {eq: $handle}}) {

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -1397,6 +1397,7 @@ export type PageSectionsDynamicZone =
    | ComponentPagePress
    | ComponentPageSplitWithImage
    | ComponentPageStats
+   | ComponentSectionBanner
    | ComponentSectionFeaturedProducts
    | ComponentSectionLifetimeWarranty
    | ComponentSectionSocialGallery
@@ -2582,6 +2583,7 @@ export type FindPageQuery = {
                        value: string;
                     } | null>;
                  }
+               | { __typename: 'ComponentSectionBanner' }
                | {
                     __typename: 'ComponentSectionFeaturedProducts';
                     id: string;

--- a/frontend/lib/strapi-sdk/operations/findPage.graphql
+++ b/frontend/lib/strapi-sdk/operations/findPage.graphql
@@ -22,6 +22,7 @@ query findPage(
                ...FeaturedProductsSectionFields
                ...SocialGallerySectionFields
                ...LifetimeWarrantySectionFields
+               ...BannersSectionFields
             }
          }
       }

--- a/frontend/models/page/index.ts
+++ b/frontend/models/page/index.ts
@@ -1,3 +1,4 @@
+import { BannersSectionSchema } from '@models/sections/banners-section';
 import { FeaturedProductsSectionSchema } from '@models/sections/featured-products-section';
 import { IFixitStatsSectionSchema } from '@models/sections/ifixit-stats-section';
 import { LifetimeWarrantySectionSchema } from '@models/sections/lifetime-warranty-section';
@@ -19,6 +20,7 @@ export const PageSectionSchema = z.union([
    FeaturedProductsSectionSchema,
    SocialGallerySectionSchema,
    LifetimeWarrantySectionSchema,
+   BannersSectionSchema,
 ]);
 
 export type Page = z.infer<typeof PageSchema>;

--- a/frontend/models/page/server.ts
+++ b/frontend/models/page/server.ts
@@ -1,6 +1,7 @@
 import { filterNullableItems } from '@helpers/application-helpers';
 import { createSectionId } from '@helpers/strapi-helpers';
 import { FindPageQuery, strapi } from '@lib/strapi-sdk';
+import { bannersSectionFromStrapi } from '@models/sections/banners-section';
 import { featuredProductsSectionFromStrapi } from '@models/sections/featured-products-section';
 import { iFixitStatsSectionFromStrapi } from '@models/sections/ifixit-stats-section';
 import { socialGallerySectionFromStrapi } from '@models/sections/social-gallery-section';
@@ -66,6 +67,9 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
                   title: section.title ?? null,
                   description: section.description ?? null,
                };
+            }
+            case 'ComponentSectionBanner': {
+               return bannersSectionFromStrapi(section, sectionId);
             }
             default: {
                return null;

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@chakra-ui/react';
+import { BannersSection } from '@components/sections/BannersSection';
 import { FeaturedProductsSection } from '@components/sections/FeaturedProductsSection';
 import { IFixitStatsSection } from '@components/sections/IFixitStatsSection';
 import { LifetimeWarrantySection } from '@components/sections/LifetimeWarrantySection';
@@ -73,6 +74,15 @@ const PageTemplate: NextPageWithLayout<PageTemplateProps> = () => {
                         key={section.id}
                         title={section.title}
                         description={section.description}
+                     />
+                  );
+               }
+               case 'Banners': {
+                  return (
+                     <BannersSection
+                        key={section.id}
+                        id={section.id}
+                        banners={section.banners}
                      />
                   );
                }


### PR DESCRIPTION
close #1558

❗❗❗After this PR is merged Strapi should be redeployed in production ❗❗❗

cc @sterlinghirsh @danielbeardsley @masonmcelvain 

## QA

1. Open [store home page preview](https://react-commerce-git-add-banners-section-to-page-template-ifixit.vercel.app/store)
2. Verify that the banners section is visible (see #1558 for reference)
3. Verify that the banners section is responsive
4. Verify that you can edit the banners from [Strapi](https://add-banners-section-to-page-template.govinor.com/admin/content-manager/collectionType/api::page.page/1?plugins[i18n][locale]=en)