### PR TITLE
Bump @core-ds/primitives to `2.5.2`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
    },
    "dependencies": {
       "@chakra-ui/react": "2.4.8",
-      "@core-ds/primitives": "2.5.1",
+      "@core-ds/primitives": "2.5.2",
       "@emotion/react": "11.10.5",
       "@emotion/styled": "11.10.5",
       "@fortawesome/fontawesome-svg-core": "6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
       '@babel/preset-env': 7.18.6
       '@babel/preset-typescript': 7.18.6
       '@chakra-ui/react': 2.4.8
-      '@core-ds/primitives': 2.5.1
+      '@core-ds/primitives': 2.5.2
       '@emotion/react': 11.10.5
       '@emotion/styled': 11.10.5
       '@fortawesome/fontawesome-svg-core': 6.2.1
@@ -126,7 +126,7 @@ importers:
       zod: 3.18.0
     dependencies:
       '@chakra-ui/react': 2.4.8_dcg2t2i3u3zsy6dxglozcx6cvu
-      '@core-ds/primitives': 2.5.1
+      '@core-ds/primitives': 2.5.2
       '@emotion/react': 11.10.5_5sk75k55old2mvxbb7qmm7otxe
       '@emotion/styled': 11.10.5_yiq25o4tea4ifunxnd2gloaxcy
       '@fortawesome/fontawesome-svg-core': 6.2.1
@@ -5054,8 +5054,8 @@ packages:
       '@chakra-ui/system': 2.4.0_dovxhg2tvkkxkdnqyoum6wzcxm
       react: 18.2.0
 
-  /@core-ds/primitives/2.5.1:
-    resolution: {integrity: sha512-VVRiZLbqccfNZ4sUdtV/fF0HwwPOrspYOxki9AO/lp+d1pZ8K+u3DRytfVKicJMPcUw3ENa26A3P0ud9IAwyHQ==}
+  /@core-ds/primitives/2.5.2:
+    resolution: {integrity: sha512-72G+3U06ABu52GFynmF0z1bwugrF+F5hE8DQNF/FPDd2pFHG0ysxWHGpC8ltadVTZPt4SPjayL89g08a5qaJYQ==}
     dev: false
 
   /@cronvel/get-pixels/3.4.1:


### PR DESCRIPTION
This version removes `Liberation Mono` from the mono font stacks: https://github.com/iFixit/core-primitives/pull/40

TL;DR it improves the vertical alignment of mono fonts on Linux.

qa_req 0 - tested in https://github.com/iFixit/core-primitives/pull/40 and represents less than 1% of users.