### PR TITLE
Vulcan: render solutions cards

### DIFF
--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -215,13 +215,12 @@ export default function SolutionCard({
          <Flex gap="24px" direction="column" flexGrow={1}>
             <SolutionHeader index={index} title={solution.heading} />
             <SolutionTexts body={solution.body} />
-            {solution.guides.length > 0 ||
-               (solution.products.length > 0 && (
-                  <LinkCards
-                     guides={solution.guides}
-                     products={solution.products}
-                  />
-               ))}
+            {(solution.guides.length > 0 || solution.products.length > 0) && (
+               <LinkCards
+                  guides={solution.guides}
+                  products={solution.products}
+               />
+            )}
          </Flex>
       </Box>
    );


### PR DESCRIPTION
We currently don't render solutions link cards, such as guides or products. This was because the conditional for rendering them was off.

## QA
1. Visit a Vulcan wiki with guides or products listed under one of the solutions
- Ex: http://localhost:3000/Vulcan/Nintendo_Switch_Blue_Screen_of_Death#display-damage
2. Make sure the link cards are rendered.

Connects to https://github.com/iFixit/ifixit/issues/48545