### PR TITLE
Footer Code Cleanup: export some things

### DIFF
--- a/packages/footer/components/Navigation.tsx
+++ b/packages/footer/components/Navigation.tsx
@@ -21,7 +21,7 @@ import type { NewsletterFormProps } from './Newsletter';
 import type { Menu as MenuType, MenuItem } from '@ifixit/menu';
 import { useTrackedOnClick } from '@ifixit/tracking-hooks';
 
-type NavSectionProps = {
+export type NavSectionProps = {
    menu1: MenuType | null;
    menu2: MenuType | null;
    menu3: MenuType | null;
@@ -52,13 +52,25 @@ export const NavigationSection = ({
    );
 };
 
-const NavigationColumn = ({ menu }: { menu: MenuType | null }) => {
+export const NavigationColumn = ({
+   menu,
+   ...otherProps
+}: {
+   menu: MenuType | null;
+}) => {
    if (!menu) {
       return null;
    }
    return (
       <>
-         <Text fontSize="sm" fontWeight="semibold" color="white" mb="3">
+         <Text
+            fontSize="sm"
+            fontWeight="semibold"
+            color="white"
+            mb="3"
+            mt="0"
+            {...otherProps}
+         >
             {menu.title}
          </Text>
          <FooterNavigationListItems menu={menu} />
@@ -66,7 +78,7 @@ const NavigationColumn = ({ menu }: { menu: MenuType | null }) => {
    );
 };
 
-const FooterNavigationListItems = ({ menu }: { menu: MenuType }) => {
+export const FooterNavigationListItems = ({ menu }: { menu: MenuType }) => {
    const listItems = menu.items.map((item: MenuItem, index: number) => {
       if (item.type !== 'link') {
          return null;
@@ -95,7 +107,7 @@ const FooterNavigationListItems = ({ menu }: { menu: MenuType }) => {
    return <>{listItems}</>;
 };
 
-const FooterTopSection = forwardRef<FlexProps, 'div'>((props, ref) => {
+export const FooterTopSection = forwardRef<FlexProps, 'div'>((props, ref) => {
    return (
       <Flex
          ref={ref}
@@ -139,6 +151,8 @@ export const FooterNavigationList = forwardRef<ListProps, 'ul'>(
                base: 4,
                sm: 0,
             }}
+            m={{ base: 0 }}
+            pl={0}
             {...otherProps}
          >
             {children}
@@ -168,6 +182,9 @@ export const FooterNavigationLink = forwardRef<FooterNavigationLinkProps, 'a'>(
             onClick={trackedOnClick}
             cursor="pointer"
             transition="all 400ms"
+            fontWeight="normal"
+            m={0}
+            p={0}
             _hover={{
                color: 'white',
                textDecoration: 'none',


### PR DESCRIPTION
We want to reuse these components in the iFixit/ifixit repo, so we need to be able to import them. We also want the styling to remain the same. Some of the default styles are slightly different in ifixit, so we need to set these here. Lastly, we can add an otherProps argument to components that we want to pass different styles into on the ifixit side.

## QA
The footer should look the exact same.

Connects to https://github.com/iFixit/ifixit/issues/45964