### PR TITLE
localStorage: require a schema validator

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -69,7 +69,11 @@ export function FilterableProductsSection({
    const currentRefinements = useCurrentRefinements();
    const [viewType, setViewType] = useLocalPreference(
       PRODUCT_VIEW_TYPE_STORAGE_KEY,
-      ProductViewType.List
+      ProductViewType.List,
+      (data) =>
+         data === ProductViewType.List || data === ProductViewType.Grid
+            ? data
+            : null
    );
 
    const productsContainerScrollRef = useScrollIntoViewEffect([hits]);

--- a/frontend/templates/product/hooks/useInternationalBuyBox.tsx
+++ b/frontend/templates/product/hooks/useInternationalBuyBox.tsx
@@ -12,7 +12,8 @@ export function useInternationalBuyBox(product: Product) {
    const [dismissed, setDismissed] = useExpiringLocalPreference<boolean | null>(
       'buy-box-this-store',
       null,
-      7 // expire in days
+      7, // expire in days
+      (data: any) => (data === true || data === false ? data : null)
    );
    const [selectedVariant] = useSelectedVariant(product);
    const buyBox = useQuery(

--- a/packages/ui/hooks/index.ts
+++ b/packages/ui/hooks/index.ts
@@ -196,7 +196,7 @@ export function useLocalPreference<Data = any>(
          if (serializedData != null) {
             const data = validator(JSON.parse(serializedData));
             if (data !== null) {
-               setData(data as Data);
+               setData(data);
             }
          }
       } catch (error) {}


### PR DESCRIPTION
Now corrupt values in localStorage won't be used if they don't pass the validator (which is required to return the same type as the data or null).

Closes #1656