### PR TITLE
Sentry: Drop invalid strapi filter reporting

### DIFF
--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -15,7 +15,6 @@ import type { DefaultLayoutProps } from '@layouts/default/server';
 import { getLayoutServerSideProps } from '@layouts/default/server';
 import { ProductList, ProductListType } from '@models/product-list';
 import { findProductList } from '@models/product-list/server';
-import * as Sentry from '@sentry/nextjs';
 import compose from 'lodash/flowRight';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { ParsedUrlQuery } from 'querystring';
@@ -238,11 +237,6 @@ async function getSafeServerState({
       return { serverState: await tryGetServerState(productList) };
    } catch (e) {
       console.error('Error getting instantsearch server state', e);
-      Sentry.withScope((scope) => {
-         scope.setExtra('Productlist', productList);
-         scope.setExtra('Filters from Strapi', productList?.filters);
-         Sentry.captureException(e);
-      });
       const serverState = await tryGetServerState({
          ...productList,
          filters: null,


### PR DESCRIPTION
Drops a sentry report about invalid strapi filters. We already have a UI component to alert Strapi admin users that the filter field is invalid, so reporting to Sentry is just extra noise.

qa_req 0