### PR TITLE
Catch localstorage Access Errors

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -47,6 +47,7 @@ const moduleExports = {
       '@ifixit/helpers',
       '@ifixit/icons',
       '@ifixit/ifixit-api-client',
+      '@ifixit/local-storage',
       '@ifixit/newsletter-sdk',
       '@ifixit/sentry',
       '@ifixit/shopify-storefront-client',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
       "@ifixit/helpers": "workspace:*",
       "@ifixit/icons": "workspace:*",
       "@ifixit/ifixit-api-client": "workspace:*",
+      "@ifixit/local-storage": "workspace:*",
       "@ifixit/menu": "workspace:*",
       "@ifixit/newsletter-sdk": "workspace:*",
       "@ifixit/sentry": "workspace:*",

--- a/packages/cart-sdk/hooks/use-checkout.ts
+++ b/packages/cart-sdk/hooks/use-checkout.ts
@@ -3,6 +3,7 @@ import { useAppContext } from '@ifixit/app';
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { assertNever, isError } from '@ifixit/helpers';
 import { useIFixitApiClient } from '@ifixit/ifixit-api-client';
+import { useSafeLocalStorage } from '@ifixit/local-storage';
 import { useShopifyStorefrontClient } from '@ifixit/shopify-storefront-client';
 import * as React from 'react';
 import z from 'zod';
@@ -245,24 +246,20 @@ interface LocalCheckout {
 }
 
 function getLocalCheckout(): LocalCheckout | null {
-   try {
-      const session = localStorage.getItem(LOCAL_CHECKOUT_STORAGE_KEY);
-      if (session == null) {
-         return null;
-      }
-      return JSON.parse(session);
-   } catch (error) {
+   const safeLocalStorage = useSafeLocalStorage();
+   const session = safeLocalStorage.getItem(LOCAL_CHECKOUT_STORAGE_KEY);
+   if (session == null) {
       return null;
    }
+   return JSON.parse(session);
 }
 
 function setLocalCheckout(checkout: LocalCheckout) {
-   try {
-      localStorage.setItem(
-         LOCAL_CHECKOUT_STORAGE_KEY,
-         JSON.stringify(checkout)
-      );
-   } catch (error) {}
+   const safeLocalStorage = useSafeLocalStorage();
+   safeLocalStorage.setItem(
+      LOCAL_CHECKOUT_STORAGE_KEY,
+      JSON.stringify(checkout)
+   );
 }
 
 const checkoutCreateMutation = /* GraphQL */ `

--- a/packages/cart-sdk/package.json
+++ b/packages/cart-sdk/package.json
@@ -7,9 +7,10 @@
    "dependencies": {
       "@ifixit/analytics": "workspace:*",
       "@ifixit/app": "workspace:*",
+      "@ifixit/auth-sdk": "workspace:*",
       "@ifixit/helpers": "workspace:*",
       "@ifixit/ifixit-api-client": "workspace:*",
-      "@ifixit/auth-sdk": "workspace:*",
+      "@ifixit/local-storage": "workspace:*",
       "@ifixit/shopify-storefront-client": "workspace:*"
    },
    "peerDependencies": {

--- a/packages/local-storage/index.tsx
+++ b/packages/local-storage/index.tsx
@@ -1,0 +1,50 @@
+interface SafeStorage {
+   getItem(key: string): string | null;
+   setItem(key: string, value: string): void;
+   removeItem(key: string): void;
+   key(index: number): string | null;
+   clear(): void;
+}
+
+export function useSafeLocalStorage(): SafeStorage {
+   const safeLocalStorage = {
+      setItem: function (key: string, value: string): void {
+         try {
+            localStorage.setItem(key, value);
+         } catch (error) {}
+      },
+
+      getItem: function (key: string): string | null {
+         try {
+            const item = localStorage.getItem(key);
+            if (item === null || item === 'null') {
+               return null;
+            }
+            return item;
+         } catch (error) {
+            return null;
+         }
+      },
+
+      removeItem: function (key: string): void {
+         try {
+            localStorage.removeItem(key);
+         } catch (error) {}
+      },
+
+      key: function (index: number): string | null {
+         try {
+            return localStorage.key(index);
+         } catch (error) {
+            return null;
+         }
+      },
+
+      clear: function (): void {
+         try {
+            localStorage.clear();
+         } catch (error) {}
+      },
+   };
+   return safeLocalStorage;
+}

--- a/packages/local-storage/package.json
+++ b/packages/local-storage/package.json
@@ -1,0 +1,19 @@
+{
+   "name": "@ifixit/local-storage",
+   "version": "0.0.0",
+   "main": "./index.tsx",
+   "types": "./index.tsx",
+   "license": "MIT",
+   "exports": {
+      ".": "./index.tsx"
+   },
+   "devDependencies": {
+      "@ifixit/tsconfig": "workspace:*",
+      "typescript": "4.8.4"
+   },
+   "scripts": {
+      "build": "",
+      "clean": "",
+      "type-check": "tsc --pretty --noEmit"
+   }
+}

--- a/packages/local-storage/tsconfig.json
+++ b/packages/local-storage/tsconfig.json
@@ -1,0 +1,5 @@
+{
+   "extends": "@ifixit/tsconfig/react-library.json",
+   "include": ["."],
+   "exclude": ["dist", "build", "node_modules"]
+}

--- a/packages/ui/hooks/index.ts
+++ b/packages/ui/hooks/index.ts
@@ -1,4 +1,5 @@
 import { useBreakpointValue } from '@chakra-ui/react';
+import { useSafeLocalStorage } from '@ifixit/local-storage';
 import * as React from 'react';
 
 export function useDebounce<Value = any>(value: Value, delay: number): Value {
@@ -147,21 +148,18 @@ export function useExpiringLocalPreference<Data = any>(
    const [data, setData] = React.useState(defaultData);
 
    React.useEffect(() => {
-      try {
-         const serializedData = localStorage.getItem(key);
-         if (serializedData != null) {
-            const data = JSON.parse(serializedData) as ExpiringData;
-            const expiresAt = Number.isInteger(data?.expires)
-               ? data.expires
-               : 0;
-            const validData = validator(data?.value);
-            if (validData !== null && expiresAt && Date.now() < expiresAt) {
-               setData(validData);
-            } else {
-               localStorage.removeItem(key);
-            }
+      const safeLocalStorage = useSafeLocalStorage();
+      const serializedData = safeLocalStorage.getItem(key);
+      if (serializedData != null) {
+         const data = JSON.parse(serializedData) as ExpiringData;
+         const expiresAt = Number.isInteger(data?.expires) ? data.expires : 0;
+         const validData = validator(data?.value);
+         if (validData !== null && expiresAt && Date.now() < expiresAt) {
+            setData(validData);
+         } else {
+            safeLocalStorage.removeItem(key);
          }
-      } catch (error) {}
+      }
    }, []);
 
    const setAndSave = (data: Data) => {
@@ -171,7 +169,8 @@ export function useExpiringLocalPreference<Data = any>(
          expires: Date.now() + expireInDays * 1000 * 86400,
       } as ExpiringData;
       const serializedData = JSON.stringify(expiringData);
-      localStorage.setItem(key, serializedData);
+      const safeLocalStorage = useSafeLocalStorage();
+      safeLocalStorage.setItem(key, serializedData);
    };
 
    return [data, setAndSave];
@@ -191,23 +190,24 @@ export function useLocalPreference<Data = any>(
    const [data, setData] = React.useState(defaultData);
 
    React.useEffect(() => {
-      try {
-         const serializedData = localStorage.getItem(key);
-         if (serializedData != null) {
-            const data = validator(JSON.parse(serializedData));
-            if (data !== null) {
-               setData(data);
-            }
+      const safeLocalStorage = useSafeLocalStorage();
+      const serializedData = safeLocalStorage.getItem(key);
+      if (serializedData != null) {
+         if (!serializedData) {
+            throw new Error('serializedData is null');
          }
-      } catch (error) {}
+         const data = validator(JSON.parse(serializedData));
+         if (data !== null) {
+            setData(data);
+         }
+      }
    }, []);
 
    const setAndSave = (data: Data) => {
       setData(data);
       const serializedData = JSON.stringify(data);
-      try {
-         localStorage.setItem(key, serializedData);
-      } catch (error) {}
+      const safeLocalStorage = useSafeLocalStorage();
+      safeLocalStorage.setItem(key, serializedData);
    };
 
    return [data, setAndSave];

--- a/packages/ui/hooks/index.ts
+++ b/packages/ui/hooks/index.ts
@@ -147,9 +147,9 @@ export function useExpiringLocalPreference<Data = any>(
    const [data, setData] = React.useState(defaultData);
 
    React.useEffect(() => {
-      const serializedData = localStorage.getItem(key);
-      if (serializedData != null) {
-         try {
+      try {
+         const serializedData = localStorage.getItem(key);
+         if (serializedData != null) {
             const data = JSON.parse(serializedData) as ExpiringData;
             const expiresAt = Number.isInteger(data?.expires)
                ? data.expires
@@ -158,10 +158,10 @@ export function useExpiringLocalPreference<Data = any>(
             if (validData !== null && expiresAt && Date.now() < expiresAt) {
                setData(validData);
             } else {
-               localStorage.deleteIem(key);
+               localStorage.removeItem(key);
             }
-         } catch (error) {}
-      }
+         }
+      } catch (error) {}
    }, []);
 
    const setAndSave = (data: Data) => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
       "@ifixit/cart-sdk": "workspace:*",
       "@ifixit/helpers": "workspace:*",
       "@ifixit/icons": "workspace:*",
+      "@ifixit/local-storage": "workspace:*",
       "@ifixit/newsletter-sdk": "workspace:*"
    },
    "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@ifixit/ifixit-api-client':
         specifier: workspace:*
         version: link:../packages/ifixit-api-client
+      '@ifixit/local-storage':
+        specifier: workspace:*
+        version: link:../packages/local-storage
       '@ifixit/menu':
         specifier: workspace:*
         version: link:../packages/menu
@@ -503,6 +506,9 @@ importers:
       '@ifixit/ifixit-api-client':
         specifier: workspace:*
         version: link:../ifixit-api-client
+      '@ifixit/local-storage':
+        specifier: workspace:*
+        version: link:../local-storage
       '@ifixit/shopify-storefront-client':
         specifier: workspace:*
         version: link:../shopify-storefront-client
@@ -661,6 +667,15 @@ importers:
         specifier: 4.8.4
         version: 4.8.4
 
+  packages/local-storage:
+    devDependencies:
+      '@ifixit/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: 4.8.4
+        version: 4.8.4
+
   packages/menu:
     devDependencies:
       '@ifixit/tsconfig':
@@ -790,6 +805,9 @@ importers:
       '@ifixit/icons':
         specifier: workspace:*
         version: link:../icons
+      '@ifixit/local-storage':
+        specifier: workspace:*
+        version: link:../local-storage
       '@ifixit/newsletter-sdk':
         specifier: workspace:*
         version: link:../newsletter-sdk


### PR DESCRIPTION
## Overview
This pull does 2 things.
1.) Move localstorage calls into try block.
2.) Replace "deleteIem" with removeItem()

## QA

Not quite how to qa this. I was able to make sure the removeItem() works now on chrome by just loading a product page while logged in. I think the errors in question have have to do with third party cookie blocking, which makes testing it on the test sites hard.

Closes: #1798
qa_req 0