### PR TITLE
Tests: Deflake flaky tests

### DIFF
--- a/frontend/tests/playwright/product-list/parts-page-search.spec.ts
+++ b/frontend/tests/playwright/product-list/parts-page-search.spec.ts
@@ -54,7 +54,9 @@ test.describe('Parts Page Search', () => {
       expect(page.url()).toContain(`?q=${searchText}`);
 
       // Empty the search-box
-      await page.getByTestId('collections-search-box').fill('');
+      const inputField = await page.getByTestId('collections-search-box');
+      await inputField.selectText();
+      await inputField.press('Backspace');
 
       // Check that url doesn't have the query parameter containing ?q
       await page.waitForURL('**/Parts');

--- a/frontend/tests/playwright/test-fixtures.ts
+++ b/frontend/tests/playwright/test-fixtures.ts
@@ -29,6 +29,7 @@ import { createWorkerFixture } from 'playwright-msw';
 import { format } from 'util';
 import { handlers } from './msw/handlers';
 import { exec } from 'node:child_process';
+import { cloneDeep } from 'lodash';
 
 export const test = base.extend<
    ProductFixtures &
@@ -76,7 +77,10 @@ export const test = base.extend<
       },
       { scope: 'test', auto: true },
    ],
-   findProductQueryMock,
+   // eslint-disable-next-line no-empty-pattern
+   findProductQueryMock: async ({}, use) => {
+      await use(cloneDeep(findProductQueryMock));
+   },
    clientRequestHandler: createWorkerFixture(handlers),
    /**
     * The following fixtures are dependent on the customServer fixture. By being


### PR DESCRIPTION
## Summary
Fixes https://github.com/ifixit/react-commerce/issues/1639. 

1. Worked together with @ardelato on debugging and fixing the bug for the `findProductQueryMock` mutation. 
This deflaked most of the tests making them pass on the first try again.
2. Fixed the `parts-page-search` test by using a different way to properly clear the input field. 

## QA notes
1. Make sure CI is passing. 
2. Re-run the `E2E` workflow and make sure the jobs pass and don't reach the `15m` mark.

closes #1639  