### PR TITLE
Mitigate cls on page

### DIFF
--- a/frontend/templates/product-list/hooks/useSearchQuery.tsx
+++ b/frontend/templates/product-list/hooks/useSearchQuery.tsx
@@ -10,8 +10,8 @@ export const SearchQueryContext =
    React.createContext<SearchQueryContext | null>(null);
 
 export const SearchQueryProvider = ({ children }: React.PropsWithChildren) => {
-   const { query } = useSearchBox();
-   const [searchQuery, setSearchQuery] = React.useState(query);
+   const { query: initialQuery } = useSearchBox();
+   const [searchQuery, setSearchQuery] = React.useState(initialQuery);
    return (
       <SearchQueryContext.Provider value={{ searchQuery, setSearchQuery }}>
          {children}
@@ -19,7 +19,7 @@ export const SearchQueryProvider = ({ children }: React.PropsWithChildren) => {
    );
 };
 
-export const useSearchQueryContext = () => {
+export const useSearchQuery = () => {
    const context = React.useContext(SearchQueryContext);
    if (!context) {
       throw new Error(

--- a/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/CurrentRefinements.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Flex } from '@chakra-ui/react';
 import { faClose } from '@fortawesome/pro-solid-svg-icons';
 import { formatFacetName } from '@helpers/algolia-helpers';
-import { useSearchQueryContext } from '@templates/product-list/hooks/useSearchQuery';
+import { useSearchQuery } from '@templates/product-list/hooks/useSearchQuery';
 import { FaIcon } from '@ifixit/icons';
 import * as React from 'react';
 import {
@@ -11,7 +11,7 @@ import {
 } from 'react-instantsearch-hooks-web';
 
 export function CurrentRefinements() {
-   const { setSearchQuery } = useSearchQueryContext();
+   const { setSearchQuery } = useSearchQuery();
    const currentRefinements = useCurrentRefinements();
    const clearRefinements = useClearRefinements({
       excludedAttributes: [],

--- a/frontend/templates/product-list/sections/FilterableProductsSection/SearchInput.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/SearchInput.tsx
@@ -21,7 +21,7 @@ import { useSearchBox } from 'react-instantsearch-hooks-web';
 type SearchInputProps = InputGroupProps;
 
 const MAX_SEARCH_QUERY_LENGTH = 100;
-const DEBOUNCE_INTERVAL_MILLIS = 300;
+const DEBOUNCE_INTERVAL_MILLIS = 50;
 
 export const SearchInput = forwardRef<SearchInputProps, 'div'>((props, ref) => {
    const { query, refine, clear } = useSearchBox({

--- a/frontend/templates/product-list/sections/FilterableProductsSection/SearchInput.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/SearchInput.tsx
@@ -13,7 +13,7 @@ import {
    faMagnifyingGlass,
 } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon } from '@ifixit/icons';
-import { useSearchQueryContext } from '@templates/product-list/hooks/useSearchQuery';
+import { useSearchQuery } from '@templates/product-list/hooks/useSearchQuery';
 import debounce from 'lodash/debounce';
 import * as React from 'react';
 import { useSearchBox } from 'react-instantsearch-hooks-web';
@@ -27,7 +27,7 @@ export const SearchInput = forwardRef<SearchInputProps, 'div'>((props, ref) => {
    const { query, refine, clear } = useSearchBox({
       queryHook: debouncedQueryHook,
    });
-   const { searchQuery, setSearchQuery } = useSearchQueryContext();
+   const { searchQuery, setSearchQuery } = useSearchQuery();
 
    const inputRef = React.useRef<HTMLInputElement>(null);
 

--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -31,7 +31,7 @@ import {
 } from '@models/product-list';
 import {
    SearchQueryProvider,
-   useSearchQueryContext,
+   useSearchQuery,
 } from '@templates/product-list/hooks/useSearchQuery';
 import * as React from 'react';
 import {
@@ -202,7 +202,7 @@ type EmptyStateProps = BoxProps & {
 
 const ProductListEmptyState = forwardRef<EmptyStateProps, 'div'>(
    ({ productList, ...otherProps }, ref) => {
-      const { setSearchQuery } = useSearchQueryContext();
+      const { setSearchQuery } = useSearchQuery();
       const clearRefinements = useClearRefinements({ excludedAttributes: [] });
 
       const currentRefinements = useCurrentRefinements();

--- a/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
@@ -4,7 +4,11 @@ import { productListPath } from '@helpers/path-helpers';
 import { ProductList } from '@models/product-list';
 import NextLink from 'next/link';
 import * as React from 'react';
-import { useCurrentRefinements, useHits } from 'react-instantsearch-hooks-web';
+import {
+   useCurrentRefinements,
+   useHits,
+   useSearchBox,
+} from 'react-instantsearch-hooks-web';
 import { useDevicePartsItemType } from '../hooks/useDevicePartsItemType';
 
 export type ProductListChildrenSectionProps = {
@@ -20,6 +24,7 @@ export function ProductListChildrenSection({
    const [showAll, setShowAll] = React.useState(false);
 
    const { items } = useCurrentRefinements();
+   const { query } = useSearchBox();
    const { hits } = useHits();
    const itemType = useDevicePartsItemType(productList);
 
@@ -28,8 +33,10 @@ export function ProductListChildrenSection({
       const nonItemTypeRefinements = items.filter(
          (item) => item.attribute !== 'facet_tags.Item Type'
       );
-      return !hits.length && itemType && !nonItemTypeRefinements.length;
-   }, [items, itemType, hits]);
+      return (
+         !hits.length && itemType && !nonItemTypeRefinements.length && !query
+      );
+   }, [items, itemType, hits, query]);
 
    return isUnfilteredItemTypeWithNoHits ? null : (
       <Box>


### PR DESCRIPTION
connects #1643 

First attempt to mitigate CLS deriving from on page user interactions.

We suspect that the root cause of this might be some slow network requests.
Google leaves only 500ms from a user interaction and the connected layout shifts. 
So if a response from the API comes back slow, any shift deriving from that response would count towards CLS.

To mitigate the problem we are removing induced delays like the debounceTime of the search field on product list pages.

Moreover, we noticed that `productListChildren` were wrongly removed if a specific search query did not match any result on itemType collections, we fixed that condition.

### QA

1. Visit Vercel Preview
2. The product list page ui should behave like before with a reduced debounce time for the search input
3. Product list children should not disappear anymore even if a particular search query produces no results on an itemType collection