### PR TITLE
Still Show Facet Filter Sidebar If 1 Product Fits Filters

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -61,12 +61,12 @@ export function FilterableProductsSection({
 }: SectionProps) {
    const { hits } = useHits<ProductSearchHit>();
    const hasAnyVisibleFacet = useHasAnyVisibleFacet(productList);
-
    const products = React.useMemo(
       () => filterFalsyItems(hits.map(productPreviewFromAlgoliaHit)),
       [hits]
    );
    const currentRefinements = useCurrentRefinements();
+   const hasCurrentRefinements = currentRefinements.items.length > 0;
    const [viewType, setViewType] = useLocalPreference(
       PRODUCT_VIEW_TYPE_STORAGE_KEY,
       ProductViewType.List,
@@ -120,8 +120,7 @@ export function FilterableProductsSection({
                   display={{
                      base: 'none',
                      md:
-                        hasAnyVisibleFacet ||
-                        currentRefinements.items.length > 0
+                        hasAnyVisibleFacet || hasCurrentRefinements
                            ? 'block'
                            : 'none',
                   }}
@@ -130,7 +129,7 @@ export function FilterableProductsSection({
                   flexGrow="0"
                >
                   <Collapse
-                     in={currentRefinements.items.length > 0}
+                     in={hasCurrentRefinements}
                      animateOpacity
                      data-testid="current-refinements"
                   >
@@ -141,8 +140,7 @@ export function FilterableProductsSection({
                   <Divider
                      display={{
                         md:
-                           hasAnyVisibleFacet &&
-                           currentRefinements.items.length > 0
+                           hasAnyVisibleFacet && hasCurrentRefinements
                               ? 'block'
                               : 'none',
                      }}

--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -119,7 +119,11 @@ export function FilterableProductsSection({
                   overflow="auto"
                   display={{
                      base: 'none',
-                     md: hasAnyVisibleFacet ? 'block' : 'none',
+                     md:
+                        hasAnyVisibleFacet ||
+                        currentRefinements.items.length > 0
+                           ? 'block'
+                           : 'none',
                   }}
                   position="sticky"
                   top="4"
@@ -133,9 +137,21 @@ export function FilterableProductsSection({
                      <Flex mt="1.5" mb="3" wrap="wrap" align="flex-start">
                         <CurrentRefinements />
                      </Flex>
-                     <Divider borderColor="gray.300" opacity="1" />
                   </Collapse>
-                  <FacetsAccordion productList={productList} />
+                  <Divider
+                     display={{
+                        md:
+                           hasAnyVisibleFacet &&
+                           currentRefinements.items.length > 0
+                              ? 'block'
+                              : 'none',
+                     }}
+                     borderColor="gray.300"
+                     opacity="1"
+                  />
+                  <Collapse in={hasAnyVisibleFacet} animateOpacity>
+                     <FacetsAccordion productList={productList} />
+                  </Collapse>
                </Box>
                <Flex direction="column" flex="1">
                   <Toolbar

--- a/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/index.tsx
@@ -136,20 +136,9 @@ export function FilterableProductsSection({
                      <Flex mt="1.5" mb="3" wrap="wrap" align="flex-start">
                         <CurrentRefinements />
                      </Flex>
+                     <Divider borderColor="gray.300" opacity="1" />
                   </Collapse>
-                  <Divider
-                     display={{
-                        md:
-                           hasAnyVisibleFacet && hasCurrentRefinements
-                              ? 'block'
-                              : 'none',
-                     }}
-                     borderColor="gray.300"
-                     opacity="1"
-                  />
-                  <Collapse in={hasAnyVisibleFacet} animateOpacity>
-                     <FacetsAccordion productList={productList} />
-                  </Collapse>
+                  <FacetsAccordion productList={productList} />
                </Box>
                <Flex direction="column" flex="1">
                   <Toolbar


### PR DESCRIPTION
## Overview

We want to show the facet filter sidebar if there is only 1 product that fits the filters so that users can still deselect the filters. This implements that change.

## CR

Is there a cleaner way to do this?

## QA

Do the facet filters work the same except now if only 1 product is in the filters it still shows the filters sections with the `clear all sections`. 

Closes: https://github.com/iFixit/react-commerce/issues/1728