### PR TITLE
Product Page: Add compatibility disclosure

### DIFF
--- a/frontend/components/common/CompatibleDevice.tsx
+++ b/frontend/components/common/CompatibleDevice.tsx
@@ -1,71 +1,127 @@
-import { Flex, Img, Text } from '@chakra-ui/react';
+import {
+   chakra,
+   Flex,
+   HTMLChakraProps,
+   Img,
+   Text,
+   useDisclosure,
+} from '@chakra-ui/react';
 import type { Product } from '@pages/api/nextjs/cache/product';
-import * as React from 'react';
+import NextLink from 'next/link';
 
-export type CompatibleDeviceProps = {
+export interface CompatibleDeviceProps extends HTMLChakraProps<'a'> {
    device: NonNullable<Product['compatibility']>['devices'][number];
    maxModelLines?: number;
-};
+   truncateModels?: boolean;
+}
 
 export function CompatibleDevice({
    device,
    maxModelLines = 0,
+   truncateModels = true,
+   ...otherProps
 }: CompatibleDeviceProps) {
-   const variants = device.variants;
-   const [visibleVariants, hiddenVariantCount] = React.useMemo(
-      () =>
-         maxModelLines > 0 && variants.length > maxModelLines
-            ? [
-                 variants.slice(0, maxModelLines - 1),
-                 variants.length - maxModelLines + 1,
-              ]
-            : [variants, 0],
-      [maxModelLines, variants]
-   );
+   const { variants } = device;
+   const [visibleVariants, hiddenVariants] =
+      maxModelLines > 0 && variants.length > maxModelLines
+         ? [variants.slice(0, maxModelLines), variants.slice(maxModelLines)]
+         : [variants, []];
+   const { isOpen, getDisclosureProps, getButtonProps, onToggle } =
+      useDisclosure();
    return (
-      <>
-         <Img
-            src={device.imageUrl}
-            alt={device.deviceName ?? ''}
-            w="12"
-            mr="3"
-            borderWidth="1px"
-            borderStyle="solid"
-            borderColor="gray.300"
-            borderRadius="base"
-         />
-         <Flex
-            minH="12"
-            flexDir="column"
-            alignSelf="flex-start"
-            justifyContent="center"
+      <NextLink href={device.deviceUrl} passHref>
+         <chakra.a
+            display="flex"
+            alignItems="start"
+            transition="all 300m"
+            {...otherProps}
          >
-            <Text
-               my="2px"
-               fontWeight="medium"
-               _groupHover={{ color: 'brand.500' }}
+            <Img
+               src={device.imageUrl}
+               alt={device.deviceName ?? ''}
+               w="12"
+               mr="3"
+               borderWidth="1px"
+               borderStyle="solid"
+               borderColor="gray.300"
+               borderRadius="base"
+            />
+            <Flex
+               minH="12"
+               flexDir="column"
+               alignSelf="flex-start"
+               justifyContent="center"
             >
-               {device.deviceName}
-            </Text>
-            <Flex flexDir="column">
-               {visibleVariants.map((variant) => (
+               <Text
+                  my="2px"
+                  fontWeight="medium"
+                  _groupHover={{ color: 'brand.500' }}
+               >
+                  {device.deviceName}
+               </Text>
+               <Flex flexDir="column">
+                  {visibleVariants.map((variant) => (
+                     <Text
+                        key={variant}
+                        lineHeight="short"
+                        fontSize="xs"
+                        color="gray.600"
+                     >
+                        {variant}
+                     </Text>
+                  ))}
+               </Flex>
+               <Flex flexDir="column" {...getDisclosureProps()}>
+                  {hiddenVariants.map((variant) => (
+                     <Text
+                        key={variant}
+                        lineHeight="short"
+                        fontSize="xs"
+                        color="gray.600"
+                     >
+                        {variant}
+                     </Text>
+                  ))}
+               </Flex>
+               {truncateModels && hiddenVariants.length > 0 && (
                   <Text
-                     key={variant}
+                     mb="2px"
                      lineHeight="short"
                      fontSize="xs"
                      color="gray.600"
                   >
-                     {variant}
+                     And {hiddenVariants.length} other model
+                     {hiddenVariants.length > 1 ? 's' : ''}...
                   </Text>
-               ))}
+               )}
+               {!truncateModels && hiddenVariants.length > 0 && (
+                  <Text
+                     mt="2px"
+                     lineHeight="short"
+                     fontSize="xs"
+                     fontWeight="medium"
+                     color="brand.500"
+                     {...getButtonProps()}
+                     onClick={(event) => {
+                        onToggle();
+                        event.preventDefault();
+                        event.stopPropagation();
+                     }}
+                     onKeyDown={(event) => {
+                        if ('Enter' === event.code) {
+                           onToggle();
+                           event.preventDefault();
+                           event.stopPropagation();
+                        }
+                     }}
+                  >
+                     {isOpen
+                        ? 'Show fewer models'
+                        : `Show all ${variants.length} models`}
+                  </Text>
+               )}
             </Flex>
-            {hiddenVariantCount > 0 && (
-               <Text mb="2px" lineHeight="short" fontSize="xs" color="gray.600">
-                  And {hiddenVariantCount} other model
-                  {hiddenVariantCount > 1 ? 's' : ''}...
-               </Text>
-            )}
-         </Flex>
-      </>
+         </chakra.a>
+      </NextLink>
    );
 }

