### PR TITLE
Link to legacy featured product pages from cross sell section

### DIFF
--- a/frontend/components/common/ProductGridItem.tsx
+++ b/frontend/components/common/ProductGridItem.tsx
@@ -7,7 +7,7 @@ import {
    ProductCardRating,
    ProductCardTitle,
 } from '@components/common';
-import { getProductPath } from '@helpers/product-helpers';
+import { productPath } from '@helpers/path-helpers';
 import {
    computeDiscountPercentage,
    shouldShowProductRating,
@@ -86,7 +86,7 @@ export function ProductGridItem({ product, onClick }: ProductGridItemProps) {
             <ProductCardImage src={product.image?.url} alt={product.title} />
             <ProductCardBody>
                <LinkOverlay
-                  href={getProductPath(product.handle)}
+                  href={productPath(product.handle)}
                   onClick={onClick}
                >
                   <ProductCardTitle

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -1,13 +1,26 @@
 import { APP_ORIGIN, IFIXIT_ORIGIN } from '@config/env';
 import { invariant } from '@ifixit/helpers';
+import type { Product } from '@models/product';
 import {
+   iFixitPageType,
    ProductList,
    ProductListType,
    StorePage,
-   iFixitPageType,
 } from '@models/product-list';
 import { GetServerSidePropsContext } from 'next';
+import { getProductIdFromGlobalId } from './product-helpers';
 import { stylizeDeviceTitle } from './product-list-helpers';
+
+export function productPath(handle: string) {
+   switch (handle) {
+      case 'pro-tech-toolkit':
+         return `${IFIXIT_ORIGIN}/Store/Tools/Pro-Tech-Toolkit/IF145-307`;
+      case 'manta-driver-kit-112-bit-driver-kit':
+         return `${IFIXIT_ORIGIN}/Store/Tools/Manta-Driver-Kit--112-Bit-Driver-Kit/IF145-392`;
+      default:
+         return `/products/${handle}`;
+   }
+}
 
 type ProductListPathAttributes = Pick<
    ProductList | StorePage,
@@ -47,6 +60,76 @@ export function productListPath(
          throw new Error(`unknown product list type: ${productList.type}`);
       }
    }
+}
+
+interface AkineoProductUrlProps {
+   product: Pick<Product, 'productcode'>;
+}
+
+export function akineoProductUrl({ product }: AkineoProductUrlProps) {
+   return `${akineoUrl()}/redirect/edit/product/${encodeURIComponent(
+      product.productcode ?? ''
+   )}`;
+}
+
+export function akineoUrl() {
+   return ifixitOriginWithSubdomain('akeneo');
+}
+
+export interface IFixitAdminProductInvetoryUrlProps {
+   product: Pick<Product, 'productcode'>;
+}
+
+export function iFixitAdminProductInventoryUrl({
+   product,
+}: IFixitAdminProductInvetoryUrlProps) {
+   const encodedProductcode = encodeURIComponent(product.productcode ?? '');
+   return `${iFixitAdminUrl()}/Inventory/inventory_report.php?searchTerm=${encodedProductcode}`;
+}
+
+interface IFixitAdminProductImagesUrlProps {
+   product: Pick<Product, 'productcode'>;
+}
+
+export function iFixitAdminProductImagesUrl({
+   product,
+}: IFixitAdminProductImagesUrlProps) {
+   const encodedProductcode = encodeURIComponent(product.productcode ?? '');
+   return `${iFixitAdminUrl()}/Product/ProductImages.php?productcode=${encodedProductcode}`;
+}
+
+export function iFixitAdminUrl() {
+   return `${IFIXIT_ORIGIN}/Admin`;
+}
+
+interface ShopifyAdminProductUrlProps {
+   product: Pick<Product, 'id'>;
+   storeCode: string;
+}
+export function shopifyStoreAdminProductUrl({
+   product,
+   storeCode,
+}: ShopifyAdminProductUrlProps) {
+   const adminProductId = getProductIdFromGlobalId(product.id);
+   return `${shopifyStoreAdminUrl({ storeCode })}/products/${adminProductId}`;
+}
+
+interface ShopifyStoreAdminUrlProps {
+   storeCode: string;
+}
+
+export function shopifyStoreAdminUrl({ storeCode }: ShopifyStoreAdminUrlProps) {
+   return `${shopifyStoreOriginUrl({ storeCode })}/admin`;
+}
+
+interface ShopifyStoreOriginUrlProps {
+   storeCode: string;
+}
+
+export function shopifyStoreOriginUrl({
+   storeCode,
+}: ShopifyStoreOriginUrlProps) {
+   return `https://ifixit-${storeCode}.myshopify.com`;
 }
 
 export function ifixitOriginFromHost(

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -62,17 +62,17 @@ export function productListPath(
    }
 }
 
