### PR TITLE
Vulcan: Load smaller Related Problems images

### DIFF
--- a/frontend/templates/troubleshooting/Problem.tsx
+++ b/frontend/templates/troubleshooting/Problem.tsx
@@ -2,7 +2,7 @@ import { Stack, Image, Text } from '@chakra-ui/react';
 import { Problem } from './hooks/useTroubleshootingProps';
 
 export default function ProblemCard({ problem }: { problem: Problem }) {
-   const { title, deviceTitle, imageUrl, url } = problem;
+   const { title, deviceTitle, imageUrlThumbnail, url } = problem;
    return (
       <a href={url}>
          <Stack
@@ -28,7 +28,7 @@ export default function ProblemCard({ problem }: { problem: Problem }) {
                   htmlWidth={48}
                   htmlHeight={48}
                   objectFit="cover"
-                  src={imageUrl}
+                  src={imageUrlThumbnail}
                   alt=""
                   outline="1px solid"
                   outlineColor="gray.300"

--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -19,7 +19,7 @@ export type Author = {
 
 export type Problem = {
    url: string;
-   imageUrl: string;
+   imageUrlThumbnail: string;
    title: string;
    deviceTitle: string;
 };


### PR DESCRIPTION
## Issue
We are displaying Related Problems images at 48x48, but loading `.huge` which are ~3000 px wide. No need to waste user bandwidth, so let's load the thumbnail versions.

<details>

![Image](https://github.com/iFixit/react-commerce/assets/1634505/c4c65873-ce96-439f-a852-2d938e320b06)

</details>

## Modifications

1. load Related Problems images as thumbnails 


## CR/QA

Part 2/2

http://localhost:3000/Vulcan/Dryer%20Not%20Spinning

<details>
<summary>Post-fix</summary>

<img width="1720" alt="Screenshot 2023-06-29 at 2 30 29 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/5d063078-b042-4b9a-beca-e73f2821ae74">

</details>

Linked to https://github.com/iFixit/ifixit/pull/48580
Closes https://github.com/iFixit/react-commerce/issues/1788