### PR TITLE
Add itemTypeOverrides to backend schema.

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -225,6 +225,16 @@
          },
          "type": "boolean",
          "default": false
+      },
+      "itemOverrides": {
+         "pluginOptions": {
+            "i18n": {
+               "localized": true
+            }
+         },
+         "type": "dynamiczone",
+         "components": ["product-list.item-type-override"],
+         "required": true
       }
    }
 }

--- a/backend/src/components/product-list/item-type-override.json
+++ b/backend/src/components/product-list/item-type-override.json
@@ -1,0 +1,29 @@
+{
+   "collectionName": "components_product_list_item_type_overrides",
+   "info": {
+      "displayName": "ItemTypeOverride",
+      "description": ""
+   },
+   "options": {},
+   "attributes": {
+      "itemType": {
+         "type": "string",
+         "required": false
+      },
+      "title": {
+         "type": "string"
+      },
+      "metaTitle": {
+         "type": "string"
+      },
+      "description": {
+         "type": "richtext"
+      },
+      "metaDescription": {
+         "type": "string"
+      },
+      "tagline": {
+         "type": "string"
+      }
+   }
+}


### PR DESCRIPTION
## Overview
The issue is probably better to read for full context, but this pull is implementing the code to allow item type product list pages to have custom title, metatitle, description, metadescription, and tagline attributes. It allows people to set custom item type data in strapi which then gets rendered on the page. This only implements the backend changes needed.

## QA

Do product list pages still work?

Connects: https://github.com/iFixit/react-commerce/issues/589

Just the backend code from https://github.com/iFixit/react-commerce/pull/1630