### PR TITLE
Sentry: Send DSN to the client

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -4,7 +4,7 @@ NEXT_PUBLIC_APP_ORIGIN=http://localhost:3000
 NEXT_PUBLIC_STRAPI_ORIGIN=http://localhost:1337
 NEXT_PUBLIC_SHOPIFY_STOREFRONT_VERSION=2022-10
 STRAPI_IMAGE_DOMAIN=ifixit-dev-strapi-uploads.s3.us-west-1.amazonaws.com
-SENTRY_DSN=https://95ab6917c0234f80b99bb0be8e720355@o186239.ingest.sentry.io/6475315
+NEXT_PUBLIC_SENTRY_DSN=https://95ab6917c0234f80b99bb0be8e720355@o186239.ingest.sentry.io/6475315
 NEXT_PUBLIC_MATOMO_URL=https://matomo.ubreakit.com
 NEXT_PUBLIC_GA_KEY=UA-30506-1
 # If we want to test Google Analytics in dev DEBUG should be true and URL should be

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -13,7 +13,7 @@ NEXT_PUBLIC_APP_ORIGIN=https://${VERCEL_URL}
 NEXT_PUBLIC_SHOPIFY_STOREFRONT_VERSION=2022-10
 STRAPI_IMAGE_DOMAIN=ifixit-strapi-uploads.s3.amazonaws.com
 # Overridden in prod
-SENTRY_DSN=https://95ab6917c0234f80b99bb0be8e720355@o186239.ingest.sentry.io/6475315
+NEXT_PUBLIC_SENTRY_DSN=https://95ab6917c0234f80b99bb0be8e720355@o186239.ingest.sentry.io/6475315
 SENTRY_AUTH_TOKEN=
 # Overridden in prod
 NEXT_PUBLIC_MATOMO_URL=https://matomo.ubreakit.com

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 import { BrowserTracing } from '@sentry/tracing';
 
-const SENTRY_DSN = process.env.SENTRY_DSN;
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 const hydrationErrors = [
    'Hydration failed because the initial UI does not match what was rendered on the server.',

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -4,7 +4,7 @@
 
 import * as Sentry from '@sentry/nextjs';
 
-const SENTRY_DSN = process.env.SENTRY_DSN;
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
    dsn: SENTRY_DSN,


### PR DESCRIPTION
This fixes a bug where no client side errors were being reported to Sentry because the DSN wasn't available to the browser as an [environment variable](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#exposing-environment-variables-to-the-browser).

Closes #1654