### PR TITLE
Cross Sell: Fallback to group image

### DIFF
--- a/frontend/templates/product/sections/CrossSellSection/index.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/index.tsx
@@ -104,7 +104,7 @@ export function CrossSellSection({
                         key={product.handle}
                         handle={product.handle}
                         title={product.title}
-                        image={selectedVariant.image}
+                        image={selectedVariant.image ?? product.images[0]}
                         reviews={product.reviews}
                         price={selectedVariant.price}
                         compareAtPrice={selectedVariant.compareAtPrice}

--- a/frontend/templates/product/sections/CrossSellSection/useOptimisticAddToCart.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/useOptimisticAddToCart.tsx
@@ -41,7 +41,7 @@ export function useOptimisticAddToCart({
                itemcode: selectedVariant.sku,
                shopifyVariantId: selectedVariant.id,
                quantity: 1,
-               imageSrc: selectedVariant.image?.url,
+               imageSrc: selectedVariant.image?.url || product.images[0]?.url,
                price: userPrice.price,
                compareAtPrice: userPrice.compareAtPrice,
             };


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/47918

And also fixes a cross sell optimistic-add-to-cart image bug.

## QA

- Make sure that the current item variant on [`/products/macbook-fan`](https://react-commerce-git-variant-fallback-image-ifixit.vercel.app/products/macbook-fan) has an image.
- Observe that when you add to cart via the cross sell section, the cart drawer image no longer flickers from an empty image to the correct image. Instead, the cart item immediately has the correct image.