### PR TITLE
Keep product-list card description visible on mobile

### DIFF
--- a/frontend/components/product-list/ProductListCard.tsx
+++ b/frontend/components/product-list/ProductListCard.tsx
@@ -46,7 +46,7 @@ export const ProductListCard = forwardRef<ProductListCardProps, 'div'>(
             borderRadius="base"
             borderStyle="solid"
             p="2"
-            align="center"
+            align="flex-start"
             h="full"
             minH="16"
             {...other}
@@ -76,6 +76,7 @@ export const ProductListCard = forwardRef<ProductListCardProps, 'div'>(
             )}
             <Flex
                boxSizing="border-box"
+               h="full"
                justify="center"
                direction="column"
                flexGrow={1}
@@ -86,7 +87,6 @@ export const ProductListCard = forwardRef<ProductListCardProps, 'div'>(
                {variant === 'medium' && productList.description && (
                   <Box
                      mt="1"
-                     display={{ base: 'none', md: 'block' }}
                      color="gray.600"
                      fontSize="sm"
                      lineHeight="shorter"


### PR DESCRIPTION
closes #1747 

### QA

1. Visit Vercel preview
2. Verify that text is kept even on mobile for `variant === medium` cards
3. Verify that the image is aligned on top