### PR TITLE
Tests: Unskip mocked tests

### DIFF
--- a/.github/workflows/stress_test.yml
+++ b/.github/workflows/stress_test.yml
@@ -44,7 +44,7 @@ jobs:
       runs-on: ubuntu-latest
       needs: check-diff
       if: needs.check-diff.outputs.modified-playwright-tests != ''
-      timeout-minutes: 15
+      timeout-minutes: 20
       strategy:
          fail-fast: false
          matrix:

--- a/frontend/tests/playwright/product/disabled-product.spec.ts
+++ b/frontend/tests/playwright/product/disabled-product.spec.ts
@@ -1,35 +1,10 @@
 import { test, expect } from '../test-fixtures';
-import { createGraphQLHandler } from '../msw/request-handler';
 
 test.describe('Disabled Product Behavior', () => {
-   test.skip('Disabled Product Page Visibility and Meta Tags Validation', async ({
+   test('Disabled Product Page Visibility and Meta Tags Validation', async ({
       productPage,
-      serverRequestInterceptor,
-      findProductQueryMock,
    }) => {
-      const disabledProduct = findProductQueryMock;
-
-      disabledProduct.product!.variants.nodes.forEach((variant) => {
-         variant.enabled = null;
-      });
-
-      serverRequestInterceptor.use(
-         createGraphQLHandler({
-            request: {
-               endpoint: 'findProduct',
-               method: 'query',
-            },
-            response: {
-               status: 200,
-               body: disabledProduct,
-            },
-         })
-      );
-
-      await productPage.gotoProduct(
-         'iphone-6s-plus-replacement-battery-disabled'
-      );
-
+      await productPage.gotoProduct('hp-tt03xl-replacement-battery');
       await expect(
          productPage.page.getByTestId('not-for-sale-alert')
       ).toBeVisible();

--- a/frontend/tests/playwright/product/pro-user.spec.ts
+++ b/frontend/tests/playwright/product/pro-user.spec.ts
@@ -1,27 +1,9 @@
 import { interceptLogin } from '../utils';
 import { test, expect } from '../test-fixtures';
-import { createGraphQLHandler } from '../msw/request-handler';
 
 test.describe('Pro User Test', () => {
-   test.skip('Pro Discount Applied to Product Price', async ({
-      productPage,
-      serverRequestInterceptor,
-      findProductQueryMock,
-   }) => {
-      const proUserProduct = findProductQueryMock;
-      serverRequestInterceptor.use(
-         createGraphQLHandler({
-            request: {
-               endpoint: 'findProduct',
-               method: 'query',
-            },
-            response: {
-               status: 200,
-               body: proUserProduct,
-            },
-         })
-      );
-      await productPage.gotoProduct('pro-user-product');
+   test('Pro Discount Applied to Product Price', async ({ productPage }) => {
+      await productPage.gotoProduct('ipad-2-screw-set');
 
       // Get price from page
       const originalPrice = await productPage.getCurrentPrice();

--- a/frontend/tests/playwright/product/product-page-and-cart.spec.ts
+++ b/frontend/tests/playwright/product/product-page-and-cart.spec.ts
@@ -1,8 +1,5 @@
 import { test, expect } from '../test-fixtures';
-import {
-   createGraphQLHandler,
-   createRestHandler,
-} from '../msw/request-handler';
+import { createRestHandler } from '../msw/request-handler';
 
 test.describe('Product Page and Cart Interactions', () => {
    test('Multiple Add To Cart Clicks with Quantity Check', async ({
@@ -96,32 +93,11 @@ test.describe('Product Page and Cart Interactions', () => {
    });
 
    test.describe('Product Stock Levels', () => {
-      test.skip('Low Stock Product Inventory Management Visibility', async ({
+      test('Low Stock Product Inventory Management Visibility', async ({
          productPage,
          cartDrawer,
-         serverRequestInterceptor,
-         findProductQueryMock,
       }) => {
-         const lowStockedProduct = findProductQueryMock;
-
-         lowStockedProduct.product!.variants.nodes[0].quantityAvailable = 3;
-
-         serverRequestInterceptor.use(
-            createGraphQLHandler({
-               request: {
-                  endpoint: 'findProduct',
-                  method: 'query',
-               },
-               response: {
-                  status: 200,
-                  body: lowStockedProduct,
-               },
-            })
-         );
-
-         await productPage.gotoProduct(
-            'iphone-6s-plus-replacement-battery-low-stocked'
-         );
+         await productPage.gotoProduct('mac-mini-dual-drive-kit');
 
          const firstOptionSku = await productPage.getSku();
 
@@ -165,12 +141,10 @@ test.describe('Product Page and Cart Interactions', () => {
          await productPage.assertInventoryMessage('Only 1 left');
       });
 
-      test.skip('Out of Stock Product Notifications and Variant Switching', async ({
+      test('Out of Stock Product Notifications and Variant Switching', async ({
          productPage,
          cartDrawer,
-         serverRequestInterceptor,
          clientRequestHandler,
-         findProductQueryMock,
       }) => {
          clientRequestHandler.use(
             createRestHandler({
@@ -184,25 +158,8 @@ test.describe('Product Page and Cart Interactions', () => {
             })
          );
 
-         const outOfStockProduct = findProductQueryMock;
-
-         outOfStockProduct.product!.variants.nodes[0].quantityAvailable = 0;
-
-         serverRequestInterceptor.use(
-            createGraphQLHandler({
-               request: {
-                  endpoint: 'findProduct',
-                  method: 'query',
-               },
-               response: {
-                  status: 200,
-                  body: outOfStockProduct,
-               },
-            })
-         );
-
          await productPage.gotoProduct(
-            'iphone-6s-plus-replacement-battery-out-of-stock'
+            'apple-watch-42-mm-original-and-series-1-replacement-battery'
          );
 
          await expect(

--- a/frontend/tests/playwright/product/product-variant.spec.ts
+++ b/frontend/tests/playwright/product/product-variant.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '../test-fixtures';
-import { createGraphQLHandler } from '../msw/request-handler';
 
 test.describe('Product Variant Tests', () => {
    test('Product Variant Switch and Content Visibility', async ({
@@ -56,59 +55,11 @@ test.describe('Product Variant Tests', () => {
       ).not.toBeVisible();
    });
 
-   test.skip('Switch Variants and Add To Cart', async ({
+   test('Switch Variants and Add To Cart', async ({
       productPage,
       cartDrawer,
-      serverRequestInterceptor,
-      findProductQueryMock,
    }) => {
-      const productWithDifferentVariants = findProductQueryMock;
-      const values = [
-         'Repair Business Toolkit 2023',
-         'Repair Business Toolkit 2023 without Pro Tech Toolkit',
-      ];
-      productWithDifferentVariants.product!.options = [
-         {
-            id: 'gid://shopify/ProductOption/8799814352986',
-            name: 'Condition',
-            values: ['New'],
-         },
-         {
-            id: 'gid://shopify/ProductOption/8799814385754',
-            name: 'Style',
-            values: [...values],
-         },
-      ];
-
-      for (let i = 0; i < values.length; i++) {
-         const selectedOption = [
-            {
-               name: 'Condition',
-               value: 'New',
-            },
-            {
-               name: 'Style',
-               value: values[i],
-            },
-         ];
-         productWithDifferentVariants.product!.variants.nodes[
-            i
-         ].selectedOptions = selectedOption;
-      }
-
-      serverRequestInterceptor.use(
-         createGraphQLHandler({
-            request: {
-               endpoint: 'findProduct',
-               method: 'query',
-            },
-            response: {
-               status: 200,
-               body: productWithDifferentVariants,
-            },
-         })
-      );
-      await productPage.gotoProduct('product-with-different-variants');
+      await productPage.gotoProduct('detailing-brush');
       const productInfoSection = productPage.page.getByTestId(
          'product-info-section'
       );


### PR DESCRIPTION
## Summary
Unskipped some of the skipped tests because of the next 13 update.

Since there is no way to mock the server-side api calls on next 13, we are going to use some hard-coded products.
Most of these products are stocked by a cron job on `iFixit/ifixit` side in https://github.com/iFixit/ifixit/pull/48707, so it's a bit safe, but not a permanent solution, since a data change on Akeneo could cause some of the tests to fail.

For the moment, this lets us have at least some test coverage until we merge this repo to the monorepo.

## QA notes
All CI checks for the playwright tests should pass.

closes https://github.com/iFixit/ifixit/issues/48312