### PR TITLE
Add command timeout to Redis client

### DIFF
--- a/frontend/lib/redis/index.ts
+++ b/frontend/lib/redis/index.ts
@@ -16,6 +16,7 @@ function getClient() {
       // When not connected to redis, return error, don't add operations to a
       // queue
       enableOfflineQueue: false,
+      commandTimeout: 500,
    });
 }
 


### PR DESCRIPTION
closes #1671 

This PR adds a timeout for when a Redis command takes too long to respond.

From #1671
> If we don't have access to redis (connection is missing or timeout or whatever), pretend a cache miss

@danielbeardsley I've read through the code and tested it locally with a non-existent Redis server and it looks like connection errors are handled correctly an interpreted as cache misses. The only cause that came to mind for the logs that we're seeing is that a Redis command takes too long to respond.
Let me know if you think there's more to it.

## QA

I'm not sure if we want to QA this. Either way to simulate a command timeout error locally I've followed these steps:

1. **Prerequisites**: Ensure you have Redis installed and running locally on your computer. Follow the instructions in [this guide](https://redis.io/docs/getting-started/) if you haven't installed Redis yet.

2. **Enable `DEBUG` command in Redis**:
    - Locate the Redis configuration file (e.g., `/opt/homebrew/etc/redis.conf` if installed with Homebrew).
    - Open the configuration file in a text editor.
    - Add or update the `enable-debug-command` option and set its value to `yes`:
      ```
      enable-debug-command yes
      ```
    - Save the changes and restart the Redis server with the updated configuration file:
      ```
      redis-server /path/to/redis.conf
      ```

3. **Update Next.js REDIS_URL**: Set `REDIS_URL` environment variable in `frontend/.env.local` to your local Redis instance (e.g. `redis://localhost:6379`).
4. **Start Next.js app**: Start next.js app, visit a product page and verify that you can see logs from caching. E.g. if you load the page twice you'll see something like:

    <img width="817" alt="Screenshot 2023-05-12 at 11 49 59" src="https://github.com/iFixit/react-commerce/assets/4640135/2cf52690-d496-4e2b-99ce-ee5954f8fe76">

5. **Simulate slow Redis server**:
    - Open a terminal and connect to the local Redis server using `redis-cli`:
      ```
      redis-cli
      ```
    - Run the `DEBUG SLEEP` command to block the Redis server for a specified number of seconds (e.g., 30 seconds):
      ```
      DEBUG SLEEP 30
      ```

6. **Test Next.js app with slow Redis server**:
    - Reload the product page and verify that the page still render. You should see a `cache miss` log

7. **Clean up**:
    - When you're done testing, disable the `DEBUG` command in the Redis configuration file by setting the `enable-debug-command` option to `no` or removing the line entirely:
      ```
      enable-debug-command no
      ```

