### PR TITLE
Reviews Edit : Use sku for url

### DIFF
--- a/frontend/models/product/reviews.ts
+++ b/frontend/models/product/reviews.ts
@@ -19,6 +19,7 @@ export type ProductReview = Partial<{
    modified_date: number;
    productName: string;
    productVariantName: string;
+   sku: string;
    rating: number;
    reviewid: number;
 }>;

--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -230,7 +230,7 @@ function ProductReviewLineItem({ review }: ProductReviewLineItemProps) {
          borderColor="gray.200"
          data-testid="product-review-line-item"
       >
-         {isAdminUser && variantSku && (
+         {isAdminUser && (
             <Button
                variant="link"
                as={Link}

--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -122,7 +122,6 @@ export function ProductReviewsSection({
                            <ProductReviewLineItem
                               key={review.reviewid}
                               review={review}
-                              variantSku={selectedVariant.sku}
                            />
                         );
                      })}
@@ -219,12 +218,8 @@ function ReviewsStats({
 
 type ProductReviewLineItemProps = {
    review: ProductReview;
-   variantSku: string | undefined | null;
 };
-function ProductReviewLineItem({
-   review,
-   variantSku,
-}: ProductReviewLineItemProps) {
+function ProductReviewLineItem({ review }: ProductReviewLineItemProps) {
    const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
    const appContext = useAppContext();
 
@@ -248,7 +243,7 @@ function ProductReviewLineItem({
                color="brand.500"
                textAlign="center"
                paddingBottom="10px"
-               href={`${appContext.ifixitOrigin}/User/Reviews/${variantSku}?userid=${review.author?.userid}`}
+               href={`${appContext.ifixitOrigin}/User/Reviews/${review.sku}?userid=${review.author?.userid}`}
             >
                Edit
             </Button>


### PR DESCRIPTION
@c00perdanny pointed out in https://github.com/iFixit/react-commerce/issues/1500#issuecomment-1507555803 that the url that the Edit button points to is incorrect. 

In https://github.com/iFixit/ifixit/pull/47399, we add the sku field to the API. This allows us to access the sku for the product that corresponds to a review.

This PR uses this new field to build the correct url. 

Closes #1500 

CC: @danielbeardsley 