### PR TITLE
Add meta viewport tag to default layout

### DIFF
--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -165,6 +165,11 @@ const DefaultLayoutComponent = function ({
                   href="https://assets.cdn.ifixit.com/static/icons/ifixit/safari-pinned-tab.svg"
                   color="#5bbad5"
                />
+
+               <meta
+                  name="viewport"
+                  content="width=device-width, initial-scale=1"
+               />
             </Head>
             <Flex direction="column" minH="100vh">
                <Header>


### PR DESCRIPTION
## Summary
We're missing this meta tag on commerce. Let's add it so mobile pages behave consistently.

https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag

## Modifications
1. [add meta viewport tag to default layout](https://github.com/iFixit/react-commerce/commit/f221666f718af905d5368aaeb1d479b4b847ad0d)

## CR/QA Notes
This is intentionally added at the default layout level. We want it applied on all pages.

There should be no visual difference.