### PR TITLE
Troubleshooting: Update test to require Vulcan canonical link

### DIFF
--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -19,7 +19,10 @@ test.describe('Vulcan Page Content and SEO', () => {
       await page.goto('/Vulcan/Dryer_Not_Spinning');
       // check that the canonical link is a resonable URL
       const canonical = page.locator('link[rel="canonical"]');
-      await expect(canonical).toHaveAttribute('href', /Dryer.*Not.*Spinning/);
+      await expect(canonical).toHaveAttribute(
+         'href',
+         /Vulcan\/Dryer.*Not.*Spinning/
+      );
       // Check that the canonical link is an absolute URL
       await expect(canonical).toHaveAttribute('href', /^http/);
    });


### PR DESCRIPTION
This ensures the canonical link points at the new page and not at the original WIKI the data is sourced from. This test already passes; I just wanted to add something to confirm that it works as-expected.

qa_req 0
This only changes a test.

Closes https://github.com/iFixit/ifixit/issues/48082