### PR TITLE
Use fontawesome env var in npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,5 +2,5 @@ shamefully-hoist=true
 always-auth=false
 @fortawesome:registry=https://npm.fontawesome.com/
 strict-peer-dependencies=false
-//npm.fontawesome.com/:_authToken=\process.env.FONT_AWESOME_NPM_TOKEN
+//npm.fontawesome.com/:_authToken=${FONT_AWESOME_NPM_TOKEN}
 //npm.fontawesome.com/:always-auth=true

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,4 +1,4 @@
 always-auth=false
 @fortawesome:registry=https://npm.fontawesome.com/
-//npm.fontawesome.com/:_authToken=\process.env.FONT_AWESOME_NPM_TOKEN
+//npm.fontawesome.com/:_authToken=${FONT_AWESOME_NPM_TOKEN}
 //npm.fontawesome.com/:always-auth=true


### PR DESCRIPTION
Using process.env in  #1636 seems to have broken preview deployments, see https://github.com/iFixit/react-commerce/pull/1647 for an example.

qa_req 0 If it passes CI

CC @ianrohde @danielbeardsley 

<img src="https://user-images.githubusercontent.com/52104630/236277825-ac9345c9-c06c-4699-bca6-e2b7700f316a.png">