### PR TITLE
Sentry: Stop reporting http status 499 from `fetch()`

### DIFF
--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -54,8 +54,7 @@ const withSentry: FetchMiddleware =
          if (
             !shouldIgnoreUserAgent &&
             response.status >= 400 &&
-            response.status !== 401 &&
-            response.status !== 404
+            ![401, 404, 499].includes(response.status)
          ) {
             const msg = `fetch() HTTP error: ${response.status} ${response.statusText}`;
             Sentry.captureException(new Error(msg), (scope) => {


### PR DESCRIPTION
Closes  https://github.com/iFixit/ifixit/issues/48949

qa_req 0