### PR TITLE
Apply default featured product list in case of retrieval errors

### DIFF
--- a/frontend/models/sections/featured-products-section.ts
+++ b/frontend/models/sections/featured-products-section.ts
@@ -52,10 +52,15 @@ export async function featuredProductsSectionFromStrapi({
          filters: productList.filters ?? null,
       });
 
-      products = await getProductPreviewsFromAlgolia({
-         filters,
-         hitsPerPage: 12,
-      });
+      try {
+         products = await getProductPreviewsFromAlgolia({
+            filters,
+            hitsPerPage: 12,
+         });
+      } catch (e) {
+         console.error('Error getting featured products from Algolia', e);
+         products = fallbackProducts;
+      }
    } else {
       products = fallbackProducts;
    }


### PR DESCRIPTION
closes #1733 

### QA

1. Visit Vercel preview
2. Verify that using a wrong filter value in the linked featured collection makes the whole featured collection section to hide, since the default product list is currently an empty array