### PR TITLE
GitHub Actions: Fix Duplicate Nextjs Bundle Analysis Comments

### DIFF
--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -54,7 +54,7 @@ jobs:
          # Here's the first place where next-bundle-analysis' own script is used
          # This step pulls the raw bundle stats for the current bundle
          - name: Analyze bundle
-           run: npx -p nextjs-bundle-analysis report
+           run: npx -p nextjs-bundle-analysis@0.5.0 report
 
          - name: Upload bundle
            uses: actions/upload-artifact@v2
@@ -85,7 +85,7 @@ jobs:
          # entry in your package.json file.
          - name: Compare with base branch bundle
            if: success() && github.event.number
-           run: ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis compare
+           run: ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis@0.5.0 compare
 
          - name: Get comment body
            id: get-comment-body

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -103,7 +103,8 @@ jobs:
            id: fc
            with:
               issue-number: ${{ github.event.number }}
-              body-includes: '<!-- __NEXTJS_BUNDLE -->'
+              comment-author: 'github-actions[bot]'
+              body-includes: 'Next.js Bundle Analysis'
 
          - name: Create or Update comment
            uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
## Description 

The `nextjs-bundle-analysis package` has been updated, which caused a change in the comment text that the search logic was previously relying on. The relevant change can be found in the following commit: hashicorp/nextjs-bundle-analysis@067cb5d

Due to this update, a new `Nextjs Bundle Analysis` comment is created on every new run instead of updating the existing comment in the PR.

### CR Notes:

This updates the comment finding logic to use a different substring and to ensure it is from the `github-actions[bot]` user. 

To avoid this issue in the future I added a specific version to use for `npx -p nextjs-bundle-analysis`. 

### QA Notes:

- [ ] Verify the `Next.js Bundle Analysis` comment does not get duplicated on new pull workflow runs.

Closes: #1578 
