### PR TITLE
Strapi: time all calls to strapi

### DIFF
--- a/frontend/models/global-settings.ts
+++ b/frontend/models/global-settings.ts
@@ -1,5 +1,6 @@
 import { strapi } from '@lib/strapi-sdk';
 import { cache } from '@lib/cache';
+import { timeAsync } from '@ifixit/helpers';
 
 export interface GlobalSettings {
    newsletterForm: {
@@ -15,7 +16,10 @@ export async function getGlobalSettings(): Promise<GlobalSettings> {
 }
 
 async function getGlobalSettingsFromStrapi(): Promise<GlobalSettings> {
-   const result = await strapi.getGlobalSettings();
+   const result = await timeAsync(
+      'strapi.getGlobalSettings',
+      strapi.getGlobalSettings
+   );
    const newsletterForm =
       result.global?.data?.attributes?.newsletterForm || null;
    if (newsletterForm == null) {

--- a/frontend/models/page/server.ts
+++ b/frontend/models/page/server.ts
@@ -11,19 +11,22 @@ import type { Page, PageSection } from '.';
 import { browseSectionFromStrapi } from './sections/browse-section';
 import { heroSectionFromStrapi } from './sections/hero-section';
 import { pressQuotesSectionFromStrapi } from './sections/press-quotes-section';
+import { timeAsync } from '@ifixit/helpers';
 
 interface FindPageArgs {
    path: string;
 }
 
 export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
-   const response = await strapi.findPage({
-      filters: {
-         path: {
-            eq: path,
+   const response = await timeAsync('strapi.findPage', () =>
+      strapi.findPage({
+         filters: {
+            path: {
+               eq: path,
+            },
          },
-      },
-   });
+      })
+   );
    const page = pageFromStrapi(response);
 
    if (page == null) {

--- a/frontend/models/product/server.ts
+++ b/frontend/models/product/server.ts
@@ -34,9 +34,11 @@ export async function findProduct({
                handle,
             })
          ),
-         strapi.findProduct({
-            handle,
-         }),
+         timeAsync('strapi.findProduct', () =>
+            strapi.findProduct({
+               handle,
+            })
+         ),
          fetchProductData(
             new IFixitAPIClient({ origin: ifixitOrigin }),
             handle

--- a/frontend/models/store.ts
+++ b/frontend/models/store.ts
@@ -3,6 +3,7 @@ import type { Awaited } from '@helpers/application-helpers';
 import { cache } from '@lib/cache';
 import type { FindStoreQuery } from '@lib/strapi-sdk';
 import { strapi } from '@lib/strapi-sdk';
+import { timeAsync } from '@ifixit/helpers';
 import type {
    ImageLinkMenuItem,
    LinkMenuItem,
@@ -33,9 +34,11 @@ export function findStoreByCode(code: string) {
 }
 
 async function findStoreByCodeFromStrapi(code: string) {
-   const result = await strapi.findStore({
-      filters: { code: { eq: code } },
-   });
+   const result = await timeAsync('strapi.findStore', () =>
+      strapi.findStore({
+         filters: { code: { eq: code } },
+      })
+   );
    const store = result.store?.data?.[0]?.attributes;
    if (store == null) {
       throw new Error('Store not found');
@@ -87,7 +90,7 @@ export function getStoreList(): Promise<StoreListItem[]> {
 }
 
 async function getStoreListFromStrapi(): Promise<StoreListItem[]> {
-   const result = await strapi.getStoreList();
+   const result = await timeAsync('strapi.getStoreList', strapi.getStoreList);
    const stores = result.stores?.data || [];
    return filterNullableItems(
       stores.map((store) => {


### PR DESCRIPTION
Let's get `timeAsync()` around every call so we can graph them in datadog. Previously, we were only timing `getProductList`, now we time them all.

Connect #1607 
