### PR TITLE
PixelPing: Add to Vulcan pages

### DIFF
--- a/frontend/components/analytics/PixelPing.tsx
+++ b/frontend/components/analytics/PixelPing.tsx
@@ -1,11 +1,22 @@
 import { PIXEL_PING_URL } from '@config/env';
 
-export const PixelPing = ({ id }: { id: string }) => {
+export const PixelPing = ({
+   type,
+   id,
+   site = 'ifixit',
+   lang = 'en',
+}: {
+   type: string;
+   id: string;
+   site?: string;
+   lang?: string;
+}) => {
    if (!PIXEL_PING_URL) {
       return null;
    }
 
-   const url = `${PIXEL_PING_URL}?key=${encodeURIComponent(id)}`;
+   const key = `${site}/${type}/${id}/${lang}`;
+   const url = `${PIXEL_PING_URL}?key=${encodeURIComponent(key)}`;
    return (
       // eslint-disable-next-line @next/next/no-img-element
       <img src={url} width="1" height="1" alt="" style={{ display: 'none' }} />

--- a/frontend/components/analytics/PixelPing.tsx
+++ b/frontend/components/analytics/PixelPing.tsx
@@ -1,0 +1,13 @@
+import { PIXEL_PING_URL } from '@config/env';
+
+export const PixelPing = ({ id }: { id: string }) => {
+   if (!PIXEL_PING_URL) {
+      return null;
+   }
+
+   const url = `${PIXEL_PING_URL}?key=${encodeURIComponent(id)}`;
+   return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={url} width="1" height="1" alt="" style={{ display: 'none' }} />
+   );
+};

--- a/frontend/components/analytics/PixelPing.tsx
+++ b/frontend/components/analytics/PixelPing.tsx
@@ -7,7 +7,7 @@ export const PixelPing = ({
    lang = 'en',
 }: {
    type: string;
-   id: string;
+   id: number;
    site?: string;
    lang?: string;
 }) => {
@@ -15,7 +15,8 @@ export const PixelPing = ({
       return null;
    }
 
-   const key = `${site}/${type}/${id}/${lang}`;
+   const intId = Math.trunc(id);
+   const key = `${site}/${type}/${intId}/${lang}`;
    const url = `${PIXEL_PING_URL}?key=${encodeURIComponent(key)}`;
    return (
       // eslint-disable-next-line @next/next/no-img-element

--- a/frontend/templates/product/components/PixelPing.tsx
+++ b/frontend/templates/product/components/PixelPing.tsx
@@ -1,8 +1,5 @@
 import { PixelPing } from '@components/analytics/PixelPing';
 
 export const ProductPixelPing = ({ productcode }: { productcode: string }) => {
-   return (
-      // eslint-disable-next-line @next/next/no-img-element
-      <PixelPing id={`ifixit/product/${productcode}/en`} />
-   );
+   return <PixelPing id={`ifixit/product/${productcode}/en`} />;
 };

--- a/frontend/templates/product/components/PixelPing.tsx
+++ b/frontend/templates/product/components/PixelPing.tsx
@@ -1,5 +1,5 @@
 import { PixelPing } from '@components/analytics/PixelPing';
 
 export const ProductPixelPing = ({ productcode }: { productcode: string }) => {
-   return <PixelPing id={`ifixit/product/${productcode}/en`} />;
+   return <PixelPing id={productcode} type="product" />;
 };

--- a/frontend/templates/product/components/PixelPing.tsx
+++ b/frontend/templates/product/components/PixelPing.tsx
@@ -1,8 +1,8 @@
-import { PixelPing as PixelPingComponent } from '@components/analytics/PixelPing';
+import { PixelPing } from '@components/analytics/PixelPing';
 
-export const PixelPing = ({ productcode }: { productcode: string }) => {
+export const ProductPixelPing = ({ productcode }: { productcode: string }) => {
    return (
       // eslint-disable-next-line @next/next/no-img-element
-      <PixelPingComponent id={`ifixit/product/${productcode}/en`} />
+      <PixelPing id={`ifixit/product/${productcode}/en`} />
    );
 };

--- a/frontend/templates/product/components/PixelPing.tsx
+++ b/frontend/templates/product/components/PixelPing.tsx
@@ -1,13 +1,8 @@
-import { PIXEL_PING_URL } from '@config/env';
+import { PixelPing as PixelPingComponent } from '@components/analytics/PixelPing';
 
 export const PixelPing = ({ productcode }: { productcode: string }) => {
-   if (!PIXEL_PING_URL) {
-      return null;
-   }
-   const key = `ifixit/product/${productcode}/en`;
-   const url = `${PIXEL_PING_URL}?key=${encodeURIComponent(key)}`;
    return (
       // eslint-disable-next-line @next/next/no-img-element
-      <img src={url} width="1" height="1" alt="" style={{ display: 'none' }} />
+      <PixelPingComponent id={`ifixit/product/${productcode}/en`} />
    );
 };

--- a/frontend/templates/product/components/PixelPing.tsx
+++ b/frontend/templates/product/components/PixelPing.tsx
@@ -1,5 +1,5 @@
 import { PixelPing } from '@components/analytics/PixelPing';
 
-export const ProductPixelPing = ({ productcode }: { productcode: string }) => {
+export const ProductPixelPing = ({ productcode }: { productcode: number }) => {
    return <PixelPing id={productcode} type="product" />;
 };

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -259,7 +259,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
             })}
          </Box>
          {product.productcode && (
-            <ProductPixelPing productcode={product.productcode} />
+            <ProductPixelPing productcode={parseInt(product.productcode)} />
          )}
       </React.Fragment>
    );

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -26,7 +26,7 @@ import { ProductPreview } from '@models/components/product-preview';
 import { useInternationalBuyBox } from '@templates/product/hooks/useInternationalBuyBox';
 import * as React from 'react';
 import { LifetimeWarrantySection } from '../../components/sections/LifetimeWarrantySection';
-import { PixelPing } from './components/PixelPing';
+import { ProductPixelPing } from './components/PixelPing';
 import { SecondaryNavigation } from './components/SecondaryNavigation';
 import { useIsProductForSale } from './hooks/useIsProductForSale';
 import { useProductPageAdminLinks } from './hooks/useProductPageAdminLinks';
@@ -259,7 +259,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
             })}
          </Box>
          {product.productcode && (
-            <PixelPing productcode={product.productcode} />
+            <ProductPixelPing productcode={product.productcode} />
          )}
       </React.Fragment>
    );

