### PR TITLE
Product Page: Use Sorted Variants (with no bugs!)

### DIFF
--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -5,6 +5,16 @@ import { z } from 'zod';
 
 export type DeviceWiki = Record<string, any>;
 
+export type DeviceWikiApiResponse = {
+   variantOptions: {
+      [o_code: string]: string[];
+   };
+};
+
+export type VariantOptions = {
+   [o_code: string]: string[];
+};
+
 export async function fetchDeviceWiki(
    client: IFixitAPIClient,
    deviceTitle: string
@@ -16,6 +26,22 @@ export async function fetchDeviceWiki(
          'deviceHandle cannot be a blank string'
       );
       return await client.get(`cart/part_collections/devices/${deviceHandle}`);
+   } catch (error: any) {
+      return null;
+   }
+}
+
+export async function fetchProductData(
+   client: IFixitAPIClient,
+   handle: string
+): Promise<DeviceWikiApiResponse | null> {
+   const productHandle = encodeURIComponent(handle);
+   try {
+      invariant(
+         productHandle.length > 0,
+         'productHandle cannot be a blank string'
+      );
+      return await client.get(`store/product/${productHandle}`);
    } catch (error: any) {
       return null;
    }

--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -5,16 +5,6 @@ import { z } from 'zod';
 
 export type DeviceWiki = Record<string, any>;
 
-export type DeviceWikiApiResponse = {
-   variantOptions: {
-      [o_code: string]: string[];
-   };
-};
-
-export type VariantOptions = {
-   [o_code: string]: string[];
-};
-
 export async function fetchDeviceWiki(
    client: IFixitAPIClient,
    deviceTitle: string
@@ -26,22 +16,6 @@ export async function fetchDeviceWiki(
          'deviceHandle cannot be a blank string'
       );
       return await client.get(`cart/part_collections/devices/${deviceHandle}`);
-   } catch (error: any) {
-      return null;
-   }
-}
-
-export async function fetchProductData(
-   client: IFixitAPIClient,
-   handle: string
-): Promise<DeviceWikiApiResponse | null> {
-   const productHandle = encodeURIComponent(handle);
-   try {
-      invariant(
-         productHandle.length > 0,
-         'productHandle cannot be a blank string'
-      );
-      return await client.get(`store/product/${productHandle}`);
    } catch (error: any) {
       return null;
    }

--- a/frontend/lib/ifixit-api/productData.ts
+++ b/frontend/lib/ifixit-api/productData.ts
@@ -1,0 +1,28 @@
+import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
+import { invariant } from '@ifixit/helpers';
+
+export type ProductDataApiResponse = {
+   variantOptions: {
+      [o_code: string]: string[];
+   };
+};
+
+export type VariantOptions = {
+   [o_code: string]: string[];
+};
+
+export async function fetchProductData(
+   client: IFixitAPIClient,
+   handle: string
+): Promise<ProductDataApiResponse | null> {
+   const productHandle = encodeURIComponent(handle);
+   try {
+      invariant(
+         productHandle.length > 0,
+         'productHandle cannot be a blank string'
+      );
+      return await client.get(`store/product/${productHandle}`);
+   } catch (error: any) {
+      return null;
+   }
+}

--- a/frontend/models/product/components/product-option.ts
+++ b/frontend/models/product/components/product-option.ts
@@ -15,7 +15,7 @@ export function productOptionFromShopify(
    variants: ProductVariant[],
    iFixitOptions?: string[]
 ): ProductOption {
-   const values = iFixitOptions ?? option.values;
+   const values = iFixitOptions?.length ? iFixitOptions : option.values;
    const valuesWithMatchingVariants = values.filter((value: string) =>
       valueHasMatchingVariant(value, option, variants)
    );

--- a/frontend/models/product/components/product-option.ts
+++ b/frontend/models/product/components/product-option.ts
@@ -12,9 +12,11 @@ export const ProductOptionSchema = z.object({
 
 export function productOptionFromShopify(
    option: ProductOptionFieldsFragment,
-   variants: ProductVariant[]
+   variants: ProductVariant[],
+   iFixitOptions?: string[]
 ): ProductOption {
-   const valuesWithMatchingVariants = option.values.filter((value) =>
+   const values = iFixitOptions ?? option.values;
+   const valuesWithMatchingVariants = values.filter((value: string) =>
       valueHasMatchingVariant(value, option, variants)
    );
    return {

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -45,6 +45,7 @@ import {
    ProductVideosSchema,
 } from './components/product-video';
 import { getProductSections, ProductSectionSchema } from './sections';
+import { DeviceWikiApiResponse } from '@lib/ifixit-api/devices';
 
 export type {
    ProductVariant,
@@ -84,15 +85,18 @@ export const ProductSchema = z.object({
 
 type ShopifyProduct = NonNullable<ShopifyFindProductQuery['product']>;
 type StrapiProduct = NonNullable<StrapiFindProductQuery['products']>['data'][0];
+type iFixitProduct = NonNullable<DeviceWikiApiResponse>;
 
 interface GetProductArgs {
    shopifyProduct: ShopifyProduct | null | undefined;
    strapiProduct: StrapiProduct | null | undefined;
+   iFixitProduct: iFixitProduct | null | undefined;
 }
 
 export async function getProduct({
    shopifyProduct,
    strapiProduct,
+   iFixitProduct,
 }: GetProductArgs): Promise<Product | null> {
    if (shopifyProduct == null) return null;
 
@@ -131,7 +135,11 @@ export async function getProduct({
       tags: shopifyProduct.tags,
       images: imagesFromQueryProduct(shopifyProduct, variants),
       options: shopifyProduct.options.map((option) =>
-         productOptionFromShopify(option, variants)
+         productOptionFromShopify(
+            option,
+            variants,
+            iFixitProduct?.variantOptions[option.name]
+         )
       ),
       variants,
       isEnabled: hasActiveVariants,

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -45,7 +45,7 @@ import {
    ProductVideosSchema,
 } from './components/product-video';
 import { getProductSections, ProductSectionSchema } from './sections';
-import { DeviceWikiApiResponse } from '@lib/ifixit-api/devices';
+import { ProductDataApiResponse } from '@lib/ifixit-api/productData';
 
 export type {
    ProductVariant,
@@ -85,7 +85,7 @@ export const ProductSchema = z.object({
 
 type ShopifyProduct = NonNullable<ShopifyFindProductQuery['product']>;
 type StrapiProduct = NonNullable<StrapiFindProductQuery['products']>['data'][0];
-type iFixitProduct = NonNullable<DeviceWikiApiResponse>;
+type iFixitProduct = NonNullable<ProductDataApiResponse>;
 
 interface GetProductArgs {
    shopifyProduct: ShopifyProduct | null | undefined;

--- a/frontend/models/product/server.ts
+++ b/frontend/models/product/server.ts
@@ -3,15 +3,19 @@ import { getServerShopifyStorefrontSdk } from '@lib/shopify-storefront-sdk';
 import { strapi } from '@lib/strapi-sdk';
 import { Product, getProduct } from '.';
 import { findStoreByCode } from '../store';
+import { fetchProductData } from '@lib/ifixit-api/devices';
+import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
 
 export type FindProductArgs = {
    handle: string;
    storeCode: string;
+   ifixitOrigin: string;
 };
 
 export async function findProduct({
    handle,
    storeCode,
+   ifixitOrigin,
 }: FindProductArgs): Promise<Product | null> {
    const store = await findStoreByCode(storeCode);
    const { storefrontDomain, storefrontDelegateAccessToken } = store.shopify;
@@ -23,21 +27,26 @@ export async function findProduct({
       shopDomain: storefrontDomain,
       storefrontDelegateToken: storefrontDelegateAccessToken,
    });
-
-   const [shopifyQueryResponse, strapiQueryResponse] = await Promise.all([
-      timeAsync('shopify_api.findProduct', () =>
-         storefront.findProduct({
+   const [shopifyQueryResponse, strapiQueryResponse, iFixitQueryResponse] =
+      await Promise.all([
+         timeAsync('shopify_api.findProduct', () =>
+            storefront.findProduct({
+               handle,
+            })
+         ),
+         strapi.findProduct({
             handle,
-         })
-      ),
-      strapi.findProduct({
-         handle,
-      }),
-   ]);
+         }),
+         fetchProductData(
+            new IFixitAPIClient({ origin: ifixitOrigin }),
+            handle
+         ),
+      ]);
 
    const product = await getProduct({
       shopifyProduct: shopifyQueryResponse.product,
       strapiProduct: strapiQueryResponse.products?.data[0],
+      iFixitProduct: iFixitQueryResponse,
    });
    if (product == null) {
       return null;

--- a/frontend/models/product/server.ts
+++ b/frontend/models/product/server.ts
@@ -3,7 +3,7 @@ import { getServerShopifyStorefrontSdk } from '@lib/shopify-storefront-sdk';
 import { strapi } from '@lib/strapi-sdk';
 import { Product, getProduct } from '.';
 import { findStoreByCode } from '../store';
-import { fetchProductData } from '@lib/ifixit-api/devices';
+import { fetchProductData } from '@lib/ifixit-api/productData';
 import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
 
 export type FindProductArgs = {

--- a/frontend/pages/api/nextjs/cache/product.ts
+++ b/frontend/pages/api/nextjs/cache/product.ts
@@ -16,12 +16,14 @@ export default withCache({
    variablesSchema: z.object({
       handle: z.string(),
       storeCode: z.string(),
+      ifixitOrigin: z.string(),
    }),
    valueSchema: ProductSchema.nullable(),
-   async getFreshValue({ handle, storeCode }) {
+   async getFreshValue({ handle, storeCode, ifixitOrigin }) {
       return findProduct({
          handle,
          storeCode,
+         ifixitOrigin,
       });
    },
    ttl: Duration(1).minute,

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -23,9 +23,11 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       const { stores, ...otherLayoutProps } = await getLayoutServerSideProps({
          storeCode: DEFAULT_STORE_CODE,
       });
+      const ifixitOrigin = ifixitOriginFromHost(context);
       const product = await Product.get({
          handle,
          storeCode: DEFAULT_STORE_CODE,
+         ifixitOrigin,
       });
 
       if (product == null) {

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -73,7 +73,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
             stores: storesWithProductUrls,
          },
          appProps: {
-            ifixitOrigin: ifixitOriginFromHost(context),
+            ifixitOrigin: ifixitOrigin,
          },
          product,
       };


### PR DESCRIPTION
## Overview
![Alt Text](https://media.tenor.com/idcVQVMSDvMAAAAC/again-guess-whos-back-again.gif)

A redux of https://github.com/iFixit/react-commerce/pull/1572
Same as last time but this time empty option fields fall back to shopify option values. This should solve the issues we were seeing on pages like [repair business toolkit](https://ifixit.slack.com/archives/C0252FETV2S/p1681408439081469)

## QA
Same as last time but make sure it works on the repair business toolkit as well. 