### PR TITLE
Update README with Verdaccio Authentication Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Here's one way you can get all the right versions installed and setup:
 2. `nvm use`
    -  run this command in the project root to install compatible versions of `node` and `npm`
 3. `npm install -g pnpm@8`
+4. `npm install -g yarn`
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ Here's one way you can get all the right versions installed and setup:
 
 We use [Verdaccio](https://verdaccio.org/) as our private npm registry. To install packages from Verdaccio, you will need to setup an authentication token.
 
+**You can retrieve the token from Slack** and then save it to `.env.local` as `VERDACCIO_AUTH_TOKEN`.
+
+Otherwise, you can follow the steps below to create a new token:
+
+<details>
+<summary>Verdaccio - Creating Personal Access Token </summary>
+
 ⚠️ **_You will need to be IP whitelisted to be able to access our Verdaccio registry._**
 
 <br/>
@@ -68,6 +75,8 @@ Once you've signed up, or logged in, the Verdaccio auth token will be saved to y
    pnpm logout --registry=https://verdaccio.ubreakit.com
    ```
    -  This will remove the Verdaccio auth token from your `~/.npmrc`, and so long as you've exported the token to `.env.local`, you will still be able to install packages from Verdaccio for this repo.
+
+</details>
 
 #### Setup strapi Env file
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,54 @@ Here's one way you can get all the right versions installed and setup:
 
 ### Setup
 
+#### Setup Verdaccio Auth Token
+
+We use [Verdaccio](https://verdaccio.org/) as our private npm registry. To install packages from Verdaccio, you will need to setup an authentication token.
+
+⚠️ **_You will need to be IP whitelisted to be able to access our Verdaccio registry._**
+
+<br/>
+
+**New Users** <br/>
+If you've never created a Verdaccio account, you can follow these steps:
+
+1. Copy `.env.local.example` to `.env.local`
+   ```
+   cp .env.local.example .env.local
+   ```
+2. Run
+   ```
+   pnpm adduser --registry=https://verdaccio.ubreakit.com
+   ```
+   -  _You will then be prompted to enter some information_
+3. Enter a `username`
+4. Enter a `password` - _make it rememberable and strong_
+5. Enter an `email address`
+
+**Login** <br/>
+If you've already created a Verdaccio account, and need to grab the token again, you can follow these steps:
+
+1. Run
+   ```
+   pnpm login --registry=https://verdaccio.ubreakit.com
+   ```
+2. Enter your `username`
+3. Enter your `password`
+
+<br/>
+
+**Setting the Env Token** <br/>
+Once you've signed up, or logged in, the Verdaccio auth token will be saved to your `~/.npmrc`. You can grab the token from there and save it to `.env.local` as `VERDACCIO_AUTH_TOKEN`.
+
+<br/>
+
+⚠️ **_If you don't want to use the Verdaccio registry outside of this repo, you can run the following:_**
+
+-  ```
+   pnpm logout --registry=https://verdaccio.ubreakit.com
+   ```
+   -  This will remove the Verdaccio auth token from your `~/.npmrc`, and so long as you've exported the token to `.env.local`, you will still be able to install packages from Verdaccio for this repo.
+
 #### Setup strapi Env file
 
 1. Copy `backend/.env.example` to `backend/.env`


### PR DESCRIPTION
## Description

We recently migrated to using [Verdaccio](https:/verdaccio.org) as our private npm registry, #1815. That said the steps for how to retrieve a `VERDACCIO_AUTH_TOKEN` was tribal knowledge.

This updates the `README.md` with instructions on how to either create a new account or log in to our Verdaccio registry.

### QA

- [ ] Grammar check
- [ ] Follow the instructions in the README and validate they are correct
	- ⚠️ If you do create a new _test_ user, please take note of the `username` you used so we can delete it from the registry later.

**Reference:**
https://ifixit.slack.com/archives/C01K32B4FPX/p1689354809125539