### PR TITLE
Rename Upsell to Cross Sell

### DIFF
--- a/packages/cart-sdk/hooks/use-cart.ts
+++ b/packages/cart-sdk/hooks/use-cart.ts
@@ -11,7 +11,7 @@ import {
    Cart,
    CartAPIResponse,
    CartLineItem,
-   UpsellProduct,
+   CrossSellProduct,
 } from '../types';
 import { cartKeys } from '../utils';
 
@@ -82,6 +82,7 @@ function createCart(input: APICart): Cart {
            }
          : null;
 
+   const crossSellProducts = input.upsellProducts ?? input.crossSellProducts;
    return {
       hasItemsInCart: input.totalNumItems > 0,
       lineItems,
@@ -91,8 +92,8 @@ function createCart(input: APICart): Cart {
          price: totalPrice,
          compareAtPrice: totalCompareAtPrice,
       },
-      upsellProducts: filterNullableItems(
-         input.upsellProducts.map<UpsellProduct | null>((apiProduct) => {
+      crossSellProducts: filterNullableItems(
+         crossSellProducts.map<CrossSellProduct | null>((apiProduct) => {
             if (apiProduct.subPrice == null) {
                return null;
             }

--- a/packages/cart-sdk/types.ts
+++ b/packages/cart-sdk/types.ts
@@ -13,7 +13,7 @@ export interface Cart {
       price: Money;
       compareAtPrice?: Money | null | undefined;
    };
-   upsellProducts: UpsellProduct[];
+   crossSellProducts: CrossSellProduct[];
 }
 
 export interface CartLineItem {
@@ -48,9 +48,10 @@ export interface APICart {
    miniCart: {
       products: MiniCartProduct[];
    };
-   upsellProducts: APIUpsellProduct[];
+   upsellProducts: APICrossSellProduct[];
+   crossSellProducts: APICrossSellProduct[];
 }
-export interface UpsellProduct {
+export interface CrossSellProduct {
    marketingTitle: string | null;
    marketingBlurb: string | null;
    itemcode: string;
@@ -63,7 +64,7 @@ export interface UpsellProduct {
    handle: string;
 }
 
-interface APIUpsellProduct {
+interface APICrossSellProduct {
    compare_at_price: string | null;
    handle: string;
    imageSrc: string | null;

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -37,7 +37,7 @@ import { CartDrawerTrigger } from './CartDrawerTrigger';
 import { CartEmptyState } from './CartEmptyState';
 import { CartLineItem } from './CartLineItem';
 import { useCartDrawer } from './hooks/useCartDrawer';
-import { Upsell } from './Upsell';
+import { CrossSell } from './CrossSell';
 
 // This is a temporary type fix for Framer Motion since
 // React 18 typings breaks FC which Framer Motion relies on.
@@ -54,8 +54,8 @@ export function CartDrawer() {
    const cart = useCart();
    const checkout = useCheckout();
 
-   const upsellItem = React.useMemo(() => {
-      const item = cart.data?.upsellProducts[0];
+   const crossSellItem = React.useMemo(() => {
+      const item = cart.data?.crossSellProducts[0];
       const isAlreadyInCart =
          item &&
          cart.data?.lineItems.find(
@@ -153,7 +153,7 @@ export function CartDrawer() {
                               })}
                            </AnimatePresence>
                         </Box>
-                        {upsellItem && <Upsell item={upsellItem} />}
+                        {crossSellItem && <CrossSell item={crossSellItem} />}
                      </ScaleFade>
                      <Collapse
                         animateOpacity

--- a/packages/ui/cart/drawer/CrossSell.tsx
+++ b/packages/ui/cart/drawer/CrossSell.tsx
@@ -9,17 +9,17 @@ import {
 } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { useAddToCart } from '@ifixit/cart-sdk';
-import { UpsellProduct } from '@ifixit/cart-sdk/types';
+import { CrossSellProduct } from '@ifixit/cart-sdk/types';
 import { useCallback } from 'react';
 import { ProductVariantPrice, useUserPrice } from '../../commerce';
 import { CartLineItemImage } from './CartLineItemImage';
 import { useCartDrawer } from './hooks/useCartDrawer';
 
-export interface UpsellProps {
-   item: UpsellProduct;
+export interface CrossSellProps {
+   item: CrossSellProduct;
 }
 
-export function Upsell({ item }: UpsellProps) {
+export function CrossSell({ item }: CrossSellProps) {
    const { onClose } = useCartDrawer();
    const addToCart = useAddToCart('Cart Drawer');
    const userPrice = useUserPrice({


### PR DESCRIPTION
## Overview

We aren't upselling, technically. We are cross selling. So lets have the names be accurate.

The remaining references to "upsells" are because we don't want the code to break as we change the ifixit api response to be "crossSellProducts". Basically just so we can smoothly swap things out. 

## QA 

Does the upsell section in the cart still work fine? 

Connects https://github.com/iFixit/ifixit/issues/46262