### PR TITLE
Tests: Skip parts-page-navigation test

### DIFF
--- a/frontend/tests/playwright/product-list/parts-page-navigation.spec.ts
+++ b/frontend/tests/playwright/product-list/parts-page-navigation.spec.ts
@@ -5,7 +5,7 @@ test.describe('Parts Page Navigation', () => {
       await page.goto('/Parts');
    });
 
-   test('Navigate Through All Device Pages', async ({ page }) => {
+   test.skip('Navigate Through All Device Pages', async ({ page }) => {
       const viewPort = page.viewportSize();
 
       await expect(


### PR DESCRIPTION
## Summary
This test started failing on main because the headings on the `/Parts` pages aren't showing up in CI.

Created an issue to unskip it here: https://github.com/iFixit/react-commerce/issues/1844

qa_req 0