### PR TITLE
Troubleshooting: Update tests for new canonical URLs

### DIFF
--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -24,6 +24,11 @@ test.describe('Vulcan Page Content and SEO', () => {
       await expect(canonical).toHaveAttribute('href', /^http/);
    });
 
+   test('Redirect to Canonical URL', async ({ page }) => {
+      await page.goto('/Vulcan/Dryer_Not_Spinning');
+      await expect(page.url()).toMatch(/Not%20Spinning/);
+   });
+
    test('Breadcrumbs Visible', async ({ page }) => {
       await page.goto('/Vulcan/Dryer_Not_Spinning');
       const nav = page.getByRole('navigation', { name: 'breadcrumb' });

--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -19,10 +19,7 @@ test.describe('Vulcan Page Content and SEO', () => {
       await page.goto('/Vulcan/Dryer_Not_Spinning');
       // check that the canonical link is a resonable URL
       const canonical = page.locator('link[rel="canonical"]');
-      await expect(canonical).toHaveAttribute(
-         'href',
-         /Vulcan\/Dryer.*Not.*Spinning/
-      );
+      await expect(canonical).toHaveAttribute('href', /Not%20Spinning/);
       // Check that the canonical link is an absolute URL
       await expect(canonical).toHaveAttribute('href', /^http/);
    });


### PR DESCRIPTION
This updates an existing test to ensure that it doesn't break when we change what the canonical URLs look like. It also adds a new test to ensure that the Troubleshooting pages redirect to the canonical URL when it doesn't match the page URL. This is important (mildly) because it's the mechanism by which our existing (non-public) Vulcan URLs will continue to end up at the right URLs after we start using the final URLs as the canonical URLs.