### PR TITLE
Correct algolia integration url handling

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -10,7 +10,7 @@ import {
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { assertNever } from '@ifixit/helpers';
 import { usePrevious } from '@ifixit/ui';
-import { FacetWidgetType, ProductListType } from '@models/product-list';
+import { FacetWidgetType } from '@models/product-list';
 import { useFacets } from '@templates/product-list/sections/FilterableProductsSection/facets/useFacets';
 import algoliasearch from 'algoliasearch/lite';
 import singletonRouter from 'next/router';
@@ -29,7 +29,6 @@ type InstantSearchProviderProps = React.PropsWithChildren<AlgoliaProps>;
 export type AlgoliaProps = {
    url: string;
    indexName: string;
-   productListType: ProductListType;
    serverState?: InstantSearchServerState;
    apiKey: string;
    logContextName: string;
@@ -47,7 +46,6 @@ export function InstantSearchProvider({
    children,
    url,
    indexName,
-   productListType,
    serverState,
    apiKey,
    logContextName,
@@ -89,8 +87,7 @@ export function InstantSearchProvider({
             .filter((part) => part !== '');
          const firstPathSegment = pathParts.length >= 1 ? pathParts[0] : '';
          const deviceHandle = pathParts.length >= 2 ? pathParts[1] : '';
-         const isDevicePartsPage =
-            productListType === ProductListType.DeviceParts;
+         const isDevicePartsPage = firstPathSegment === 'Parts' && deviceHandle;
 
          let path = `/${firstPathSegment}`;
          if (deviceHandle) {
@@ -141,9 +138,10 @@ export function InstantSearchProvider({
          const pathParts = location.pathname
             .split('/')
             .filter((part) => part !== '');
+         const firstPathSegment = pathParts.length >= 1 ? pathParts[0] : '';
+         const deviceHandle = pathParts.length >= 2 ? pathParts[1] : '';
          const itemType = pathParts.length >= 3 ? pathParts[2] : '';
-         const isDevicePartsPage =
-            productListType === ProductListType.DeviceParts;
+         const isDevicePartsPage = firstPathSegment === 'Parts' && deviceHandle;
 
          const { q, p, filter } = qsModule.parse(location.search, {
             ignoreQueryPrefix: true,

--- a/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
+++ b/frontend/templates/product-list/sections/ProductListChildrenSection.tsx
@@ -2,7 +2,6 @@ import { Box, Button, SimpleGrid, Text } from '@chakra-ui/react';
 import { ProductListCard } from '@components/product-list/ProductListCard';
 import { productListPath } from '@helpers/path-helpers';
 import { ProductList } from '@models/product-list';
-import NextLink from 'next/link';
 import * as React from 'react';
 import {
    useCurrentRefinements,
@@ -62,22 +61,18 @@ export function ProductListChildrenSection({
                         defaultShowAllChildrenOnLgSizes
                      )}
                   >
-                     <NextLink
+                     <ProductListCard
+                        as="a"
                         href={productListPath({
                            deviceTitle: child.deviceTitle,
                            handle: child.handle,
                            type: child.type,
                         })}
-                        passHref
-                     >
-                        <ProductListCard
-                           as="a"
-                           productList={{
-                              title: child.title,
-                              imageUrl: child.image?.url,
-                           }}
-                        />
-                     </NextLink>
+                        productList={{
+                           title: child.title,
+                           imageUrl: child.image?.url,
+                        }}
+                     />
                   </Box>
                );
             })}

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -204,7 +204,6 @@ export const getProductListServerSideProps = ({
             indexName,
             url: urlFromContext(context),
             apiKey: productList.algolia.apiKey,
-            productListType,
             logContextName: 'algolia.getServerState',
          },
          ifixitOrigin,


### PR DESCRIPTION
closes #1764

RouterOptions' createURL and parseURL functions were not pure anymore due to the references to `productListType`. InstantSearch seems to live across page render and to preserve the first read `productListType` value even after navigation.
It was reverted to the old logic.

closes #1765 

Intermediate states are due to the fact that Algolia share the provider across renders and if we move via Next links Algolia reacts to the url changes only after the effective page change. 
These shifts might also have an impact on CLS since page content is moved around with a not so small delay from user interaction (connects #1643)

A possible solution to this was to force regenerating the Algolia provider on every url change (as suggested [here](https://github.com/algolia/instantsearch/issues/5241#issuecomment-1438318404)).
This proved to be a valid solution for intermediate states but still showed issues in correctly dealing with browser back button (see [here](https://github.com/algolia/instantsearch/issues/5622) and the video below)

https://github.com/iFixit/react-commerce/assets/7805759/984bcdfe-34aa-43c3-b98a-e5e5f1eda0e7

To solve all this issue `productListChildren` were moved from Next links to basic anchor tags.

closes #1766 


 