### PR TITLE
Vulcan: fix mobile table overflow

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -538,7 +538,7 @@ function LastUpdatedDate({
    return (
       <Link
          href={historyUrl}
-         fontWeight="regular"
+         fontWeight="normal"
          fontSize="14px"
          color="gray.500"
       >
@@ -578,7 +578,7 @@ function AuthorListing({
          </Link>
          {authorCount > 0 && (
             <>
-               <chakra.span as="span" fontWeight="regular" color="gray.900">
+               <chakra.span as="span" color="gray.900">
                   {' and '}
                </chakra.span>
                <Link {...linkStyle} href={historyUrl}>

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -568,11 +568,10 @@ function AuthorListing({
       authorCount > 1 ? 'contributors' : 'contributor';
    const linkStyle = {
       fontWeight: 'medium',
-      fontSize: '14px',
       color: 'brand.500',
    };
    return (
-      <>
+      <Box fontSize="14px">
          <Link href={authorProfileUrl} {...linkStyle}>
             {primaryAuthorName}
          </Link>
@@ -586,7 +585,7 @@ function AuthorListing({
                </Link>
             </>
          )}
-      </>
+      </Box>
    );
 }
 

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -572,7 +572,7 @@ function AuthorListing({
       color: 'brand.500',
    };
    return (
-      <Box>
+      <>
          <Link href={authorProfileUrl} {...linkStyle}>
             {primaryAuthorName}
          </Link>
@@ -586,13 +586,13 @@ function AuthorListing({
                </Link>
             </>
          )}
-      </Box>
+      </>
    );
 }
 
 function IntroductionSection({ intro }: { intro: Section }) {
    return (
-      <Box>
+      <>
          {intro.heading && (
             <HeadingSelfLink
                marginBottom={6}
@@ -604,18 +604,18 @@ function IntroductionSection({ intro }: { intro: Section }) {
             </HeadingSelfLink>
          )}
          <Prerendered html={intro.body} />
-      </Box>
+      </>
    );
 }
 
 function ConclusionSection({ conclusion }: { conclusion: Section }) {
    return (
-      <Box>
+      <>
          <HeadingSelfLink marginBottom={6} selfLinked>
             {conclusion.heading}
          </HeadingSelfLink>
          <Prerendered html={conclusion.body} />
-      </Box>
+      </>
    );
 }
 

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -83,6 +83,26 @@ const renderStyles: SystemStyleObject = {
       padding: '4px',
    },
 
+   '.table-overflow': {
+      overflowX: 'auto',
+   },
+
+   '.table-container': {
+      position: 'relative',
+   },
+
+   '.table-container::after': {
+      content: '""',
+      position: 'absolute',
+      top: '17px',
+      right: '0',
+      bottom: '17px',
+      width: '20px',
+      display: 'block',
+      background:
+         'linear-gradient(90deg, rgba(249,250,251, 0) 0%, rgb(249,250,251) 75%)',
+   },
+
    'lite-youtube': {
       marginTop: '8px',
       marginBottom: '8px',
@@ -204,26 +224,23 @@ const renderStyles: SystemStyleObject = {
    },
 };
 
-const Prerendered = chakra(
-   function Prerendered({
-      html,
-      className,
-   }: {
-      html: string;
-      className?: string;
-   }) {
-      useEffect(() => {
-         import('lite-youtube-embed');
-      }, []);
-      return (
-         <Box
-            className={className}
-            sx={renderStyles}
-            dangerouslySetInnerHTML={{ __html: html }}
-         />
-      );
-   },
-   { baseStyle: { fontSize: '16px' } }
-);
+const Prerendered = chakra(function Prerendered({
+   html,
+   className,
+}: {
+   html: string;
+   className?: string;
+}) {
+   useEffect(() => {
+      import('lite-youtube-embed');
+   }, []);
+   return (
+      <Box
+         className={className}
+         sx={renderStyles}
+         dangerouslySetInnerHTML={{ __html: html }}
+      />
+   );
+});
 
 export default Prerendered;

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -30,7 +30,6 @@ const renderStyles: SystemStyleObject = {
 
    p: {
       lineHeight: '1.38',
-      fontWeight: 'regular',
       color: 'gray.700',
       alignSelf: 'stretch',
       paddingBottom: 6,

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -34,6 +34,7 @@ const renderStyles: SystemStyleObject = {
       color: 'gray.700',
       alignSelf: 'stretch',
       paddingBottom: 6,
+      marginTop: 4,
       '&:last-child': {
          paddingBottom: 0,
       },
@@ -80,7 +81,7 @@ const renderStyles: SystemStyleObject = {
    td: {
       border: '1px solid',
       borderColor: 'gray.300',
-      padding: '4px',
+      padding: 3,
    },
 
    '.table-overflow': {
@@ -94,13 +95,13 @@ const renderStyles: SystemStyleObject = {
    '.table-container::after': {
       content: '""',
       position: 'absolute',
-      top: '17px',
+      top: '0',
       right: '0',
-      bottom: '17px',
+      bottom: '0',
       width: '20px',
       display: 'block',
       background:
-         'linear-gradient(90deg, rgba(249,250,251, 0) 0%, rgb(249,250,251) 75%)',
+         'linear-gradient(90deg, rgba(255,255,255, 0) 0%, rgb(255,255,255) 75%)',
    },
 
    'lite-youtube': {
@@ -187,8 +188,6 @@ const renderStyles: SystemStyleObject = {
    '.imageBox_left': {
       clear: 'left',
       float: 'left',
-      marginBottom: '8px',
-      marginTop: '8px',
       marginRight: '30px',
       '> img': {
          clear: 'left',
@@ -203,8 +202,6 @@ const renderStyles: SystemStyleObject = {
    '.imageBox_right': {
       clear: 'right',
       float: 'right',
-      marginBottom: '8px',
-      marginTop: '8px',
       marginLeft: '30px',
       '>img': {
          clear: 'right',
@@ -212,12 +209,6 @@ const renderStyles: SystemStyleObject = {
    },
 
    '.imageBox_center': {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      clear: 'both',
-      marginBottom: '8px',
-      marginTop: '8px',
       '>img': {
          clear: 'both',
       },

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -44,7 +44,7 @@ const renderStyles: SystemStyleObject = {
       paddingLeft: 4,
    },
 
-   '>ul, >ol': {
+   '>ul:not(:last-child), >ol:not(:last-child)': {
       paddingBottom: 6,
    },
 

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -44,12 +44,7 @@ const _SolutionFooter = () => (
          borderTopWidth="1px"
          alignSelf="stretch"
       >
-         <Text
-            fontWeight="regular"
-            fontSize="14px"
-            color="gray.900"
-            textAlign="center"
-         >
+         <Text fontSize="14px" color="gray.900" textAlign="center">
             This solution was suggested by
          </Text>
          <Avatar size="24x24">
@@ -62,7 +57,7 @@ const _SolutionFooter = () => (
             textAlign="center"
          >
             <span>Kyle Wiens</span>
-            <Box as="span" fontWeight="regular" color="gray.900">
+            <Box as="span" color="gray.900">
                {' '}
                in{' '}
             </Box>

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -195,9 +195,9 @@ const SolutionHeader = ({
 );
 
 const SolutionTexts = ({ body }: { body: string }) => (
-   <Stack justify="flex-start" align="flex-start">
+   <>
       <Prerendered html={body} />
-   </Stack>
+   </>
 );
 
 export default function SolutionCard({
@@ -208,7 +208,7 @@ export default function SolutionCard({
    solution: SolutionSection;
 }) {
    return (
-      <Flex
+      <Box
          id={solutionHeadingToId(solution.heading)}
          background="white"
          borderRadius="4px"
@@ -222,7 +222,7 @@ export default function SolutionCard({
             <SolutionTexts body={solution.body} />
             <LinkCards guides={solution.guides} products={solution.products} />
          </Flex>
-      </Flex>
+      </Box>
    );
 }
 

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -210,12 +210,18 @@ export default function SolutionCard({
          borderColor="gray.300"
          borderStyle="solid"
          borderWidth="1px"
-         padding="24px 24px 12px 24px"
+         padding="24px"
       >
          <Flex gap="24px" direction="column" flexGrow={1}>
             <SolutionHeader index={index} title={solution.heading} />
             <SolutionTexts body={solution.body} />
-            <LinkCards guides={solution.guides} products={solution.products} />
+            {solution.guides.length > 0 ||
+               (solution.products.length > 0 && (
+                  <LinkCards
+                     guides={solution.guides}
+                     products={solution.products}
+                  />
+               ))}
          </Flex>
       </Box>
    );


### PR DESCRIPTION
## Issue

We added containers to our wiki tables to handle overflow in https://github.com/iFixit/ifixit/pull/48424. Now let's get the tables looking nice on Vulcan 💅 

## Modified

1. [fix overflow: block elements for parent wrappers](https://github.com/iFixit/react-commerce/commit/5ad243dc73f7ccda0477c0e6e036e1189b78f8f2)
2. [remove unnecessary DOM elements](https://github.com/iFixit/react-commerce/commit/b5c0da956846718cf8dc7c57f06430b286ebf445)
3. [add mobile overflow styling from pr 48424](https://github.com/iFixit/react-commerce/commit/7f25abb9e3186126e64d86bd82237b6fe58765ec)
4. [fix imageBox layout & tweak table styling](https://github.com/iFixit/react-commerce/commit/d4c6dd63999c657521cb5bc51c2cdd43bbb6eabe)
5. [remove unnecessary fontWeight applications](https://github.com/iFixit/react-commerce/commit/972a5131739db058d291a13830a37869de7928ef)

## QA

`/Vulcan/iPhone_Black_Screen` has three nested images. It's a good test-case.

<details>
<summary>Post-fix video</summary>

https://github.com/iFixit/react-commerce/assets/1634505/1904b3ac-65e8-41a8-9669-a7babbec79ec

</details>

Closes https://github.com/iFixit/react-commerce/issues/1750