### PR TITLE
Fix MSW Handler Race Condition

### DIFF
--- a/frontend/tests/playwright/msw/request-handler.ts
+++ b/frontend/tests/playwright/msw/request-handler.ts
@@ -167,10 +167,20 @@ export const createGraphQLHandler = ({
       '*',
       customResolver ??
          ((req, res, ctx) => {
+            const delayAmount = 2000; // 2 seconds
             if (passthrough) return req.passthrough();
-            if (once) return res.once(ctx.status(status), ctx.data(body));
+            if (once)
+               return res.once(
+                  ctx.delay(delayAmount),
+                  ctx.status(status),
+                  ctx.data(body)
+               );
 
-            return res(ctx.status(status), ctx.data(body));
+            return res(
+               ctx.delay(delayAmount),
+               ctx.status(status),
+               ctx.data(body)
+            );
          })
    );
 };
@@ -202,7 +212,8 @@ export const createRestHandler = ({
          ((req, res, ctx) => {
             if (passthrough) return req.passthrough();
 
-            const transformers = [ctx.status(status)];
+            const delayAmount = 2000; // 2 seconds
+            const transformers = [ctx.delay(delayAmount), ctx.status(status)];
 
             if (headers) {
                transformers.push(ctx.set(headers));


### PR DESCRIPTION
## Description
There was an issue with the msw request handlers for `strapi` requests. https://github.com/iFixit/react-commerce/issues/1627

After digging into the issue, it seems to be an issue with `node-fetch` or `strapi` itself. The trigger for it was 3 requests being made directly to `strapi`: `strapi.getGlobalSettings`, `strapi.getStoreList`, and `strapi.findStore`. These requests were not matched by any of the msw request handlers, so they were passed through to the real `strapi` server.

Then a `strapi.getProductList` request was made, which was matched by the msw request handler, so it was intercepted and mocked. However, this request was immediately returned while the previous 3 requests were still pending. This caused the `FetchError: socket hang up` error to be thrown by `node-fetch` as the queue of pending requests was closed since the lastest request was already returned. In order to fix this, we need to delay the mocked responses to ensure that the previous requests have been returned before the next request is mocked. This also mimics the behavior of real requests, which are not returned immediately.

### CR

Worked with @batbattur on this.

In order to figure out the issue behind #1627, we hooked onto the `life-cycle` events from the MSW server[^1] and modified the source code, within the `node_modules` directory, of the MSW `SetupServerAPI` class to log out steps.

From there, we noticed that the `interceptor.on('response'...)` event [^2] was called when there were no handlers defined for `strapi`, but once the `getProductList` handler was defined, the other `strapi` requests errored and never triggered this event.

### QA:

Unskip the tests in https://github.com/iFixit/react-commerce/blob/item-type-overrides--frontend/frontend/tests/playwright/product/product-list.spec.ts#L5.

- [ ] Confirm a `socket hangup` error is no longer being thrown like in the original branch.
	> ⚠️ The tests will still fail as the tests themselves need to be fixed.

**cc:** @danielcliu-ifixit 

Closes: #1627 

[^1]: https://mswjs.io/docs/extensions/life-cycle-events
[^2]: https://github.com/mswjs/msw/blob/c32241627da09af8b34c4068cc17dd1941ff3b0d/src/node/SetupServerApi.ts#L105