### PR TITLE
Fix marketing page extra blank header

### DIFF
--- a/frontend/templates/product-list/ProductListDeviceNavigation.tsx
+++ b/frontend/templates/product-list/ProductListDeviceNavigation.tsx
@@ -2,7 +2,7 @@ import { Flex, FlexProps } from '@chakra-ui/react';
 import { SecondaryNavbarItem, SecondaryNavbarLink } from '@components/common';
 import { IFIXIT_ORIGIN } from '@config/env';
 import { stylizeDeviceTitle } from '@helpers/product-list-helpers';
-import { ProductList } from '@models/product-list';
+import { ProductList, ProductListType } from '@models/product-list';
 
 type ProductListDeviceNavigationProps = FlexProps & {
    productList: ProductList;
@@ -12,13 +12,12 @@ export function ProductListDeviceNavigation({
    productList,
    ...flexProps
 }: ProductListDeviceNavigationProps) {
-   const isRootProductList = productList.ancestors.length === 0;
    let guideUrl: string | undefined;
    let answersUrl: string | undefined;
-   if (isRootProductList) {
-      guideUrl = `${IFIXIT_ORIGIN}/Guide`;
-      answersUrl = `${IFIXIT_ORIGIN}/Answers`;
-   } else if (productList.deviceTitle && productList.deviceTitle.length > 0) {
+   if (
+      productList.type === ProductListType.DeviceParts &&
+      productList.deviceTitle
+   ) {
       const deviceHandle = encodeURIComponent(
          stylizeDeviceTitle(productList.deviceTitle)
       );

--- a/frontend/templates/product-list/SecondaryNavigation.tsx
+++ b/frontend/templates/product-list/SecondaryNavigation.tsx
@@ -16,11 +16,8 @@ interface SecondaryNavigationProps {
 }
 
 export function SecondaryNavigation({ productList }: SecondaryNavigationProps) {
-   const isToolsProductList =
-      productList.type === ProductListType.AllTools ||
-      productList.type === ProductListType.ToolsCategory;
-   const hasDeviceNavigation =
-      productList.type !== ProductListType.AllParts && !isToolsProductList;
+   const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
+   const hasDeviceNavigation = productList.type === ProductListType.DeviceParts;
    const { currentItemTitle, ancestors } = useProductListAncestors(productList);
    const breadCrumbs: BreadcrumbItem[] = ancestors.map((ancestor) => ({
       label: ancestor.title,
@@ -30,7 +27,7 @@ export function SecondaryNavigation({ productList }: SecondaryNavigationProps) {
       label: currentItemTitle,
       url: undefined,
    });
-   const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
+
    const adminLinks = useMemo(
       () =>
          getAdminLinks({
@@ -42,7 +39,7 @@ export function SecondaryNavigation({ productList }: SecondaryNavigationProps) {
       <>
          <SecondaryNavbar
             display={{
-               base: hasDeviceNavigation ? 'initial' : 'none',
+               base: hasDeviceNavigation || isAdminUser ? 'initial' : 'none',
                sm: 'initial',
             }}
          >
@@ -66,6 +63,10 @@ export function SecondaryNavigation({ productList }: SecondaryNavigationProps) {
                      w={{ base: 'full', sm: 'min-content' }}
                      boxSizing="border-box"
                      justify="space-between"
+                     direction={{
+                        base: hasDeviceNavigation ? 'row' : 'row-reverse',
+                        sm: 'row',
+                     }}
                   >
                      <ProductListDeviceNavigation productList={productList} />
                      {isAdminUser && <PageEditMenu links={adminLinks} />}


### PR DESCRIPTION
closes #1754 

Device breadcrumbs are now shown only for devicePart collections
The additional header bar is eventually shown also to display admin user actions.

### QA

1. Visit Vercel preview
2. Verify that there is not anymore an empty bar on marketing collections
3. Verify that in case of admin user the bar is displayed to show admin actions