### PR TITLE
Algolia: count facet results after doing distinct

### DIFF
--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -495,6 +495,7 @@ async function findDevicesWithProducts(devices: string[]) {
          facets: ['device'],
          filters: `public = 1${deviceFilterSuffix}`,
          maxValuesPerFacet: 1000,
+         facetingAfterDistinct: true,
          hitsPerPage: 0,
       });
       return facets?.device ? facets?.device : {};

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -44,7 +44,11 @@ export function ProductListView({ productList }: ProductListViewProps) {
          <SecondaryNavigation productList={productListWithOverrides} />
          <Wrapper py={{ base: 4, md: 6 }}>
             <VStack align="stretch" spacing={{ base: 4, md: 6 }}>
-               <Configure filters={filters} hitsPerPage={24} />
+               <Configure
+                  filters={filters}
+                  hitsPerPage={24}
+                  facetingAfterDistinct={true}
+               />
                <MetaTags productList={productListWithOverrides} />
                {productListWithOverrides.heroImage ? (
                   <HeroWithBackgroundSection


### PR DESCRIPTION
We'll now be using the "attributeForDistinct" feature. This means that for some products there will be more than one algolia document that represents it. We'll be turning on this attributeForDistinct feature which will ensure we only get one result per product in the result set. However, the result counts in the facets will show the number of documents instead of the number of products until we set this option.

See: https://www.algolia.com/doc/api-reference/api-parameters/facetingAfterDistinct/

Connect https://github.com/iFixit/ifixit/issues/47734