### PR TITLE
Product list swr cache

### DIFF
--- a/frontend/codegen.yml
+++ b/frontend/codegen.yml
@@ -13,6 +13,16 @@ generates:
       config:
          documentMode: 'string'
          dedupeFragments: true
+   lib/strapi-sdk/generated/validation.ts:
+      schema: http://localhost:1337/graphql
+      plugins:
+         - typescript-validation-schema
+      hooks:
+         afterOneFileWrite:
+            - prettier --write
+      config:
+         importFrom: ./sdk
+         schema: zod
    lib/shopify-storefront-sdk/generated/sdk.ts:
       schema: lib/shopify-storefront-sdk/schema.graphql
       documents: 'lib/shopify-storefront-sdk/operations/**/*.graphql'

--- a/frontend/lib/strapi-sdk/generated/validation.ts
+++ b/frontend/lib/strapi-sdk/generated/validation.ts
@@ -1,0 +1,1174 @@
+import { z } from 'zod';
+import {
+   BannerFiltersInput,
+   BannerInput,
+   BooleanFilterInput,
+   CompanyFiltersInput,
+   CompanyInput,
+   ComponentGlobalNewsletterFormInput,
+   ComponentGlobalPersonFiltersInput,
+   ComponentPageCallToActionFiltersInput,
+   ComponentPageCallToActionInput,
+   ComponentPageCategoryFiltersInput,
+   ComponentPagePressQuoteFiltersInput,
+   ComponentPageStatItemFiltersInput,
+   ComponentSectionQuoteCardFiltersInput,
+   ComponentStoreFooterFiltersInput,
+   ComponentStoreFooterInput,
+   ComponentStoreHeaderFiltersInput,
+   ComponentStoreHeaderInput,
+   ComponentStoreShopifySettingsFiltersInput,
+   ComponentStoreShopifySettingsInput,
+   ComponentStoreSocialMediaAccountsFiltersInput,
+   ComponentStoreSocialMediaAccountsInput,
+   DateTimeFilterInput,
+   Enum_Componentpagesplitwithimage_Imageposition,
+   Enum_Componentsectionfeaturedproducts_Background,
+   Enum_Productlist_Type,
+   Enum_Store_Currency,
+   FaqFiltersInput,
+   FaqInput,
+   FileInfoInput,
+   FloatFilterInput,
+   GlobalInput,
+   I18NLocaleFiltersInput,
+   IdFilterInput,
+   IntFilterInput,
+   JsonFilterInput,
+   MenuFiltersInput,
+   MenuInput,
+   PageFiltersInput,
+   PageInput,
+   PaginationArg,
+   ProductFiltersInput,
+   ProductInput,
+   ProductListFiltersInput,
+   ProductListInput,
+   PublicationState,
+   SocialPostFiltersInput,
+   SocialPostInput,
+   StoreFiltersInput,
+   StoreInput,
+   StringFilterInput,
+   UploadFileFiltersInput,
+   UploadFileInput,
+   UploadFolderFiltersInput,
+   UploadFolderInput,
+   UsersPermissionsLoginInput,
+   UsersPermissionsPermissionFiltersInput,
+   UsersPermissionsRegisterInput,
+   UsersPermissionsRoleFiltersInput,
+   UsersPermissionsRoleInput,
+   UsersPermissionsUserFiltersInput,
+   UsersPermissionsUserInput,
+} from './sdk';
+
+type Properties<T> = Required<{
+   [K in keyof T]: z.ZodType<T[K], any, T[K]>;
+}>;
+
+type definedNonNullAny = {};
+
+export const isDefinedNonNullAny = (v: any): v is definedNonNullAny =>
+   v !== undefined && v !== null;
+
+export const definedNonNullAnySchema = z
+   .any()
+   .refine((v) => isDefinedNonNullAny(v));
+
+export function BannerFiltersInputSchema(): z.ZodObject<
+   Properties<BannerFiltersInput>
+> {
+   return z.object<Properties<BannerFiltersInput>>({
+      and: z
+         .array(z.lazy(() => BannerFiltersInputSchema().nullable()))
+         .nullish(),
+      callToAction: z.lazy(() =>
+         ComponentPageCallToActionFiltersInputSchema().nullish()
+      ),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      description: z.lazy(() => StringFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      label: z.lazy(() => StringFilterInputSchema().nullish()),
+      locale: z.lazy(() => StringFilterInputSchema().nullish()),
+      localizations: z.lazy(() => BannerFiltersInputSchema().nullish()),
+      not: z.lazy(() => BannerFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => BannerFiltersInputSchema().nullable()))
+         .nullish(),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      title: z.lazy(() => StringFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function BannerInputSchema(): z.ZodObject<Properties<BannerInput>> {
+   return z.object<Properties<BannerInput>>({
+      callToAction: z.lazy(() =>
+         ComponentPageCallToActionInputSchema().nullish()
+      ),
+      description: z.string().nullish(),
+      image: z.string().nullish(),
+      label: z.string().nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+      title: z.string().nullish(),
+   });
+}
+
+export function BooleanFilterInputSchema(): z.ZodObject<
+   Properties<BooleanFilterInput>
+> {
+   return z.object<Properties<BooleanFilterInput>>({
+      and: z.array(z.boolean().nullable()).nullish(),
+      between: z.array(z.boolean().nullable()).nullish(),
+      contains: z.boolean().nullish(),
+      containsi: z.boolean().nullish(),
+      endsWith: z.boolean().nullish(),
+      eq: z.boolean().nullish(),
+      eqi: z.boolean().nullish(),
+      gt: z.boolean().nullish(),
+      gte: z.boolean().nullish(),
+      in: z.array(z.boolean().nullable()).nullish(),
+      lt: z.boolean().nullish(),
+      lte: z.boolean().nullish(),
+      ne: z.boolean().nullish(),
+      not: z.lazy(() => BooleanFilterInputSchema().nullish()),
+      notContains: z.boolean().nullish(),
+      notContainsi: z.boolean().nullish(),
+      notIn: z.array(z.boolean().nullable()).nullish(),
+      notNull: z.boolean().nullish(),
+      null: z.boolean().nullish(),
+      or: z.array(z.boolean().nullable()).nullish(),
+      startsWith: z.boolean().nullish(),
+   });
+}
+
+export function CompanyFiltersInputSchema(): z.ZodObject<
+   Properties<CompanyFiltersInput>
+> {
+   return z.object<Properties<CompanyFiltersInput>>({
+      and: z
+         .array(z.lazy(() => CompanyFiltersInputSchema().nullable()))
+         .nullish(),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      name: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => CompanyFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => CompanyFiltersInputSchema().nullable()))
+         .nullish(),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function CompanyInputSchema(): z.ZodObject<Properties<CompanyInput>> {
+   return z.object<Properties<CompanyInput>>({
+      logo: z.string().nullish(),
+      name: z.string().nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+   });
+}
+
+export function ComponentGlobalNewsletterFormInputSchema(): z.ZodObject<
+   Properties<ComponentGlobalNewsletterFormInput>
+> {
+   return z.object<Properties<ComponentGlobalNewsletterFormInput>>({
+      callToActionButtonTitle: z.string().nullish(),
+      id: z.string().nullish(),
+      inputPlaceholder: z.string().nullish(),
+      subtitle: z.string().nullish(),
+      title: z.string().nullish(),
+   });
+}
+
+export function ComponentGlobalPersonFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentGlobalPersonFiltersInput>
+> {
+   return z.object<Properties<ComponentGlobalPersonFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() => ComponentGlobalPersonFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      name: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => ComponentGlobalPersonFiltersInputSchema().nullish()),
+      or: z
+         .array(
+            z.lazy(() => ComponentGlobalPersonFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      role: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function ComponentPageCallToActionFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentPageCallToActionFiltersInput>
+> {
+   return z.object<Properties<ComponentPageCallToActionFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() =>
+               ComponentPageCallToActionFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      not: z.lazy(() =>
+         ComponentPageCallToActionFiltersInputSchema().nullish()
+      ),
+      or: z
+         .array(
+            z.lazy(() =>
+               ComponentPageCallToActionFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      title: z.lazy(() => StringFilterInputSchema().nullish()),
+      url: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function ComponentPageCallToActionInputSchema(): z.ZodObject<
+   Properties<ComponentPageCallToActionInput>
+> {
+   return z.object<Properties<ComponentPageCallToActionInput>>({
+      id: z.string().nullish(),
+      title: z.string().nullish(),
+      url: z.string().nullish(),
+   });
+}
+
+export function ComponentPageCategoryFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentPageCategoryFiltersInput>
+> {
+   return z.object<Properties<ComponentPageCategoryFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() => ComponentPageCategoryFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      not: z.lazy(() => ComponentPageCategoryFiltersInputSchema().nullish()),
+      or: z
+         .array(
+            z.lazy(() => ComponentPageCategoryFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      productList: z.lazy(() => ProductListFiltersInputSchema().nullish()),
+   });
+}
+
+export function ComponentPagePressQuoteFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentPagePressQuoteFiltersInput>
+> {
+   return z.object<Properties<ComponentPagePressQuoteFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() => ComponentPagePressQuoteFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      company: z.lazy(() => CompanyFiltersInputSchema().nullish()),
+      not: z.lazy(() => ComponentPagePressQuoteFiltersInputSchema().nullish()),
+      or: z
+         .array(
+            z.lazy(() => ComponentPagePressQuoteFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      text: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function ComponentPageStatItemFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentPageStatItemFiltersInput>
+> {
+   return z.object<Properties<ComponentPageStatItemFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() => ComponentPageStatItemFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      label: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => ComponentPageStatItemFiltersInputSchema().nullish()),
+      or: z
+         .array(
+            z.lazy(() => ComponentPageStatItemFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      value: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function ComponentSectionQuoteCardFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentSectionQuoteCardFiltersInput>
+> {
+   return z.object<Properties<ComponentSectionQuoteCardFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() =>
+               ComponentSectionQuoteCardFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      author: z.lazy(() => ComponentGlobalPersonFiltersInputSchema().nullish()),
+      not: z.lazy(() =>
+         ComponentSectionQuoteCardFiltersInputSchema().nullish()
+      ),
+      or: z
+         .array(
+            z.lazy(() =>
+               ComponentSectionQuoteCardFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      text: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function ComponentStoreFooterFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentStoreFooterFiltersInput>
+> {
+   return z.object<Properties<ComponentStoreFooterFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() => ComponentStoreFooterFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      bottomMenu: z.lazy(() => MenuFiltersInputSchema().nullish()),
+      menu1: z.lazy(() => MenuFiltersInputSchema().nullish()),
+      menu2: z.lazy(() => MenuFiltersInputSchema().nullish()),
+      menu3: z.lazy(() => MenuFiltersInputSchema().nullish()),
+      not: z.lazy(() => ComponentStoreFooterFiltersInputSchema().nullish()),
+      or: z
+         .array(
+            z.lazy(() => ComponentStoreFooterFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      partners: z.lazy(() => MenuFiltersInputSchema().nullish()),
+   });
+}
+
+export function ComponentStoreFooterInputSchema(): z.ZodObject<
+   Properties<ComponentStoreFooterInput>
+> {
+   return z.object<Properties<ComponentStoreFooterInput>>({
+      bottomMenu: z.string().nullish(),
+      id: z.string().nullish(),
+      menu1: z.string().nullish(),
+      menu2: z.string().nullish(),
+      menu3: z.string().nullish(),
+      partners: z.string().nullish(),
+   });
+}
+
+export function ComponentStoreHeaderFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentStoreHeaderFiltersInput>
+> {
+   return z.object<Properties<ComponentStoreHeaderFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() => ComponentStoreHeaderFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      menu: z.lazy(() => MenuFiltersInputSchema().nullish()),
+      not: z.lazy(() => ComponentStoreHeaderFiltersInputSchema().nullish()),
+      or: z
+         .array(
+            z.lazy(() => ComponentStoreHeaderFiltersInputSchema().nullable())
+         )
+         .nullish(),
+   });
+}
+
+export function ComponentStoreHeaderInputSchema(): z.ZodObject<
+   Properties<ComponentStoreHeaderInput>
+> {
+   return z.object<Properties<ComponentStoreHeaderInput>>({
+      id: z.string().nullish(),
+      menu: z.string().nullish(),
+   });
+}
+
+export function ComponentStoreShopifySettingsFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentStoreShopifySettingsFiltersInput>
+> {
+   return z.object<Properties<ComponentStoreShopifySettingsFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() =>
+               ComponentStoreShopifySettingsFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      delegateAccessToken: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() =>
+         ComponentStoreShopifySettingsFiltersInputSchema().nullish()
+      ),
+      or: z
+         .array(
+            z.lazy(() =>
+               ComponentStoreShopifySettingsFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      storefrontAccessToken: z.lazy(() => StringFilterInputSchema().nullish()),
+      storefrontDomain: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function ComponentStoreShopifySettingsInputSchema(): z.ZodObject<
+   Properties<ComponentStoreShopifySettingsInput>
+> {
+   return z.object<Properties<ComponentStoreShopifySettingsInput>>({
+      delegateAccessToken: z.string().nullish(),
+      id: z.string().nullish(),
+      storefrontAccessToken: z.string().nullish(),
+      storefrontDomain: z.string().nullish(),
+   });
+}
+
+export function ComponentStoreSocialMediaAccountsFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentStoreSocialMediaAccountsFiltersInput>
+> {
+   return z.object<Properties<ComponentStoreSocialMediaAccountsFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() =>
+               ComponentStoreSocialMediaAccountsFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      facebook: z.lazy(() => StringFilterInputSchema().nullish()),
+      instagram: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() =>
+         ComponentStoreSocialMediaAccountsFiltersInputSchema().nullish()
+      ),
+      or: z
+         .array(
+            z.lazy(() =>
+               ComponentStoreSocialMediaAccountsFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      repairOrg: z.lazy(() => StringFilterInputSchema().nullish()),
+      tiktok: z.lazy(() => StringFilterInputSchema().nullish()),
+      twitter: z.lazy(() => StringFilterInputSchema().nullish()),
+      youtube: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function ComponentStoreSocialMediaAccountsInputSchema(): z.ZodObject<
+   Properties<ComponentStoreSocialMediaAccountsInput>
+> {
+   return z.object<Properties<ComponentStoreSocialMediaAccountsInput>>({
+      facebook: z.string().nullish(),
+      id: z.string().nullish(),
+      instagram: z.string().nullish(),
+      repairOrg: z.string().nullish(),
+      tiktok: z.string().nullish(),
+      twitter: z.string().nullish(),
+      youtube: z.string().nullish(),
+   });
+}
+
+export function DateTimeFilterInputSchema(): z.ZodObject<
+   Properties<DateTimeFilterInput>
+> {
+   return z.object<Properties<DateTimeFilterInput>>({
+      and: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      between: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      contains: definedNonNullAnySchema.nullish(),
+      containsi: definedNonNullAnySchema.nullish(),
+      endsWith: definedNonNullAnySchema.nullish(),
+      eq: definedNonNullAnySchema.nullish(),
+      eqi: definedNonNullAnySchema.nullish(),
+      gt: definedNonNullAnySchema.nullish(),
+      gte: definedNonNullAnySchema.nullish(),
+      in: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      lt: definedNonNullAnySchema.nullish(),
+      lte: definedNonNullAnySchema.nullish(),
+      ne: definedNonNullAnySchema.nullish(),
+      not: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      notContains: definedNonNullAnySchema.nullish(),
+      notContainsi: definedNonNullAnySchema.nullish(),
+      notIn: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      notNull: z.boolean().nullish(),
+      null: z.boolean().nullish(),
+      or: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      startsWith: definedNonNullAnySchema.nullish(),
+   });
+}
+
+export const Enum_Componentpagesplitwithimage_ImagepositionSchema =
+   z.nativeEnum(Enum_Componentpagesplitwithimage_Imageposition);
+
+export const Enum_Componentsectionfeaturedproducts_BackgroundSchema =
+   z.nativeEnum(Enum_Componentsectionfeaturedproducts_Background);
+
+export const Enum_Productlist_TypeSchema = z.nativeEnum(Enum_Productlist_Type);
+
+export const Enum_Store_CurrencySchema = z.nativeEnum(Enum_Store_Currency);
+
+export function FaqFiltersInputSchema(): z.ZodObject<
+   Properties<FaqFiltersInput>
+> {
+   return z.object<Properties<FaqFiltersInput>>({
+      and: z.array(z.lazy(() => FaqFiltersInputSchema().nullable())).nullish(),
+      answer: z.lazy(() => StringFilterInputSchema().nullish()),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      not: z.lazy(() => FaqFiltersInputSchema().nullish()),
+      or: z.array(z.lazy(() => FaqFiltersInputSchema().nullable())).nullish(),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      question: z.lazy(() => StringFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function FaqInputSchema(): z.ZodObject<Properties<FaqInput>> {
+   return z.object<Properties<FaqInput>>({
+      answer: z.string().nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+      question: z.string().nullish(),
+   });
+}
+
+export function FileInfoInputSchema(): z.ZodObject<Properties<FileInfoInput>> {
+   return z.object<Properties<FileInfoInput>>({
+      alternativeText: z.string().nullish(),
+      caption: z.string().nullish(),
+      name: z.string().nullish(),
+   });
+}
+
+export function FloatFilterInputSchema(): z.ZodObject<
+   Properties<FloatFilterInput>
+> {
+   return z.object<Properties<FloatFilterInput>>({
+      and: z.array(z.number().nullable()).nullish(),
+      between: z.array(z.number().nullable()).nullish(),
+      contains: z.number().nullish(),
+      containsi: z.number().nullish(),
+      endsWith: z.number().nullish(),
+      eq: z.number().nullish(),
+      eqi: z.number().nullish(),
+      gt: z.number().nullish(),
+      gte: z.number().nullish(),
+      in: z.array(z.number().nullable()).nullish(),
+      lt: z.number().nullish(),
+      lte: z.number().nullish(),
+      ne: z.number().nullish(),
+      not: z.lazy(() => FloatFilterInputSchema().nullish()),
+      notContains: z.number().nullish(),
+      notContainsi: z.number().nullish(),
+      notIn: z.array(z.number().nullable()).nullish(),
+      notNull: z.boolean().nullish(),
+      null: z.boolean().nullish(),
+      or: z.array(z.number().nullable()).nullish(),
+      startsWith: z.number().nullish(),
+   });
+}
+
+export function GlobalInputSchema(): z.ZodObject<Properties<GlobalInput>> {
+   return z.object<Properties<GlobalInput>>({
+      newsletterForm: z.lazy(() =>
+         ComponentGlobalNewsletterFormInputSchema().nullish()
+      ),
+      publishedAt: definedNonNullAnySchema.nullish(),
+   });
+}
+
+export function I18NLocaleFiltersInputSchema(): z.ZodObject<
+   Properties<I18NLocaleFiltersInput>
+> {
+   return z.object<Properties<I18NLocaleFiltersInput>>({
+      and: z
+         .array(z.lazy(() => I18NLocaleFiltersInputSchema().nullable()))
+         .nullish(),
+      code: z.lazy(() => StringFilterInputSchema().nullish()),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      name: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => I18NLocaleFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => I18NLocaleFiltersInputSchema().nullable()))
+         .nullish(),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function IdFilterInputSchema(): z.ZodObject<Properties<IdFilterInput>> {
+   return z.object<Properties<IdFilterInput>>({
+      and: z.array(z.string().nullable()).nullish(),
+      between: z.array(z.string().nullable()).nullish(),
+      contains: z.string().nullish(),
+      containsi: z.string().nullish(),
+      endsWith: z.string().nullish(),
+      eq: z.string().nullish(),
+      eqi: z.string().nullish(),
+      gt: z.string().nullish(),
+      gte: z.string().nullish(),
+      in: z.array(z.string().nullable()).nullish(),
+      lt: z.string().nullish(),
+      lte: z.string().nullish(),
+      ne: z.string().nullish(),
+      not: z.lazy(() => IdFilterInputSchema().nullish()),
+      notContains: z.string().nullish(),
+      notContainsi: z.string().nullish(),
+      notIn: z.array(z.string().nullable()).nullish(),
+      notNull: z.boolean().nullish(),
+      null: z.boolean().nullish(),
+      or: z.array(z.string().nullable()).nullish(),
+      startsWith: z.string().nullish(),
+   });
+}
+
+export function IntFilterInputSchema(): z.ZodObject<
+   Properties<IntFilterInput>
+> {
+   return z.object<Properties<IntFilterInput>>({
+      and: z.array(z.number().nullable()).nullish(),
+      between: z.array(z.number().nullable()).nullish(),
+      contains: z.number().nullish(),
+      containsi: z.number().nullish(),
+      endsWith: z.number().nullish(),
+      eq: z.number().nullish(),
+      eqi: z.number().nullish(),
+      gt: z.number().nullish(),
+      gte: z.number().nullish(),
+      in: z.array(z.number().nullable()).nullish(),
+      lt: z.number().nullish(),
+      lte: z.number().nullish(),
+      ne: z.number().nullish(),
+      not: z.lazy(() => IntFilterInputSchema().nullish()),
+      notContains: z.number().nullish(),
+      notContainsi: z.number().nullish(),
+      notIn: z.array(z.number().nullable()).nullish(),
+      notNull: z.boolean().nullish(),
+      null: z.boolean().nullish(),
+      or: z.array(z.number().nullable()).nullish(),
+      startsWith: z.number().nullish(),
+   });
+}
+
+export function JsonFilterInputSchema(): z.ZodObject<
+   Properties<JsonFilterInput>
+> {
+   return z.object<Properties<JsonFilterInput>>({
+      and: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      between: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      contains: definedNonNullAnySchema.nullish(),
+      containsi: definedNonNullAnySchema.nullish(),
+      endsWith: definedNonNullAnySchema.nullish(),
+      eq: definedNonNullAnySchema.nullish(),
+      eqi: definedNonNullAnySchema.nullish(),
+      gt: definedNonNullAnySchema.nullish(),
+      gte: definedNonNullAnySchema.nullish(),
+      in: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      lt: definedNonNullAnySchema.nullish(),
+      lte: definedNonNullAnySchema.nullish(),
+      ne: definedNonNullAnySchema.nullish(),
+      not: z.lazy(() => JsonFilterInputSchema().nullish()),
+      notContains: definedNonNullAnySchema.nullish(),
+      notContainsi: definedNonNullAnySchema.nullish(),
+      notIn: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      notNull: z.boolean().nullish(),
+      null: z.boolean().nullish(),
+      or: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      startsWith: definedNonNullAnySchema.nullish(),
+   });
+}
+
+export function MenuFiltersInputSchema(): z.ZodObject<
+   Properties<MenuFiltersInput>
+> {
+   return z.object<Properties<MenuFiltersInput>>({
+      and: z.array(z.lazy(() => MenuFiltersInputSchema().nullable())).nullish(),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      locale: z.lazy(() => StringFilterInputSchema().nullish()),
+      localizations: z.lazy(() => MenuFiltersInputSchema().nullish()),
+      not: z.lazy(() => MenuFiltersInputSchema().nullish()),
+      or: z.array(z.lazy(() => MenuFiltersInputSchema().nullable())).nullish(),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      title: z.lazy(() => StringFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function MenuInputSchema(): z.ZodObject<Properties<MenuInput>> {
+   return z.object<Properties<MenuInput>>({
+      items: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+      title: z.string().nullish(),
+   });
+}
+
+export function PageFiltersInputSchema(): z.ZodObject<
+   Properties<PageFiltersInput>
+> {
+   return z.object<Properties<PageFiltersInput>>({
+      and: z.array(z.lazy(() => PageFiltersInputSchema().nullable())).nullish(),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      locale: z.lazy(() => StringFilterInputSchema().nullish()),
+      localizations: z.lazy(() => PageFiltersInputSchema().nullish()),
+      not: z.lazy(() => PageFiltersInputSchema().nullish()),
+      or: z.array(z.lazy(() => PageFiltersInputSchema().nullable())).nullish(),
+      path: z.lazy(() => StringFilterInputSchema().nullish()),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      title: z.lazy(() => StringFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
+   return z.object<Properties<PageInput>>({
+      path: z.string().nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+      sections: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
+      title: z.string().nullish(),
+   });
+}
+
+export function PaginationArgSchema(): z.ZodObject<Properties<PaginationArg>> {
+   return z.object<Properties<PaginationArg>>({
+      limit: z.number().nullish(),
+      page: z.number().nullish(),
+      pageSize: z.number().nullish(),
+      start: z.number().nullish(),
+   });
+}
+
+export function ProductFiltersInputSchema(): z.ZodObject<
+   Properties<ProductFiltersInput>
+> {
+   return z.object<Properties<ProductFiltersInput>>({
+      and: z
+         .array(z.lazy(() => ProductFiltersInputSchema().nullable()))
+         .nullish(),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      handle: z.lazy(() => StringFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      not: z.lazy(() => ProductFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => ProductFiltersInputSchema().nullable()))
+         .nullish(),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function ProductInputSchema(): z.ZodObject<Properties<ProductInput>> {
+   return z.object<Properties<ProductInput>>({
+      handle: z.string().nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+      sections: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
+   });
+}
+
+export function ProductListFiltersInputSchema(): z.ZodObject<
+   Properties<ProductListFiltersInput>
+> {
+   return z.object<Properties<ProductListFiltersInput>>({
+      and: z
+         .array(z.lazy(() => ProductListFiltersInputSchema().nullable()))
+         .nullish(),
+      brandLogoWidth: z.lazy(() => IntFilterInputSchema().nullish()),
+      children: z.lazy(() => ProductListFiltersInputSchema().nullish()),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      defaultShowAllChildrenOnLgSizes: z.lazy(() =>
+         BooleanFilterInputSchema().nullish()
+      ),
+      description: z.lazy(() => StringFilterInputSchema().nullish()),
+      deviceTitle: z.lazy(() => StringFilterInputSchema().nullish()),
+      filters: z.lazy(() => StringFilterInputSchema().nullish()),
+      forceNoindex: z.lazy(() => BooleanFilterInputSchema().nullish()),
+      h1: z.lazy(() => StringFilterInputSchema().nullish()),
+      handle: z.lazy(() => StringFilterInputSchema().nullish()),
+      hideFromParent: z.lazy(() => BooleanFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      legacyDescription: z.lazy(() => StringFilterInputSchema().nullish()),
+      legacyPageId: z.lazy(() => IntFilterInputSchema().nullish()),
+      locale: z.lazy(() => StringFilterInputSchema().nullish()),
+      localizations: z.lazy(() => ProductListFiltersInputSchema().nullish()),
+      metaDescription: z.lazy(() => StringFilterInputSchema().nullish()),
+      metaTitle: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => ProductListFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => ProductListFiltersInputSchema().nullable()))
+         .nullish(),
+      parent: z.lazy(() => ProductListFiltersInputSchema().nullish()),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      sortPriority: z.lazy(() => IntFilterInputSchema().nullish()),
+      tagline: z.lazy(() => StringFilterInputSchema().nullish()),
+      title: z.lazy(() => StringFilterInputSchema().nullish()),
+      type: z.lazy(() => StringFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function ProductListInputSchema(): z.ZodObject<
+   Properties<ProductListInput>
+> {
+   return z.object<Properties<ProductListInput>>({
+      brandLogo: z.string().nullish(),
+      brandLogoWidth: z.number().nullish(),
+      children: z.array(z.string().nullable()).nullish(),
+      defaultShowAllChildrenOnLgSizes: z.boolean().nullish(),
+      description: z.string().nullish(),
+      deviceTitle: z.string().nullish(),
+      filters: z.string().nullish(),
+      forceNoindex: z.boolean().nullish(),
+      h1: z.string().nullish(),
+      handle: z.string().nullish(),
+      heroImage: z.string().nullish(),
+      hideFromParent: z.boolean().nullish(),
+      image: z.string().nullish(),
+      legacyDescription: z.string().nullish(),
+      legacyPageId: z.number().nullish(),
+      metaDescription: z.string().nullish(),
+      metaTitle: z.string().nullish(),
+      parent: z.string().nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+      sections: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
+      sortPriority: z.number().nullish(),
+      tagline: z.string().nullish(),
+      title: z.string().nullish(),
+      type: Enum_Productlist_TypeSchema.nullish(),
+   });
+}
+
+export const PublicationStateSchema = z.nativeEnum(PublicationState);
+
+export function SocialPostFiltersInputSchema(): z.ZodObject<
+   Properties<SocialPostFiltersInput>
+> {
+   return z.object<Properties<SocialPostFiltersInput>>({
+      and: z
+         .array(z.lazy(() => SocialPostFiltersInputSchema().nullable()))
+         .nullish(),
+      author: z.lazy(() => StringFilterInputSchema().nullish()),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      not: z.lazy(() => SocialPostFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => SocialPostFiltersInputSchema().nullable()))
+         .nullish(),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      title: z.lazy(() => StringFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      url: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function SocialPostInputSchema(): z.ZodObject<
+   Properties<SocialPostInput>
+> {
+   return z.object<Properties<SocialPostInput>>({
+      author: z.string().nullish(),
+      image: z.string().nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+      title: z.string().nullish(),
+      url: z.string().nullish(),
+   });
+}
+
+export function StoreFiltersInputSchema(): z.ZodObject<
+   Properties<StoreFiltersInput>
+> {
+   return z.object<Properties<StoreFiltersInput>>({
+      and: z
+         .array(z.lazy(() => StoreFiltersInputSchema().nullable()))
+         .nullish(),
+      code: z.lazy(() => StringFilterInputSchema().nullish()),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      currency: z.lazy(() => StringFilterInputSchema().nullish()),
+      footer: z.lazy(() => ComponentStoreFooterFiltersInputSchema().nullish()),
+      header: z.lazy(() => ComponentStoreHeaderFiltersInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      name: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => StoreFiltersInputSchema().nullish()),
+      or: z.array(z.lazy(() => StoreFiltersInputSchema().nullable())).nullish(),
+      publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      shopifySettings: z.lazy(() =>
+         ComponentStoreShopifySettingsFiltersInputSchema().nullish()
+      ),
+      socialMediaAccounts: z.lazy(() =>
+         ComponentStoreSocialMediaAccountsFiltersInputSchema().nullish()
+      ),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      url: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function StoreInputSchema(): z.ZodObject<Properties<StoreInput>> {
+   return z.object<Properties<StoreInput>>({
+      code: z.string().nullish(),
+      currency: Enum_Store_CurrencySchema.nullish(),
+      footer: z.lazy(() => ComponentStoreFooterInputSchema().nullish()),
+      header: z.lazy(() => ComponentStoreHeaderInputSchema().nullish()),
+      name: z.string().nullish(),
+      publishedAt: definedNonNullAnySchema.nullish(),
+      shopifySettings: z.lazy(() =>
+         ComponentStoreShopifySettingsInputSchema().nullish()
+      ),
+      socialMediaAccounts: z.lazy(() =>
+         ComponentStoreSocialMediaAccountsInputSchema().nullish()
+      ),
+      url: z.string().nullish(),
+   });
+}
+
+export function StringFilterInputSchema(): z.ZodObject<
+   Properties<StringFilterInput>
+> {
+   return z.object<Properties<StringFilterInput>>({
+      and: z.array(z.string().nullable()).nullish(),
+      between: z.array(z.string().nullable()).nullish(),
+      contains: z.string().nullish(),
+      containsi: z.string().nullish(),
+      endsWith: z.string().nullish(),
+      eq: z.string().nullish(),
+      eqi: z.string().nullish(),
+      gt: z.string().nullish(),
+      gte: z.string().nullish(),
+      in: z.array(z.string().nullable()).nullish(),
+      lt: z.string().nullish(),
+      lte: z.string().nullish(),
+      ne: z.string().nullish(),
+      not: z.lazy(() => StringFilterInputSchema().nullish()),
+      notContains: z.string().nullish(),
+      notContainsi: z.string().nullish(),
+      notIn: z.array(z.string().nullable()).nullish(),
+      notNull: z.boolean().nullish(),
+      null: z.boolean().nullish(),
+      or: z.array(z.string().nullable()).nullish(),
+      startsWith: z.string().nullish(),
+   });
+}
+
+export function UploadFileFiltersInputSchema(): z.ZodObject<
+   Properties<UploadFileFiltersInput>
+> {
+   return z.object<Properties<UploadFileFiltersInput>>({
+      alternativeText: z.lazy(() => StringFilterInputSchema().nullish()),
+      and: z
+         .array(z.lazy(() => UploadFileFiltersInputSchema().nullable()))
+         .nullish(),
+      caption: z.lazy(() => StringFilterInputSchema().nullish()),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      ext: z.lazy(() => StringFilterInputSchema().nullish()),
+      folder: z.lazy(() => UploadFolderFiltersInputSchema().nullish()),
+      folderPath: z.lazy(() => StringFilterInputSchema().nullish()),
+      formats: z.lazy(() => JsonFilterInputSchema().nullish()),
+      hash: z.lazy(() => StringFilterInputSchema().nullish()),
+      height: z.lazy(() => IntFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      mime: z.lazy(() => StringFilterInputSchema().nullish()),
+      name: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => UploadFileFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => UploadFileFiltersInputSchema().nullable()))
+         .nullish(),
+      previewUrl: z.lazy(() => StringFilterInputSchema().nullish()),
+      provider: z.lazy(() => StringFilterInputSchema().nullish()),
+      provider_metadata: z.lazy(() => JsonFilterInputSchema().nullish()),
+      size: z.lazy(() => FloatFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      url: z.lazy(() => StringFilterInputSchema().nullish()),
+      width: z.lazy(() => IntFilterInputSchema().nullish()),
+   });
+}
+
+export function UploadFileInputSchema(): z.ZodObject<
+   Properties<UploadFileInput>
+> {
+   return z.object<Properties<UploadFileInput>>({
+      alternativeText: z.string().nullish(),
+      caption: z.string().nullish(),
+      ext: z.string().nullish(),
+      folder: z.string().nullish(),
+      folderPath: z.string().nullish(),
+      formats: definedNonNullAnySchema.nullish(),
+      hash: z.string().nullish(),
+      height: z.number().nullish(),
+      mime: z.string().nullish(),
+      name: z.string().nullish(),
+      previewUrl: z.string().nullish(),
+      provider: z.string().nullish(),
+      provider_metadata: definedNonNullAnySchema.nullish(),
+      size: z.number().nullish(),
+      url: z.string().nullish(),
+      width: z.number().nullish(),
+   });
+}
+
+export function UploadFolderFiltersInputSchema(): z.ZodObject<
+   Properties<UploadFolderFiltersInput>
+> {
+   return z.object<Properties<UploadFolderFiltersInput>>({
+      and: z
+         .array(z.lazy(() => UploadFolderFiltersInputSchema().nullable()))
+         .nullish(),
+      children: z.lazy(() => UploadFolderFiltersInputSchema().nullish()),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      files: z.lazy(() => UploadFileFiltersInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      name: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => UploadFolderFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => UploadFolderFiltersInputSchema().nullable()))
+         .nullish(),
+      parent: z.lazy(() => UploadFolderFiltersInputSchema().nullish()),
+      path: z.lazy(() => StringFilterInputSchema().nullish()),
+      pathId: z.lazy(() => IntFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function UploadFolderInputSchema(): z.ZodObject<
+   Properties<UploadFolderInput>
+> {
+   return z.object<Properties<UploadFolderInput>>({
+      children: z.array(z.string().nullable()).nullish(),
+      files: z.array(z.string().nullable()).nullish(),
+      name: z.string().nullish(),
+      parent: z.string().nullish(),
+      path: z.string().nullish(),
+      pathId: z.number().nullish(),
+   });
+}
+
+export function UsersPermissionsLoginInputSchema(): z.ZodObject<
+   Properties<UsersPermissionsLoginInput>
+> {
+   return z.object<Properties<UsersPermissionsLoginInput>>({
+      identifier: z.string(),
+      password: z.string(),
+      provider: z.string(),
+   });
+}
+
+export function UsersPermissionsPermissionFiltersInputSchema(): z.ZodObject<
+   Properties<UsersPermissionsPermissionFiltersInput>
+> {
+   return z.object<Properties<UsersPermissionsPermissionFiltersInput>>({
+      action: z.lazy(() => StringFilterInputSchema().nullish()),
+      and: z
+         .array(
+            z.lazy(() =>
+               UsersPermissionsPermissionFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      not: z.lazy(() =>
+         UsersPermissionsPermissionFiltersInputSchema().nullish()
+      ),
+      or: z
+         .array(
+            z.lazy(() =>
+               UsersPermissionsPermissionFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      role: z.lazy(() => UsersPermissionsRoleFiltersInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function UsersPermissionsRegisterInputSchema(): z.ZodObject<
+   Properties<UsersPermissionsRegisterInput>
+> {
+   return z.object<Properties<UsersPermissionsRegisterInput>>({
+      email: z.string(),
+      password: z.string(),
+      username: z.string(),
+   });
+}
+
+export function UsersPermissionsRoleFiltersInputSchema(): z.ZodObject<
+   Properties<UsersPermissionsRoleFiltersInput>
+> {
+   return z.object<Properties<UsersPermissionsRoleFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() => UsersPermissionsRoleFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      description: z.lazy(() => StringFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      name: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => UsersPermissionsRoleFiltersInputSchema().nullish()),
+      or: z
+         .array(
+            z.lazy(() => UsersPermissionsRoleFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      permissions: z.lazy(() =>
+         UsersPermissionsPermissionFiltersInputSchema().nullish()
+      ),
+      type: z.lazy(() => StringFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      users: z.lazy(() => UsersPermissionsUserFiltersInputSchema().nullish()),
+   });
+}
+
+export function UsersPermissionsRoleInputSchema(): z.ZodObject<
+   Properties<UsersPermissionsRoleInput>
+> {
+   return z.object<Properties<UsersPermissionsRoleInput>>({
+      description: z.string().nullish(),
+      name: z.string().nullish(),
+      permissions: z.array(z.string().nullable()).nullish(),
+      type: z.string().nullish(),
+      users: z.array(z.string().nullable()).nullish(),
+   });
+}
+
+export function UsersPermissionsUserFiltersInputSchema(): z.ZodObject<
+   Properties<UsersPermissionsUserFiltersInput>
+> {
+   return z.object<Properties<UsersPermissionsUserFiltersInput>>({
+      and: z
+         .array(
+            z.lazy(() => UsersPermissionsUserFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      blocked: z.lazy(() => BooleanFilterInputSchema().nullish()),
+      confirmationToken: z.lazy(() => StringFilterInputSchema().nullish()),
+      confirmed: z.lazy(() => BooleanFilterInputSchema().nullish()),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      email: z.lazy(() => StringFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      not: z.lazy(() => UsersPermissionsUserFiltersInputSchema().nullish()),
+      or: z
+         .array(
+            z.lazy(() => UsersPermissionsUserFiltersInputSchema().nullable())
+         )
+         .nullish(),
+      password: z.lazy(() => StringFilterInputSchema().nullish()),
+      provider: z.lazy(() => StringFilterInputSchema().nullish()),
+      resetPasswordToken: z.lazy(() => StringFilterInputSchema().nullish()),
+      role: z.lazy(() => UsersPermissionsRoleFiltersInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      username: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function UsersPermissionsUserInputSchema(): z.ZodObject<
+   Properties<UsersPermissionsUserInput>
+> {
+   return z.object<Properties<UsersPermissionsUserInput>>({
+      blocked: z.boolean().nullish(),
+      confirmationToken: z.string().nullish(),
+      confirmed: z.boolean().nullish(),
+      email: z.string().nullish(),
+      password: z.string().nullish(),
+      provider: z.string().nullish(),
+      resetPasswordToken: z.string().nullish(),
+      role: z.string().nullish(),
+      username: z.string().nullish(),
+   });
+}

--- a/frontend/lib/strapi-sdk/index.ts
+++ b/frontend/lib/strapi-sdk/index.ts
@@ -2,6 +2,7 @@ import { STRAPI_ORIGIN } from '@config/env';
 import * as Sentry from '@sentry/nextjs';
 import { getSdk, Requester } from './generated/sdk';
 export * from './generated/sdk';
+export * from './generated/validation';
 
 const requester: Requester = async <R, V>(
    doc: string,

--- a/frontend/lib/swr-cache/index.ts
+++ b/frontend/lib/swr-cache/index.ts
@@ -49,11 +49,15 @@ interface CacheOptions<
    staleWhileRevalidate?: number;
 }
 
+type GetOptions = {
+   forceMiss?: boolean;
+};
+
 type NextApiHandlerWithProps<
    Variables = unknown,
    Value = unknown
 > = NextApiHandler & {
-   get: (variables: Variables, forceMiss: boolean) => Promise<Value>;
+   get: (variables: Variables, options: GetOptions) => Promise<Value>;
    revalidate: (variables: Variables) => Promise<void>;
 };
 
@@ -128,7 +132,8 @@ export const withCache = <
    const get: NextApiHandlerWithProps<
       z.infer<VariablesSchema>,
       ValueSchema
-   >['get'] = async (variables, forceMiss) => {
+   >['get'] = async (variables, options = {}) => {
+      const { forceMiss } = options;
       const key = createCacheKey(endpoint, variables);
       logger.info(`${endpoint}.key: "${key}"`);
       let start = performance.now();

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -197,7 +197,7 @@ const StorePageSchema = BaseProductListSchema.extend({
 });
 export type StorePage = z.infer<typeof StorePageSchema>;
 
-const ProductListSchema = z.union([
+export const ProductListSchema = z.union([
    AllPartsProductListSchema,
    DevicePartsProductListSchema,
    AllToolsProductListSchema,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,6 +109,7 @@
       "eslint-plugin-jest": "27.2.0",
       "eslint-plugin-react": "7.23.0",
       "eslint-plugin-react-hooks": "4.2.0",
+      "graphql-codegen-typescript-validation-schema": "0.8.0",
       "graphql-tag": "2.12.6",
       "graphqurl": "1.0.1",
       "identity-obj-proxy": "3.0.0",

--- a/frontend/pages/api/nextjs/cache/product-list.ts
+++ b/frontend/pages/api/nextjs/cache/product-list.ts
@@ -1,0 +1,21 @@
+import { Duration } from '@lib/duration';
+import { ProductListFiltersInputSchema } from '@lib/strapi-sdk';
+import { withCache } from '@lib/swr-cache';
+import { findProductList } from '@models/product-list/server';
+import { ProductListSchema } from '@models/product-list/types';
+import { z } from 'zod';
+
+export default withCache({
+   endpoint: 'api/nextjs/cache/product-list',
+   statName: 'cache.findProductList',
+   variablesSchema: z.object({
+      filters: ProductListFiltersInputSchema(),
+      ifixitOrigin: z.string(),
+   }),
+   valueSchema: ProductListSchema.nullable(),
+   async getFreshValue({ filters, ifixitOrigin }) {
+      return findProductList(filters, ifixitOrigin);
+   },
+   ttl: Duration(1).hour,
+   staleWhileRevalidate: Duration(1).day,
+});

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -51,6 +51,7 @@ export const getProductListServerSideProps = ({
       let shouldRedirectToCanonical = false;
       let canonicalPath: string | null = null;
       const ifixitOrigin = ifixitOriginFromHost(context);
+      const cacheOptions = { forceMiss: hasDisableCacheGets(context) };
 
       switch (productListType) {
          case ProductListType.AllParts: {
@@ -60,7 +61,7 @@ export const getProductListServerSideProps = ({
                      filters: { handle: { eq: 'Parts' } },
                      ifixitOrigin,
                   },
-                  hasDisableCacheGets(context)
+                  cacheOptions
                )
             );
             break;
@@ -96,7 +97,7 @@ export const getProductListServerSideProps = ({
                      },
                      ifixitOrigin,
                   },
-                  hasDisableCacheGets(context)
+                  cacheOptions
                )
             );
 
@@ -115,7 +116,7 @@ export const getProductListServerSideProps = ({
             productList = await timeAsync('findProductList', () =>
                ProductListCache.get(
                   { filters: { handle: { eq: 'Tools' } }, ifixitOrigin },
-                  hasDisableCacheGets(context)
+                  cacheOptions
                )
             );
             break;
@@ -130,7 +131,7 @@ export const getProductListServerSideProps = ({
             productList = await timeAsync('findProductList', () =>
                ProductListCache.get(
                   { filters: { handle: { eqi: handle } }, ifixitOrigin },
-                  hasDisableCacheGets(context)
+                  cacheOptions
                )
             );
 
@@ -164,7 +165,7 @@ export const getProductListServerSideProps = ({
                      },
                      ifixitOrigin,
                   },
-                  hasDisableCacheGets(context)
+                  cacheOptions
                )
             );
             shouldRedirectToCanonical =

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
             storeCode: DEFAULT_STORE_CODE,
             ifixitOrigin,
          },
-         hasDisableCacheGets(context)
+         { forceMiss: hasDisableCacheGets(context) }
       );
 
       if (product == null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,7 @@ importers:
       eslint-plugin-react-hooks: 4.2.0
       framer-motion: 6.2.7
       graphql: 15.5.3
+      graphql-codegen-typescript-validation-schema: 0.8.0
       graphql-tag: 2.12.6
       graphqurl: 1.0.1
       identity-obj-proxy: 3.0.0
@@ -209,6 +210,7 @@ importers:
       eslint-plugin-jest: 27.2.0_lcz5w44t34fa6q67rkgvfsa4ci
       eslint-plugin-react: 7.23.0_eslint@7.23.0
       eslint-plugin-react-hooks: 4.2.0_eslint@7.23.0
+      graphql-codegen-typescript-validation-schema: 0.8.0_graphql@15.5.3
       graphql-tag: 2.12.6_graphql@15.5.3
       graphqurl: 1.0.1_w23x7n7zvvy4jtcrbeyi4toj7i
       identity-obj-proxy: 3.0.0
@@ -5569,6 +5571,20 @@ packages:
       tslib: 2.4.1
     dev: true
 
+  /@graphql-codegen/plugin-helpers/4.2.0_graphql@15.5.3:
+    resolution: {integrity: sha512-THFTCfg+46PXlXobYJ/OoCX6pzjI+9woQqCjdyKtgoI0tn3Xq2HUUCiidndxUpEYVrXb5pRiRXb7b/ZbMQqD0A==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-tools/utils': 9.2.1_graphql@15.5.3
+      change-case-all: 1.0.15
+      common-tags: 1.8.2
+      graphql: 15.5.3
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.5.0
+    dev: true
+
   /@graphql-codegen/schema-ast/2.5.1_graphql@15.5.3:
     resolution: {integrity: sha512-tewa5DEKbglWn7kYyVBkh3J8YQ5ALqAMVmZwiVFIGOao5u66nd+e4HuFqp0u+Jpz4SJGGi0ap/oFrEvlqLjd2A==}
     peerDependencies:
@@ -5578,6 +5594,17 @@ packages:
       '@graphql-tools/utils': 8.12.0_graphql@15.5.3
       graphql: 15.5.3
       tslib: 2.4.1
+    dev: true
+
+  /@graphql-codegen/schema-ast/3.0.1_graphql@15.5.3:
+    resolution: {integrity: sha512-rTKTi4XiW4QFZnrEqetpiYEWVsOFNoiR/v3rY9mFSttXFbIwNXPme32EspTiGWmEEdHY8UuTDtZN3vEcs/31zw==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 4.2.0_graphql@15.5.3
+      '@graphql-tools/utils': 9.2.1_graphql@15.5.3
+      graphql: 15.5.3
+      tslib: 2.5.0
     dev: true
 
   /@graphql-codegen/typescript-generic-sdk/2.5.1_6aqbksp2bzfqiuihkviabctooa:
@@ -5666,6 +5693,27 @@ packages:
       graphql-tag: 2.12.6_graphql@15.5.3
       parse-filepath: 1.0.2
       tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@graphql-codegen/visitor-plugin-common/3.1.1_graphql@15.5.3:
+    resolution: {integrity: sha512-uAfp+zu/009R3HUAuTK2AamR1bxIltM6rrYYI6EXSmkM3rFtFsLTuJhjUDj98HcUCszJZrADppz8KKLGRUVlNg==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 4.2.0_graphql@15.5.3
+      '@graphql-tools/optimize': 1.3.1_graphql@15.5.3
+      '@graphql-tools/relay-operation-optimizer': 6.5.6_graphql@15.5.3
+      '@graphql-tools/utils': 9.2.1_graphql@15.5.3
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      dependency-graph: 0.11.0
+      graphql: 15.5.3
+      graphql-tag: 2.12.6_graphql@15.5.3
+      parse-filepath: 1.0.2
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6081,6 +6129,16 @@ packages:
       tslib: 2.3.1
     dev: true
 
+  /@graphql-tools/utils/9.2.1_graphql@15.5.3:
+    resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0_graphql@15.5.3
+      graphql: 15.5.3
+      tslib: 2.5.0
+    dev: true
+
   /@graphql-tools/wrap/8.4.16_graphql@15.4.0:
     resolution: {integrity: sha512-b3yz7uN0en44sBEv/fAEQIqdiCEM/gQJSaLyA7Z2hWJwM0gQ5kiq0XMwKvyUAIY8NGig7IywC7bbup5Jc2F35Q==}
     peerDependencies:
@@ -6105,6 +6163,14 @@ packages:
       graphql: 15.5.3
       tslib: 2.3.1
       value-or-promise: 1.0.11
+    dev: true
+
+  /@graphql-typed-document-node/core/3.2.0_graphql@15.5.3:
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.5.3
     dev: true
 
   /@hapi/hoek/9.3.0:
@@ -8960,6 +9026,21 @@ packages:
       upper-case-first: 2.0.2
     dev: true
 
+  /change-case-all/1.0.15:
+    resolution: {integrity: sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==}
+    dependencies:
+      change-case: 4.1.2
+      is-lower-case: 2.0.2
+      is-upper-case: 2.0.2
+      lower-case: 2.0.2
+      lower-case-first: 2.0.2
+      sponge-case: 1.0.1
+      swap-case: 2.0.2
+      title-case: 3.0.3
+      upper-case: 2.0.2
+      upper-case-first: 2.0.2
+    dev: true
+
   /change-case/4.1.2:
     resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
     dependencies:
@@ -11046,6 +11127,21 @@ packages:
 
   /graceful-fs/4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+
+  /graphql-codegen-typescript-validation-schema/0.8.0_graphql@15.5.3:
+    resolution: {integrity: sha512-GmqRL00owVLihjt6EjNnKJZjG0UTBcNhvWmG/jCKi44bheIEQGdi+3vYiCwY7y6D+XuT3pgVzHc1Gpp3r/APMQ==}
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 4.2.0_graphql@15.5.3
+      '@graphql-codegen/schema-ast': 3.0.1_graphql@15.5.3
+      '@graphql-codegen/visitor-plugin-common': 3.1.1_graphql@15.5.3
+      '@graphql-tools/utils': 9.2.1_graphql@15.5.3
+      graphql: 15.5.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
 
   /graphql-config/4.3.0_3s3rpwqch76ikmhiikbv5xaw6a:
     resolution: {integrity: sha512-Uiu3X7+s5c056WyrvdZVz2vG1fhAipMlYmtiCU/4Z2mX79OXDr1SqIon2MprC/pExIWJfAQZCcjYDY76fPBUQg==}


### PR DESCRIPTION
- Adds a [dev dependency](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-validation-schema) ([GitHub](https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema/tree/main)) to generate zod schemas for all inputs in Strapi's graphql schema.
- Adds a swr-cache endpoint to cache the product list model, with a 1 hour TTL and a 1 day SWR.

Closes https://github.com/iFixit/react-commerce/issues/1612

## QA

- Smoke test the product list pages to make sure they match main and don't produce any new errors in the logs or Sentry.
- While visiting the product list pages, open the Vercel logs and confirm that we get cache misses, stales, and hits when appropriate based on the timings listed above.