### PR TITLE
Change the text from reviews to ratings

### DIFF
--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -209,7 +209,7 @@ function ReviewsStats({
             <Text fontSize="5xl">{averageRating}</Text>
             <Rating value={averageRating ?? 0} />
             {totalReviewsCount && (
-               <Text fontSize="sm">{totalReviewsCount} reviews</Text>
+               <Text fontSize="sm">{totalReviewsCount} ratings</Text>
             )}
          </Flex>
       </Stack>


### PR DESCRIPTION
As specified in the issue, when the page displays a number it is followed by reviews but the number also takes into account the ratings given to the product. Therefore, it makes sense to change this text accordingly.

From my understanding, the `totalReviewsCount` is the value we get from `reviewsData.count` which probably counts the number of ratings instead of written reviews.

Closes https://github.com/iFixit/ifixit/issues/47653