### PR TITLE
Add top level error boundary

### DIFF
--- a/frontend/layouts/default/LayoutErrorBoundary.tsx
+++ b/frontend/layouts/default/LayoutErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Alert, AlertDescription, AlertTitle, Center } from '@chakra-ui/react';
+import { FaIcon } from '@ifixit/icons';
+import { faCircleExclamation } from '@fortawesome/pro-solid-svg-icons';
+import * as Sentry from '@sentry/nextjs';
+import { ErrorBoundary } from 'react-error-boundary';
+
+type LayoutErrorBoundaryProps = React.PropsWithChildren;
+
+export function LayoutErrorBoundary({ children }: LayoutErrorBoundaryProps) {
+   return (
+      <ErrorBoundary
+         FallbackComponent={Fallback}
+         onError={(error, info) => {
+            Sentry.captureException(error, {
+               extra: info,
+               tags: { error_boundary: true },
+            });
+         }}
+      >
+         {children}
+      </ErrorBoundary>
+   );
+}
+
+function Fallback() {
+   return (
+      <Center p={4}>
+         <Alert
+            status="error"
+            variant="subtle"
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+            textAlign="center"
+            height="200px"
+            maxW="1280px"
+         >
+            <FaIcon icon={faCircleExclamation} h="10" color="red.500" />
+            <AlertTitle mt={4} mb={1} fontSize="lg">
+               Something went wrong
+            </AlertTitle>
+            <AlertDescription maxWidth="sm">
+               Please try to reload the page. If the problem persists, please
+               contact{' '}
+               <a href="mailto:support@ifixit.com">support@ifixit.com</a>.
+            </AlertDescription>
+         </Alert>
+      </Center>
+   );
+}

--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -63,6 +63,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import * as React from 'react';
 import { CartFooter } from './Footer';
