### PR TITLE
Vulcan: fix missing linkcard images

### DIFF
--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -60,7 +60,11 @@ export function ProductResource({ product }: { product: Product }) {
       <Resource
          href={productUrl}
          title={product.title}
-         imageUrl={selectedVariant.image?.url}
+         imageUrl={
+            selectedVariant.image?.url ||
+            product.images[0]?.thumbnailUrl ||
+            product.images[0]?.url
+         }
          spacing="4px"
          showBuyButton={isForSale}
          openInNewTab={true}

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -237,12 +237,20 @@ function LinkCards({
    products,
    ...props
 }: { guides: Guide[]; products: Product[] } & BoxProps) {
+   const uniqueGuides = guides.filter(
+      (guide, index) =>
+         guides.findIndex((g) => g.guideid === guide.guideid) === index
+   );
+   const uniqueProducts = products.filter(
+      (product, index) =>
+         products.findIndex((p) => p.id === product.id) === index
+   );
    return (
       <VStack spacing="6px" {...props}>
-         {guides.map((guide: Guide) => (
+         {uniqueGuides.map((guide: Guide) => (
             <GuideResource key={guide.guideid} guide={guide} />
          ))}
-         {products.map((product: Product) => (
+         {uniqueProducts.map((product: Product) => (
             <ProductResource key={product.id} product={product} />
          ))}
       </VStack>


### PR DESCRIPTION
## Overview
Some link cards were missing images because the product variant didn't have an image set. The variant image is not guaranteed to exist, and we have always fell back to the first product image. We didn't do that here so we were missing images.

This also removes duplicate link cards from the same solution.

## QA
1. View a Vulcan wiki with a product link card that is missing an image.
Ex: http://localhost:3000/Vulcan/Nintendo%20Switch%20Blue%20Screen%20of%20Death#display-damage (the [`Nintendo Switch Screen OLED Assembly`](http://localhost:3000/products/nintendo-switch-oled-screen-assembly) product card)
2. The link card should now have an image.
3. Viewing a solution with duplicate links should no longer show duplicate link cards
Ex: http://localhost:3000/Vulcan/Nintendo%20Switch%20Blue%20Screen%20of%20Death#Section_CPU_Disconnect

Closes https://github.com/iFixit/ifixit/issues/48545