### PR TITLE
fix videoFrame layout

### DIFF
--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -138,11 +138,7 @@ const renderStyles: SystemStyleObject = {
 
    '.videoFrame': {
       maxWidth: '100%',
-      border: '1px solid #e5e7eb',
-      marginTop: '8px',
-      marginBottom: '8px',
-      padding: '1px',
-      borderRadius: 0,
+      marginBlock: '8px',
       height: 'auto',
 
       '@media only screen and (max-width: 575px)': {
@@ -179,11 +175,12 @@ const renderStyles: SystemStyleObject = {
 
    '.videoBox': {
       position: 'relative',
-      width: 'auto !important',
       overflow: 'hidden',
       maxWidth: '100%',
-      height: 0,
-      paddingBottom: '56.25%',
+      aspectRatio: '16 / 9',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
 
       video: {
          position: 'absolute',


### PR DESCRIPTION
## Issue
Vimeo videos were overflowing past the page bounds on mobile. Details and screenshots of issue in https://github.com/iFixit/react-commerce/issues/1787

## CR/QA

- I removed the previous border/padding intentionally to match youtube embeds
- `aspect-ratio` support: https://caniuse.com/?search=aspect-ratio

`Vulcan/iPhone_Bluetooth_Not_Working`

<details>

https://github.com/iFixit/react-commerce/assets/1634505/7d667bbc-1167-4a27-ba32-0dae9bd82a97


</details>


Closes https://github.com/iFixit/react-commerce/issues/1787