### PR TITLE
Tests: Add `/Shop` page test

### DIFF
--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -174,7 +174,7 @@ test.describe('Product List Filtering', () => {
             .locator('[data-testid^=collapsed-facet-accordion-item-]');
 
          // Get the visible facets
-         let visibleFacetList = [];
+         const visibleFacetList = [];
          for (let i = 0; i < (await facetList.count()); i++) {
             const element = facetList.nth(i);
             if (await element.isVisible()) {

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -173,16 +173,20 @@ test.describe('Product List Filtering', () => {
             .getByTestId('facets-accordion')
             .locator('[data-testid^=collapsed-facet-accordion-item-]');
 
-         // Get the visible facets
-         const visibleFacetList = [];
-         for (let i = 0; i < (await facetList.count()); i++) {
-            const element = facetList.nth(i);
+         // Get the visible facet
+         let visibleFacet = null;
+         for (const element of await facetList.all()) {
             if (await element.isVisible()) {
-               visibleFacetList.push(element);
+               visibleFacet = element;
+               break;
             }
          }
-         const firstCollapsedAccordionItem =
-            await visibleFacetList[0].elementHandle();
+
+         if (!visibleFacet) {
+            throw new Error('Could not find a visible facet');
+         }
+
+         const firstCollapsedAccordionItem = await visibleFacet.elementHandle();
 
          // Check current url path and search params.
          const url = new URL(page.url());

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -171,9 +171,16 @@ test.describe('Product List Filtering', () => {
             .getByTestId('facets-accordion')
             .locator('[data-testid^=collapsed-facet-accordion-item-]');
 
-         const firstCollapsedAccordionItem = await facetList
-            .nth(0)
-            .elementHandle();
+         // Get the visible facets
+         let visibleFacetList = [];
+         for (let i = 0; i < (await facetList.count()); i++) {
+            const element = facetList.nth(i);
+            if (await element.isVisible()) {
+               visibleFacetList.push(element);
+            }
+         }
+         const firstCollapsedAccordionItem =
+            await visibleFacetList[0].elementHandle();
 
          // Click the first facet accordion item.
          if (!firstCollapsedAccordionItem) {

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -86,6 +86,8 @@ async function resetAndCheckRefinements(buttonText: string, page: Page) {
    ).toBe(0);
 }
 
+const SHOP_PAGE_URL = '/Shop/Samsung_Repair_Kits';
+
 test.describe('Product List Filtering', () => {
    test.describe('Desktop Filters', () => {
       test.skip(({ page }) => {
@@ -165,7 +167,7 @@ test.describe('Product List Filtering', () => {
       });
 
       test('Filter Products on /Shop Page', async ({ page }) => {
-         await page.goto('/Shop/Samsung_Repair_Kits');
+         await page.goto(SHOP_PAGE_URL);
 
          const facetList = page
             .getByTestId('facets-accordion')
@@ -181,6 +183,11 @@ test.describe('Product List Filtering', () => {
          }
          const firstCollapsedAccordionItem =
             await visibleFacetList[0].elementHandle();
+
+         // Check current url path and search params.
+         const url = new URL(page.url());
+         expect(url.pathname).toEqual(SHOP_PAGE_URL);
+         expect(url.search).toEqual('');
 
          // Click the first facet accordion item.
          if (!firstCollapsedAccordionItem) {
@@ -214,7 +221,17 @@ test.describe('Product List Filtering', () => {
             results
          );
 
+         // Check that url pathname is still /Shop/Samsung_Repair_Kits
+         // after clicking on a facet button.
+         const urlAfterApplyingFilters = new URL(page.url());
+         expect(urlAfterApplyingFilters.pathname).toEqual(SHOP_PAGE_URL);
+         expect(urlAfterApplyingFilters.search).not.toEqual('');
+
          await resetAndCheckRefinements('Clear all filters', page);
+
+         const urlAfterClearingFilters = new URL(page.url());
+         expect(urlAfterClearingFilters.pathname).toEqual(SHOP_PAGE_URL);
+         expect(urlAfterClearingFilters.search).toEqual('');
       });
    });
 
@@ -286,7 +303,12 @@ test.describe('Product List Filtering', () => {
       });
 
       test('Filter Products on /Shop Page', async ({ page }) => {
-         await page.goto('/Shop/Samsung_Repair_Kits');
+         await page.goto(SHOP_PAGE_URL);
+
+         // Check current url path and search params.
+         const url = new URL(page.url());
+         expect(url.pathname).toEqual(SHOP_PAGE_URL);
+         expect(url.search).toEqual('');
 
          // Select the first filter and close the drawer
          await page
@@ -320,7 +342,17 @@ test.describe('Product List Filtering', () => {
             results
          );
 
+         // Check that url pathname is still /Shop/Samsung_Repair_Kits
+         // after clicking on a facet button.
+         const urlAfterApplyingFilters = new URL(page.url());
+         expect(urlAfterApplyingFilters.pathname).toEqual(SHOP_PAGE_URL);
+         expect(urlAfterApplyingFilters.search).not.toEqual('');
+
          await resetAndCheckRefinements('Clear all filters', page);
+
+         const urlAfterClearingFilters = new URL(page.url());
+         expect(urlAfterClearingFilters.pathname).toEqual(SHOP_PAGE_URL);
+         expect(urlAfterClearingFilters.search).toEqual('');
       });
 
       test('Facet Drawer Apply and Clear All Buttons', async ({ page }) => {

--- a/frontend/tests/playwright/product-list/filters.spec.ts
+++ b/frontend/tests/playwright/product-list/filters.spec.ts
@@ -87,17 +87,15 @@ async function resetAndCheckRefinements(buttonText: string, page: Page) {
 }
 
 test.describe('Product List Filtering', () => {
-   test.beforeEach(async ({ page }) => {
-      await page.goto('/Parts');
-   });
-
    test.describe('Desktop Filters', () => {
       test.skip(({ page }) => {
          const viewPort = page.viewportSize();
          return !viewPort || viewPort.width < 768;
       }, 'Only run on desktop.');
 
-      test('Filter Products', async ({ page }) => {
+      test('Filter Products on /Parts Page', async ({ page }) => {
+         await page.goto('/Parts');
+
          const facetList = page
             .getByTestId('facets-accordion')
             .locator('[data-testid^=collapsed-facet-accordion-item-]');
@@ -165,6 +163,10 @@ test.describe('Product List Filtering', () => {
          );
          await resetAndCheckRefinements('Clear all filters', page);
       });
+
+      test('Filter Products on /Shop Page', async ({ page }) => {
+         await page.goto('/Shop/Samsung_Repair_Kits');
+      });
    });
 
    test.describe('Mobile and Tablet Filters', () => {
@@ -173,7 +175,9 @@ test.describe('Product List Filtering', () => {
          return !viewPort || viewPort.width > 768;
       }, 'Only run on mobile and tablet.');
 
-      test('Filter Products', async ({ page }) => {
+      test('Filter Products on /Parts Page', async ({ page }) => {
+         await page.goto('/Parts');
+
          // Select the first filter and close the drawer
          await page
             .getByRole('button', { name: 'Filters', exact: true })
@@ -232,7 +236,13 @@ test.describe('Product List Filtering', () => {
          await resetAndCheckRefinements('Clear all filters', page);
       });
 
+      test('Filter Products on /Shop Page', async ({ page }) => {
+         await page.goto('/Shop/Samsung_Repair_Kits');
+      });
+
       test('Facet Drawer Apply and Clear All Buttons', async ({ page }) => {
+         await page.goto('/Parts');
+
          // Select the first filter and click Apply button
          await page
             .getByRole('button', { name: 'Filters', exact: true })


### PR DESCRIPTION
## Summary
Added tests for `/Shop` pages on desktop and mobile.
Mostly re-used the existing tests with slight modifications.

The test ensures that navigating to `/Shop/xyz` page loads, and clicking on a facet keeps
the URL pathname same and adds the filter as query params. 

For example, after clicking the `Phone` Device category filter on `Shop/Samsung_Repair_Kits`
page should redirect to `/Shop/Samsung_Repair_Kits?filter[facet_tags.Device Category]=Phone`
instead of `/Shop/Samsung_Repair_Kits/Phone`.


## CR Notes
Easier to review by commit by commit.

qa_req 0 passing ci is enough
closes #1701