### PR TITLE
Playwright: Add Test Suites to Trace Output Path

### DIFF
--- a/frontend/tests/playwright/fixtures/trace-override.ts
+++ b/frontend/tests/playwright/fixtures/trace-override.ts
@@ -6,21 +6,20 @@ export function traceOutputDirTemplate(testInfo: TestInfo) {
    // in the Playwright config
    const globalOutputDir = testInfo.project.outputDir;
 
-   // titlePath houses the path to the test file relevant to the test directory
-   // e.g. 'product/add_to_cart.spec.ts' -> 'product/add_to_cart'
-   const testFile = testInfo.titlePath[0].replace(/\.spec\.ts$/, '');
-
-   const testName = formatTestNameForDirectory(testInfo.title);
+   // titlePath houses a split up path to the test case which includes:
+   // - The test file name and relative path from the test directory (e.g. 'product/add_to_cart.spec.ts')
+   // - The test suite names (e.g. test.describe('<test suite name>', ...))
+   // - The test case name (e.g. test('<test case name>', ...))
+   const testCasePath = formatName(
+      testInfo.titlePath.join('/').replace(/\.spec\.ts/, '')
+   );
 
    // The 'device' the test was ran on
-   const projectName = testInfo.project.name.replace(/\s/g, '-').toLowerCase();
+   const projectName = formatName(testInfo.project.name);
 
-   return path.join(globalOutputDir, testFile, testName, projectName);
+   return path.join(globalOutputDir, testCasePath, projectName);
 }
 
-function formatTestNameForDirectory(testName: string) {
-   const formattedName = testName.replace(/[^a-zA-Z0-9]+/g, '-');
-   const directoryName = formattedName.toLowerCase();
-
-   return directoryName;
+function formatName(name: string) {
+   return name.replace(/[^a-zA-Z0-9//]+/g, '-').toLowerCase();
 }


### PR DESCRIPTION
## Description

We added this trace fixture in https://github.com/iFixit/react-commerce/pull/1563, but while addressing https://github.com/iFixit/react-commerce/issues/1569 I noticed an issue with the trace output path. There are some test cases that have similar names, but are under different test suites. This causes the trace outputs to be overwritten.

To fix this, we can take full advantage of the `titlePath` property to create the trace output path. The `titlePath` property is a convenient array of strings that represents the relative path to the test case from root test directory. This includes the file name, the test suite tree, and the test case name.

In addition, we can refactor the `formatTestNameForDirectory` function for more general usage. As such it will now be called `formatName`.

|Before|After|
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/22064420/231808979-41a393b1-3039-411f-a682-264bf1d15483.png) |  ![image](https://user-images.githubusercontent.com/22064420/231808416-0b39d660-228d-4c27-811b-55f3e415f5ca.png)     |


qa_req 0

Connects: #1569 
Connects: #1496 
