### PR TITLE
Playwright: Record Metrics for Test Runs 

### DIFF
--- a/.github/actions/setup-ci-env-vars/action.yml
+++ b/.github/actions/setup-ci-env-vars/action.yml
@@ -1,0 +1,34 @@
+name: Set CI Environment Variables
+description: Set CI Environment Variables
+runs:
+   using: 'composite'
+   steps:
+      - name: Get Action Job Info
+        uses: octokit/request-action@v2.x
+        id: get_action_job_data
+        with:
+           route: GET /repos/${{ github.repository }}/actions/runs/${{github.run_id}}/jobs
+
+      - name: Get job url and start date
+        id: get_job_url_and_date
+        run: |
+           JOB_DATA_JSON=$(echo $job_data_json | jq '.jobs | .[]? | select(.name == "${{ env.GITHUB_JOB_NAME }}")')
+           echo "job-url=$(echo $JOB_DATA_JSON | jq '.html_url')" >> $GITHUB_OUTPUT
+           echo "job-start-time=$(echo $JOB_DATA_JSON | jq '.started_at')" >> $GITHUB_OUTPUT
+        env:
+           job_data_json: ${{ steps.get_action_job_data.outputs.data }}
+        shell: bash
+
+      - name: Set Environment Variables
+        run: |
+           echo "QUEUED_AT=$(date --date="${{ steps.get_job_url_and_date.outputs.job-start-time }}" +%s)" >> $GITHUB_ENV
+           echo "BUILD_COMMIT=${{ github.event.pull_request.head.sha || github.sha }}" >> $GITHUB_ENV
+           echo "BUILD_LOG_URL=${{ steps.get_job_url_and_date.outputs.job-url }}" >> $GITHUB_ENV
+           echo "BUILD_BRANCH=${{ github.event.pull_request.head.ref || github.ref_name }}" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Fetch relevant commits needed for tests
+        run: |
+           git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+           git fetch --no-tags --prune --depth=1 origin "${{ github.event.pull_request.head.ref }}"
+        shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,3 +86,35 @@ jobs:
               name: ${{ env.playwright-upload-result-path }}
               path: ${{ steps.test-result.outputs.result-path }}
               retention-days: 1
+
+   record-playwright-metrics:
+      name: record-playwright-metrics
+      runs-on: [self-hosted, metrics-runner]
+      needs: [playwright-run]
+      if: success() || failure()
+      timeout-minutes: 5
+      steps:
+         - name: Checkout ifixit
+           uses: actions/checkout@v3
+           with:
+              repository: iFixit/ifixit
+              token: ${{ secrets.ACTION_PAT }}
+
+         - name: Download playwright test results
+           if: always()
+           uses: actions/download-artifact@v3
+
+         - name: Install deps
+           run: make deps.unit-tests
+
+         - name: Combine all results
+           if: always()
+           run: find "${{ env.playwright-upload-result-path }}" -type f -print0 | xargs -0 cat > playwright-all-test-results
+
+         - name: Preview the results
+           if: always()
+           run: cat playwright-all-test-results
+
+         - name: Record test runs
+           if: always()
+           run: cat playwright-all-test-results | Tests/Exec/report-test-run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: E2E tests
 on: [push]
 env:
    npm_config_userconfig: './.npmrc'
+   playwright-upload-result-path: 'playwright-results'
 jobs:
    playwright-run:
       timeout-minutes: 15
@@ -20,6 +21,12 @@ jobs:
       steps:
          - name: Checkout
            uses: actions/checkout@v3
+
+         - name: Setup CI Environment Variables
+           uses: ./.github/actions/setup-ci-env-vars
+           env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GITHUB_JOB_NAME: ${{ github.job }} (${{ matrix.project }})
 
          - name: Install Node.js
            uses: actions/setup-node@v3
@@ -59,3 +66,23 @@ jobs:
               name: playwright-artifacts
               path: frontend/tests/playwright/test-results/artifacts
               retention-days: 7
