### PR TITLE
Vulcan: Add featured blockquote styling

### DIFF
--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -81,6 +81,10 @@ const renderStyles: SystemStyleObject = {
          borderTopWidth: '1px',
          borderBottomWidth: '1px',
       },
+      
+      '& > p': {
+         marginBlock: '8px',
+      },
    },
 
    td: {

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -81,7 +81,7 @@ const renderStyles: SystemStyleObject = {
          borderTopWidth: '1px',
          borderBottomWidth: '1px',
       },
-      
+
       '& > p': {
          marginBlock: '8px',
       },

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -75,6 +75,12 @@ const renderStyles: SystemStyleObject = {
       borderLeftWidth: '5px',
       borderLeftStyle: 'solid',
       padding: '2px 8px 2px 12px',
+
+      '&.featured': {
+         borderColor: '#fe6f15',
+         borderTopWidth: '1px',
+         borderBottomWidth: '1px',
+      },
    },
 
    td: {


### PR DESCRIPTION
This matches the wiki view styling and applies to all featured blockquotes in Vulcan.

We still need to allow block quotes in the wysiwyg editor, but using plaintext still lets us add a featured block quote to wikis, so this won't break anything.

## QA
1. Open a vulcan wiki and add a featured block quote to the wiki text.
- Ex: https://me.cominor.com/Wiki/Edit/Dryer_Stops_Mid_Cycle
- Add this text: `[quote|format=featured]This is a featured blockquote! -Alex[/quote]`
2. Viewing the Vulcan wiki should render the block quote with this styling:
- Ex: http://localhost:3000/Vulcan/Dryer_Stops_Mid_Cycle
![image](https://github.com/iFixit/react-commerce/assets/43479402/0b6e67d0-17f4-4269-a8df-80afe588120e)

Part 1 of 2 for https://github.com/iFixit/ifixit/issues/48526