### PR TITLE
Improve Docker compose file to persist media files across re-deployments

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -18,12 +18,7 @@ services:
       ports:
          - '${HOST_PORT:-1337}:1337'
       volumes:
-         - uploads:/opt/app/public/uploads
-         - ./config:/opt/app/config
-         - ./src:/opt/app/src
-         - ./package.json:/opt/package.json
-         - ./yarn.lock:/opt/yarn.lock
-         - ./.env:/opt/app/.env
+         - ./public/uploads:/opt/public/uploads
       depends_on:
          - postgres
       command: 'strapi start'
@@ -39,4 +34,3 @@ services:
 
 volumes:
    db_data:
-   uploads:


### PR DESCRIPTION
closes #1628 
qa_req 0

deploy_block 🛑 on confirming that changing the docker compose file doesn't affect the Strapi production instance (i.e. we're not using the Docker compose file to deploy production, correct?)

cc @masonmcelvain @danielbeardsley @sterlinghirsh 