+
+         - name: Prepare results to upload for project matrix
+           if: success() || failure()
+           id: test-result
+           run: |
+              MATRIX_NAME=$(echo "${{ matrix.project }}" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+              RESULT_ORIGINAL_NAME="playwright-result-$BUILD_COMMIT"
+              RESULT_FINAL_NAME="$RESULT_ORIGINAL_NAME-$MATRIX_NAME"
+              mv "frontend/$RESULT_ORIGINAL_NAME" "frontend/$RESULT_FINAL_NAME"
+              RESULT_PATH="frontend/$RESULT_FINAL_NAME"
+              echo "Result path: $RESULT_PATH"
+              echo "result-path=$RESULT_PATH" >> $GITHUB_OUTPUT
+
+         - name: Upload Playwright Test Result Metrics
+           if: success() || failure()
+           uses: actions/upload-artifact@v3
+           with:
+              name: ${{ env.playwright-upload-result-path }}
+              path: ${{ steps.test-result.outputs.result-path }}
+              retention-days: 1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,6 +101,7 @@
       "@types/react-dom": "18.0.8",
       "@types/react-virtualized-auto-sizer": "1.0.1",
       "@types/react-window": "1.8.4",
+      "@types/uuid": "^9.0.2",
       "@typescript-eslint/eslint-plugin": "5.48.1",
       "@typescript-eslint/parser": "5.48.1",
       "babel-jest": "28.1.3",
@@ -126,6 +127,7 @@
       "playwright-msw": "2.1.0",
       "prettier": "2.7.1",
       "typescript": "4.8.4",
+      "uuid": "^9.0.0",
       "webpack": "5.73.0"
    },
    "nextBundleAnalysis": {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -39,17 +39,17 @@ const config: PlaywrightTestConfig = {
    /* Opt out of parallel tests on CI. */
    workers: process.env.CI ? '100%' : '25%',
    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-   reporter: [
-      process.env.CI
-         ? ['list']
-         : [
+   reporter: process.env.CI
+      ? [['list'], ['./tests/playwright/fixtures/metrics-reporter.ts']]
+      : [
+           [
               'html',
               {
                  open: 'never', // will not try to automatically open the report in the browser if test fails
                  outputFolder: 'tests/playwright/test-results/reports/',
               },
            ],
-   ],
+        ],
    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
    use: {
       /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/frontend/tests/playwright/fixtures/metrics-reporter.ts
+++ b/frontend/tests/playwright/fixtures/metrics-reporter.ts
@@ -112,9 +112,23 @@ class MetricsReporter implements Reporter {
       });
    }
 
+   // format the results into a file to read from stdin for the report-test-run script
+   createJsonResult() {
+      const resultFileName = `playwright-result-${this.commit}.txt`;
+      try {
+         const jsonString =
+            this.results.map((result) => JSON.stringify(result)).join('\n\n') +
+            '\n\n';
+         fs.writeFileSync(resultFileName, jsonString);
+      } catch (error) {
+         console.error('Error saving playwright test results to a file', error);
+      }
+   }
+
    onEnd(fullResult: FullResult) {
       this.timeEnd = Date.now();
       this.addFullResult(fullResult);
+      this.createJsonResult();
    }
 }
 

--- a/frontend/tests/playwright/fixtures/metrics-reporter.ts
+++ b/frontend/tests/playwright/fixtures/metrics-reporter.ts
@@ -1,0 +1,98 @@
+import {
+   FullResult,
+   Reporter,
+   TestCase,
+   TestResult,
+} from '@playwright/test/reporter';
+import { execSync } from 'child_process';
+import { v4 as uuidv4 } from 'uuid';
+import fs from 'fs';
+
+interface ResultParams {
+   id: string;
+   test_name: string;
+   time_start: number;
+   time_end: number;
+   time_taken: number;
+   pass: string;
+   test_suite_id: string | null;
+   file_path: string | null;
+}
+
+class MetricsReporter implements Reporter {
+   branch: string;
+   commit: string;
+   test_suite_id: string;
+   results: Array<Object>;
+
+   constructor() {
+      this.branch =
+         process.env.BUILD_BRANCH ||
+         execSync('git rev-parse --abbrev-ref HEAD', {
+            encoding: 'utf-8',
+         }).trim();
+      this.commit =
+         process.env.BUILD_COMMIT ||
+         execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+      this.test_suite_id = uuidv4();
+
+      this.results = [];
+   }
+
+   getTestName(test: TestCase) {
+      return test.titlePath().slice(3).join(' -> ');
+   }
+
+   getStatus(status: string): number {
+      if (status === 'passed') {
+         return 1;
+      } else if (status === 'interrupted') {
+         return -1;
+      } else {
+         return 0;
+      }
+   }
+
+   addResult({
+      id,
+      test_name,
+      time_start,
+      time_end,
+      time_taken,
+      pass,
+      test_suite_id,
+      file_path,
+   }: ResultParams) {
+      this.results.push({
+         id: id,
+         test_name: test_name,
+         time_start: time_start / 1000,
+         time_end: time_end / 1000,
+         time_taken: time_taken / 1000,
+         pass: this.getStatus(pass),
+         test_suite_id: test_suite_id,
+         file_path: file_path,
+         commit: this.commit,
+         branch: this.branch,
+      });
+   }
+
+   onTestEnd(test: TestCase, result: TestResult) {
+      if (result.status !== 'skipped') {
+         this.addResult({
+            id: uuidv4(),
+            test_name: this.getTestName(test),
+            time_start: result.startTime.valueOf(),
+            time_end: result.startTime.valueOf() + result.duration,
+            time_taken: result.duration,
+            pass: result.status,
+            test_suite_id: this.test_suite_id,
+            file_path: test.location.file,
+         });
+      }
+   }
+
+   onEnd(fullResult: FullResult) {}
+}
+
+export default MetricsReporter;

--- a/frontend/tests/playwright/fixtures/metrics-reporter.ts
+++ b/frontend/tests/playwright/fixtures/metrics-reporter.ts
@@ -114,7 +114,7 @@ class MetricsReporter implements Reporter {
 
    // format the results into a file to read from stdin for the report-test-run script
    createJsonResult() {
-      const resultFileName = `playwright-result-${this.commit}.txt`;
+      const resultFileName = `playwright-result-${this.commit}`;
       try {
          const jsonString =
             this.results.map((result) => JSON.stringify(result)).join('\n\n') +

--- a/frontend/tests/playwright/fixtures/metrics-reporter.ts
+++ b/frontend/tests/playwright/fixtures/metrics-reporter.ts
@@ -24,6 +24,8 @@ class MetricsReporter implements Reporter {
    commit: string;
    test_suite_id: string;
    results: Array<Object>;
+   timeStart!: number;
+   timeEnd!: number;
 
    constructor() {
       this.branch =
@@ -37,6 +39,10 @@ class MetricsReporter implements Reporter {
       this.test_suite_id = uuidv4();
 
       this.results = [];
+   }
+
+   onBegin(): void {
+      this.timeStart = Date.now();
    }
 
    getTestName(test: TestCase) {
@@ -92,7 +98,24 @@ class MetricsReporter implements Reporter {
       }
    }
 
-   onEnd(fullResult: FullResult) {}
+   // Add the total time for the test suite took to run
+   addFullResult(fullResult: FullResult) {
+      this.addResult({
+         id: this.test_suite_id,
+         test_name: 'ci-playwright',
+         time_start: this.timeStart,
+         time_end: this.timeEnd,
+         time_taken: this.timeEnd - this.timeStart,
+         pass: fullResult.status,
+         test_suite_id: null,
+         file_path: process.env.BUILD_LOG_URL || null,
+      });
+   }
+
+   onEnd(fullResult: FullResult) {
+      this.timeEnd = Date.now();
+      this.addFullResult(fullResult);
+   }
 }
 
 export default MetricsReporter;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       '@types/react-window':
         specifier: 1.8.4
         version: 1.8.4
+      '@types/uuid':
+        specifier: ^9.0.2
+        version: 9.0.2
       '@typescript-eslint/eslint-plugin':
         specifier: 5.48.1
         version: 5.48.1(@typescript-eslint/parser@5.48.1)(eslint@7.23.0)(typescript@4.8.4)
@@ -328,6 +331,9 @@ importers:
       typescript:
         specifier: 4.8.4
         version: 4.8.4
+      uuid:
+        specifier: ^9.0.0
+        version: 9.0.0
       webpack:
         specifier: 5.73.0
         version: 5.73.0
@@ -7794,6 +7800,10 @@ packages:
 
   /@types/tough-cookie@4.0.2:
     resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==}
+    dev: true
+
+  /@types/uuid@9.0.2:
+    resolution: {integrity: sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==}
     dev: true
 
   /@types/webidl-conversions@7.0.0:
@@ -16138,6 +16148,11 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: false
+
+  /uuid@9.0.0:
+    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    hasBin: true
+    dev: true
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}


### PR DESCRIPTION
## Summary
Now we will record playwright test metrics. Link to [dashboard (at the bottom right corner)](https://dashboards.cominor.com/d/IAl9Y4Knz/quality-assurance?orgId=1).

## CR Notes

1. Created a playwright `metrics-reporter.ts` that runs in CI. It generates a test result file in the format that can be used for our `Tests/Exec/report-test-run` in `iFixit/ifixit` which is used to send metrics to CI metrics db.
2. Edited the `playwright-run` job in `E2E tests` to upload the result file as an artifact.
3. Then added a second job (called `record-playwright-metrics`) in `main.yml` that runs after tests finish running. It checks out `iFixit/ifixit`, downloads the artifacts from the `playwright-run` jobs, combines all of them into a single file, and runs `Tests/Exec/report-test-run`. Since it runs on a `self-hosted` runner, it has access/permissions to CI metrics db.

## QA Notes

Check the [dashboard](https://dashboards.cominor.com/d/IAl9Y4Knz/quality-assurance?orgId=1&var-TEST_NAME=Parts%20Page%20Navigation%20-%3E%20Navigate%20Through%20All%20Device%20Pages), and verify that the `record-playwright-metrics` job finished successfully. 

closes #1393