### PR TITLE
Add stat name to iFixit API client

### DIFF
--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -15,7 +15,10 @@ export async function fetchDeviceWiki(
          deviceHandle.length > 0,
          'deviceHandle cannot be a blank string'
       );
-      return await client.get(`cart/part_collections/devices/${deviceHandle}`);
+      return await client.get(
+         `cart/part_collections/devices/${deviceHandle}`,
+         'device-wiki'
+      );
    } catch (error: any) {
       return null;
    }
@@ -52,7 +55,8 @@ export async function fetchMultipleDeviceImages(
    });
    try {
       const result = await client.get(
-         `wikis/topic_images?` + params.toString()
+         `wikis/topic_images?` + params.toString(),
+         'device-images'
       );
       return MultipleDeviceApiResponseSchema.parse(result);
    } catch (error) {

--- a/frontend/lib/ifixit-api/international-buy-box.ts
+++ b/frontend/lib/ifixit-api/international-buy-box.ts
@@ -27,6 +27,7 @@ export function getBuyBoxForProduct(
 ): Promise<BuyBoxResponse | null> {
    // TODO pull country override from browser url
    return client.get(
-      `internal/international_store_promotion/buybox?productcode=${productcode}`
+      `internal/international_store_promotion/buybox?productcode=${productcode}`,
+      'international-store-promotion-buybox'
    );
 }

--- a/frontend/lib/ifixit-api/productData.ts
+++ b/frontend/lib/ifixit-api/productData.ts
@@ -18,7 +18,7 @@ export async function fetchProductData(
          productHandle.length > 0,
          'productHandle cannot be a blank string'
       );
-      return await client.get(`store/product/${productHandle}`);
+      return await client.get(`store/product/${productHandle}`, 'product-data');
    } catch (error: any) {
       return null;
    }

