### PR TITLE
Product Page:  Compatibility Notes Section

### DIFF
--- a/frontend/lib/ifixit-api/productData.ts
+++ b/frontend/lib/ifixit-api/productData.ts
@@ -5,10 +5,7 @@ export type ProductDataApiResponse = {
    variantOptions: {
       [o_code: string]: string[];
    };
-};
-
-export type VariantOptions = {
-   [o_code: string]: string[];
+   compatibilityNotes: string;
 };
 
 export async function fetchProductData(

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -72,6 +72,7 @@ export const ProductSchema = z.object({
    productVideos: z.string().nullable(),
    productVideosJson: ProductVideosSchema.nullable(),
    compatibility: ProductDeviceCompatibilitySchema.nullable(),
+   compatibilityNotes: z.string().nullable(),
    metaTitle: z.string().nullable(),
    shortDescription: z.string().nullable(),
    reviews: ProductReviewsSchema.nullable(),
@@ -152,6 +153,7 @@ export async function getProduct({
       compatibility: productDeviceCompatibilityFromMetafield(
          shopifyProduct.compatibility?.value
       ),
+      compatibilityNotes: iFixitProduct?.compatibilityNotes ?? null,
       metaTitle: shopifyProduct.metaTitle?.value ?? null,
       shortDescription: shopifyProduct.shortDescription?.value ?? null,
       reviews: productReviewsFromMetafields(

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -85,7 +85,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
          }),
       [product.productcode, product.id]
    );
-
+   const hasCompatibilityNotes = !!product.compatibilityNotes;
    return (
       <React.Fragment key={product.handle}>
          <MetaTags product={product} selectedVariant={selectedVariant} />
@@ -190,10 +190,12 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                   }
                   case 'DeviceCompatibility':
                      return (
-                        <CompatibilitySection
-                           key={section.id}
-                           compatibility={product.compatibility}
-                        />
+                        !hasCompatibilityNotes && (
+                           <CompatibilitySection
+                              key={section.id}
+                              compatibility={product.compatibility}
+                           />
+                        )
                      );
                   case 'FeaturedProducts': {
                      return (

--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -65,7 +65,7 @@ export function ProductOverviewSection({
       [onVariantChange]
    );
    const isForSale = useIsProductForSale(product);
-
+   const hasCompatibilityNotes = !!product.compatibilityNotes;
    return (
       <Wrapper as="section" id={PRODUCT_OVERVIEW_SECTION_ID} mb="16" pt="6">
          <Flex>
@@ -219,12 +219,25 @@ export function ProductOverviewSection({
                         product.compatibility.devices.length <= 0
                      }
                   >
-                     <CustomAccordionButton>
-                        Compatibility
-                     </CustomAccordionButton>
-                     <CustomAccordionPanel data-testid="product-compatibility-dropdown">
-                        <CompatibleDevices product={product} />
-                     </CustomAccordionPanel>
+                     {hasCompatibilityNotes ? (
+                        <>
+                           <CustomAccordionButton>
+                              Compatibility Notes
+                           </CustomAccordionButton>
+                           <CustomAccordionPanel>
+                              {product.compatibilityNotes}
+                           </CustomAccordionPanel>
+                        </>
+                     ) : (
+                        <>
+                           <CustomAccordionButton>
+                              Compatibility
+                           </CustomAccordionButton>
+                           <CustomAccordionPanel data-testid="product-compatibility-dropdown">
+                              <CompatibleDevices product={product} />
+                           </CustomAccordionPanel>
+                        </>
+                     )}
                   </AccordionItem>
 
                   <WikiHtmlAccordianItem title="Specifications">

--- a/frontend/tests/jest/__mocks__/products/battery.ts
+++ b/frontend/tests/jest/__mocks__/products/battery.ts
@@ -161,6 +161,7 @@ export const mockedBatteryProduct: Product = {
       ],
       hasMoreDevices: false,
    },
+   compatibilityNotes: null,
    metaTitle: 'Moto G7 Play Battery',
    shortDescription:
       'Replace a JE40 model battery compatible with the Motorola Moto G7 Play smartphone.  3000 mAh. 11.4 Watt Hours (Wh). 3.8 Volts (V).',

--- a/frontend/tests/jest/__mocks__/products/generic.ts
+++ b/frontend/tests/jest/__mocks__/products/generic.ts
@@ -258,6 +258,7 @@ export const mockedProduct: Product = {
       ],
       hasMoreDevices: false,
    },
+   compatibilityNotes: null,
    metaTitle: 'iPhone 6s Plus Battery: Replacement Part / Repair Kit',
    shortDescription:
       'A new replacement 2750 mAh battery compatible with the iPhone 6s Plus. 3.80 Volts (V), 10.45 Watt Hours (Wh). This replacement does not require soldering and is compatible with all iPhone 6s Plus models (not iPhone 6, 6 Plus, or 6s).',

--- a/frontend/tests/jest/__mocks__/products/part.ts
+++ b/frontend/tests/jest/__mocks__/products/part.ts
@@ -170,6 +170,7 @@ export const mockedPartProduct: Product = {
       ],
       hasMoreDevices: false,
    },
+   compatibilityNotes: null,
    metaTitle: 'Galaxy A51 Screen',
    shortDescription:
       'Replace an AMOLED screen compatible with the Samsung Galaxy A51 smartphone.',

--- a/frontend/tests/jest/__mocks__/products/tool.ts
+++ b/frontend/tests/jest/__mocks__/products/tool.ts
@@ -109,6 +109,7 @@ export const mockedToolProduct: Product = {
    productVideos: null,
    productVideosJson: null,
    compatibility: null,
+   compatibilityNotes: null,
    metaTitle: 'Hakko 5B SA Curved Tweezers',
    shortDescription: 'Hakko 5B SA Curved tweezers great for microsoldering.',
    oemPartnership: null,


### PR DESCRIPTION
## Overview

Now that we have them being [returned by the product api,](https://github.com/iFixit/ifixit/pull/47394) we can use the compatibility notes on the product page. This replaces the compatibility sidebar section with a compatibility notes section if the api returned some. It also hides the compatibility section on the page if there are compatibility notes. 

## QA
Make sure that the compatibility notes display correctly on the page and the compatibility section is hidden when appropriate.
@sterlinghirsh its ok for the compatibility notes to just be a block of text right?

Closes: #https://github.com/iFixit/ifixit/issues/47096