-interface AkineoProductUrlProps {
+interface AkeneoProductUrlProps {
    product: Pick<Product, 'productcode'>;
 }
 
-export function akineoProductUrl({ product }: AkineoProductUrlProps) {
-   return `${akineoUrl()}/redirect/edit/product/${encodeURIComponent(
+export function akeneoProductUrl({ product }: AkeneoProductUrlProps) {
+   return `${akeneoUrl()}/redirect/edit/product/${encodeURIComponent(
       product.productcode ?? ''
    )}`;
 }
 
-export function akineoUrl() {
+export function akeneoUrl() {
    return ifixitOriginWithSubdomain('akeneo');
 }
 

--- a/frontend/helpers/product-helpers.ts
+++ b/frontend/helpers/product-helpers.ts
@@ -1,65 +1,6 @@
-import { PageEditMenuLink } from '@components/admin';
-import { IFIXIT_ORIGIN } from '@config/env';
-import {
-   faArrowUpRightFromSquare,
-   faImage,
-   faShop,
-   faWarehouse,
-} from '@fortawesome/pro-solid-svg-icons';
-import { ifixitOriginWithSubdomain } from './path-helpers';
-
-export function getProductPath(handle: string) {
-   switch (handle) {
-      case 'pro-tech-toolkit':
-         return `${IFIXIT_ORIGIN}/Store/Tools/Pro-Tech-Toolkit/IF145-307`;
-      case 'manta-driver-kit-112-bit-driver-kit':
-         return `${IFIXIT_ORIGIN}/Store/Tools/Manta-Driver-Kit--112-Bit-Driver-Kit/IF145-392`;
-      default:
-         return `/products/${handle}`;
-   }
-}
-
-type GetAdminLinksProps = {
-   productcode?: string;
-   productId: string;
-   storeCode: string;
-};
-
-export function getAdminLinks({
-   productcode,
-   productId,
-   storeCode,
-}: GetAdminLinksProps): PageEditMenuLink[] {
-   const encodedProductcode = encodeURIComponent(productcode ?? '');
-   const encodedProductId = encodeProductId(productId);
-   const akeneoOrigin = ifixitOriginWithSubdomain('akeneo');
-   return [
-      {
-         icon: faArrowUpRightFromSquare,
-         label: 'Akeneo',
-         url: `${akeneoOrigin}/redirect/edit/product/${encodedProductcode}`,
-      },
-      {
-         icon: faShop,
-         label: 'Shopify',
-         url: `https://ifixit-${storeCode}.myshopify.com/admin/products/${encodedProductId}`,
-      },
-      {
-         icon: faWarehouse,
-         label: 'View Inventory',
-         url: `${IFIXIT_ORIGIN}/Admin/Inventory/inventory_report.php?searchTerm=${encodedProductcode}`,
-      },
-      {
-         icon: faImage,
-         label: 'Edit Images',
-         url: `${IFIXIT_ORIGIN}/Admin/Product/ProductImages.php?productcode=${encodedProductcode}`,
-      },
-   ];
-}
-
-export function encodeProductId(productId: string) {
-   if (!productId.startsWith('gid://')) {
+export function getProductIdFromGlobalId(globalProductId: string) {
+   if (!globalProductId.startsWith('gid://')) {
       throw new Error('Product id must be a global shopify product id');
    }
-   return productId.replace(/^gid:\/\/shopify\/Product\//, '');
+   return globalProductId.replace(/^gid:\/\/shopify\/Product\//, '');
 }

--- a/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/ProductList.tsx
@@ -13,9 +13,7 @@ import {
    VStack,
 } from '@chakra-ui/react';
 import { Rating } from '@components/ui';
-import { flags } from '@config/flags';
-import { getProductPath } from '@helpers/product-helpers';
-import { useAppContext } from '@ifixit/app';
+import { productPath } from '@helpers/path-helpers';
 import {
    IconBadge,
    ProductVariantPrice,
@@ -54,8 +52,6 @@ export interface ProductListItemProps {
 }
 
 export function ProductListItem({ product }: ProductListItemProps) {
-   const appContext = useAppContext();
-
    const { price, compareAtPrice, isDiscounted, percentage, proPricesByTier } =
       useProductSearchHitPricing(product);
 
@@ -230,13 +226,7 @@ export function ProductListItem({ product }: ProductListItemProps) {
                            Only {quantityAvailable} left in stock
                         </Text>
                      )}
-                     <LinkOverlay
-                        href={
-                           flags.PRODUCT_PAGE_ENABLED
-                              ? getProductPath(product.handle)
-                              : `${appContext.ifixitOrigin}${product.url}`
-                        }
-                     >
+                     <LinkOverlay href={productPath(product.handle)}>
                         <Button as="div" minW="20" colorScheme="brand">
                            View
                         </Button>

--- a/frontend/templates/product/hooks/useProductPageAdminLinks.tsx
+++ b/frontend/templates/product/hooks/useProductPageAdminLinks.tsx
@@ -1,0 +1,51 @@
+import type { PageEditMenuLink } from '@components/admin';
+import {
+   faArrowUpRightFromSquare,
+   faImage,
+   faShop,
+   faWarehouse,
+} from '@fortawesome/pro-solid-svg-icons';
+import {
+   akineoProductUrl,
+   iFixitAdminProductImagesUrl,
+   iFixitAdminProductInventoryUrl,
+   shopifyStoreAdminProductUrl,
+} from '@helpers/path-helpers';
+import type { Product } from '@models/product';
+import { useMemo } from 'react';
+
+interface UseProductPageAdminLinksOptions {
+   product: Product;
+   storeCode: string;
+}
+
+export function useProductPageAdminLinks({
+   product,
+   storeCode,
+}: UseProductPageAdminLinksOptions): PageEditMenuLink[] {
+   return useMemo(
+      () => [
+         {
+            icon: faArrowUpRightFromSquare,
+            label: 'Akeneo',
+            url: akineoProductUrl({ product }),
+         },
+         {
+            icon: faShop,
+            label: 'Shopify',
+            url: shopifyStoreAdminProductUrl({ product, storeCode }),
+         },
+         {
+            icon: faWarehouse,
+            label: 'View Inventory',
+            url: iFixitAdminProductInventoryUrl({ product }),
+         },
+         {
+            icon: faImage,
+            label: 'Edit Images',
+            url: iFixitAdminProductImagesUrl({ product }),
+         },
+      ],
+      [product, storeCode]
+   );
+}

--- a/frontend/templates/product/hooks/useProductPageAdminLinks.tsx
+++ b/frontend/templates/product/hooks/useProductPageAdminLinks.tsx
@@ -6,7 +6,7 @@ import {
    faWarehouse,
 } from '@fortawesome/pro-solid-svg-icons';
 import {
-   akineoProductUrl,
+   akeneoProductUrl,
    iFixitAdminProductImagesUrl,
    iFixitAdminProductInventoryUrl,
    shopifyStoreAdminProductUrl,
@@ -28,7 +28,7 @@ export function useProductPageAdminLinks({
          {
             icon: faArrowUpRightFromSquare,
             label: 'Akeneo',
-            url: akineoProductUrl({ product }),
+            url: akeneoProductUrl({ product }),
          },
          {
             icon: faShop,

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -9,7 +9,6 @@ import { ReplacementGuidesSection } from '@components/sections/ReplacementGuides
 import { ServiceValuePropositionSection } from '@components/sections/ServiceValuePropositionSection';
 import { SplitWithImageContentSection } from '@components/sections/SplitWithImageSection';
 import { DEFAULT_STORE_CODE } from '@config/env';
-import { getAdminLinks } from '@helpers/product-helpers';
 import {
    trackGoogleProductView,
    trackInMatomoAndGA,
@@ -26,21 +25,22 @@ import { DefaultLayout } from '@layouts/default';
 import { ProductPreview } from '@models/components/product-preview';
 import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
 import * as React from 'react';
+import { LifetimeWarrantySection } from '../../components/sections/LifetimeWarrantySection';
 import { PixelPing } from './components/PixelPing';
 import { SecondaryNavigation } from './components/SecondaryNavigation';
 import { useIsProductForSale } from './hooks/useIsProductForSale';
+import { useProductPageAdminLinks } from './hooks/useProductPageAdminLinks';
 import {
    ProductTemplateProps,
    useProductTemplateProps,
 } from './hooks/useProductTemplateProps';
 import { useSelectedVariant } from './hooks/useSelectedVariant';
 import { MetaTags } from './MetaTags';
+import { CompatibilityNotesSection } from './sections/CompatibilityNotesSection';
 import { CompatibilitySection } from './sections/CompatibilitySection';
 import { CrossSellSection } from './sections/CrossSellSection';
-import { LifetimeWarrantySection } from '../../components/sections/LifetimeWarrantySection';
 import { ProductOverviewSection } from './sections/ProductOverviewSection';
 import { ProductReviewsSection } from './sections/ProductReviewsSection';
-import { CompatibilityNotesSection } from './sections/CompatibilityNotesSection';
 
 const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
    const { product } = useProductTemplateProps();
@@ -77,15 +77,11 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
       []
    );
 
-   const adminLinks = React.useMemo(
-      () =>
-         getAdminLinks({
-            productcode: product.productcode,
-            productId: product.id,
-            storeCode: DEFAULT_STORE_CODE,
-         }),
-      [product.productcode, product.id]
-   );
+   const adminLinks = useProductPageAdminLinks({
+      product,
+      storeCode: DEFAULT_STORE_CODE,
+   });
+
    return (
       <React.Fragment key={product.handle}>
          <MetaTags product={product} selectedVariant={selectedVariant} />

--- a/frontend/templates/product/sections/CrossSellSection/CrossSellVariantCard.tsx
+++ b/frontend/templates/product/sections/CrossSellSection/CrossSellVariantCard.tsx
@@ -12,6 +12,7 @@ import { ProductRating } from '@components/common';
 import { Card } from '@components/ui';
 import { faImage } from '@fortawesome/pro-duotone-svg-icons';
 import { faCircleCheck } from '@fortawesome/pro-solid-svg-icons';
+import { productPath } from '@helpers/path-helpers';
 import { FaIcon } from '@ifixit/icons';
 import { ProductVariantPrice, ResponsiveImage } from '@ifixit/ui';
 import type { Image } from '@models/components/image';
@@ -46,7 +47,7 @@ export function CrossSellVariantCard({
    onChange,
 }: CrossSellVariantCardProps) {
    return (
-      <NextLink href={`/products/${handle}`} passHref legacyBehavior>
+      <NextLink href={productPath(handle)} passHref legacyBehavior>
          <Card
             data-testid="cross-sell-item"
             as="a"

--- a/packages/ui/slider/index.tsx
+++ b/packages/ui/slider/index.tsx
@@ -219,7 +219,7 @@ export const Slider = forwardRef<SliderProps, 'div'>(
          <Box ref={ref} pos="relative" overflow="hidden" {...other}>
             <Flex
                ref={trackRef}
-               sx={{ 'touch-action': 'pan-y' }}
+               sx={{ touchAction: 'pan-y' }}
                transition="transform ease-in-out 300ms"
                transform={computeTransform({
                   activeIndex: activeIndex,
@@ -276,6 +276,7 @@ export const Slider = forwardRef<SliderProps, 'div'>(
                         })
                      ) : (
                         <Bullet
+                           key={index}
                            isActive={index === activeIndex}
                            onClick={() => handleBulletClick(index)}
                         />


### PR DESCRIPTION
closes #1719 

This fixes #1719 as well as a couple of minor React warnings. I've also done some refactoring on the path helpers

## QA

1. Open [this product page preview](https://react-commerce-git-fix-product-links-ifixit.vercel.app/products/tesa-61395-tape)
2. Scroll to the Frequently Bought Together section and click on the pro tech toolkit card
3. Verified that you are redirected to the legacy php product page