### PR TITLE
Troubleshooting API: Drop unneeded param

### DIFF
--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -84,7 +84,7 @@ export const getServerSideProps: GetServerSideProps<TroubleshootingProps> =
       let troubleshootingData: TroubleshootingApiData;
       try {
          troubleshootingData = await client.get<TroubleshootingApiData>(
-            `Troubleshooting/${wikiname}?vulcan=1&fullGuides=1`,
+            `Troubleshooting/${wikiname}?vulcan=1`,
             'troubleshooting'
          );
       } catch (e) {


### PR DESCRIPTION
We have now removed the param and cut over to always sending the full guide.

Let's remove the unneeded code.

qa_req 0

Connects: https://github.com/iFixit/ifixit/issues/48100
Connects: https://github.com/iFixit/ifixit/pull/48640