### PR TITLE
Rely on Next image instead of Strapi formats for some Strapi provided images

### DIFF
--- a/frontend/helpers/strapi-helpers.ts
+++ b/frontend/helpers/strapi-helpers.ts
@@ -10,13 +10,15 @@ interface Image {
 
 export function getImageFromStrapiImage(
    image: Pick<UploadFile, 'formats' | 'alternativeText' | 'url'>,
-   format: StrapiImageFormat
+   format?: StrapiImageFormat
 ): Image | null {
    if (image == null) {
       return null;
    }
    const result: Image = {
-      url: `${image.formats[format] ? image.formats[format].url : image.url}`,
+      url: `${
+         format && image.formats[format] ? image.formats[format].url : image.url
+      }`,
       formats: image.formats,
       alternativeText: null,
    };

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -98,10 +98,7 @@ export async function findProductList(
       filters: productList?.filters ?? null,
       forceNoindex: productList?.forceNoindex ?? null,
       heroImage: productList?.heroImage?.data?.attributes
-         ? getImageFromStrapiImage(
-              productList.heroImage.data.attributes,
-              'large'
-           )
+         ? getImageFromStrapiImage(productList.heroImage.data.attributes)
          : null,
       image: null,
       brandLogo: productList?.brandLogo?.data?.attributes


### PR DESCRIPTION
connects #1611

This PR removes the capping of hero images due to Strapi formats.
We remove the capping only on this section to verify that NextJS images scaling performs well and do not produce delays when downscaling large images.
If this proves effective for the hero we can think to rely more on Next image, removing the Strapi formats capping also on other Strapi provided images.

### QA

1. Visit Vercel preview
2. Verify that hero images are not capped anymore to 1000px width
3. Verify that hero images are scaled down by Next image to an acceptable size even when the originals are quite large