### PR TITLE
Id is required for inline script

### DIFF
--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -37,11 +37,10 @@ function GA4() {
    return (
       <>
          <Script
-            id="gtag-ga4"
             strategy="afterInteractive"
             src={`https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`}
          ></Script>
-         <Script>
+         <Script id="gtag-ga4">
             {`
          window.dataLayer = window.dataLayer || [];
          function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Hotfix for a small issue on main causing build failures.

Due to a typo the id was placed on the `Script` tag with src instead on the one with inline content.
According to Nextjs documentation it is needed only for inline scripts.

See https://nextjs.org/docs/messages/inline-script-id

qa_req 0