### PR TITLE
Prerendered: Support SVG icons from FontAwesome

### DIFF
--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -213,7 +213,7 @@ const renderStyles: SystemStyleObject = {
       },
    },
 
-   '.svg-icon': {
+   '.fa-svg-icon': {
       svg: {
          width: '1em',
          height: '1em',

--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -212,6 +212,28 @@ const renderStyles: SystemStyleObject = {
          clear: 'both',
       },
    },
+
+   '.svg-icon': {
+      svg: {
+         width: '1em',
+         height: '1em',
+         display: 'inline-block',
+
+         path: {
+            fill: 'currentColor',
+         },
+      },
+
+      '&.xs svg': {
+         width: '0.5em',
+         height: '0.5em',
+      },
+
+      '&.sm svg': {
+         width: '0.75em',
+         height: '0.75em',
+      },
+   },
 };
 
 const Prerendered = chakra(function Prerendered({


### PR DESCRIPTION
We're considering adding inline SVG icons to wikitext under some conditions; this adds the necessary CSS to support them.

## QA Notes
This is tricky to test, because we need to render some SVGs in order to see if the CSS is working. There's a parallel PR which can be checked out to start generating these SVG icons: https://github.com/iFixit/ifixit/pull/48569
With that checked out (and possibly with some caches busted), loading a problem page with links which open in a new tab should show nice icons to the right of each link.

qa_req 0 https://github.com/iFixit/react-commerce/pull/1783#issuecomment-1622529267