--- a/frontend/templates/product/sections/CompatibilitySection/index.tsx
+++ b/frontend/templates/product/sections/CompatibilitySection/index.tsx
@@ -1,8 +1,7 @@
-import { Box, chakra, Heading, SimpleGrid } from '@chakra-ui/react';
+import { Box, Heading, SimpleGrid } from '@chakra-ui/react';
 import { CompatibleDevice } from '@components/common/CompatibleDevice';
 import { Wrapper } from '@ifixit/ui';
 import type { Product } from '@pages/api/nextjs/cache/product';
-import NextLink from 'next/link';
 
 export type CompatibilitySectionProps = {
    compatibility: Product['compatibility'];
@@ -30,29 +29,26 @@ export function CompatibilitySection({
                margin={{ base: 5, sm: 0 }}
             >
                {compatibility?.devices.map((device, index) => (
-                  <NextLink key={index} href={device.deviceUrl} passHref>
-                     <chakra.a
-                        display="flex"
-                        p="3"
-                        bg="white"
-                        borderWidth="1px"
-                        borderStyle="solid"
-                        borderColor="gray.300"
-                        borderRadius="base"
-                        transition="all 300ms"
-                        _hover={{
-                           boxShadow: 'md',
-                        }}
-                        alignItems="flex-start"
-                        gridColumnStart={
-                           compatibility.devices.length === 1
-                              ? { base: 1, md: 2 }
-                              : 'unset'
-                        }
-                     >
-                        <CompatibleDevice device={device} />
-                     </chakra.a>
-                  </NextLink>
+                  <CompatibleDevice
+                     key={index}
+                     device={device}
+                     maxModelLines={10}
+                     truncateModels={false}
+                     p="3"
+                     bg="white"
+                     borderWidth="1px"
+                     borderStyle="solid"
+                     borderColor="gray.300"
+                     borderRadius="base"
+                     _hover={{
+                        boxShadow: 'md',
+                     }}
+                     gridColumnStart={
+                        compatibility.devices.length === 1
+                           ? { base: 1, md: 2 }
+                           : 'unset'
+                     }
+                  />
                ))}
             </SimpleGrid>
          </Wrapper>

--- a/frontend/templates/product/sections/ProductOverviewSection/CompatibleDevices.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/CompatibleDevices.tsx
@@ -8,7 +8,7 @@ export type CompatibleDevicesProps = {
 };
 
 const MAX_VISIBLE_DEVICES = 3;
-const MAX_MODEL_LINES_PER_DEVICE = 4;
+const MAX_MODEL_LINES_PER_DEVICE = 3;
 
 export function CompatibleDevices({ product }: CompatibleDevicesProps) {
    const devices = product.compatibility?.devices ?? [];

--- a/frontend/templates/product/sections/ProductOverviewSection/CompatibleDevices.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/CompatibleDevices.tsx
@@ -1,4 +1,4 @@
-import { chakra, Link } from '@chakra-ui/react';
+import { Link } from '@chakra-ui/react';
 import { CompatibleDevice } from '@components/common';
 import type { Product } from '@pages/api/nextjs/cache/product';
 import NextLink from 'next/link';
@@ -22,20 +22,13 @@ export function CompatibleDevices({ product }: CompatibleDevicesProps) {
    return (
       <>
          {devices.slice(0, 3).map((device, index) => (
-            <NextLink key={index} href={device.deviceUrl} passHref>
-               <chakra.a
-                  role="group"
-                  display="flex"
-                  alignItems="flex-start"
-                  transition="all 300m"
-                  mb="6px"
-               >
-                  <CompatibleDevice
-                     device={device}
-                     maxModelLines={MAX_MODEL_LINES_PER_DEVICE}
-                  />
-               </chakra.a>
-            </NextLink>
+            <CompatibleDevice
+               key={index}
+               device={device}
+               maxModelLines={MAX_MODEL_LINES_PER_DEVICE}
+               role="group"
+               mb="6px"
+            />
          ))}
 
          {hasMoreToShow ? (

--- a/frontend/tests/jest/tests/CompatibleDevice.test.tsx
+++ b/frontend/tests/jest/tests/CompatibleDevice.test.tsx
@@ -22,10 +22,11 @@ describe('CompatibleDevice', () => {
    it('renders and matches the snapshot with truncated variants', async () => {
       const product = getMockProduct();
       const device = product!.compatibility!.devices[0];
+      expect(device.variants.length).toBeGreaterThan(2);
 
       // @ts-ignore
       const { asFragment } = renderWithAppContext(
-         <CompatibleDevice device={device} maxModelLines={2} />
+         <CompatibleDevice device={device} maxModelLines={1} />
       );
 
       (expect(screen.queryByText(/other models.../i)) as any).toBeVisible();

--- a/frontend/tests/jest/tests/__snapshots__/CompatibleDevice.test.tsx.snap
+++ b/frontend/tests/jest/tests/__snapshots__/CompatibleDevice.test.tsx.snap
@@ -2,39 +2,49 @@
 
 exports[`CompatibleDevice renders and matches the snapshot 1`] = `
 <DocumentFragment>
-  <img
-    alt="iPhone 6s Plus"
-    class="chakra-image css-ky1liq"
-    src="https://mmcelvain.cominor.com/igi/cMVbyIbIrTEbi2j5.thumbnail"
-  />
-  <div
-    class="css-qi8j5b"
+  <a
+    class="css-1tbib0t"
+    href="/Device/iPhone_6s_Plus"
   >
-    <p
-      class="chakra-text css-1h9z0di"
-    >
-      iPhone 6s Plus
-    </p>
+    <img
+      alt="iPhone 6s Plus"
+      class="chakra-image css-ky1liq"
+      src="https://mmcelvain.cominor.com/igi/cMVbyIbIrTEbi2j5.thumbnail"
+    />
     <div
-      class="css-j7qwjs"
+      class="css-qi8j5b"
     >
       <p
-        class="chakra-text css-4137gr"
+        class="chakra-text css-1h9z0di"
       >
-        A1634 US AT&T Locked or SIM Free
+        iPhone 6s Plus
       </p>
-      <p
-        class="chakra-text css-4137gr"
+      <div
+        class="css-j7qwjs"
       >
-        A1687 US Sprint/Verizon and Global
-      </p>
-      <p
-        class="chakra-text css-4137gr"
-      >
-        A1699 Mainland China
-      </p>
+        <p
+          class="chakra-text css-4137gr"
+        >
+          A1634 US AT&T Locked or SIM Free
+        </p>
+        <p
+          class="chakra-text css-4137gr"
+        >
+          A1687 US Sprint/Verizon and Global
+        </p>
+        <p
+          class="chakra-text css-4137gr"
+        >
+          A1699 Mainland China
+        </p>
+      </div>
+      <div
+        class="css-j7qwjs"
+        hidden=""
+        id="disclosure-:r1:"
+      />
     </div>
-  </div>
+  </a>
   <span
     hidden=""
     id="__chakra_env"
@@ -44,34 +54,55 @@ exports[`CompatibleDevice renders and matches the snapshot 1`] = `
 
 exports[`CompatibleDevice renders and matches the snapshot with truncated variants 1`] = `
 <DocumentFragment>
-  <img
-    alt="iPhone 6s Plus"
-    class="chakra-image css-ky1liq"
-    src="https://mmcelvain.cominor.com/igi/cMVbyIbIrTEbi2j5.thumbnail"
-  />
-  <div
-    class="css-qi8j5b"
+  <a
+    class="css-1tbib0t"
+    href="/Device/iPhone_6s_Plus"
   >
-    <p
-      class="chakra-text css-1h9z0di"
-    >
-      iPhone 6s Plus
-    </p>
+    <img
+      alt="iPhone 6s Plus"
+      class="chakra-image css-ky1liq"
+      src="https://mmcelvain.cominor.com/igi/cMVbyIbIrTEbi2j5.thumbnail"
+    />
     <div
-      class="css-j7qwjs"
+      class="css-qi8j5b"
     >
       <p
-        class="chakra-text css-4137gr"
+        class="chakra-text css-1h9z0di"
       >
-        A1634 US AT&T Locked or SIM Free
+        iPhone 6s Plus
+      </p>
+      <div
+        class="css-j7qwjs"
+      >
+        <p
+          class="chakra-text css-4137gr"
+        >
+          A1634 US AT&T Locked or SIM Free
+        </p>
+      </div>
+      <div
+        class="css-j7qwjs"
+        hidden=""
+        id="disclosure-:r3:"
+      >
+        <p
+          class="chakra-text css-4137gr"
+        >
+          A1687 US Sprint/Verizon and Global
+        </p>
+        <p
+          class="chakra-text css-4137gr"
+        >
+          A1699 Mainland China
+        </p>
+      </div>
+      <p
+        class="chakra-text css-1ji9qma"
+      >
+        And 2 other models...
       </p>
     </div>
-    <p
-      class="chakra-text css-1ji9qma"
-    >
-      And 2 other models...
-    </p>
-  </div>
+  </a>
   <span
     hidden=""
     id="__chakra_env"


### PR DESCRIPTION
Collapses the product page compatibility component when there are more than 10 model number lines.

## CR

The diff is easier to view with whitespace ignored.

It also seems like the Jest test that was changed was broken before. The product being tested only has 3 variants on the compatible device, so the previous test implementation should have produced `other model...`, however the test was asserting for `other models...`.

## QA
- Find a product with a compatible device that has >10 model numbers.
- Make sure the implementation matches the disclosure [mockup](https://www.figma.com/file/BolmFORO6ZfHXePOSyEGSS/iFixit---Page-sections?node-id=159-5560) (disregard the search bar for this PR).
- Make sure _both_ compatibility components otherwise match their `main` counterparts.

Closes https://github.com/iFixit/react-commerce/issues/1436