### PR TITLE
Vulcan: Remove double dividing line if no introduction

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -154,7 +154,9 @@ const Wiki: NextPageWithLayout<{
             {wikiData.introduction.map((intro) => (
                <IntroductionSection key={intro.heading} intro={intro} />
             ))}
-            <Spacer borderBottom="1px" borderColor="gray.300" />
+            {wikiData.introduction.length > 0 && (
+               <Spacer borderBottom="1px" borderColor="gray.300" />
+            )}
             {wikiData.solutions.length > 0 && (
                <>
                   <HeadingSelfLink


### PR DESCRIPTION
## Description
Render one of the double dividing lines only when there is a `wikiData.introduction.length`.

## Modified
1. [render Spacer only on wikiData.introduction.length](https://github.com/iFixit/react-commerce/commit/f25bb0af2cad4e35a97c613d9561ada17d0b24fb)

Closes: https://github.com/iFixit/react-commerce/issues/1751