--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -39,6 +39,7 @@ export type SolutionSection = Omit<
 
 export type TroubleshootingApiData = {
    title: string;
+   id: number;
    toc: string;
    introduction: Section[];
    solutions: ApiSolutionSection[];

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -187,7 +187,7 @@ const Wiki: NextPageWithLayout<{
             {wikiData.linkedProblems.length > 0 && (
                <RelatedProblems problems={wikiData.linkedProblems} />
             )}
-            <PixelPing id={String(id)} type="troubleshooting" />
+            <PixelPing id={id} type="troubleshooting" />
          </Flex>
       </Flex>
    );

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -187,7 +187,7 @@ const Wiki: NextPageWithLayout<{
             {wikiData.linkedProblems.length > 0 && (
                <RelatedProblems problems={wikiData.linkedProblems} />
             )}
-            <PixelPing id={`ifixit/troubleshooting/${id}/en`} />
+            <PixelPing id={String(id)} type="troubleshooting" />
          </Flex>
       </Flex>
    );

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -51,6 +51,7 @@ import {
 import { BreadCrumbs } from '@ifixit/breadcrumbs';
 import { HeadingSelfLink } from './components/HeadingSelfLink';
 import ProblemCard from './Problem';
+import { PixelPing } from '@components/analytics/PixelPing';
 
 const Wiki: NextPageWithLayout<{
    wikiData: TroubleshootingData;
@@ -64,6 +65,7 @@ const Wiki: NextPageWithLayout<{
       canonicalUrl,
       mainImageUrl,
       mainImageUrlLarge,
+      id,
    } = wikiData;
    const { isOpen, onOpen, onClose } = useDisclosure();
    const metadata = (
@@ -185,6 +187,7 @@ const Wiki: NextPageWithLayout<{
             {wikiData.linkedProblems.length > 0 && (
                <RelatedProblems problems={wikiData.linkedProblems} />
             )}
+            <PixelPing id={`ifixit/troubleshooting/${id}/en`} />
          </Flex>
       </Flex>
    );


### PR DESCRIPTION
QA
---

* Load a vulcan page
* Check for a network request to `https://ping.ubreakit.com/?key=ifixit%wiki%2F<SOMEID>%2Fen"`
* Ensure pixel pings for product pages [still match](https://github.com/iFixit/react-commerce/pull/1061#issuecomment-1329540342) `https://ping.ubreakit.com/?key=ifixit%product%2F<SOMEID>%2Fen"`

Closes: https://github.com/iFixit/react-commerce/issues/1790