### PR TITLE
Set swcMinify To False

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -160,6 +160,7 @@ const moduleExports = {
          disableClientWebpackPlugin: true,
       }),
    },
+   swcMinify: false,
 };
 
 // Make sure adding Sentry options is the last code to run before exporting, to


### PR DESCRIPTION
## Overview

We've had some errors show up on sentry like [this](https://github.com/iFixit/react-commerce/issues/1808) since we updated `next.js`. Based on a github issue comment on the next js repo, turning `swcMinify` to `false` may stop these errors. You can read more about `swc` [here](https://swc.rs/) and [here](https://nextjs.org/docs/architecture/nextjs-compiler) but basically next js started using it to compile and it could be causing this error. Because `next.js` just changed the default from `false` to `true` and now this is changing it back, im not too worried about potential problems with this change, outside of slower build times and the like. Nevertheless, we should keep an eye on sentry when this deploys. 

## QA

Make sure the vercel preview seems fine. 

Connects: https://github.com/iFixit/react-commerce/issues/1808