### PR TITLE
ESLint: Turn on `no-unused-vars`

### DIFF
--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,3 +1,4 @@
 **/node_modules/*
 **/out/*
 **/.next/*
+**/generated/*

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -29,7 +29,16 @@
       "@typescript-eslint/no-var-requires": 0,
       "@typescript-eslint/no-use-before-define": 0,
       "@typescript-eslint/explicit-module-boundary-types": "off",
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+         "warn",
+         {
+            "argsIgnorePattern": "^_",
+            "caughtErrorsIgnorePattern": "^_",
+            "destructuredArrayIgnorePattern": "^_",
+            "ignoreRestSiblings": true,
+            "varsIgnorePattern": "^_"
+         }
+      ],
       "@typescript-eslint/no-empty-interface": "off",
       "@typescript-eslint/ban-types": "off",
       "@typescript-eslint/no-non-null-assertion": "off",

--- a/frontend/components/community/navigation.tsx
+++ b/frontend/components/community/navigation.tsx
@@ -9,7 +9,6 @@ import {
    TabPanel,
    TabPanels,
    Tabs,
-   useDisclosure,
 } from '@chakra-ui/react';
 import { useRouter } from 'next/dist/client/router';
 import React, { useEffect, useState } from 'react';
@@ -25,16 +24,13 @@ interface TabData {
 export default function NavigationDisplay({
    title,
    privileges,
-   setUser,
    patrolEnabled,
 }: {
    title: string;
    privileges: { isLoggedIn: boolean; isMod: boolean };
-   setUser: React.Dispatch<React.SetStateAction<{}>>;
    patrolEnabled: boolean;
 }) {
    const [onIfixit, setOnIfixit] = useState(true);
-   const { isOpen, onOpen, onClose } = useDisclosure();
    const router = useRouter();
    const visibleTabs = getTabs();
 

--- a/frontend/components/community/video.tsx
+++ b/frontend/components/community/video.tsx
@@ -1,11 +1,4 @@
-import {
-   AspectRatio,
-   Button,
-   Flex,
-   Heading,
-   Link,
-   Text,
-} from '@chakra-ui/react';
+import { AspectRatio, Button, Flex, Heading, Text } from '@chakra-ui/react';
 import links from '../../lib/links';
 import {
    color,

--- a/frontend/components/sections/BannersSection/SingleBanner.tsx
+++ b/frontend/components/sections/BannersSection/SingleBanner.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text } from '@chakra-ui/react';
+import { Box, Text } from '@chakra-ui/react';
 import { LinkButton } from '@components/ui/LinkButton';
 import { SmartLink } from '@components/ui/SmartLink';
 import { ResponsiveImage, Wrapper } from '@ifixit/ui';

--- a/frontend/helpers/application-helpers.ts
+++ b/frontend/helpers/application-helpers.ts
@@ -25,7 +25,7 @@ export function getResizedImage({ src, width }: GetResizedImageInput) {
    if (match == null) {
       return src;
    }
-   const [fullSrc, baseSrc, extension, query] = match;
+   const [_fullSrc, baseSrc, extension, query] = match;
    return `${baseSrc}_${width}x.${extension}?${query}`;
 }
 

--- a/frontend/helpers/product-helpers.ts
+++ b/frontend/helpers/product-helpers.ts
@@ -5,7 +5,6 @@ import {
    faImage,
    faShop,
    faWarehouse,
-   IconDefinition,
 } from '@fortawesome/pro-solid-svg-icons';
 import { ifixitOriginWithSubdomain } from './path-helpers';
 

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -1,6 +1,6 @@
 import { PageEditMenuLink } from '@components/admin';
 import { STRAPI_ORIGIN } from '@config/env';
-import { faDatabase, IconDefinition } from '@fortawesome/pro-solid-svg-icons';
+import { faDatabase } from '@fortawesome/pro-solid-svg-icons';
 import { FacetWidgetType, ProductListType } from '@models/product-list';
 import { z } from 'zod';
 

--- a/frontend/lib/redis/index.ts
+++ b/frontend/lib/redis/index.ts
@@ -12,7 +12,7 @@ function getClient() {
       maxRetriesPerRequest: 0,
       // Always try re-connecting since one instance is shared across the whole
       // process
-      reconnectOnError: (err) => 1,
+      reconnectOnError: (_err) => 1,
       // When not connected to redis, return error, don't add operations to a
       // queue
       enableOfflineQueue: false,

--- a/frontend/models/page/sections/browse-section.ts
+++ b/frontend/models/page/sections/browse-section.ts
@@ -22,7 +22,7 @@ export const BrowseSectionSchema = z.object({
 
 export function browseSectionFromStrapi(
    fragment: BrowseSectionFieldsFragment | null | undefined,
-   index: number
+   _index: number
 ): BrowseSection | null {
    const id = createSectionId(fragment);
    const title = fragment?.title ?? null;

--- a/frontend/models/page/sections/hero-section.ts
+++ b/frontend/models/page/sections/hero-section.ts
@@ -20,7 +20,7 @@ export const HeroSectionSchema = z.object({
 
 export function heroSectionFromStrapi(
    fragment: HeroSectionFieldsFragment | null | undefined,
-   index: number
+   _index: number
 ): HeroSection | null {
    const id = createSectionId(fragment);
    const title = fragment?.title ?? null;

--- a/frontend/models/page/sections/press-quotes-section.ts
+++ b/frontend/models/page/sections/press-quotes-section.ts
@@ -24,7 +24,7 @@ export const PressQuotesSectionSchema = z.object({
 
 export function pressQuotesSectionFromStrapi(
    fragment: PressQuotesSectionFieldsFragment | null | undefined,
-   index: number
+   _index: number
 ): PressQuotesSection | null {
    const id = createSectionId(fragment);
    const title = fragment?.title;

--- a/frontend/models/sections/ifixit-stats-section.ts
+++ b/frontend/models/sections/ifixit-stats-section.ts
@@ -21,7 +21,7 @@ export const IFixitStatsSectionSchema = z.object({
 
 export function iFixitStatsSectionFromStrapi(
    fragment: StatsSectionFieldsFragment | null | undefined,
-   index: number
+   _index: number
 ): IFixitStatsSection | null {
    const id = createSectionId(fragment);
    const stats = filterFalsyItems(fragment?.stats).map(

--- a/frontend/models/sections/social-gallery-section.ts
+++ b/frontend/models/sections/social-gallery-section.ts
@@ -19,7 +19,7 @@ export const SocialGallerySectionSchema = z.object({
 
 export async function socialGallerySectionFromStrapi(
    fragment: SocialGallerySectionFieldsFragment | null | undefined,
-   index: number
+   _index: number
 ): Promise<SocialGallerySection | null> {
    const id = createSectionId(fragment);
 

--- a/frontend/pages/CommunityNext/index.tsx
+++ b/frontend/pages/CommunityNext/index.tsx
@@ -14,7 +14,7 @@ export default function LandingPage({
    activities: Activity[];
    patrolEnabled: boolean;
 }) {
-   const [user, setUser] = useState({});
+   const [user, _setUser] = useState({});
    const [privileges, setPrivileges] = useState({
       isLoggedIn: false,
       isMod: false,
@@ -51,7 +51,6 @@ export default function LandingPage({
          <NavigationDisplay
             title={siteTitle}
             privileges={privileges}
-            setUser={setUser}
             patrolEnabled={patrolEnabled}
          />
          <InfoDisplay userLang={lang ? lang : getLocale()} />

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -17,13 +17,9 @@ import { HeroWithBackgroundSection } from './sections/HeroWithBackgroundSection'
 
 export interface ProductListViewProps {
    productList: ProductList;
-   indexName: string;
 }
 
-export function ProductListView({
-   productList,
-   indexName,
-}: ProductListViewProps) {
+export function ProductListView({ productList }: ProductListViewProps) {
    // This temporary hack allows to correctly populate the itemType facet during SSR
    // see: https://github.com/algolia/instantsearch/issues/5571
    const _ = useMenu({ attribute: 'facet_tags.Item Type' });

--- a/frontend/templates/product-list/hooks/useProductListTemplateProps.ts
+++ b/frontend/templates/product-list/hooks/useProductListTemplateProps.ts
@@ -6,7 +6,6 @@ import type { ProductList } from '@models/product-list';
 export type ProductListTemplateProps = WithProvidersProps<
    WithLayoutProps<{
       productList: ProductList;
-      indexName: string;
    }>
 >;
 

--- a/frontend/templates/product-list/index.tsx
+++ b/frontend/templates/product-list/index.tsx
@@ -4,9 +4,8 @@ import { ProductListView } from './ProductListView';
 
 const ProductListTemplate: NextPageWithLayout<ProductListTemplateProps> = ({
    productList,
-   indexName,
 }) => {
-   return <ProductListView productList={productList} indexName={indexName} />;
+   return <ProductListView productList={productList} />;
 };
 
 ProductListTemplate.getLayout = function getLayout(page, pageProps) {

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -187,13 +187,11 @@ export const getProductListServerSideProps = ({
 
       const { serverState, adminMessage } = await getSafeServerState({
          appProps,
-         indexName,
          productList,
       });
 
       const pageProps: ProductListTemplateProps = {
          productList,
-         indexName,
          layoutProps: await layoutProps,
          appProps: {
             ...appProps,
@@ -214,19 +212,17 @@ export const getProductListServerSideProps = ({
 
 type GetSafeServerStateProps = {
    appProps: AppProvidersProps;
-   indexName: string;
    productList: ProductList;
 };
 
 async function getSafeServerState({
    appProps,
-   indexName,
    productList,
 }: GetSafeServerStateProps) {
    const tryGetServerState = (productList: ProductList) => {
       const appMarkup = (
          <AppProviders {...appProps}>
-            <ProductListView productList={productList} indexName={indexName} />
+            <ProductListView productList={productList} />
          </AppProviders>
       );
       return timeAsync('getServerState', () =>

--- a/frontend/templates/product/sections/CompatibilityNotesSection/index.tsx
+++ b/frontend/templates/product/sections/CompatibilityNotesSection/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, SimpleGrid } from '@chakra-ui/react';
+import { Box, Heading } from '@chakra-ui/react';
 import { Wrapper } from '@ifixit/ui';
 import type { Product } from '@pages/api/nextjs/cache/product';
 

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -3,7 +3,6 @@ import { DefaultLayoutProps } from '@layouts/default/server';
 import Head from 'next/head';
 import React from 'react';
 import {
-   Text,
    Avatar,
    Box,
    BoxProps,

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -5,7 +5,6 @@ import {
    Text,
    Avatar,
    Button,
-   Icon,
    Badge,
    Square,
    Flex,
@@ -20,7 +19,7 @@ import { FaIcon } from '@ifixit/icons';
 import { Section } from './hooks/useTroubleshootingProps';
 import Prerendered from './prerendered';
 
-const SolutionFooter = () => (
+const _SolutionFooter = () => (
    <Stack
       justify="flex-start"
       align="flex-start"


### PR DESCRIPTION
Turns on the [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) rule, and offers prefixing with an underscore as an escape hatch.

qa_req 0