### PR TITLE
Product pages: Add Reviews Edit Button for Admin

### DIFF
--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -122,6 +122,7 @@ export function ProductReviewsSection({
                            <ProductReviewLineItem
                               key={review.reviewid}
                               review={review}
+                              variantSku={selectedVariant.sku}
                            />
                         );
                      })}
@@ -234,6 +235,25 @@ function ProductReviewLineItem({
          borderColor="gray.200"
          data-testid="product-review-line-item"
       >
+         {isAdminUser && (
+            <Button
+               variant="link"
+               as={Link}
+               bgColor="transparent"
+               textColor="brand"
+               fontFamily="heading"
+               lineHeight="1.29"
+               fontWeight="semibold"
+               fontSize="14px"
+               color="brand.500"
+               textAlign="center"
+               paddingBottom="10px"
+               href={`${appContext.ifixitOrigin}/User/Reviews/${variantSku}/userid=${review.author?.userid}`}
+            >
+               Edit
+            </Button>
+         )}
+
          {review.author && (
             <HStack>
                <Avatar

--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -248,7 +248,7 @@ function ProductReviewLineItem({
                color="brand.500"
                textAlign="center"
                paddingBottom="10px"
-               href={`${appContext.ifixitOrigin}/User/Reviews/${variantSku}/userid=${review.author?.userid}`}
+               href={`${appContext.ifixitOrigin}/User/Reviews/${variantSku}?userid=${review.author?.userid}`}
             >
                Edit
             </Button>

--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -235,7 +235,7 @@ function ProductReviewLineItem({
          borderColor="gray.200"
          data-testid="product-review-line-item"
       >
-         {isAdminUser && (
+         {isAdminUser && $variantSku && (
             <Button
                variant="link"
                as={Link}

--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -25,6 +25,7 @@ import { Wrapper } from '@ifixit/ui';
 import type { Product, ProductVariant } from '@models/product';
 import type { ProductReview } from '@models/product/reviews';
 import { useProductReviews } from '@templates/product/hooks/useProductReviews';
+import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import React from 'react';
 
 const INITIAL_VISIBILE_REVIEWS = 3;
@@ -217,8 +218,15 @@ function ReviewsStats({
 
 type ProductReviewLineItemProps = {
    review: ProductReview;
+   variantSku: string | undefined | null;
 };
-function ProductReviewLineItem({ review }: ProductReviewLineItemProps) {
+function ProductReviewLineItem({
+   review,
+   variantSku,
+}: ProductReviewLineItemProps) {
+   const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
+   const appContext = useAppContext();
+
    return (
       <Box
          py="6"

--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -235,7 +235,7 @@ function ProductReviewLineItem({
          borderColor="gray.200"
          data-testid="product-review-line-item"
       >
-         {isAdminUser && $variantSku && (
+         {isAdminUser && variantSku && (
             <Button
                variant="link"
                as={Link}


### PR DESCRIPTION
The new react product pages didn't have the `Edit` option for reviews. This PR adds the edit button for admins.

## QA
- If you go to this [link](https://react-commerce-git-product-pages-add-admin-reviews-edit-ifixit.vercel.app/products/mako-driver-kit-64-precision-bits), for example, should now have an edit option if logged in as Admin.
- The redirect from the Edit button should be similar to how it is [here](https://www.ifixit.com/Store/Tools/Pro-Tech-Toolkit/IF145-307#)

Closes #1500 