### PR TITLE
Troubleshooting: Add cards for product links

### DIFF
--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -22,9 +22,8 @@ import { DifficultyThemeLookup, GuideDifficultyNames } from './DifficultyBadge';
 import { Product } from '@models/product';
 import { useSelectedVariant } from '@templates/product/hooks/useSelectedVariant';
 import { useIsProductForSale } from '../product/hooks/useIsProductForSale';
-import { shouldShowProductRating } from '../../../packages/helpers/product-helpers';
 import { Rating } from '@components/ui';
-import { Money, formatMoney } from '@ifixit/helpers';
+import { Money, formatMoney, shouldShowProductRating } from '@ifixit/helpers';
 
 export function GuideResource({ guide }: { guide: Guide }) {
    return (

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -1,4 +1,15 @@
-import { Stack, Image, Badge, StackProps, Link, Wrap } from '@chakra-ui/react';
+import {
+   Stack,
+   Image,
+   Badge,
+   StackProps,
+   Link,
+   Wrap,
+   HStack,
+   Text,
+   Box,
+   SystemProps,
+} from '@chakra-ui/react';
 import { Guide } from './hooks/GuideModel';
 import { FaIcon } from '@ifixit/icons';
 import { faClock } from '@fortawesome/pro-solid-svg-icons';
@@ -6,6 +17,10 @@ import Prerendered from './prerendered';
 import { DifficultyThemeLookup, GuideDifficultyNames } from './DifficultyBadge';
 import { Product } from '@models/product';
 import { useSelectedVariant } from '@templates/product/hooks/useSelectedVariant';
+import { useIsProductForSale } from '../product/hooks/useIsProductForSale';
+import { shouldShowProductRating } from '../../../packages/helpers/product-helpers';
+import { Rating } from '@components/ui';
+import { Money, formatMoney } from '@ifixit/helpers';
 
 export function GuideResource({ guide }: { guide: Guide }) {
    return (
@@ -15,6 +30,7 @@ export function GuideResource({ guide }: { guide: Guide }) {
          imageUrl={guide.image.thumbnail}
          timeRequired={guide.time_required}
          difficulty={guide.difficulty}
+         spacing="6px"
       >
          {guide.introduction_rendered && (
             <Prerendered
@@ -34,14 +50,51 @@ export function GuideResource({ guide }: { guide: Guide }) {
 
 export function ProductResource({ product }: { product: Product }) {
    const [selectedVariant, _setSelectedVariant] = useSelectedVariant(product);
+   const isForSale = useIsProductForSale(product);
 
    return (
       <Resource
          href={`/products/${product.handle}`}
          title={product.title}
          imageUrl={selectedVariant.image?.url}
-         introduction={product.shortDescription}
-      />
+         spacing="4px"
+      >
+         {isForSale && <ResourceProductRating product={product} />}
+         {isForSale && <ResourceProductPrice price={selectedVariant.price} />}
+      </Resource>
+   );
+}
+
+function ResourceProductRating({ product }: { product: Product }) {
+   if (!shouldShowProductRating(product.reviews)) {
+      return null;
+   }
+   return (
+      <HStack spacing="6px" fontWeight={400}>
+         <Rating
+            value={product.reviews.rating}
+            size={3}
+            position="relative"
+            top="-1px"
+         />
+         <Text color="gray.600" fontSize="12px">
+            {product.reviews.rating}
+         </Text>
+         <Box w="1px" h="14px" bg="gray.300"></Box>
+         <Text color="gray.600" fontSize="12px">
+            {product.reviews.count} reviews
+         </Text>
+      </HStack>
+   );
+}
+
+function ResourceProductPrice({ price }: { price: Money }) {
+   return (
+      <Box alignItems="center">
+         <Text fontSize="12px" color="gray.600" fontWeight={510}>
+            {formatMoney(price)}
+         </Text>
+      </Box>
    );
 }
 

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -9,6 +9,9 @@ import {
    Text,
    Box,
    SystemProps,
+   Button,
+   ButtonProps,
+   ThemingProps,
 } from '@chakra-ui/react';
 import { Guide } from './hooks/GuideModel';
 import { FaIcon } from '@ifixit/icons';
@@ -51,13 +54,15 @@ export function GuideResource({ guide }: { guide: Guide }) {
 export function ProductResource({ product }: { product: Product }) {
    const [selectedVariant, _setSelectedVariant] = useSelectedVariant(product);
    const isForSale = useIsProductForSale(product);
+   const productUrl = `/products/${product.handle}`;
 
    return (
       <Resource
-         href={`/products/${product.handle}`}
+         href={productUrl}
          title={product.title}
          imageUrl={selectedVariant.image?.url}
          spacing="4px"
+         showBuyButton={isForSale}
       >
          {isForSale && <ResourceProductRating product={product} />}
          {isForSale && <ResourceProductPrice price={selectedVariant.price} />}
@@ -90,6 +95,41 @@ function ResourceProductPrice({ price }: { price: Money }) {
             {formatMoney(price)}
          </Text>
       </Box>
+   );
+}
+
+function BuyButton({
+   url,
+   buyButtonText,
+   buttonStyling,
+   buttonSize,
+   openInNewTab,
+   colorScheme,
+}: {
+   url: string;
+   buyButtonText: string;
+   buttonStyling?: ButtonProps;
+   buttonSize: ThemingProps<'Button'>['size'];
+   openInNewTab: boolean;
+   colorScheme: ThemingProps<'Button'>['colorScheme'];
+}) {
+   const openSettings = openInNewTab
+      ? { target: '_blank', rel: 'noopener' }
+      : {};
+
+   return (
+      <Button
+         as="a"
+         href={url}
+         {...openSettings}
+         alignSelf={{ md: 'flex-start', sm: 'flex-end', base: 'flex-end' }}
+         flexShrink={0}
+         size={buttonSize}
+         colorScheme={colorScheme}
+         {...buttonStyling}
+      >
+         {buyButtonText}
+      </Button>
    );
 }
 
@@ -127,6 +167,7 @@ function Resource({
    difficulty,
    href,
    spacing,
+   showBuyButton,
    children,
 }: React.PropsWithChildren<{
    title: string;
@@ -136,6 +177,7 @@ function Resource({
    difficulty?: string;
    spacing: SystemProps['margin'];
    href: string;
+   showBuyButton?: boolean;
 }>) {
    const difficultyTheme =
       difficulty && hasKey(DifficultyThemeLookup, difficulty)
@@ -211,6 +253,15 @@ function Resource({
                   </Wrap>
                )}
             </Stack>
+            {showBuyButton && (
+               <BuyButton
+                  colorScheme="brand"
+                  buttonSize="sm"
+                  openInNewTab={false}
+                  url={href}
+                  buyButtonText="Buy"
+               />
+            )}
          </Stack>
       </ResourceBox>
    );

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -131,6 +131,7 @@ function Resource({
    timeRequired,
    difficulty,
    href,
+   spacing,
    children,
 }: React.PropsWithChildren<{
    title: string;
@@ -138,6 +139,7 @@ function Resource({
    introduction?: string | null;
    timeRequired?: string;
    difficulty?: string;
+   spacing: SystemProps['margin'];
    href: string;
 }>) {
    const difficultyTheme =
@@ -172,14 +174,14 @@ function Resource({
             <Stack
                justify="center"
                align="flex-start"
-               spacing="6px"
+               spacing={spacing}
                flex="1"
                overflow="hidden"
             >
                <Stack
                   justify="flex-start"
                   align="flex-start"
-                  spacing="6px"
+                  spacing={spacing}
                   alignSelf="stretch"
                >
                   <Link
@@ -193,24 +195,26 @@ function Resource({
                   </Link>
                   {children}
                </Stack>
-               <Wrap spacing="4px">
-                  {timeRequired && (
-                     <Badge display="flex">
-                        <FaIcon icon={faClock} mr="4px" color="gray.500" />
-                        {timeRequired}
-                     </Badge>
-                  )}
-                  {difficulty && (
-                     <Badge display="flex" colorScheme={themeColor}>
-                        <FaIcon
-                           icon={icon}
-                           mr="4px"
-                           color={iconColor || `${themeColor}.500`}
-                        />
-                        {difficulty}
-                     </Badge>
-                  )}
-               </Wrap>
+               {(timeRequired || difficulty) && (
+                  <Wrap spacing="4px">
+                     {timeRequired && (
+                        <Badge display="flex">
+                           <FaIcon icon={faClock} mr="4px" color="gray.500" />
+                           {timeRequired}
+                        </Badge>
+                     )}
+                     {difficulty && (
+                        <Badge display="flex" colorScheme={themeColor}>
+                           <FaIcon
+                              icon={icon}
+                              mr="4px"
+                              color={iconColor || `${themeColor}.500`}
+                           />
+                           {difficulty}
+                        </Badge>
+                     )}
+                  </Wrap>
+               )}
             </Stack>
          </Stack>
       </ResourceBox>

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -4,6 +4,8 @@ import { FaIcon } from '@ifixit/icons';
 import { faClock } from '@fortawesome/pro-solid-svg-icons';
 import Prerendered from './prerendered';
 import { DifficultyThemeLookup, GuideDifficultyNames } from './DifficultyBadge';
+import { Product } from '@models/product';
+import { useSelectedVariant } from '@templates/product/hooks/useSelectedVariant';
 
 export function GuideResource({ guide }: { guide: Guide }) {
    return (
@@ -14,6 +16,19 @@ export function GuideResource({ guide }: { guide: Guide }) {
          introduction={guide.introduction_rendered}
          timeRequired={guide.time_required}
          difficulty={guide.difficulty}
+      />
+   );
+}
+
+export function ProductResource({ product }: { product: Product }) {
+   const [selectedVariant, _setSelectedVariant] = useSelectedVariant(product);
+
+   return (
+      <Resource
+         href={`/products/${product.handle}`}
+         title={product.title}
+         imageUrl={selectedVariant.image?.url}
+         introduction={product.shortDescription}
       />
    );
 }
@@ -54,15 +69,16 @@ function Resource({
    href,
 }: {
    title: string;
-   imageUrl: string;
-   introduction: string;
-   timeRequired: string;
-   difficulty: string;
+   imageUrl?: string | null;
+   introduction?: string | null;
+   timeRequired?: string;
+   difficulty?: string;
    href: string;
 }) {
-   const difficultyTheme = hasKey(DifficultyThemeLookup, difficulty)
-      ? DifficultyThemeLookup[difficulty]
-      : DifficultyThemeLookup[GuideDifficultyNames.Moderate];
+   const difficultyTheme =
+      difficulty && hasKey(DifficultyThemeLookup, difficulty)
+         ? DifficultyThemeLookup[difficulty]
+         : DifficultyThemeLookup[GuideDifficultyNames.Moderate];
    const { themeColor, iconColor, icon } = difficultyTheme;
 
    return (
@@ -75,17 +91,19 @@ function Resource({
             alignSelf="stretch"
             spacing="8px"
          >
-            <Link href={href}>
-               <Image
-                  boxSize="64px"
-                  border="1px solid"
-                  borderColor="gray.300"
-                  borderRadius="4px"
-                  objectFit="cover"
-                  alt={title}
-                  src={imageUrl}
-               />
-            </Link>
+            {imageUrl && (
+               <Link href={href}>
+                  <Image
+                     boxSize="64px"
+                     border="1px solid"
+                     borderColor="gray.300"
+                     borderRadius="4px"
+                     objectFit="cover"
+                     alt={title}
+                     src={imageUrl}
+                  />
+               </Link>
+            )}
             <Stack
                justify="center"
                align="flex-start"
@@ -122,18 +140,22 @@ function Resource({
                   )}
                </Stack>
                <Wrap spacing="4px">
-                  <Badge display="flex">
-                     <FaIcon icon={faClock} mr="4px" color="gray.500" />
-                     {timeRequired}
-                  </Badge>
-                  <Badge display="flex" colorScheme={themeColor}>
-                     <FaIcon
-                        icon={icon}
-                        mr="4px"
-                        color={iconColor || `${themeColor}.500`}
-                     />
-                     {difficulty}
-                  </Badge>
+                  {timeRequired && (
+                     <Badge display="flex">
+                        <FaIcon icon={faClock} mr="4px" color="gray.500" />
+                        {timeRequired}
+                     </Badge>
+                  )}
+                  {difficulty && (
+                     <Badge display="flex" colorScheme={themeColor}>
+                        <FaIcon
+                           icon={icon}
+                           mr="4px"
+                           color={iconColor || `${themeColor}.500`}
+                        />
+                        {difficulty}
+                     </Badge>
+                  )}
                </Wrap>
             </Stack>
          </Stack>

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -123,7 +123,7 @@ function BuyButton({
          as="a"
          href={url}
          {...openSettings}
-         alignSelf={{ md: 'flex-start', sm: 'flex-end', base: 'flex-end' }}
+         alignSelf={{ md: 'flex-start', sm: 'flex-start', base: 'flex-end' }}
          flexShrink={0}
          size={buttonSize}
          colorScheme={colorScheme}
@@ -186,7 +186,7 @@ function Resource({
          : DifficultyThemeLookup[GuideDifficultyNames.Moderate];
    const { themeColor, iconColor, icon } = difficultyTheme;
    const breakpoint = useBreakpoint();
-   const isTablet = breakpoint === 'sm' || breakpoint === 'base';
+   const isMobile = breakpoint === 'base';
 
    return (
       <ResourceBox>
@@ -255,7 +255,7 @@ function Resource({
                      )}
                   </Wrap>
                )}
-               {isTablet && showBuyButton && (
+               {isMobile && showBuyButton && (
                   <BuyButton
                      colorScheme="brand"
                      buttonSize="xs"
@@ -265,7 +265,7 @@ function Resource({
                   />
                )}
             </Stack>
-            {!isTablet && showBuyButton && (
+            {!isMobile && showBuyButton && (
                <BuyButton
                   colorScheme="brand"
                   buttonSize="sm"

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -12,6 +12,7 @@ import {
    Button,
    ButtonProps,
    ThemingProps,
+   useBreakpoint,
 } from '@chakra-ui/react';
 import { Guide } from './hooks/GuideModel';
 import { FaIcon } from '@ifixit/icons';
@@ -184,6 +185,8 @@ function Resource({
          ? DifficultyThemeLookup[difficulty]
          : DifficultyThemeLookup[GuideDifficultyNames.Moderate];
    const { themeColor, iconColor, icon } = difficultyTheme;
+   const breakpoint = useBreakpoint();
+   const isTablet = breakpoint === 'sm' || breakpoint === 'base';
 
    return (
       <ResourceBox>
@@ -252,8 +255,17 @@ function Resource({
                      )}
                   </Wrap>
                )}
+               {isTablet && showBuyButton && (
+                  <BuyButton
+                     colorScheme="brand"
+                     buttonSize="xs"
+                     openInNewTab={false}
+                     url={href}
+                     buyButtonText="Buy"
+                  />
+               )}
             </Stack>
-            {showBuyButton && (
+            {!isTablet && showBuyButton && (
                <BuyButton
                   colorScheme="brand"
                   buttonSize="sm"

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -13,10 +13,22 @@ export function GuideResource({ guide }: { guide: Guide }) {
          href={guide.url}
          title={guide.title}
          imageUrl={guide.image.thumbnail}
-         introduction={guide.introduction_rendered}
          timeRequired={guide.time_required}
          difficulty={guide.difficulty}
-      />
+      >
+         {guide.introduction_rendered && (
+            <Prerendered
+               lineHeight="1.36"
+               fontWeight="regular"
+               fontSize="12px"
+               color="gray.600"
+               overflow="hidden"
+               height="16px"
+               noOfLines={1}
+               html={guide.introduction_rendered}
+            />
+         )}
+      </Resource>
    );
 }
 
@@ -63,18 +75,18 @@ function hasKey<O>(obj: O, key: PropertyKey): key is keyof O {
 function Resource({
    title,
    imageUrl,
-   introduction,
    timeRequired,
    difficulty,
    href,
-}: {
+   children,
+}: React.PropsWithChildren<{
    title: string;
    imageUrl?: string | null;
    introduction?: string | null;
    timeRequired?: string;
    difficulty?: string;
    href: string;
-}) {
+}>) {
    const difficultyTheme =
       difficulty && hasKey(DifficultyThemeLookup, difficulty)
          ? DifficultyThemeLookup[difficulty]
@@ -126,18 +138,7 @@ function Resource({
                   >
                      {title}
                   </Link>
-                  {introduction && (
-                     <Prerendered
-                        lineHeight="1.36"
-                        fontWeight="regular"
-                        fontSize="12px"
-                        color="gray.600"
-                        overflow="hidden"
-                        height="16px"
-                        noOfLines={1}
-                        html={introduction}
-                     />
-                  )}
+                  {children}
                </Stack>
                <Wrap spacing="4px">
                   {timeRequired && (

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -71,12 +71,7 @@ function ResourceProductRating({ product }: { product: Product }) {
    }
    return (
       <HStack spacing="6px" fontWeight={400}>
-         <Rating
-            value={product.reviews.rating}
-            size={3}
-            position="relative"
-            top="-1px"
-         />
+         <Rating value={product.reviews.rating} size={3} />
          <Text color="gray.600" fontSize="12px">
             {product.reviews.rating}
          </Text>

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -64,6 +64,7 @@ export function ProductResource({ product }: { product: Product }) {
          imageUrl={selectedVariant.image?.url}
          spacing="4px"
          showBuyButton={isForSale}
+         openInNewTab={true}
       >
          {isForSale && <ResourceProductRating product={product} />}
          {isForSale && <ResourceProductPrice price={selectedVariant.price} />}
@@ -111,7 +112,7 @@ function BuyButton({
    buyButtonText: string;
    buttonStyling?: ButtonProps;
    buttonSize: ThemingProps<'Button'>['size'];
-   openInNewTab: boolean;
+   openInNewTab?: boolean;
    colorScheme: ThemingProps<'Button'>['colorScheme'];
 }) {
    const openSettings = openInNewTab
@@ -169,6 +170,7 @@ function Resource({
    href,
    spacing,
    showBuyButton,
+   openInNewTab,
    children,
 }: React.PropsWithChildren<{
    title: string;
@@ -179,6 +181,7 @@ function Resource({
    spacing: SystemProps['margin'];
    href: string;
    showBuyButton?: boolean;
+   openInNewTab?: boolean;
 }>) {
    const difficultyTheme =
       difficulty && hasKey(DifficultyThemeLookup, difficulty)
@@ -199,7 +202,7 @@ function Resource({
             spacing="8px"
          >
             {imageUrl && (
-               <Link href={href}>
+               <Link href={href} isExternal={openInNewTab}>
                   <Image
                      boxSize="64px"
                      border="1px solid"
@@ -230,6 +233,7 @@ function Resource({
                      fontWeight="semibold"
                      fontSize="14px"
                      color="gray.900"
+                     isExternal={openInNewTab}
                   >
                      {title}
                   </Link>
@@ -269,7 +273,7 @@ function Resource({
                <BuyButton
                   colorScheme="brand"
                   buttonSize="sm"
-                  openInNewTab={false}
+                  openInNewTab={openInNewTab}
                   url={href}
                   buyButtonText="Buy"
                />

--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -1,6 +1,6 @@
 import { WithProvidersProps } from '@components/common';
 import type { WithLayoutProps } from '@layouts/default/server';
-import { Product } from '../../../models/product';
+import { Product } from '@models/product';
 import { Guide } from './GuideModel';
 
 export type Section = {
@@ -26,7 +26,7 @@ export type SolutionSection = Omit<
    'guides' | 'products'
 > & {
    guides: Guide[];
-   products: Array<Product | null>;
+   products: Array<Product>;
 };
 
 export type TroubleshootingApiData = {

--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -1,5 +1,6 @@
 import { WithProvidersProps } from '@components/common';
 import type { WithLayoutProps } from '@layouts/default/server';
+import { Product } from '../../../models/product';
 import { Guide } from './GuideModel';
 
 export type Section = {
@@ -17,10 +18,15 @@ export type Author = {
 
 export type ApiSolutionSection = Section & {
    guides: number[];
+   products: string[];
 };
 
-export type SolutionSection = Omit<ApiSolutionSection, 'guides'> & {
+export type SolutionSection = Omit<
+   ApiSolutionSection,
+   'guides' | 'products'
+> & {
    guides: Guide[];
+   products: Array<Product | null>;
 };
 
 export type TroubleshootingApiData = {

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -42,7 +42,7 @@ export const getServerSideProps: GetServerSideProps<
                client.get(`guides/${guideid}`, 'guide') as Promise<Guide>
          )
       );
-      const products = await Promise.all(
+      const products: ('' | null | ProductType)[] = await Promise.all(
          solution.products.map(
             (handle: string | null) =>
                handle &&
@@ -56,15 +56,12 @@ export const getServerSideProps: GetServerSideProps<
                )
          )
       );
-      function isProduct(
-         product: ProductType | '' | null
-      ): product is ProductType {
-         return product !== '' && product !== null;
-      }
       return {
          ...solution,
          guides,
-         products: products.filter(isProduct),
+         products: products.filter((product): product is ProductType =>
+            Boolean(product)
+         ),
       };
    }
 

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -12,6 +12,7 @@ import {
 } from './hooks/useTroubleshootingProps';
 import { Guide } from './hooks/GuideModel';
 import Product from '@pages/api/nextjs/cache/product';
+import type { Product as ProductType } from '@models/product';
 import { hasDisableCacheGets } from '../../helpers/next-helpers';
 
 export const getServerSideProps: GetServerSideProps<
@@ -42,21 +43,28 @@ export const getServerSideProps: GetServerSideProps<
          )
       );
       const products = await Promise.all(
-         solution.products.map((handle: string) =>
-            Product.get(
-               {
-                  handle,
-                  storeCode: DEFAULT_STORE_CODE,
-                  ifixitOrigin,
-               },
-               { forceMiss: hasDisableCacheGets(context) }
-            )
+         solution.products.map(
+            (handle: string | null) =>
+               handle &&
+               Product.get(
+                  {
+                     handle,
+                     storeCode: DEFAULT_STORE_CODE,
+                     ifixitOrigin,
+                  },
+                  { forceMiss: hasDisableCacheGets(context) }
+               )
          )
       );
+      function isProduct(
+         product: ProductType | '' | null
+      ): product is ProductType {
+         return product !== '' && product !== null;
+      }
       return {
          ...solution,
          guides,
-         products,
+         products: products.filter(isProduct),
       };
    }
 

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -216,7 +216,7 @@ export default function SolutionCard({
          borderWidth="1px"
          padding="24px 24px 12px 24px"
       >
-         <Flex gap="24px" direction="column">
+         <Flex gap="24px" direction="column" flexGrow={1}>
             <SolutionHeader index={index} title={solution.heading} />
             <SolutionTexts body={solution.body} />
             <LinkCards guides={solution.guides} products={solution.products} />

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -20,8 +20,9 @@ import {
 import { FaIcon } from '@ifixit/icons';
 import { SolutionSection } from './hooks/useTroubleshootingProps';
 import Prerendered from './prerendered';
-import { GuideResource } from './Resource';
+import { GuideResource, ProductResource } from './Resource';
 import { Guide } from './hooks/GuideModel';
+import { Product } from '@models/product';
 
 const _SolutionFooter = () => (
    <Stack
@@ -218,17 +219,24 @@ export default function SolutionCard({
          <Flex gap="24px" direction="column">
             <SolutionHeader index={index} title={solution.heading} />
             <SolutionTexts body={solution.body} />
-            <LinkCards guides={solution.guides} />
+            <LinkCards guides={solution.guides} products={solution.products} />
          </Flex>
       </Flex>
    );
 }
 
-function LinkCards({ guides, ...props }: { guides: Guide[] } & BoxProps) {
+function LinkCards({
+   guides,
+   products,
+   ...props
+}: { guides: Guide[]; products: Product[] } & BoxProps) {
    return (
       <VStack spacing="6px" {...props}>
          {guides.map((guide: Guide) => (
             <GuideResource key={guide.guideid} guide={guide} />
+         ))}
+         {products.map((product: Product) => (
+            <ProductResource key={product.id} product={product} />
          ))}
       </VStack>
    );


### PR DESCRIPTION
Add product card links for product links in a solution.
See `/Vulcan/troubleshooting_products_test` for an example wiki.

Note that neither these cards nor guide product cards support on sale formatting for prices.

<details>
<summary>Images</summary>

Desktop/tablet
--
![image](https://github.com/iFixit/react-commerce/assets/43477081/6dd231e5-3c18-4f03-9fe8-f1dc29efeb27)

Mobile
--
![image](https://github.com/iFixit/react-commerce/assets/43477081/566b1ee9-2f6e-4eb6-856a-53540948c9b3)

</details>

Closes: https://github.com/ifixit/ifixit/issues/47437