### PR TITLE
Vulcan: Add Anchor link on headings

### DIFF
--- a/frontend/components/ui/HeadingSelfLink.tsx
+++ b/frontend/components/ui/HeadingSelfLink.tsx
@@ -1,37 +1,40 @@
 import * as React from 'react';
-import { Heading, HeadingProps, Link } from '@chakra-ui/react';
+import { forwardRef, Heading, HeadingProps, Link } from '@chakra-ui/react';
 import { FaIcon } from '@ifixit/icons';
 import { faLink } from '@fortawesome/pro-solid-svg-icons';
 
-export function HeadingSelfLink(children: any, props: HeadingProps) {
-   const id = children.toLowerCase().replace(/ /g, '-');
+export const HeadingSelfLink = forwardRef<HeadingProps, 'h2'>(
+   ({ children, ...props }, ref) => {
+      const id = `${children}.toLowerCase().replace(/ /g, '-')`;
 
-   return (
-      <Heading
-         id={id}
-         display="flex"
-         alignItems="stretch"
-         sx={{ _hover: { '& .heading_link-icon': { visibility: 'visible' } } }}
-         {...props}
-      >
-         {children}
-         <Link
-            href={`#${id}`}
-            display="inline-flex"
-            alignItems="stretch"
-            paddingLeft={2}
-            minWidth={6}
+      return (
+         <Heading
+            id={id}
+            display="flex"
+            sx={{ _hover: { '& .heading_link-icon': { opacity: '1' } } }}
+            {...ref}
+            {...props}
          >
-            <FaIcon
-               className="heading_link-icon"
-               icon={faLink}
-               height="55%"
-               maxHeight="4"
-               color="gray.500"
-               marginY="auto"
-               visibility="hidden"
-            />
-         </Link>
-      </Heading>
-   );
-}
+            {children}
+            <Link
+               href={`#${id}`}
+               display="inline-flex"
+               placeItems="center start"
+               paddingLeft={2}
+               minWidth={7}
+               aria-label={`${children} page link`}
+            >
+               <FaIcon
+                  className="heading_link-icon"
+                  icon={faLink}
+                  height="55%" // scale with smaller headings
+                  maxHeight={4} // cap size to 1em
+                  color="gray.500"
+                  opacity="0"
+                  transition="opacity 0.1s ease-in-out"
+               />
+            </Link>
+         </Heading>
+      );
+   }
+);

