### PR TITLE
Startup Script: Remove hardcoding algoliaApiKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ New iFixit e-commerce site.
 
 ## Development
 
+### Setup Script (Easiest Startup):
+
+1. Clone the repo, if not already done:
+   `git clone https://github.com/iFixit/react-commerce.git`
+2. Install [nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
+3. `cd react-commerce`
+4. Run the script with your algolia API key set:
+   `algoliaApiKey=123xyz ./startReactCommerce.sh`
+
+#### How to get Algolia API Key (two methods)
+
+-  Copy the `Search API Key` [from Algolia](https://www.algolia.com/account/api-keys/all?applicationId=XQEP3AD9ZT) (You may need to ask for access to our Algolia)
+
+-  Copy the dev key from Cominor:
+   ```sh
+   cat /etc/dozuki/algolia-keys.json | jq --raw-output .searchApiKey
+   ```
+
 ### Prerequisites
 
 -  npm v8

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ git clone https://github.com/iFixit/react-commerce.git
 nvm use && algoliaApiKey=123xyz ./startReactCommerce.sh
 ```
 
+> **Not your first time?** If you have previously setup the algolia api key (i.e. it is still saved in `frontend/.env.local`), you don't need to specify it again.
+
 > **Note:** You _may_ use an alternative method of getting the correct node version instead of nvm.
 
 #### How to get Algolia API Key (two methods)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,20 @@ New iFixit e-commerce site.
 ### Setup Script (Easiest Startup):
 
 1. Clone the repo, if not already done:
-   `git clone https://github.com/iFixit/react-commerce.git`
+
+```sh
+git clone https://github.com/iFixit/react-commerce.git
+```
+
 2. Install [nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 3. `cd react-commerce`
-4. Run the script with your algolia API key set:
-   `algoliaApiKey=123xyz ./startReactCommerce.sh`
+4. Run the script with your algolia API key set and `nvm use`:
+
+```sh
+nvm use && algoliaApiKey=123xyz ./startReactCommerce.sh
+```
+
+> **Note:** You _may_ use an alternative method of getting the correct node version instead of nvm.
 
 #### How to get Algolia API Key (two methods)
 

--- a/startReactCommerce.sh
+++ b/startReactCommerce.sh
@@ -6,7 +6,6 @@ git checkout main
 git pull
 git checkout -
 rm -rf node_modules
-nvm use
 npm install -g pnpm@8
 npm install -g yarn
 cp .env.local.example .env.local
@@ -74,8 +73,8 @@ if [ -z "$apiKey" ]; then
         echo "Algolia api key successfully passed in."
     else
         echo "You must set the algoliaApiKey variable in your environment."
-        echo -e 'Try running with: \n\nexport algoliaApiKey=YOUR_API_KEY \n./startReactCommerce.sh\n'
-        echo -e 'Or you can run it in one line with: \n\nalgoliaApiKey=xyz123 ./startReactCommerce.sh'
+        echo -e 'Try running with: \n\nexport algoliaApiKey=YOUR_API_KEY \nnvm use && ./startReactCommerce.sh\n'
+        echo -e 'Or you can run it in one line with: \n\nnvm use && algoliaApiKey=xyz123 ./startReactCommerce.sh'
         return 1
     fi
     awk -v placeholder="\"$algoliaApiKey\"" '/^ALGOLIA_API_KEY=/{gsub(/=.*/, "=" placeholder)} 1' "$envFilePath" > "$envFilePath.tmp" && mv "$envFilePath.tmp" "$envFilePath"

--- a/startReactCommerce.sh
+++ b/startReactCommerce.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 
-if [ -n "${algoliaApiKey+set}" ]; then
-    echo "Starting react-commerce localdev"
-else
-    echo "You must set the algoliaApiKey variable in your environment."
-    echo -e 'Try running with: \n\nexport algoliaApiKey=YOUR_API_KEY \n./startReactCommerce.sh\n'
-    echo -e 'Or you can run it in one line with: \n\nalgoliaApiKey=xyz123 ./startReactCommerce.sh'
-    return 1
-fi
+echo "Starting react-commerce localdev"
 
 git checkout main
 git pull
@@ -77,6 +70,14 @@ apiKey=$(grep -o '^ALGOLIA_API_KEY=.*' "$envFilePath" | cut -d '=' -f 2)
 # Check if ALGOLIA_API_KEY value is empty
 if [ -z "$apiKey" ]; then
     echo "ALGOLIA_API_KEY is empty. Filling in the value..."
+    if [ -n "${algoliaApiKey+set}" ]; then
+        echo "Algolia api key successfully passed in."
+    else
+        echo "You must set the algoliaApiKey variable in your environment."
+        echo -e 'Try running with: \n\nexport algoliaApiKey=YOUR_API_KEY \n./startReactCommerce.sh\n'
+        echo -e 'Or you can run it in one line with: \n\nalgoliaApiKey=xyz123 ./startReactCommerce.sh'
+        return 1
+    fi
     awk -v placeholder="\"$algoliaApiKey\"" '/^ALGOLIA_API_KEY=/{gsub(/=.*/, "=" placeholder)} 1' "$envFilePath" > "$envFilePath.tmp" && mv "$envFilePath.tmp" "$envFilePath"
 fi
 

--- a/startReactCommerce.sh
+++ b/startReactCommerce.sh
@@ -4,8 +4,8 @@ if [ -n "${algoliaApiKey+set}" ]; then
     echo "Starting react-commerce localdev"
 else
     echo "You must set the algoliaApiKey variable in your environment."
-    echo -e 'Try running with: \n\nexport algoliaApiKey=YOUR_API_KEY \nsource startReactCommerce.sh\n'
-    echo -e 'Or you can run it in one line with: \n\nalgoliaApiKey=xyz123 source startReactCommerce.sh'
+    echo -e 'Try running with: \n\nexport algoliaApiKey=YOUR_API_KEY \n./startReactCommerce.sh\n'
+    echo -e 'Or you can run it in one line with: \n\nalgoliaApiKey=xyz123 ./startReactCommerce.sh'
     return 1
 fi
 

--- a/startReactCommerce.sh
+++ b/startReactCommerce.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+if [ -n "${algoliaApiKey+set}" ]; then
+    echo "Starting react-commerce localdev"
+else
+    echo "You must set the algoliaApiKey variable in your environment."
+    echo -e 'Try running with: \n\nexport algoliaApiKey=YOUR_API_KEY \nsource startReactCommerce.sh\n'
+    echo -e 'Or you can run it in one line with: \n\nalgoliaApiKey=xyz123 source startReactCommerce.sh'
+    return 1
+fi
+
 git checkout main
 git pull
 git checkout -
@@ -55,7 +64,6 @@ cp backend/.env.example backend/.env
 
 envFilePath="frontend/.env.local"
 exampleEnvFilePath="frontend/.env.local.example"
-algoliaApiKey="\"12345-your-key-here\""
 
 # Check if .env.local file exists
 if [ ! -f "$envFilePath" ]; then
@@ -69,7 +77,7 @@ apiKey=$(grep -o '^ALGOLIA_API_KEY=.*' "$envFilePath" | cut -d '=' -f 2)
 # Check if ALGOLIA_API_KEY value is empty
 if [ -z "$apiKey" ]; then
     echo "ALGOLIA_API_KEY is empty. Filling in the value..."
-    awk -v placeholder="$algoliaApiKey" '/^ALGOLIA_API_KEY=/{gsub(/=.*/, "=" placeholder)} 1' "$envFilePath" > "$envFilePath.tmp" && mv "$envFilePath.tmp" "$envFilePath"
+    awk -v placeholder="\"$algoliaApiKey\"" '/^ALGOLIA_API_KEY=/{gsub(/=.*/, "=" placeholder)} 1' "$envFilePath" > "$envFilePath.tmp" && mv "$envFilePath.tmp" "$envFilePath"
 fi
 
 pnpm install:all


### PR DESCRIPTION
## Overview
Instead, let's make the user export or define the variable when running the script.
This adds a check to make sure the variable is defined before running the script and tells the user what to do if they fail the check.

## QA 
1. Run the script (`source startReactCommerce.sh`) without an algoliaApiKey env variable and make sure we stop the script and tell the user they need to export the variable.
2. Export the variable or run the script with the variable defined:
- `export algoliaApiKey=YOUR_API_KEY` and `source startReactCommerce.sh`
or
- `algoliaApiKey=xyz123 source startReactCommerce.sh`
3. The script should run successfully. Check that localhost:3000/Parts loads correctly.

CC @addison-grant 
