### PR TITLE
Fix `FONT_AWESOME_NPM_TOKEN` Population

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,5 +2,5 @@ shamefully-hoist=true
 always-auth=false
 @fortawesome:registry=https://npm.fontawesome.com/
 strict-peer-dependencies=false
-//npm.fontawesome.com/:_authToken=${FONT_AWESOME_NPM_TOKEN}
+//npm.fontawesome.com/:_authToken=\process.env.FONT_AWESOME_NPM_TOKEN
 //npm.fontawesome.com/:always-auth=true

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,4 +1,4 @@
 always-auth=false
 @fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=${FONT_AWESOME_NPM_TOKEN}
+//npm.fontawesome.com/:_authToken=\process.env.FONT_AWESOME_NPM_TOKEN
 //npm.fontawesome.com/:always-auth=true


### PR DESCRIPTION
## Summary
Use `process.env` to populate `FONT_AWESOME_NPM_TOKEN`. It wasn't working before for some reason.

<details>
  <summary>Post-fix Video of running `pnpm dev`</summary>

https://user-images.githubusercontent.com/1634505/235802322-98501121-03be-4ab8-b910-727a5e060d8d.mov

</details>

## Modified
1. [use process.env to populate fontawesome token](https://github.com/iFixit/react-commerce/commit/8d5dc7ec51ed6bafc521da8ee46dbc5e4e1b983d)

qa_req 0