+import { LayoutErrorBoundary } from './LayoutErrorBoundary';
 import type { DefaultLayoutProps } from './server';
 
 const DefaultLayoutComponent = function ({
@@ -78,242 +79,251 @@ const DefaultLayoutComponent = function ({
    const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
 
    return (
-      <ShopifyStorefrontProvider
-         shopDomain={shopifyCredentials.storefrontDomain}
-         storefrontAccessToken={shopifyCredentials.storefrontAccessToken}
-         apiVersion="2020-01"
-      >
-         <Box>
-            <Head>
-               <title>iFixit</title>
-               <link
-                  rel="apple-touch-icon"
-                  sizes="57x57"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-57x57.png"
-               />
-               <link
-                  rel="apple-touch-icon"
-                  sizes="60x60"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-60x60.png"
-               />
-               <link
-                  rel="apple-touch-icon"
-                  sizes="72x72"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-72x72.png"
-               />
-               <link
-                  rel="apple-touch-icon"
-                  sizes="76x76"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-76x76.png"
-               />
-               <link
-                  rel="apple-touch-icon"
-                  sizes="114x114"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-114x114.png"
-               />
-               <link
-                  rel="apple-touch-icon"
-                  sizes="120x120"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-120x120.png"
-               />
-               <link
-                  rel="apple-touch-icon"
-                  sizes="144x144"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-144x144.png"
-               />
-               <link
-                  rel="apple-touch-icon"
-                  sizes="152x152"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-152x152.png"
-               />
-               <link
-                  rel="apple-touch-icon"
-                  sizes="180x180"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-180x180.png"
-               />
-               <link
-                  rel="icon"
-                  type="image/png"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/favicon-32x32.png"
-                  sizes="32x32"
-               />
-               <link
-                  rel="icon"
-                  type="image/png"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/android-chrome-192x192.png"
-                  sizes="192x192"
-               />
-               <link
-                  rel="icon"
-                  type="image/png"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/favicon-96x96.png"
-                  sizes="96x96"
-               />
-               <link
-                  rel="icon"
-                  type="image/png"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/favicon-16x16.png"
-                  sizes="16x16"
-               />
-               <link
-                  rel="manifest"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/manifest.json"
-               />
-               <link
-                  rel="mask-icon"
-                  href="https://assets.cdn.ifixit.com/static/icons/ifixit/safari-pinned-tab.svg"
-                  color="#5bbad5"
-               />
-            </Head>
-            <Flex direction="column" minH="100vh">
-               <Header>
-                  <HeaderHiddenBar>
-                     <HeaderSearchForm.Mobile>
-                        <SearchInput ref={mobileSearchInputRef} />
-                     </HeaderSearchForm.Mobile>
-                     <HeaderCloseHiddenBarButton>
-                        Cancel
-                     </HeaderCloseHiddenBarButton>
-                  </HeaderHiddenBar>
-                  <HeaderBar>
-                     <HeaderPrimaryNavigation>
-                        <HeaderNavigationToggleButton aria-label="Open navigation menu" />
-                        <WordmarkLink
-                           href="/"
-                           aria-label="Go to homepage"
-                           pr="4"
-                           title="iFixit turns 20"
-                           padding={0}
-                        >
-                           <Icon as={Wordmark20th} width="auto" height="100%" />
-                        </WordmarkLink>
-                        {menu && (
-                           <NavigationMenu>
-                              {menu.items.map((item, index) => {
-                                 switch (item.type) {
-                                    case 'submenu': {
-                                       if (item.submenu === null) {
+      <LayoutErrorBoundary>
+         <ShopifyStorefrontProvider
+            shopDomain={shopifyCredentials.storefrontDomain}
+            storefrontAccessToken={shopifyCredentials.storefrontAccessToken}
+            apiVersion="2020-01"
+         >
+            <Box>
+               <Head>
+                  <title>iFixit</title>
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="57x57"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-57x57.png"
+                  />
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="60x60"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-60x60.png"
+                  />
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="72x72"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-72x72.png"
+                  />
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="76x76"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-76x76.png"
+                  />
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="114x114"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-114x114.png"
+                  />
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="120x120"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-120x120.png"
+                  />
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="144x144"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-144x144.png"
+                  />
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="152x152"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-152x152.png"
+                  />
+                  <link
+                     rel="apple-touch-icon"
+                     sizes="180x180"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/apple-touch-icon-180x180.png"
+                  />
+                  <link
+                     rel="icon"
+                     type="image/png"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/favicon-32x32.png"
+                     sizes="32x32"
+                  />
+                  <link
+                     rel="icon"
+                     type="image/png"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/android-chrome-192x192.png"
+                     sizes="192x192"
+                  />
+                  <link
+                     rel="icon"
+                     type="image/png"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/favicon-96x96.png"
+                     sizes="96x96"
+                  />
+                  <link
+                     rel="icon"
+                     type="image/png"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/favicon-16x16.png"
+                     sizes="16x16"
+                  />
+                  <link
+                     rel="manifest"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/manifest.json"
+                  />
+                  <link
+                     rel="mask-icon"
+                     href="https://assets.cdn.ifixit.com/static/icons/ifixit/safari-pinned-tab.svg"
+                     color="#5bbad5"
+                  />
+               </Head>
+               <Flex direction="column" minH="100vh">
+                  <Header>
+                     <HeaderHiddenBar>
+                        <HeaderSearchForm.Mobile>
+                           <SearchInput ref={mobileSearchInputRef} />
+                        </HeaderSearchForm.Mobile>
+                        <HeaderCloseHiddenBarButton>
+                           Cancel
+                        </HeaderCloseHiddenBarButton>
+                     </HeaderHiddenBar>
+                     <HeaderBar>
+                        <HeaderPrimaryNavigation>
+                           <HeaderNavigationToggleButton aria-label="Open navigation menu" />
+                           <WordmarkLink
+                              href="/"
+                              aria-label="Go to homepage"
+                              pr="4"
+                              title="iFixit turns 20"
+                              padding={0}
+                           >
+                              <Icon
+                                 as={Wordmark20th}
+                                 width="auto"
+                                 height="100%"
+                              />
+                           </WordmarkLink>
+                           {menu && (
+                              <NavigationMenu>
+                                 {menu.items.map((item, index) => {
+                                    switch (item.type) {
+                                       case 'submenu': {
+                                          if (item.submenu === null) {
+                                             return null;
+                                          }
+                                          return (
+                                             <NavigationMenuItem key={index}>
+                                                <NavigationMenuButton>
+                                                   {item.name}
+                                                </NavigationMenuButton>
+                                                <NavigationSubmenu>
+                                                   {item.submenu.items.map(
+                                                      (subitem, subIndex) => {
+                                                         if (
+                                                            subitem.type !==
+                                                            'link'
+                                                         ) {
+                                                            return null;
+                                                         }
+                                                         return (
+                                                            <NavigationSubmenuItem
+                                                               key={subIndex}
+                                                            >
+                                                               <SmartLink
+                                                                  as={
+                                                                     NavigationSubmenuLink
+                                                                  }
+                                                                  href={
+                                                                     subitem.url
+                                                                  }
+                                                                  behaviour={
+                                                                     subitem.url ===
+                                                                     '/Store'
+                                                                        ? 'reload'
+                                                                        : 'auto'
+                                                                  }
+                                                                  disclosureIcon={
+                                                                     <FaIcon
+                                                                        icon={
+                                                                           faArrowRight
+                                                                        }
+                                                                        h="5"
+                                                                        transform="translateY(-50%)"
+                                                                        color="white"
+                                                                     />
+                                                                  }
+                                                               >
+                                                                  <NavigationSubmenuName>
+                                                                     {
+                                                                        subitem.name
+                                                                     }
+                                                                  </NavigationSubmenuName>
+                                                                  <NavigationSubmenuDivider />
+                                                                  {subitem.description && (
+                                                                     <NavigationSubmenuDescription>
+                                                                        {
+                                                                           subitem.description
+                                                                        }
+                                                                     </NavigationSubmenuDescription>
+                                                                  )}
+                                                               </SmartLink>
+                                                            </NavigationSubmenuItem>
+                                                         );
+                                                      }
+                                                   )}
+                                                </NavigationSubmenu>
+                                             </NavigationMenuItem>
+                                          );
+                                       }
+                                       default: {
                                           return null;
                                        }
-                                       return (
-                                          <NavigationMenuItem key={index}>
-                                             <NavigationMenuButton>
-                                                {item.name}
-                                             </NavigationMenuButton>
-                                             <NavigationSubmenu>
-                                                {item.submenu.items.map(
-                                                   (subitem, subIndex) => {
-                                                      if (
-                                                         subitem.type !== 'link'
-                                                      ) {
-                                                         return null;
-                                                      }
-                                                      return (
-                                                         <NavigationSubmenuItem
-                                                            key={subIndex}
-                                                         >
-                                                            <SmartLink
-                                                               as={
-                                                                  NavigationSubmenuLink
-                                                               }
-                                                               href={
-                                                                  subitem.url
-                                                               }
-                                                               behaviour={
-                                                                  subitem.url ===
-                                                                  '/Store'
-                                                                     ? 'reload'
-                                                                     : 'auto'
-                                                               }
-                                                               disclosureIcon={
-                                                                  <FaIcon
-                                                                     icon={
-                                                                        faArrowRight
-                                                                     }
-                                                                     h="5"
-                                                                     transform="translateY(-50%)"
-                                                                     color="white"
-                                                                  />
-                                                               }
-                                                            >
-                                                               <NavigationSubmenuName>
-                                                                  {subitem.name}
-                                                               </NavigationSubmenuName>
-                                                               <NavigationSubmenuDivider />
-                                                               {subitem.description && (
-                                                                  <NavigationSubmenuDescription>
-                                                                     {
-                                                                        subitem.description
-                                                                     }
-                                                                  </NavigationSubmenuDescription>
-                                                               )}
-                                                            </SmartLink>
-                                                         </NavigationSubmenuItem>
-                                                      );
-                                                   }
-                                                )}
-                                             </NavigationSubmenu>
-                                          </NavigationMenuItem>
-                                       );
                                     }
-                                    default: {
-                                       return null;
-                                    }
-                                 }
-                              })}
-                           </NavigationMenu>
-                        )}
-                     </HeaderPrimaryNavigation>
-                     <HeaderSearchForm.Desktop>
-                        <SearchInput />
-                     </HeaderSearchForm.Desktop>
-                     <HeaderSecondaryNavigation>
-                        <HeaderOpenHiddenBarButton
-                           aria-label="Search database"
-                           _hover={{ opacity: '0.7' }}
-                           transition="0.3s"
-                           _active={{
-                              bg: 'gray.900',
-                           }}
-                           icon={
-                              <FaIcon
-                                 icon={faMagnifyingGlass}
-                                 h="22px"
-                                 color="white"
-                              />
-                           }
-                           onClick={() => {
-                              mobileSearchInputRef.current?.focus();
-                           }}
-                        />
-                        <CartDrawer />
-                        <HeaderUserMenu />
-                     </HeaderSecondaryNavigation>
-                  </HeaderBar>
-                  {menu && <LayoutNavigationDrawer menu={menu} />}
-               </Header>
-               {isAdminUser && adminMessage && (
-                  <Alert status="error">
-                     <AlertIcon />
-                     <AlertTitle>{adminMessage}</AlertTitle>
-                  </Alert>
-               )}
-               {children}
-               <CartFooter
-                  partners={currentStore.footer.partners}
-                  bottomMenu={currentStore.footer.bottomMenu}
-                  socialMediaAccounts={currentStore.socialMediaAccounts}
-                  menu1={currentStore.footer.menu1}
-                  menu2={currentStore.footer.menu2}
-                  menu3={currentStore.footer.menu3}
-                  stores={stores}
-                  globalSettings={globalSettings}
-               />
-            </Flex>
-         </Box>
-         <Matomo />
-         <GoogleAnalytics />
-      </ShopifyStorefrontProvider>
+                                 })}
+                              </NavigationMenu>
+                           )}
+                        </HeaderPrimaryNavigation>
+                        <HeaderSearchForm.Desktop>
+                           <SearchInput />
+                        </HeaderSearchForm.Desktop>
+                        <HeaderSecondaryNavigation>
+                           <HeaderOpenHiddenBarButton
+                              aria-label="Search database"
+                              _hover={{ opacity: '0.7' }}
+                              transition="0.3s"
+                              _active={{
+                                 bg: 'gray.900',
+                              }}
+                              icon={
+                                 <FaIcon
+                                    icon={faMagnifyingGlass}
+                                    h="22px"
+                                    color="white"
+                                 />
+                              }
+                              onClick={() => {
+                                 mobileSearchInputRef.current?.focus();
+                              }}
+                           />
+                           <CartDrawer />
+                           <HeaderUserMenu />
+                        </HeaderSecondaryNavigation>
+                     </HeaderBar>
+                     {menu && <LayoutNavigationDrawer menu={menu} />}
+                  </Header>
+                  {isAdminUser && adminMessage && (
+                     <Alert status="error">
+                        <AlertIcon />
+                        <AlertTitle>{adminMessage}</AlertTitle>
+                     </Alert>
+                  )}
+                  {children}
+                  <CartFooter
+                     partners={currentStore.footer.partners}
+                     bottomMenu={currentStore.footer.bottomMenu}
+                     socialMediaAccounts={currentStore.socialMediaAccounts}
+                     menu1={currentStore.footer.menu1}
+                     menu2={currentStore.footer.menu2}
+                     menu3={currentStore.footer.menu3}
+                     stores={stores}
+                     globalSettings={globalSettings}
+                  />
+               </Flex>
+            </Box>
+            <Matomo />
+            <GoogleAnalytics />
+         </ShopifyStorefrontProvider>
+      </LayoutErrorBoundary>
    );
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
       "query-string": "7.0.1",
       "react": "18.2.0",
       "react-dom": "18.2.0",
+      "react-error-boundary": "4.0.10",
       "react-instantsearch-hooks-router-nextjs": "6.42.0",
       "react-instantsearch-hooks-server": "6.42.0",
       "react-instantsearch-hooks-web": "6.42.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      react-error-boundary:
+        specifier: 4.0.10
+        version: 4.0.10(react@18.2.0)
       react-instantsearch-hooks-router-nextjs:
         specifier: 6.42.0
         version: 6.42.0(algoliasearch@4.13.1)(next@13.4.1)(react@18.2.0)
@@ -14474,6 +14477,15 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+
+  /react-error-boundary@4.0.10(react@18.2.0):
+    resolution: {integrity: sha512-pvVKdi77j2OoPHo+p3rorgE43OjDWiqFkaqkJz8sJKK6uf/u8xtzuaVfj5qJ2JnDLIgF1De3zY5AJDijp+LVPA==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.22.3
+      react: 18.2.0
+    dev: false
 
   /react-fast-compare@3.2.0:
     resolution: {integrity: sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==}


### PR DESCRIPTION
Closes #1655

Adds a catch-all error boundary at the layout level that renders a minimal fallback UI. Client errors will still be reported to Sentry.

## Bundle Size

This will increase the bundle size on all pages due to the installation of `react-error-boundary`. Bundlephobia [approximates](https://bundlephobia.com/package/react-error-boundary@4.0.10) it is 1.1 kb gzipped, which lines up with the ~1kb difference we see in the bundle stats.

## CR

Hiding whitespace will make the diff easier to view. The fallback UI is inspired by the [cart drawer fallback ui](https://github.com/iFixit/react-commerce/blob/547fccd5bdbb097c579b08b0ba1ce5067186291e/packages/ui/cart/drawer/CartDrawer.tsx#L120-L143).

## QA

Make sure unhandled client side errors render a page that looks like the following. Make sure the errors show up in the console and are reported to Sentry.

I tested this locally by throwing an error in a random component.

```ts
export function FeaturedProductsSection({...}: FeaturedProductsSectionProps) {
   throw new Error('uh oh');
```

CC @danielbeardsley @dhmacs 