### PR TITLE
Lighthouse: Render a Box instead of a Link when no `href` prop exists

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -516,7 +516,7 @@ function NavTabs({
 
          {deviceGuideUrl ? (
             <Link {...notSelectedStyleProps} href={deviceGuideUrl}>
-               Parts
+               Guides
             </Link>
          ) : (
             <Box className="isDisabled" {...notSelectedStyleProps}>

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -504,20 +504,26 @@ function NavTabs({
 
    return (
       <Flex {...props} gap={1.5} height="100%">
-         <Link
-            className={devicePartsUrl ? '' : 'isDisabled'}
-            {...notSelectedStyleProps}
-            href={devicePartsUrl}
-         >
-            Parts
-         </Link>
-         <Link
-            className={deviceGuideUrl ? '' : 'isDisabled'}
-            {...notSelectedStyleProps}
-            href={deviceGuideUrl}
-         >
-            Guides
-         </Link>
+         {devicePartsUrl ? (
+            <Link {...notSelectedStyleProps} href={devicePartsUrl}>
+               Parts
+            </Link>
+         ) : (
+            <Box className="isDisabled" {...notSelectedStyleProps}>
+               Parts
+            </Box>
+         )}
+
+         {deviceGuideUrl ? (
+            <Link {...notSelectedStyleProps} href={deviceGuideUrl}>
+               Parts
+            </Link>
+         ) : (
+            <Box className="isDisabled" {...notSelectedStyleProps}>
+               Guides
+            </Box>
+         )}
+
          <Box {...selectedStyleProps}>Answers</Box>
       </Flex>
    );


### PR DESCRIPTION
## Issue
This was flagged on a Lighthouse run for HTML semantics. We are rendering NavTabs without href attributes.

## CR/QA
This change renders a `Box` component instead of a `Link` when the href URL doesn't exist.

<details>
<summary>After Screenshot</summary>

<img width="1745" alt="Screenshot 2023-07-20 at 2 03 02 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/66b704bd-c1fe-48f9-bc90-3f2e3acdbcaa">

</details>


Closes https://github.com/iFixit/react-commerce/issues/1840