### PR TITLE
Algolia: prefer usePagination()

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -62,7 +62,7 @@ export function InstantSearchProvider({
          algoliaApiKey,
          getClientOptions(logContextName)
       );
-   }, [algoliaApiKey]);
+   }, [algoliaApiKey, logContextName]);
 
    const facets = useFacets();
 

--- a/frontend/templates/product-list/sections/FilterableProductsSection/Toolbar.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/Toolbar.tsx
@@ -17,7 +17,10 @@ import { getProductListTitle } from '@helpers/product-list-helpers';
 import { FaIcon } from '@ifixit/icons';
 import { ProductList } from '@models/product-list';
 import * as React from 'react';
-import { useCurrentRefinements, useHits } from 'react-instantsearch-hooks-web';
+import {
+   useCurrentRefinements,
+   usePagination,
+} from 'react-instantsearch-hooks-web';
 import { CurrentRefinements } from './CurrentRefinements';
 import { FacetsDrawer } from './facets/drawer';
 import { SearchInput } from './SearchInput';
@@ -130,8 +133,8 @@ export function Toolbar(props: ToolbarProps) {
 }
 
 export function NumberOfHits() {
-   const { results } = useHits();
-   const hitsCount = results?.nbHits;
+   const { nbHits } = usePagination();
+   const hitsCount = nbHits || null;
    if (hitsCount == null) {
       return null;
    }

--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/accordion/useFacetAccordionItemState.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/accordion/useFacetAccordionItemState.tsx
@@ -1,5 +1,5 @@
 import { ProductList, ProductListType } from '@models/product-list';
-import { useHits } from 'react-instantsearch-hooks-web';
+import { usePagination } from 'react-instantsearch-hooks-web';
 
 export type UseFacetAccordionItemProps = {
    attribute: string;
@@ -12,8 +12,8 @@ export function useFacetAccordionItemState({
    hasApplicableRefinements,
    productList,
 }: UseFacetAccordionItemProps) {
-   const { hits } = useHits();
-   const isProductListEmpty = hits.length === 0;
+   const { nbHits } = usePagination();
+   const isProductListEmpty = nbHits < 1;
    const isDisabled = isProductListEmpty || !hasApplicableRefinements;
 
    const isProductListEmptyState =

--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/useMenuFacet.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/useMenuFacet.tsx
@@ -3,7 +3,11 @@ import {
    PRODUCT_LIST_MAX_FACET_VALUES_COUNT,
 } from '@config/constants';
 import { ProductList, ProductListType } from '@models/product-list';
-import { useHits, useMenu, UseMenuProps } from 'react-instantsearch-hooks-web';
+import {
+   useMenu,
+   UseMenuProps,
+   usePagination,
+} from 'react-instantsearch-hooks-web';
 import { useSortBy } from './useSortBy';
 
 export type MenuFacetState = ReturnType<typeof useMenuFacet>;
@@ -44,8 +48,7 @@ function useFilteredMenu(props: UseMenuProps) {
       showMore: true,
       ...props,
    });
-   const { results } = useHits();
-   const hitsCount = results?.nbHits ?? 0;
+   const { nbHits: hitsCount } = usePagination();
    const isAnyRefined = items.some((item) => item.isRefined);
    const filteredItems = isAnyRefined
       ? items

--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/useRefinementListFacet.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/useRefinementListFacet.tsx
@@ -2,7 +2,10 @@ import {
    PRODUCT_LIST_DEFAULT_FACET_VALUES_COUNT,
    PRODUCT_LIST_MAX_FACET_VALUES_COUNT,
 } from '@config/constants';
-import { useHits, useRefinementList } from 'react-instantsearch-hooks-web';
+import {
+   useRefinementList,
+   usePagination,
+} from 'react-instantsearch-hooks-web';
 import { useSortBy } from './useSortBy';
 
 export type RefinementListFacetState = ReturnType<
@@ -24,8 +27,7 @@ export function useRefinementListFacet({
       showMore: true,
       showMoreLimit: PRODUCT_LIST_MAX_FACET_VALUES_COUNT,
    });
-   const { results } = useHits();
-   const hitsCount = results?.nbHits ?? 0;
+   const { nbHits: hitsCount } = usePagination();
    const isAnyRefined = items.some((item) => item.isRefined);
    const filteredItems =
       isAnyRefined || isPriceRange

--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -59,7 +59,7 @@ export function FilterableProductsSection({
    productList,
    algoliaSSR,
 }: SectionProps) {
-   const { hits } = useHits<ProductSearchHit>();
+   const { hits } = useHits<ProductSearchHit>({ escapeHTML: false });
    const hasAnyVisibleFacet = useHasAnyVisibleFacet(productList);
 
    const products = React.useMemo(

--- a/frontend/templates/product-list/sections/FilterableProductsSection/useHasAnyVisibleFacet.ts
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/useHasAnyVisibleFacet.ts
@@ -13,7 +13,7 @@ type HierarchicalFacet =
    SearchResults<ProductSearchHit>['hierarchicalFacets'][number];
 
 export function useHasAnyVisibleFacet(productList: TProductList): boolean {
-   const { results } = useHits<ProductSearchHit>();
+   const { results } = useHits<ProductSearchHit>({ escapeHTML: false });
    const activeFacetsName = useFilteredFacets(productList);
 
    if (!results) {

--- a/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
@@ -6,7 +6,7 @@ import NextLink from 'next/link';
 import * as React from 'react';
 import {
    useCurrentRefinements,
-   useHits,
+   usePagination,
    useSearchBox,
 } from 'react-instantsearch-hooks-web';
 import { useDevicePartsItemType } from '../hooks/useDevicePartsItemType';
@@ -25,7 +25,7 @@ export function ProductListChildrenSection({
 
    const { items } = useCurrentRefinements();
    const { query } = useSearchBox();
-   const { hits } = useHits();
+   const { nbHits } = usePagination();
    const itemType = useDevicePartsItemType(productList);
 
    const childrenCount = productListChildren.length;
@@ -33,10 +33,8 @@ export function ProductListChildrenSection({
       const nonItemTypeRefinements = items.filter(
          (item) => item.attribute !== 'facet_tags.Item Type'
       );
-      return (
-         !hits.length && itemType && !nonItemTypeRefinements.length && !query
-      );
-   }, [items, itemType, hits, query]);
+      return !nbHits && itemType && !nonItemTypeRefinements.length && !query;
+   }, [items, itemType, nbHits, query]);
 
    return isUnfilteredItemTypeWithNoHits ? null : (
       <Box>


### PR DESCRIPTION
useHits() is an expensive call on the server (> 1ms per call) and we
called it in quite a few places (some are in loops). Calling
usePagination() is < 0.1ms and provides us the thing we need most often
(hit count). This saves us ~10ms or so.

I've noticed that useHits() is not slow on the client strangely enough.

Note this savings happens twice on the server (in getServerState() and
in the next.js render-to-string phase.

This is a minimal version of pull #1723