--- a/frontend/components/ui/HeadingSelfLink.tsx
+++ b/frontend/components/ui/HeadingSelfLink.tsx
@@ -11,13 +11,6 @@ export function HeadingSelfLink({
    props: HeadingProps;
 }) {
    const id = children.toLowerCase().replace(/ /g, '-');
-   const iconStyles = {
-      height: '50%',
-      maxHeight: '4',
-      color: 'gray.500',
-      marginY: 'auto',
-      visibility: 'hidden',
-   };
    const sharedStyles = {
       display: 'inline-flex',
       alignItems: 'stretch',
@@ -32,7 +25,14 @@ export function HeadingSelfLink({
       >
          {children}
          <Link href={`#${id}`} paddingLeft={2} minWidth={6} {...sharedStyles}>
-            <FaIcon icon={faLink} {...iconStyles} />
+            <FaIcon
+               icon={faLink}
+               height="50%"
+               maxHeight="4"
+               color="gray.500"
+               marginY="auto"
+               visibility="hidden"
+            />
          </Link>
       </Heading>
    );

--- a/frontend/components/ui/HeadingSelfLink.tsx
+++ b/frontend/components/ui/HeadingSelfLink.tsx
@@ -3,31 +3,29 @@ import { Heading, HeadingProps, Link } from '@chakra-ui/react';
 import { FaIcon } from '@ifixit/icons';
 import { faLink } from '@fortawesome/pro-solid-svg-icons';
 
-export function HeadingSelfLink({
-   children,
-   ...props
-}: {
-   children: any;
-   props: HeadingProps;
-}) {
+export function HeadingSelfLink(children: any, props: HeadingProps) {
    const id = children.toLowerCase().replace(/ /g, '-');
-   const sharedStyles = {
-      display: 'inline-flex',
-      alignItems: 'stretch',
-   };
 
    return (
       <Heading
          id={id}
-         sx={{ _hover: { '& svg': { visibility: 'visible' } } }}
-         {...sharedStyles}
+         display="flex"
+         alignItems="stretch"
+         sx={{ _hover: { '& .heading_link-icon': { visibility: 'visible' } } }}
          {...props}
       >
          {children}
-         <Link href={`#${id}`} paddingLeft={2} minWidth={6} {...sharedStyles}>
+         <Link
+            href={`#${id}`}
+            display="inline-flex"
+            alignItems="stretch"
+            paddingLeft={2}
+            minWidth={6}
+         >
             <FaIcon
+               className="heading_link-icon"
                icon={faLink}
-               height="50%"
+               height="55%"
                maxHeight="4"
                color="gray.500"
                marginY="auto"

--- a/frontend/components/ui/HeadingSelfLink.tsx
+++ b/frontend/components/ui/HeadingSelfLink.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Heading, HeadingProps, Link } from '@chakra-ui/react';
+import { FaIcon } from '@ifixit/icons';
+import { faLink } from '@fortawesome/pro-solid-svg-icons';
+
+export function HeadingSelfLink({
+   children,
+   ...props
+}: {
+   children: any;
+   props: HeadingProps;
+}) {
+   const id = children.toLowerCase().replace(/ /g, '-');
+   const iconStyles = {
+      height: '50%',
+      maxHeight: '4',
+      color: 'gray.500',
+      marginY: 'auto',
+      visibility: 'hidden',
+   };
+   const sharedStyles = {
+      display: 'inline-flex',
+      alignItems: 'stretch',
+   };
+
+   return (
+      <Heading
+         id={id}
+         sx={{ _hover: { '& svg': { visibility: 'visible' } } }}
+         {...sharedStyles}
+         {...props}
+      >
+         {children}
+         <Link href={`#${id}`} paddingLeft={2} minWidth={6} {...sharedStyles}>
+            <FaIcon icon={faLink} {...iconStyles} />
+         </Link>
+      </Heading>
+   );
+}

--- a/frontend/components/ui/HeadingSelfLink.tsx
+++ b/frontend/components/ui/HeadingSelfLink.tsx
@@ -5,7 +5,8 @@ import { faLink } from '@fortawesome/pro-solid-svg-icons';
 
 export const HeadingSelfLink = forwardRef<HeadingProps, 'h2'>(
    ({ children, ...props }, ref) => {
-      const id = `${children}.toLowerCase().replace(/ /g, '-')`;
+      const heading = children as string;
+      const id = heading.toLowerCase().replace(/ /g, '-');
 
       return (
          <Heading

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -11,7 +11,6 @@ import {
    Button,
    Flex,
    FlexProps,
-   Heading,
    IconButton,
    Link,
    LinkProps,
@@ -38,6 +37,7 @@ import {
    faPenToSquare,
 } from '@fortawesome/pro-solid-svg-icons';
 import { BreadCrumbs } from '@ifixit/breadcrumbs';
+import { HeadingSelfLink } from '@components/ui/HeadingSelfLink';
 
 const Wiki: NextPageWithLayout<{
    wikiData: TroubleshootingData;
@@ -77,9 +77,14 @@ const Wiki: NextPageWithLayout<{
                {metadata}
                <HreflangUrls urls={wikiData.hreflangUrls} />
             </Head>
-            <Heading as="h1" fontSize="3xl" fontWeight="500" marginTop={6}>
+            <HeadingSelfLink
+               as="h1"
+               fontSize="3xl"
+               fontWeight="500"
+               marginTop={6}
+            >
                {wikiData.title}
-            </Heading>
+            </HeadingSelfLink>
             <AuthorInformation
                lastUpdatedDate={lastUpdatedDate}
                authors={wikiData.authors}
@@ -91,9 +96,9 @@ const Wiki: NextPageWithLayout<{
             <Spacer borderBottom="1px" borderColor="gray.300" />
             {wikiData.solutions.length > 0 && (
                <>
-                  <Heading as="h2" fontSize="20px" fontWeight="600">
+                  <HeadingSelfLink as="h2" fontSize="20px" fontWeight="600">
                      {'Causes'}
-                  </Heading>
+                  </HeadingSelfLink>
                   <TableOfContents solutions={wikiData.solutions} />
                </>
             )}
@@ -512,9 +517,9 @@ function IntroductionSection({ intro }: { intro: Section }) {
    return (
       <Box>
          {intro.heading && (
-            <Heading marginBottom={6} fontSize="2xl" fontWeight="600">
+            <HeadingSelfLink marginBottom={6} fontSize="2xl" fontWeight="600">
                {intro.heading}
-            </Heading>
+            </HeadingSelfLink>
          )}
          <Prerendered html={intro.body} />
       </Box>
@@ -524,7 +529,9 @@ function IntroductionSection({ intro }: { intro: Section }) {
 function ConclusionSection({ conclusion }: { conclusion: Section }) {
    return (
       <Box>
-         <Heading marginBottom={6}>{conclusion.heading}</Heading>
+         <HeadingSelfLink marginBottom={6}>
+            {conclusion.heading}
+         </HeadingSelfLink>
          <Prerendered html={conclusion.body} />
       </Box>
    );

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -22,6 +22,7 @@ import { SolutionSection } from './hooks/useTroubleshootingProps';
 import Prerendered from './prerendered';
 import { GuideResource } from './Resource';
 import { Guide } from './hooks/GuideModel';
+import { HeadingSelfLink } from '@components/ui/HeadingSelfLink';
 
 const _SolutionFooter = () => (
    <Stack
@@ -164,14 +165,14 @@ const SolutionHeader = ({
             {index}
          </Square>
       </Stack>
-      <Heading
+      <HeadingSelfLink
          fontWeight="medium"
          fontSize="24px"
          color="brand.500"
          alignSelf="center"
       >
          {title}
-      </Heading>
+      </HeadingSelfLink>
       {popularity !== undefined && (
          <Stack direction="row" justify="flex-start" align="flex-start">
             <Badge

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -1,6 +1,5 @@
 import {
    Box,
-   Heading,
    Stack,
    Text,
    Avatar,


### PR DESCRIPTION
## Summary
Adds a component to mimic the heading link functionality found on the mono, but with the link icon placed on the right side to balance design better: https://www.ifixit.com/Wiki/Dryer_Not_Spinning

<details>
  <summary>Result Video</summary>

https://github.com/iFixit/react-commerce/assets/1634505/b57a1772-0688-4337-908a-b4e769b74d14

</details>

## Modifications
1. [create shared HeadingSelfLink component](https://github.com/iFixit/react-commerce/commit/4f3192728494f1d1c227a190c90ace41722d2181)
2. [use HeadingSelfLink component](https://github.com/iFixit/react-commerce/commit/0f0f15997ce9509784882d5a7b80574b73d43cea)

## CR/QA Notes
- Icon placed at the right of the text intentionally to balance design
- The icon size at a static 16px was too large for the `Causes` heading, so I added some styles to adjust based on the font size, but cap at 16px/1em

Closes: https://github.com/iFixit/react-commerce/issues/1688