### PR TITLE
Quick Fix: Revert change to theme sizes

### DIFF
--- a/packages/ui/theme/foundations/sizes.ts
+++ b/packages/ui/theme/foundations/sizes.ts
@@ -1,11 +1,5 @@
 import type { ThemeOverride } from '@chakra-ui/react';
-import { breakpoint as primitiveBreakpoint } from '@core-ds/primitives';
 
 export const sizes: ThemeOverride['sizes'] = {
    header: '68px',
-   sm: primitiveBreakpoint.sm,
-   md: primitiveBreakpoint.md,
-   lg: primitiveBreakpoint.lg,
-   xl: primitiveBreakpoint.xl,
-   '2xl': primitiveBreakpoint['2xl'],
 };

--- a/packages/ui/theme/index.ts
+++ b/packages/ui/theme/index.ts
@@ -10,6 +10,7 @@ import { colors } from './foundations/colors';
 import { fonts } from './foundations/fonts';
 import { radii } from './foundations/radii';
 import { shadow } from './foundations/shadow';
+import { sizes } from './foundations/sizes';
 import { space } from './foundations/space';
 import { zIndices } from './foundations/zIndices';
 import { styles } from './styles';
@@ -20,6 +21,7 @@ export const theme: ThemeOverride = {
    fonts,
    radii,
    shadows: shadow,
+   sizes,
    space,
    styles,
    zIndices,

--- a/packages/ui/theme/index.ts
+++ b/packages/ui/theme/index.ts
@@ -10,7 +10,6 @@ import { colors } from './foundations/colors';
 import { fonts } from './foundations/fonts';
 import { radii } from './foundations/radii';
 import { shadow } from './foundations/shadow';
-import { sizes } from './foundations/sizes';
 import { space } from './foundations/space';
 import { zIndices } from './foundations/zIndices';
 import { styles } from './styles';
@@ -21,7 +20,6 @@ export const theme: ThemeOverride = {
    fonts,
    radii,
    shadows: shadow,
-   sizes,
    space,
    styles,
    zIndices,


### PR DESCRIPTION
## Overview
Fixes a live bug as a result of https://github.com/iFixit/react-commerce/pull/1669

## Modifications
Revert the addition of the `primitiveBreakpoint` values from the mono theme:
- these are used differently than the mono repo so we may be able to bypass
- we'll know more as we get closer to sharing chakra themes

## CR/QA:
Main issue observed at: https://www.ifixit.com/products/nintendo-switch-joy-con-joystick

Previous correct version: https://web.archive.org/web/20230314234255/https://www.ifixit.com/products/nintendo-switch-joy-con-joystick

cc @erinemay 

Closes: https://github.com/iFixit/react-commerce/issues/1676