--- a/frontend/models/product/reviews.ts
+++ b/frontend/models/product/reviews.ts
@@ -38,7 +38,8 @@ export async function fetchProductReviews(
 ): Promise<ProductReviewData | null> {
    const response = await apiClient.get(
       // TODO: get store code from user session or fall back to default
-      `reviews/${productId}?storeCode=${DEFAULT_STORE_CODE}`
+      `reviews/${productId}?storeCode=${DEFAULT_STORE_CODE}`,
+      'product-reviews'
    );
 
    invariant(isRecord(response), 'unexpected api response');

--- a/frontend/templates/product/sections/ProductOverviewSection/AddToCart/NotifyMeForm.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/AddToCart/NotifyMeForm.tsx
@@ -43,17 +43,21 @@ export function NotifyMeForm({ sku }: NotifyMeFormProps) {
          if (typeof email != 'string') {
             throw new Error('email is required');
          }
-         await ifixitAPI.post('cart/product/notifyWhenSkuInStock', {
-            credentials: 'same-origin',
-            headers: {
-               'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-               sku,
-               shop_domain: layoutProps.shopifyCredentials.storefrontDomain,
-               email,
-            }),
-         });
+         await ifixitAPI.post(
+            'cart/product/notifyWhenSkuInStock',
+            'notify-when-sku-in-stock',
+            {
+               credentials: 'same-origin',
+               headers: {
+                  'Content-Type': 'application/json',
+               },
+               body: JSON.stringify({
+                  sku,
+                  shop_domain: layoutProps.shopifyCredentials.storefrontDomain,
+                  email,
+               }),
+            }
+         );
          setStatus(NotifyMeStatus.Submitted);
       } catch (error) {
          setStatus(NotifyMeStatus.Error);

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -28,6 +28,7 @@ export const getServerSideProps: GetServerSideProps<
 
    const wikiData = await client.get<TroubleshootingData>(
       `Troubleshooting/${wikiname}`,
+      'troubleshooting',
       {
          credentials: 'include',
       }

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -67,7 +67,7 @@ const UserApiResponseSchema = z.object({
 async function fetchAuthenticatedUser(
    apiClient: IFixitAPIClient
 ): Promise<User | null> {
-   const payload = await apiClient.get('user');
+   const payload = await apiClient.get('user', 'user');
    const userSchema = UserApiResponseSchema.parse(payload);
    return {
       id: userSchema.userid,

--- a/packages/cart-sdk/hooks/use-add-to-cart.ts
+++ b/packages/cart-sdk/hooks/use-add-to-cart.ts
@@ -32,6 +32,7 @@ export function useAddToCart(analyticsMessage?: string) {
             case 'product': {
                return iFixitApiClient.post(
                   `store/user/cart/product/${input.product.itemcode}`,
+                  'add-to-cart',
                   {
                      body: JSON.stringify({
                         quantity: input.product.quantity,
@@ -40,16 +41,20 @@ export function useAddToCart(analyticsMessage?: string) {
                );
             }
             case 'bundle': {
-               return iFixitApiClient.post(`store/user/cart/product`, {
-                  body: JSON.stringify({
-                     skus: input.bundle.items.map((item) =>
-                        getProductVariantSku(item.itemcode)
-                     ),
-                     pageSku: getProductVariantSku(
-                        input.bundle.currentItemCode
-                     ),
-                  }),
-               });
+               return iFixitApiClient.post(
+                  `store/user/cart/product`,
+                  'add-to-cart-bundle',
+                  {
+                     body: JSON.stringify({
+                        skus: input.bundle.items.map((item) =>
+                           getProductVariantSku(item.itemcode)
+                        ),
+                        pageSku: getProductVariantSku(
+                           input.bundle.currentItemCode
+                        ),
+                     }),
+                  }
+               );
             }
             default: {
                throw assertNever(input);

--- a/packages/cart-sdk/hooks/use-cart.ts
+++ b/packages/cart-sdk/hooks/use-cart.ts
@@ -21,7 +21,7 @@ import { cartKeys } from '../utils';
 export function useCart() {
    const client = useIFixitApiClient();
    const query = useQuery(cartKeys.cart, async (): Promise<Cart | null> => {
-      const result = await client.get('store/user/cart');
+      const result = await client.get('store/user/cart', 'cart');
       if (!isValidCartPayload(result)) {
          return null;
       }

--- a/packages/cart-sdk/hooks/use-checkout.ts
+++ b/packages/cart-sdk/hooks/use-checkout.ts
@@ -116,7 +116,10 @@ function useDraftOrderCheckout() {
    const shopifyClient = useShopifyStorefrontClient();
    const ssoRoute = `${appContext.ifixitOrigin}/User/sso/shopify/${shopifyClient.shopDomain}?checkout=1`;
    return async () => {
-      const result = await client.post('cart/order/draftOrder');
+      const result = await client.post(
+         'cart/order/draftOrder',
+         'create-draft-order'
+      );
       const draftOrder = DraftOrderResponseSchema.parse(result);
       const returnToUrl = new URL(draftOrder.invoiceUrl);
       const ssoUrl = new URL(ssoRoute);

--- a/packages/cart-sdk/hooks/use-remove-line-item.ts
+++ b/packages/cart-sdk/hooks/use-remove-line-item.ts
@@ -17,7 +17,8 @@ export function useRemoveLineItem() {
    const mutation = useMutation(
       async (input) => {
          await iFixitApiClient.delete(
-            `store/user/cart/product/${input.itemcode}`
+            `store/user/cart/product/${input.itemcode}`,
+            'remove-line-item'
          );
          return true;
       },

--- a/packages/cart-sdk/hooks/use-update-line-item-quantity.ts
+++ b/packages/cart-sdk/hooks/use-update-line-item-quantity.ts
@@ -19,6 +19,7 @@ export function useUpdateLineItemQuantity() {
       async (input) => {
          return iFixitApiClient.post(
             `store/user/cart/product/${input.itemcode}`,
+            'update-line-item-quantity',
             {
                body: JSON.stringify({
                   quantity: input.quantity,

--- a/packages/ifixit-api-client/index.tsx
+++ b/packages/ifixit-api-client/index.tsx
@@ -17,9 +17,10 @@ export class IFixitAPIClient {
 
    async get<Data = unknown>(
       endpoint: string,
+      statName: string,
       init?: RequestInit
    ): Promise<Data> {
-      return this.fetch(endpoint, {
+      return this.fetch(endpoint, statName, {
          ...init,
          method: 'GET',
       });
@@ -27,9 +28,10 @@ export class IFixitAPIClient {
 
    async post<Data = unknown>(
       endpoint: string,
+      statName: string,
       init?: RequestInit
    ): Promise<Data> {
-      return this.fetch(endpoint, {
+      return this.fetch(endpoint, statName, {
          ...init,
          method: 'POST',
       });
@@ -37,9 +39,10 @@ export class IFixitAPIClient {
 
    async put<Data = unknown>(
       endpoint: string,
+      statName: string,
       init?: RequestInit
    ): Promise<Data> {
-      return this.fetch(endpoint, {
+      return this.fetch(endpoint, statName, {
          ...init,
          method: 'PUT',
       });
@@ -47,18 +50,19 @@ export class IFixitAPIClient {
 
    async delete<Data = unknown>(
       endpoint: string,
+      statName: string,
       init?: RequestInit
    ): Promise<Data> {
-      return this.fetch(endpoint, {
+      return this.fetch(endpoint, statName, {
          ...init,
          method: 'DELETE',
       });
    }
 
-   async fetch(endpoint: string, init?: RequestInit) {
+   async fetch(endpoint: string, statName: string, init?: RequestInit) {
       const url = `${this.origin}/api/${this.version}/${endpoint}`;
       const response = await timeAsync(
-         `iFixit API ${init?.method || 'GET'}:${truncate(endpoint, 70)}`,
+         `ifixit-api.${init?.method?.toLowerCase() || 'get'}.${statName}`,
          () =>
             fetch(url, {
                credentials: 'include',

--- a/packages/newsletter-sdk/index.tsx
+++ b/packages/newsletter-sdk/index.tsx
@@ -38,9 +38,13 @@ export function useSubscribeToNewsletter(): [Subscription, SubscribeFn] {
             status: SubscriptionStatus.Subscribing,
          }));
          try {
-            await client.post('cart/newsletter/subscribe', {
-               body: JSON.stringify({ email }),
-            });
+            await client.post(
+               'cart/newsletter/subscribe',
+               'subscribe-to-newsletter',
+               {
+                  body: JSON.stringify({ email }),
+               }
+            );
             setState(() => ({
                status: SubscriptionStatus.Subscribed,
                error: undefined,


### PR DESCRIPTION
Adds a mandatory stat name param to the iFixit API client's methods. This will help us measure timings of the same kinds of requests in DataDog, even if they are to different endpoints.

Connects https://github.com/iFixit/react-commerce/issues/1612

CC @danielbeardsley 

## QA

Verify that iFixit api requests follow the format `ifixit-api.get.stat-name` instead of `iFixit API GET:endpoint/name` in the Vercel logs.