### PR TITLE
Vulcan: Fix Windows+Chrome header bar bug

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -274,7 +274,7 @@ function NavBar({
                   }}
                   position="relative"
                   flex="1 2"
-                  overflowX="scroll"
+                  overflowX="auto"
                >
                   <NavTabs
                      overflowX="auto"


### PR DESCRIPTION
## Description
Remove Windows+Chrome Parts/Guides/Answers section scrollbar.

https://react-commerce.vercel.app/Vulcan/Dyson_Brush_Not_Spinning

<details>
<summary>Screenshot</summary>

<img width="1695" alt="Screenshot 2023-06-09 at 3 31 43 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/a297b6b3-6dcd-46de-95cd-96816aa19227">

</details>

## Modified
[fix windows container overflow bug](https://github.com/iFixit/react-commerce/commit/c00973655185da984ab4d8c3715f852eea83dfff)

## QA
This issue is only present on Windows using Chromium browser

https://react-commerce-prod-git-vulcan-fix-windows-chrome-b883a3-ifixit.vercel.app/Vulcan/Dyson_Brush_Not_Spinning

Closes: https://github.com/iFixit/ifixit/issues/48141