### PR TITLE
Vulcan: Fix styling on bulleted lists

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -114,16 +114,18 @@ const Wiki: NextPageWithLayout<{
 
 function TableOfContents({ solutions }: { solutions: Section[] }) {
    return (
-      <OrderedList marginBottom="24px" spacing="8px">
+      <OrderedList
+         marginBottom="24px"
+         spacing="8px"
+         sx={{ marginInlineStart: '2em' }}
+      >
          {solutions.map((solution, index) => (
-            <ListItem key={solution.heading}>
-               <Link
-                  href={`#solution-${index + 1}`}
-                  color="brand.500"
-                  fontWeight="bold"
-               >
-                  {solution.heading}
-               </Link>
+            <ListItem
+               color="brand.500"
+               fontWeight="bold"
+               key={solution.heading}
+            >
+               <Link href={`#solution-${index + 1}`}>{solution.heading}</Link>
             </ListItem>
          ))}
       </OrderedList>
@@ -504,7 +506,7 @@ function AuthorListing({
 function IntroductionSection({ intro }: { intro: Section }) {
    return (
       <Box>
-         <Heading marginBottom={6}>{intro.heading}</Heading>
+         {intro.heading && <Heading marginBottom={6}>{intro.heading}</Heading>}
          <Prerendered html={intro.body} />
       </Box>
    );

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -40,6 +40,7 @@ const renderStyles: SystemStyleObject = {
    },
 
    'ul,ol': {
+      marginInlineStart: '1em',
       paddingLeft: 4,
    },
 


### PR DESCRIPTION
## Summary
Clean up the styling on bulleted lists. Match Figma design indentation and get order lists following same indentation.

> The bulleted lists on the NextJS page aren't currently indented as they are on our wiki pages. Compare against https://www.ifixit.com/Wiki/Dryer_Not_Spinning and https://www.ifixit.com/Wiki/Electric_Dryer_Not_Heating (notice the bullets floating to the right of the image at the bottom of the page).

## Modifications
1. [sync ol and ul margins to align and match design](https://github.com/iFixit/react-commerce/commit/d5c1d031d5b2b50325aad5e2247d854ba730d642)
   - ol, moved styling up to parent to also apply to pseudo element numbers
   - conditionally load `intro.heading` only if it exists

## CR/QA Notes
http://localhost:3000/Vulcan/Dryer_Not_Spinning

<details>
  <summary>Alignment Screenshot</summary>

<img width="1453" alt="Screenshot 2023-05-15 at 4 37 08 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/caa08a00-728d-46df-a5c9-cb4d318ed78a">

</details>

Closes: https://github.com/iFixit/ifixit/issues/47910