### PR TITLE
Troubleshooting: Redirect to relative URL

### DIFF
--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -107,15 +107,11 @@ export const getServerSideProps: GetServerSideProps<TroubleshootingProps> =
       }
 
       const canonicalUrl = new URL(troubleshootingData.canonicalUrl);
-      canonicalUrl.protocol = /localhost/.test(context.req.headers.host || '')
-         ? 'http'
-         : 'https';
-      canonicalUrl.host = context.req.headers.host || canonicalUrl.host;
 
       if (context.resolvedUrl !== canonicalUrl.pathname.toString()) {
          return {
             redirect: {
-               destination: canonicalUrl.toString(),
+               destination: canonicalUrl.pathname.toString(),
                permanent: true,
             },
          };

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -107,11 +107,22 @@ export const getServerSideProps: GetServerSideProps<TroubleshootingProps> =
       }
 
       const canonicalUrl = new URL(troubleshootingData.canonicalUrl);
+      /*
+       * Since `resolvedUrl` doesn't include a hostname or protocol,
+       * we're providing a fake one. We never actually read it out,
+       * so it doesn't much matter what we use.
+       */
+      const currentUrl = new URL(
+         context.resolvedUrl,
+         'https://vulcan.ifixit.com'
+      );
 
-      if (context.resolvedUrl !== canonicalUrl.pathname.toString()) {
+      if (currentUrl.pathname.toString() !== canonicalUrl.pathname.toString()) {
          return {
             redirect: {
-               destination: canonicalUrl.pathname.toString(),
+               destination:
+                  canonicalUrl.pathname.toString() +
+                  currentUrl.search.toString(),
                permanent: true,
             },
          };


### PR DESCRIPTION
The `Location` header supports relative URLs; let's use those to allow the browser to handle the protocol/host matching for the redirect.

This code seems to have been causing weird redirect problems in prod; I'm not sure what's going wrong, but simplifying it seems to be a good first thing to try.

Connects https://github.com/iFixit/ifixit/issues/48621