### PR TITLE
E2E Tests: Don't rely on Cominor

### DIFF
--- a/frontend/tests/playwright/fixtures/shopify-mocked-queries.ts
+++ b/frontend/tests/playwright/fixtures/shopify-mocked-queries.ts
@@ -611,7 +611,7 @@ export const findProductQueryMock: FindProductQuery = {
                   currencyCode: CurrencyCode.Usd,
                },
                proPricesByTier: {
-                  value: '{"pro_1":29.99,"pro_2":29.99,"pro_3":29.99,"pro_4":29.99}',
+                  value: '{"pro_1":22.99,"pro_2":21.99,"pro_3":20.99,"pro_4":19.99}',
                },
                selectedOptions: [
                   {

--- a/frontend/tests/playwright/product/pro-user.spec.ts
+++ b/frontend/tests/playwright/product/pro-user.spec.ts
@@ -1,9 +1,27 @@
 import { interceptLogin } from '../utils';
 import { test, expect } from '../test-fixtures';
+import { createGraphQLHandler } from '../msw/request-handler';
 
 test.describe('Pro User Test', () => {
-   test('Pro Discount Applied to Product Price', async ({ productPage }) => {
-      await productPage.gotoProduct('repair-business-toolkit');
+   test('Pro Discount Applied to Product Price', async ({
+      productPage,
+      serverRequestInterceptor,
+      findProductQueryMock,
+   }) => {
+      const proUserProduct = findProductQueryMock;
+      serverRequestInterceptor.use(
+         createGraphQLHandler({
+            request: {
+               endpoint: 'findProduct',
+               method: 'query',
+            },
+            response: {
+               status: 200,
+               body: proUserProduct,
+            },
+         })
+      );
+      await productPage.gotoProduct('pro-user-product');
 
       // Get price from page
       const originalPrice = await productPage.getCurrentPrice();

--- a/frontend/tests/playwright/product/product-variant.spec.ts
+++ b/frontend/tests/playwright/product/product-variant.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../test-fixtures';
+import { createGraphQLHandler } from '../msw/request-handler';
 
 test.describe('Product Variant Tests', () => {
    test('Product Variant Switch and Content Visibility', async ({
@@ -58,8 +59,56 @@ test.describe('Product Variant Tests', () => {
    test('Switch Variants and Add To Cart', async ({
       productPage,
       cartDrawer,
+      serverRequestInterceptor,
+      findProductQueryMock,
    }) => {
-      await productPage.gotoProduct('repair-business-toolkit');
+      const productWithDifferentVariants = findProductQueryMock;
+      const values = [
+         'Repair Business Toolkit 2023',
+         'Repair Business Toolkit 2023 without Pro Tech Toolkit',
+      ];
+      productWithDifferentVariants.product!.options = [
+         {
+            id: 'gid://shopify/ProductOption/8799814352986',
+            name: 'Condition',
+            values: ['New'],
+         },
+         {
+            id: 'gid://shopify/ProductOption/8799814385754',
+            name: 'Style',
+            values: [...values],
+         },
+      ];
+
+      for (let i = 0; i < values.length; i++) {
+         const selectedOption = [
+            {
+               name: 'Condition',
+               value: 'New',
+            },
+            {
+               name: 'Style',
+               value: values[i],
+            },
+         ];
+         productWithDifferentVariants.product!.variants.nodes[
+            i
+         ].selectedOptions = selectedOption;
+      }
+
+      serverRequestInterceptor.use(
+         createGraphQLHandler({
+            request: {
+               endpoint: 'findProduct',
+               method: 'query',
+            },
+            response: {
+               status: 200,
+               body: productWithDifferentVariants,
+            },
+         })
+      );
+      await productPage.gotoProduct('product-with-different-variants');
       const productInfoSection = productPage.page.getByTestId(
          'product-info-section'
       );


### PR DESCRIPTION
## Summary
The following two tests were failing on master because the default SKU for RBT has changed:
- `product/pro-user.spec.ts:5:8 › Pro User Test › Pro Discount Applied to Product Price`
- `product/product-variant.spec.ts:58:8 › Product Variant Tests › Switch Variants and Add To Cart`

Instead of relying on Cominor, we are now mocking RBT so it's less likely to fail if RBT gets out of stock again or edited. 

## QA notes
Passing E2E and stress test checks in CI is enough.

closes #1699