### PR TITLE
Swap kit contents and assembly contents position

### DIFF
--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -205,12 +205,12 @@ export function ProductOverviewSection({
                      </CustomAccordionPanel>
                   </AccordionItem>
 
-                  <WikiHtmlAccordianItem title="Kit contents">
-                     {selectedVariant.kitContents}
-                  </WikiHtmlAccordianItem>
-
                   <WikiHtmlAccordianItem title="Assembly contents">
                      {selectedVariant.assemblyContents}
+                  </WikiHtmlAccordianItem>
+
+                  <WikiHtmlAccordianItem title="Kit contents">
+                     {selectedVariant.kitContents}
                   </WikiHtmlAccordianItem>
 
                   <AccordionItem


### PR DESCRIPTION
closes #1598 

Swapped as requested.
The first two accordion item in the list were expanded by default (`Description` and `Kit contents`)
Since `Assembly contents` has more relevance than `Kit contents` I supposed that `Assembly contents` should now be the one expanded by default.

### QA

1. Visit Vercel Preview
2. Verify that the accordions are now ordered as requested