### PR TITLE
Page: Add banner link fallback spacing

### DIFF
--- a/frontend/components/sections/BannersSection/SingleBanner.tsx
+++ b/frontend/components/sections/BannersSection/SingleBanner.tsx
@@ -30,38 +30,42 @@ export function SingleBanner({ id, banner }: SingleBannerProps) {
                />
             </Box>
          )}
-         <Wrapper>
-            <Box textAlign="center" position="relative">
-               {banner.label && (
-                  <Text color="white" mb="3" fontSize="sm">
-                     {banner.label}
-                  </Text>
-               )}
-               {banner.title && (
-                  <SectionHeading color="white" mb="2.5">
-                     {banner.title}
-                  </SectionHeading>
-               )}
-               {banner.description && (
-                  <SectionDescription
-                     richText={banner.description}
-                     color="white"
-                     maxW="750px"
-                     mx="auto"
-                  />
-               )}
-               {banner.callToAction && (
-                  <Box position="absolute" w="full" bottom="-20">
-                     <SmartLink
-                        as={LinkButton}
-                        href={banner.callToAction.url}
-                        colorScheme="brand"
-                     >
-                        {banner.callToAction.title}
-                     </SmartLink>
-                  </Box>
-               )}
-            </Box>
+         <Wrapper position="relative" textAlign="center">
+            {banner.label && (
+               <Text color="white" mb="3" fontSize="sm">
+                  {banner.label}
+               </Text>
+            )}
+            {banner.title && (
+               <SectionHeading color="white" mb="2.5">
+                  {banner.title}
+               </SectionHeading>
+            )}
+            {banner.description && (
+               <SectionDescription
+                  richText={banner.description}
+                  color="white"
+                  maxW="750px"
+                  mx="auto"
+               />
+            )}
+            {banner.callToAction && (
+               <Box
+                  position="absolute"
+                  w="full"
+                  bottom="-20"
+                  left="50%"
+                  transform="translateX(-50%)"
+               >
+                  <SmartLink
+                     as={LinkButton}
+                     href={banner.callToAction.url}
+                     colorScheme="brand"
+                  >
+                     {banner.callToAction.title}
+                  </SmartLink>
+               </Box>
+            )}
          </Wrapper>
       </Center>
    );

--- a/frontend/components/sections/BannersSection/SingleBanner.tsx
+++ b/frontend/components/sections/BannersSection/SingleBanner.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@chakra-ui/react';
+import { Box, Center, Text } from '@chakra-ui/react';
 import { LinkButton } from '@components/ui/LinkButton';
 import { SmartLink } from '@components/ui/SmartLink';
 import { ResponsiveImage, Wrapper } from '@ifixit/ui';
@@ -13,7 +13,7 @@ interface SingleBannerProps {
 
 export function SingleBanner({ id, banner }: SingleBannerProps) {
    return (
-      <Box as="section" id={id} position="relative" w="full" py="144px">
+      <Center as="section" id={id} position="relative" w="full" minH="390px">
          <Box
             position="absolute"
             bgGradient="linear(to-r, blackAlpha.600 50%, blackAlpha.400)"
@@ -73,6 +73,6 @@ export function SingleBanner({ id, banner }: SingleBannerProps) {
                )}
             </Box>
          </Wrapper>
-      </Box>
+      </Center>
    );
 }

--- a/frontend/components/sections/BannersSection/SingleBanner.tsx
+++ b/frontend/components/sections/BannersSection/SingleBanner.tsx
@@ -13,7 +13,7 @@ interface SingleBannerProps {
 
 export function SingleBanner({ id, banner }: SingleBannerProps) {
    return (
-      <Box as="section" id={id} position="relative" w="full" pt="36" pb="16">
+      <Box as="section" id={id} position="relative" w="full" py="144px">
          <Box
             position="absolute"
             bgGradient="linear(to-r, blackAlpha.600 50%, blackAlpha.400)"
@@ -41,7 +41,7 @@ export function SingleBanner({ id, banner }: SingleBannerProps) {
             </Box>
          )}
          <Wrapper>
-            <Box textAlign="center">
+            <Box textAlign="center" position="relative">
                {banner.label && (
                   <Text color="white" mb="3" fontSize="sm">
                      {banner.label}
@@ -61,14 +61,15 @@ export function SingleBanner({ id, banner }: SingleBannerProps) {
                   />
                )}
                {banner.callToAction && (
-                  <SmartLink
-                     as={LinkButton}
-                     href={banner.callToAction.url}
-                     colorScheme="brand"
-                     mt="10"
-                  >
-                     {banner.callToAction.title}
-                  </SmartLink>
+                  <Box position="absolute" w="full" bottom="-20">
+                     <SmartLink
+                        as={LinkButton}
+                        href={banner.callToAction.url}
+                        colorScheme="brand"
+                     >
+                        {banner.callToAction.title}
+                     </SmartLink>
+                  </Box>
                )}
             </Box>
          </Wrapper>

--- a/frontend/components/sections/BannersSection/SingleBanner.tsx
+++ b/frontend/components/sections/BannersSection/SingleBanner.tsx
@@ -18,20 +18,10 @@ export function SingleBanner({ id, banner }: SingleBannerProps) {
             position="absolute"
             bgGradient="linear(to-r, blackAlpha.600 50%, blackAlpha.400)"
             zIndex={-1}
-            top="0"
-            left="0"
-            bottom="0"
-            right="0"
+            inset="0"
          />
          {banner.image && (
-            <Box
-               position="absolute"
-               zIndex={-2}
-               top="0"
-               left="0"
-               bottom="0"
-               right="0"
-            >
+            <Box position="absolute" zIndex={-2} inset="0">
                <ResponsiveImage
                   src={banner.image.url}
                   alt=""


### PR DESCRIPTION
Keeps the banner text vertically aligned if the link is missing.

Closes #1703

## QA

- Visit `/products/repair-business-toolkit`
- On https://page-header-alignment.govinor.com/admin, get rid of the banner call to action for the repair business toolkit page.
- Verify that the height of the image remains unchanged, and that the text is vertically aligned.
- With the call to action, the UI should match `main`.