### PR TITLE
Cross Sell: Display Multiple Items

### DIFF
--- a/packages/cart-sdk/hooks/use-cart.ts
+++ b/packages/cart-sdk/hooks/use-cart.ts
@@ -82,7 +82,7 @@ function createCart(input: APICart): Cart {
            }
          : null;
 
-   const crossSellProducts = input.upsellProducts ?? input.crossSellProducts;
+   const crossSellProducts = input.crossSellProducts;
    return {
       hasItemsInCart: input.totalNumItems > 0,
       lineItems,

--- a/packages/cart-sdk/types.ts
+++ b/packages/cart-sdk/types.ts
@@ -48,7 +48,6 @@ export interface APICart {
    miniCart: {
       products: MiniCartProduct[];
    };
-   upsellProducts: APICrossSellProduct[];
    crossSellProducts: APICrossSellProduct[];
 }
 export interface CrossSellProduct {

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -54,15 +54,18 @@ export function CartDrawer() {
    const cart = useCart();
    const checkout = useCheckout();
 
-   const crossSellItem = React.useMemo(() => {
-      const item = cart.data?.crossSellProducts[0];
-      const isAlreadyInCart =
-         item &&
-         cart.data?.lineItems.find(
-            (lineItem) => lineItem.itemcode === item.itemcode
-         );
-      if (isAlreadyInCart) return null;
-      return item;
+   const crossSellItems = React.useMemo(() => {
+      const crossSells =
+         cart.data?.crossSellProducts.filter((item) => {
+            const isAlreadyInCart =
+               item &&
+               cart.data?.lineItems.find(
+                  (lineItem) => lineItem.itemcode === item.itemcode
+               );
+            if (isAlreadyInCart) return null;
+            return item;
+         }) ?? [];
+      return crossSells;
    }, [cart.data]);
 
    return (
@@ -153,7 +156,18 @@ export function CartDrawer() {
                               })}
                            </AnimatePresence>
                         </Box>
-                        {crossSellItem && <CrossSell item={crossSellItem} />}
+                        <Box as="ul" data-testid="cart-drawer-x-sell-items">
+                           <AnimatePresence>
+                              {crossSellItems.map((crossSellItem) => {
+                                 return (
+                                    <ListItem key={crossSellItem.itemcode}>
+                                       <CrossSell item={crossSellItem} />
+                                       <Divider borderColor="gray.200" />
+                                    </ListItem>
+                                 );
+                              })}
+                           </AnimatePresence>
+                        </Box>
                      </ScaleFade>
                      <Collapse
                         animateOpacity

--- a/packages/ui/cart/drawer/CrossSell.tsx
+++ b/packages/ui/cart/drawer/CrossSell.tsx
@@ -99,7 +99,7 @@ export function CrossSell({ item }: CrossSellProps) {
                w="full"
                colorScheme="brand"
                mt="3"
-               data-testid="upsell-add-to-cart-button"
+               data-testid="x-sell-add-to-cart-button"
             >
                Add to cart
             </Button>


### PR DESCRIPTION
## Overview

We want to have mulitple x-sell items show up in minicart. This makes it so that happens. 

It also does away with some unnecessary `upsell` diction that i forgot to clean up previously.

## QA

For now, just make sure the cross sell works the same as before

Connects: https://github.com/iFixit/ifixit/issues/48134