### PR TITLE
Store homepage: Add param to search store facet

### DIFF
--- a/frontend/templates/page/sections/BrowseSection.tsx
+++ b/frontend/templates/page/sections/BrowseSection.tsx
@@ -95,6 +95,7 @@ function SearchBox() {
          w="full"
          justify="center"
       >
+         <input type="hidden" name="doctype" value="product" />
          <InputGroup
             transform="translateY(-50%)"
             size="lg"


### PR DESCRIPTION
Closes #1741

## QA

Searching the store homepage should navigate you to results on the "Store" tab of site search

![image](https://github.com/iFixit/react-commerce/assets/52104630/c9a050d0-e708-431e-9e7c-1e6f8529ff3d)


CC @davidrans 