### PR TITLE
Make `disableCacheGets` force a swr cache miss

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -18,8 +18,7 @@ export const withLogging: GetServerSidePropsMiddleware = (next) => {
          ...context.params,
          ...context.query,
       });
-      const isCacheDisabled =
-         CACHE_DISABLED || context.query.disableCacheGets !== undefined;
+      const isCacheDisabled = CACHE_DISABLED || hasDisableCacheGets(context);
       return next(context)
          .then((result) => {
             if (isCacheDisabled) {
@@ -50,3 +49,7 @@ export const withNoindexDevDomains: GetServerSidePropsMiddleware = (next) => {
       return result;
    };
 };
+
+export function hasDisableCacheGets(context: GetServerSidePropsContext) {
+   return context.query.disableCacheGets !== undefined;
+}

--- a/frontend/lib/swr-cache/index.ts
+++ b/frontend/lib/swr-cache/index.ts
@@ -53,7 +53,7 @@ type NextApiHandlerWithProps<
    Variables = unknown,
    Value = unknown
 > = NextApiHandler & {
-   get: (variables: Variables) => Promise<Value>;
+   get: (variables: Variables, forceMiss: boolean) => Promise<Value>;
    revalidate: (variables: Variables) => Promise<void>;
 };
 
@@ -128,43 +128,46 @@ export const withCache = <
    const get: NextApiHandlerWithProps<
       z.infer<VariablesSchema>,
       ValueSchema
-   >['get'] = async (variables) => {
+   >['get'] = async (variables, forceMiss) => {
       const key = createCacheKey(endpoint, variables);
       logger.info(`${endpoint}.key: "${key}"`);
       let start = performance.now();
-      let cachedEntry: CacheEntry | null = null;
-      try {
-         cachedEntry = await cache.get(key);
-      } catch (error) {
-         logger.warning(
-            `${endpoint}.error: unable to get entry with key. ${printError(
-               error
-            )}`
-         );
-      }
-      if (isValidCacheEntry(cachedEntry)) {
-         const valueValidation = valueSchema.safeParse(cachedEntry.value);
-         if (valueValidation.success) {
-            if (isStale(cachedEntry)) {
-               await requestRevalidation(variables);
-               const elapsed = performance.now() - start;
-               logger.success.event(`${statName}.stale`);
-               logger.success.timing(`${statName}.stale`, elapsed);
-            } else {
-               const elapsed = performance.now() - start;
-               logger.success.event(`${statName}.hit`);
-               logger.success.timing(`${statName}.hit`, elapsed);
-            }
-            return valueValidation.data;
+      if (!forceMiss) {
+         let cachedEntry: CacheEntry | null = null;
+         try {
+            cachedEntry = await cache.get(key);
+         } catch (error) {
+            logger.warning(
+               `${endpoint}.error: unable to get entry with key. ${printError(
+                  error
+               )}`
+            );
          }
-         logger.warning(`${endpoint}.warning: Invalid value. If you've changed the value schema, this error is expected. We'll get a fresh value and update the cache.\n
-            ${printZodError(valueValidation.error)}`);
+         if (isValidCacheEntry(cachedEntry)) {
+            const valueValidation = valueSchema.safeParse(cachedEntry.value);
+            if (valueValidation.success) {
+               if (isStale(cachedEntry)) {
+                  await requestRevalidation(variables);
+                  const elapsed = performance.now() - start;
+                  logger.success.event(`${statName}.stale`);
+                  logger.success.timing(`${statName}.stale`, elapsed);
+               } else {
+                  const elapsed = performance.now() - start;
+                  logger.success.event(`${statName}.hit`);
+                  logger.success.timing(`${statName}.hit`, elapsed);
+               }
+               return valueValidation.data;
+            }
+            logger.warning(`${endpoint}.warning: Invalid value. If you've changed the value schema, this error is expected. We'll get a fresh value and update the cache.\n
+               ${printZodError(valueValidation.error)}`);
+         }
       }
       start = performance.now();
       const value = await getFreshValue(variables);
       let elapsed = performance.now() - start;
-      logger.warning.event(`${statName}.miss`);
-      logger.warning.timing(`${statName}.miss`, elapsed);
+      const missType = forceMiss ? 'force_miss' : 'miss';
+      logger.warning.event(`${statName}.${missType}`);
+      logger.warning.timing(`${statName}.${missType}`, elapsed);
       if (ttl != null && ttl > 0) {
          start = performance.now();
          const cacheEntry = createCacheEntry(value, {

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -1,6 +1,10 @@
 import { DEFAULT_STORE_CODE } from '@config/env';
 import { withCacheLong } from '@helpers/cache-control-helpers';
-import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
+import {
+   hasDisableCacheGets,
+   withLogging,
+   withNoindexDevDomains,
+} from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { invariant } from '@ifixit/helpers';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
@@ -24,11 +28,14 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
          storeCode: DEFAULT_STORE_CODE,
       });
       const ifixitOrigin = ifixitOriginFromHost(context);
-      const product = await Product.get({
-         handle,
-         storeCode: DEFAULT_STORE_CODE,
-         ifixitOrigin,
-      });
+      const product = await Product.get(
+         {
+            handle,
+            storeCode: DEFAULT_STORE_CODE,
+            ifixitOrigin,
+         },
+         hasDisableCacheGets(context)
+      );
 
       if (product == null) {
          return {


### PR DESCRIPTION
Connects https://github.com/iFixit/react-commerce/issues/1612

CC @danielbeardsley @dhmacs 

## QA

- Visit the vercel preview, and open up the vercel logs page in a new tab.
- Visit a product page with a `disableCacheGets` query param. Confirm that you see `cache.findProduct.force_miss` in the logs.
- Without `disableCacheGets`, the behavior of product swr caching should match `main`.