### PR TITLE
Add browse section category custom description

### DIFF
--- a/backend/src/components/page/category.json
+++ b/backend/src/components/page/category.json
@@ -2,7 +2,8 @@
    "collectionName": "components_page_categories",
    "info": {
       "displayName": "category",
-      "icon": "border-all"
+      "icon": "border-all",
+      "description": ""
    },
    "options": {},
    "attributes": {
@@ -10,6 +11,9 @@
          "type": "relation",
          "relation": "oneToOne",
          "target": "api::product-list.product-list"
+      },
+      "description": {
+         "type": "string"
       }
    }
 }

--- a/backend/src/components/page/category.json
+++ b/backend/src/components/page/category.json
@@ -13,7 +13,7 @@
          "target": "api::product-list.product-list"
       },
       "description": {
-         "type": "string"
+         "type": "text"
       }
    }
 }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -266,12 +266,14 @@ export type ComponentPageCallToActionInput = {
 
 export type ComponentPageCategory = {
    __typename?: 'ComponentPageCategory';
+   description?: Maybe<Scalars['String']>;
    id: Scalars['ID'];
    productList?: Maybe<ProductListEntityResponse>;
 };
 
 export type ComponentPageCategoryFiltersInput = {
    and?: InputMaybe<Array<InputMaybe<ComponentPageCategoryFiltersInput>>>;
+   description?: InputMaybe<StringFilterInput>;
    not?: InputMaybe<ComponentPageCategoryFiltersInput>;
    or?: InputMaybe<Array<InputMaybe<ComponentPageCategoryFiltersInput>>>;
    productList?: InputMaybe<ProductListFiltersInput>;

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2552,6 +2552,7 @@ export type FindPageQuery = {
                     categories?: Array<{
                        __typename?: 'ComponentPageCategory';
                        id: string;
+                       description?: string | null;
                        productList?: {
                           __typename?: 'ProductListEntityResponse';
                           data?: {
@@ -4217,6 +4218,7 @@ export type BrowseSectionFieldsFragment = {
    categories?: Array<{
       __typename?: 'ComponentPageCategory';
       id: string;
+      description?: string | null;
       productList?: {
          __typename?: 'ProductListEntityResponse';
          data?: {
@@ -4249,6 +4251,7 @@ export type BrowseSectionFieldsFragment = {
 export type CategoryFieldsFragment = {
    __typename?: 'ComponentPageCategory';
    id: string;
+   description?: string | null;
    productList?: {
       __typename?: 'ProductListEntityResponse';
       data?: {
@@ -4739,6 +4742,7 @@ export const ProductListFieldsFragmentDoc = `
 export const CategoryFieldsFragmentDoc = `
     fragment CategoryFields on ComponentPageCategory {
   id
+  description
   productList {
     data {
       ...ProductListFields

--- a/frontend/lib/strapi-sdk/generated/validation.ts
+++ b/frontend/lib/strapi-sdk/generated/validation.ts
@@ -247,6 +247,7 @@ export function ComponentPageCategoryFiltersInputSchema(): z.ZodObject<
             z.lazy(() => ComponentPageCategoryFiltersInputSchema().nullable())
          )
          .nullish(),
+      description: z.lazy(() => StringFilterInputSchema().nullish()),
       not: z.lazy(() => ComponentPageCategoryFiltersInputSchema().nullish()),
       or: z
          .array(

--- a/frontend/lib/strapi-sdk/operations/sections/BrowseSectionFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/BrowseSectionFields.fragment.graphql
@@ -9,12 +9,3 @@ fragment BrowseSectionFields on ComponentPageBrowse {
       ...CategoryFields
    }
 }
-
-fragment CategoryFields on ComponentPageCategory {
-   id
-   productList {
-      data {
-         ...ProductListFields
-      }
-   }
-}

--- a/frontend/lib/strapi-sdk/operations/sections/CategoryFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/sections/CategoryFields.fragment.graphql
@@ -1,0 +1,9 @@
+fragment CategoryFields on ComponentPageCategory {
+   id
+   description
+   productList {
+      data {
+         ...ProductListFields
+      }
+   }
+}

--- a/frontend/models/page/components/browse-category.ts
+++ b/frontend/models/page/components/browse-category.ts
@@ -1,7 +1,7 @@
 import { CategoryFieldsFragment } from '@lib/strapi-sdk';
+import { imageFromStrapi, ImageSchema } from '@models/components/image';
 import { ProductListType } from '@models/product-list';
 import { getProductListType } from '@models/product-list/server';
-import { ImageSchema, imageFromStrapi } from '@models/components/image';
 import { z } from 'zod';
 
 export const BrowseCategorySchema = z.object({
@@ -10,7 +10,7 @@ export const BrowseCategorySchema = z.object({
    handle: z.string(),
    title: z.string(),
    deviceTitle: z.string().nullable(),
-   metaDescription: z.string().nullable(),
+   description: z.string().nullable(),
    image: ImageSchema.nullable(),
 });
 
@@ -21,6 +21,8 @@ export function browseCategoryFromStrapi(
 ): BrowseCategory | null {
    const id = fragment?.id;
    const attributes = fragment?.productList?.data?.attributes;
+   const description = fragment?.description ?? null;
+
    if (id == null || attributes == null) {
       return null;
    }
@@ -30,7 +32,7 @@ export function browseCategoryFromStrapi(
       handle: attributes.handle,
       title: attributes.title,
       deviceTitle: attributes.deviceTitle ?? null,
-      metaDescription: attributes.metaDescription ?? null,
+      description,
       image: imageFromStrapi(attributes.image),
    };
 }

--- a/frontend/templates/page/sections/BrowseSection.tsx
+++ b/frontend/templates/page/sections/BrowseSection.tsx
@@ -160,7 +160,7 @@ function FeaturedCategories({ categories }: FeaturedCategoriesProps) {
                         productList={{
                            title: category.title,
                            imageUrl: category.image?.url,
-                           description: category.metaDescription,
+                           description: category.description,
                         }}
                      />
                   </NextLink>


### PR DESCRIPTION
closes #1633 

## QA

1. Visit [Strapi Govinor instance](https://add-browse-section-category-custom-description.govinor.com/admin/content-manager/collectionType/api::page.page/1?plugins[i18n][locale]=en)
2. Visit Content Manager > Page and view the `/Store` page
3. Verify that browse section categories have a description field
    <img width="911" alt="Screenshot 2023-05-02 at 17 08 11" src="https://user-images.githubusercontent.com/4640135/235707540-2e8259f8-4fde-4549-ab47-772282136be0.png">

4. Write a short description for the first two categories
5. Visit the [store home page preview](https://react-commerce-git-add-browse-section-category-cu-8a0a8f-ifixit.vercel.app/Store)
6. Verify that the description field is being used
    ![Screenshot 2023-05-02 at 17 03 52](https://user-images.githubusercontent.com/4640135/235706426-f4240bb2-75a6-4d6c-9c38-4d62e0e32490.png)
