### PR TITLE
Troubleshooting--hide-related-pages-section

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -520,9 +520,12 @@ function ConclusionSection({ conclusion }: { conclusion: Section }) {
 }
 
 function Conclusion({ conclusion: conclusions }: { conclusion: Section[] }) {
+   const filteredConclusions = conclusions.filter(
+      (conclusion) => conclusion.heading !== 'Related Pages'
+   );
    return (
       <>
-         {conclusions.map((conclusion) => (
+         {filteredConclusions.map((conclusion) => (
             <ConclusionSection
                key={conclusion.heading}
                conclusion={conclusion}

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -105,12 +105,7 @@ const Wiki: NextPageWithLayout<{
                   solution={solution}
                />
             ))}
-            {wikiData.conclusion.map((conclusion) => (
-               <ConclusionSection
-                  key={conclusion.heading}
-                  conclusion={conclusion}
-               />
-            ))}
+            <Conclusion conclusion={wikiData.conclusion} />
             <AnswersCTA answersUrl={wikiData.answersUrl} />
          </Flex>
       </Flex>
@@ -521,6 +516,19 @@ function ConclusionSection({ conclusion }: { conclusion: Section }) {
          <Heading marginBottom={6}>{conclusion.heading}</Heading>
          <Prerendered html={conclusion.body} />
       </Box>
+   );
+}
+
+function Conclusion({ conclusion: conclusions }: { conclusion: Section[] }) {
+   return (
+      <>
+         {conclusions.map((conclusion) => (
+            <ConclusionSection
+               key={conclusion.heading}
+               conclusion={conclusion}
+            />
+         ))}
+      </>
    );
 }
 


### PR DESCRIPTION
This hides any section with the heading `Related Pages`.

We generally only have links to other troubleshooting pages in such a section, and because those links will be included as "Related Problems" cards, we don't want to include that section on the page.

## QA Notes
Does what it says on the tin.
https://react-commerce-git-troubleshooting-hide-related-p-fd2fc5-ifixit.vercel.app/Vulcan/Dryer_Making_Loud_Noise should be a good example page that has a "Related Pages" section which this pull should hide.