### PR TITLE
README: update with instructions to use vercel cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ tmp
 tsconfig.tsbuildinfo
 
 .env.local
+.env
 .vercel
 
 .next

--- a/README.md
+++ b/README.md
@@ -20,34 +20,42 @@ Here's one way you can get all the right versions installed and setup:
 
 ### Setup
 
-This command will install both backend and frontend dependencies:
+#### Setup strapi Env file
 
-Copy `.env.local.example` to `.env.local` and fill in the values.
+1. Copy `backend/.env.example` to `backend/.env`
+
+#### Setup next.js environment file (with vercel account)
+
+1. Setup pnpm so installed modules are in your PATH:
+
+-  `pnpm setup && source ~/.bashrc` (if you haven't already done so)
+
+2. Install vercel cli: `pnpm install -g vercel`
+3. `vercel login`
+4. `cd path/to/this/repo && vercel link --project=react-commerce`
+5. `vercel env pull`
+6. `ln -s ../.env frontend/.env.local
+
+#### Setup next.js environment file (without vercel account)
+
+1. Copy `frontend/.env.local.example` to `frontend/.env.local`
+2. Fill in the Algolia API Key
+   -  In `frontend/.env.local` fill in `ALGOLIA_API_KEY` by either:
+      -  Copying the `Search API Key` [from Algolia](https://www.algolia.com/account/api-keys/all?applicationId=XQEP3AD9ZT)
+         -  :warning: You may need to ask for access to our Algolia
+      -  Or copying the dev key from Cominor:
+         ```sh
+         cat /etc/dozuki/algolia-keys.json | jq --raw-output .searchApiKey
+         ```
+   -  Note: `SENTRY_AUTH_TOKEN` is not needed in development
+
+#### Install Dependencies
+
+This command will install both backend and frontend dependencies:
 
 ```sh
 pnpm install:all
 ```
-
-#### Copy the environment files to local
-
-1. Copy `backend/.env.example` to `backend/.env`
-2. Copy `frontend/.env.local.example` to `frontend/.env.local`
-
-#### Fill in the Algolia API Key
-
-In `frontend/.env.local` fill in `ALGOLIA_API_KEY` by either:
-
--  Copying the `Search API Key` [from Algolia](https://www.algolia.com/account/api-keys/all?applicationId=XQEP3AD9ZT)
-
-   -  :warning: You may need to ask for access to our Algolia
-
--  Or copy the dev key from Cominor:
-
-   ```sh
-   cat /etc/dozuki/algolia-keys.json | jq --raw-output .searchApiKey
-   ```
-
-> Note: `SENTRY_AUTH_TOKEN` is not needed in development
 
 ### Start dev server
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Here's one way you can get all the right versions installed and setup:
 2. Install vercel cli: `pnpm install -g vercel`
 3. `vercel login`
 4. `cd path/to/this/repo && vercel link --project=react-commerce`
-5. `vercel env pull`
-6. `ln -s ../.env frontend/.env.local`
+5. Choose the `iFixit` scope when it asks which scope to use
+6. `vercel env pull`
+7. `ln -s ../.env frontend/.env.local`
 
 #### Setup next.js environment file (without vercel account)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here's one way you can get all the right versions installed and setup:
 3. `vercel login`
 4. `cd path/to/this/repo && vercel link --project=react-commerce`
 5. `vercel env pull`
-6. `ln -s ../.env frontend/.env.local
+6. `ln -s ../.env frontend/.env.local`
 
 #### Setup next.js environment file (without vercel account)
 


### PR DESCRIPTION
You can pull down all the appropriate env vars with `vercel env pull`, so let's update the instructions with two ways of getting an env file.

If you don't have a vercel account, I've left (and reformatted) the previous instructions.

Closes #1617 

