### PR TITLE
Strapi deploy: announce it to slack

### DIFF
--- a/backend/strapi-deploy
+++ b/backend/strapi-deploy
@@ -4,6 +4,7 @@ set -o pipefail -e nounset
 
 export STRAPI_COMMIT=$(git rev-parse HEAD)
 DEPLOY_TAG=last-strapi-deploy
+SLACK="/home/ifixit/Code/Exec/slackAnnounce.php"
 
 git fetch --tags --quiet
 
@@ -21,11 +22,16 @@ if git diff "$DEPLOY_TAG...HEAD" --exit-code --name-only -- backend/; then
 fi
 echo "There have been changes to the backend/ dir since then, deploying strapi at $STRAPI_COMMIT"
 
+SUBJECT=$(git rev-list --format="%s" --max-count=1 "$STRAPI_COMMIT" | tail -1)
+COMMIT_LINK="<https://$BUILD_REPO/commit/$STRAPI_COMMIT|${SUBJECT}>"
+DEPLOY_LOG_TS=$($SLACK --message="Strapi Deploy: Deploying ${COMMIT_LINK} - 📃 <$BUILD_LOG_URL|build log>")
+$SLACK --thread_ts="$DEPLOY_LOG_TS" --message="Building Docker image"
 
 strapi_dir="$(git rev-parse --show-toplevel)/backend"
 cd "$strapi_dir"
 ./build-docker-and-push
 
+$SLACK --thread_ts="$DEPLOY_LOG_TS" --message="Deploying"
 # Yes, capistrano is only available in our main repo...
 # This wont be a problem when these repos are joined though :-)
 cd /home/ifixit/Code
@@ -35,3 +41,5 @@ cap prod strapi:deploy
 cd "$strapi_dir"
 git tag -f "$DEPLOY_TAG" "$STRAPI_COMMIT"
 git push -f origin "$DEPLOY_TAG"
+
+$SLACK --thread_ts="$DEPLOY_LOG_TS" --message="Deploy complete!"


### PR DESCRIPTION
Just like our main app deploy

Yes, this is borrowing a tool from our main repo, but these will soon be one repo, so I'm not concerned long term.