### PR TITLE
Cache invalidation: make request to stable host

### DIFF
--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -56,7 +56,8 @@ export const CACHE_DISABLED = process.env.NEXT_PUBLIC_CACHE_DISABLED === 'true';
 
 export const REDIS_URL = process.env.REDIS_URL;
 
-export const VERCEL_HOST = process.env.VERCEL_URL;
+export const VERCEL_HOST =
+   process.env.VERCEL_STABLE_HOST || process.env.VERCEL_URL;
 
 export const COLORLESS_LOGS = process.env.COLORLESS_LOGS;
 

--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -56,7 +56,7 @@ export const CACHE_DISABLED = process.env.NEXT_PUBLIC_CACHE_DISABLED === 'true';
 
 export const REDIS_URL = process.env.REDIS_URL;
 
-export const VERCEL_URL = process.env.VERCEL_URL;
+export const VERCEL_HOST = process.env.VERCEL_URL;
 
 export const COLORLESS_LOGS = process.env.COLORLESS_LOGS;
 

--- a/frontend/lib/swr-cache/index.ts
+++ b/frontend/lib/swr-cache/index.ts
@@ -15,7 +15,7 @@
  *   e.g. `const productList = await ProductList.get({ ... })`
  */
 
-import { APP_ORIGIN, VERCEL_URL } from '@config/env';
+import { APP_ORIGIN, VERCEL_HOST } from '@config/env';
 import { log as defaultLog, Logger } from '@ifixit/helpers';
 import * as http from 'http';
 import * as https from 'https';
@@ -32,7 +32,7 @@ import {
    printZodError,
 } from './utils';
 
-const { request } = VERCEL_URL ? https : http;
+const { request } = VERCEL_HOST ? https : http;
 
 interface CacheOptions<
    VariablesSchema extends z.ZodTypeAny,
@@ -86,8 +86,8 @@ export const withCache = <
          }, 50);
          const postData = JSON.stringify(variables);
          const req = request({
-            hostname: VERCEL_URL || new URL(APP_ORIGIN).hostname,
-            ...(!VERCEL_URL && { port: new URL(APP_ORIGIN).port }),
+            hostname: VERCEL_HOST || new URL(APP_ORIGIN).hostname,
+            ...(!VERCEL_HOST && { port: new URL(APP_ORIGIN).port }),
             path: `/${endpoint}`,
             method: 'POST',
             headers: {


### PR DESCRIPTION
In prod, VERCEL_URL looks like: react-commerce-prod-48uflsij4-ifixit.vercel.app

While this does correct to the correct service, it's reported to the
in the logs (and thus to datadog) as a different service who's name
keeps changing. This makes filtering logs for just react-commerce logs
really hard.

Let's allow overriding this in an env var.

qa_req 0 (CI + typescript is enough)