### PR TITLE
Playwright: Update Vulcan Tests

### DIFF
--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -26,14 +26,14 @@ test.describe('Vulcan Page Content and SEO', () => {
       await page.goto('/Vulcan/Dryer_Not_Spinning');
       // check that the canonical link is a resonable URL
       const canonical = page.locator('link[rel="canonical"]');
-      await expect(canonical).toHaveAttribute('href', /Not%20Spinning/);
+      await expect(canonical).toHaveAttribute('href', /Not\+Spinning/);
       // Check that the canonical link is an absolute URL
       await expect(canonical).toHaveAttribute('href', /^http/);
    });
 
    test('Redirect to Canonical URL', async ({ page }) => {
       await page.goto('/Vulcan/Dryer_Not_Spinning');
-      await expect(page.url()).toMatch(/Not%20Spinning/);
+      expect(page.url()).toMatch(/Not\+Spinning/);
    });
 
    test('Breadcrumbs Visible', async ({ page }) => {

--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -26,14 +26,14 @@ test.describe('Vulcan Page Content and SEO', () => {
       await page.goto('/Vulcan/Dryer_Not_Spinning');
       // check that the canonical link is a resonable URL
       const canonical = page.locator('link[rel="canonical"]');
-      await expect(canonical).toHaveAttribute('href', /Not\+Spinning/);
+      await expect(canonical).toHaveAttribute('href', /Not.Spinning/);
       // Check that the canonical link is an absolute URL
       await expect(canonical).toHaveAttribute('href', /^http/);
    });
 
    test('Redirect to Canonical URL', async ({ page }) => {
       await page.goto('/Vulcan/Dryer_Not_Spinning');
-      expect(page.url()).toMatch(/Not\+Spinning/);
+      expect(page.url()).toMatch(/Not.Spinning/);
    });
 
    test('Breadcrumbs Visible', async ({ page }) => {


### PR DESCRIPTION
## Description

We made a change in the iFixit/ifixit repo which replaced spaces in urls with '+' characters (https://github.com/iFixit/ifixit/pull/48898).

As a result, the playwright tests in the `react-commerce` repo have started to fail because we were matching with `%20` instead of `+`.

This updates the tests with the new url format and also dropped an unnecessary `await` in the `loading.spec.ts` test.

qa_req 0 CI should pass

**Reference:** https://ifixit.slack.com/archives/C97UC89AR/p1690403596540979