### PR TITLE
Vulcan: Update styles for "First Steps" heading

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -78,7 +78,7 @@ const Wiki: NextPageWithLayout<{
                {metadata}
                <HreflangUrls urls={wikiData.hreflangUrls} />
             </Head>
-            <Heading as="h1" marginTop={6}>
+            <Heading as="h1" fontSize="3xl" fontWeight="500" marginTop={6}>
                {wikiData.title}
             </Heading>
             <AuthorInformation
@@ -92,7 +92,7 @@ const Wiki: NextPageWithLayout<{
             <Spacer borderBottom="1px" borderColor="gray.300" />
             {wikiData.solutions.length > 0 && (
                <>
-                  <Heading as="h2" fontSize="20px">
+                  <Heading as="h2" fontSize="20px" fontWeight="600">
                      {'Causes'}
                   </Heading>
                   <TableOfContents solutions={wikiData.solutions} />
@@ -504,7 +504,9 @@ function AuthorListing({
 function IntroductionSection({ intro }: { intro: Section }) {
    return (
       <Box>
-         <Heading marginBottom={6}>{intro.heading}</Heading>
+         <Heading marginBottom={6} fontSize="2xl" fontWeight="600">
+            {intro.heading}
+         </Heading>
          <Prerendered html={intro.body} />
       </Box>
    );


### PR DESCRIPTION
## Summary
Address QA comment with heading font styles not fully matching design. I found more than one, so I correct them all.

https://github.com/iFixit/ifixit/discussions/46185#discussioncomment-5851368

https://www.figma.com/file/jRG4EyQXRDMGfyLqut08KP/iFixit---Working-files?type=design&node-id=12684-293207&t=BS6ygGmXZmUgAJ1D-4

## Modifications
1. [update page Heading styles to match design](https://github.com/iFixit/react-commerce/commit/4260c828fe08ccda469d4c2f5ed4dd5e1cbabe14)

## CR/QA Notes
http://localhost:3000/Vulcan/Samsung_TV_Turns_On_By_Itself

<details>
  <summary>Post fix video</summary>

https://github.com/iFixit/react-commerce/assets/1634505/b4c79ffc-e55d-41b3-b152-1714efef0181

</details>

Closes: https://github.com/iFixit/ifixit/issues/47916