### PR TITLE
Vulcan: Fix device image flash on mobile

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -114,21 +114,26 @@ const Wiki: NextPageWithLayout<{
                   borderBottom="1px"
                   borderColor="gray.300"
                >
-                  <Hide below="sm">
-                     <Image
-                        src={mainImageUrl}
-                        onClick={onOpen}
-                        cursor="pointer"
-                        alt={title}
-                        htmlWidth={120}
-                        htmlHeight={90}
-                        objectFit="contain"
-                        borderRadius="md"
-                        outline="1px solid"
-                        outlineColor="gray.300"
-                        marginRight={3}
-                     />
-                  </Hide>
+                  <Image
+                     sx={{
+                        display: 'none',
+                        // sm breakpoint
+                        '@media (min-width: 576px)': {
+                           display: 'block',
+                        },
+                     }}
+                     src={mainImageUrl}
+                     onClick={onOpen}
+                     cursor="pointer"
+                     alt={title}
+                     htmlWidth={120}
+                     htmlHeight={90}
+                     objectFit="contain"
+                     borderRadius="md"
+                     outline="1px solid"
+                     outlineColor="gray.300"
+                     marginRight={3}
+                  />
                   <Modal isOpen={isOpen} onClose={onClose}>
                      <ModalOverlay />
                      <ModalContent

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -34,6 +34,7 @@ import {
    chakra,
    HStack,
    SimpleGrid,
+   useToken,
 } from '@chakra-ui/react';
 import Prerendered from './prerendered';
 import type {
@@ -72,6 +73,7 @@ const Wiki: NextPageWithLayout<{
       id,
    } = wikiData;
    const { isOpen, onOpen, onClose } = useDisclosure();
+   const smBreakpoint = useToken('breakpoints', 'sm');
    const metadata = (
       <>
          <meta name="description" content={metaDescription} />
@@ -82,6 +84,13 @@ const Wiki: NextPageWithLayout<{
          <TagManager />
       </>
    );
+
+   const imageSx: any = {
+      display: 'none',
+   };
+   imageSx[`@media (min-width: ${smBreakpoint})`] = {
+      display: 'block',
+   };
 
    return (
       <>
@@ -114,13 +123,7 @@ const Wiki: NextPageWithLayout<{
                   borderColor="gray.300"
                >
                   <Image
-                     sx={{
-                        display: 'none',
-                        // sm breakpoint
-                        '@media (min-width: 576px)': {
-                           display: 'block',
-                        },
-                     }}
+                     sx={imageSx}
                      src={mainImageUrl}
                      onClick={onOpen}
                      cursor="pointer"

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -12,7 +12,6 @@ import {
    Container,
    Flex,
    FlexProps,
-   Hide,
    IconButton,
    Image,
    Link,


### PR DESCRIPTION
Fix the device image showing on first render on mobile on Troubleshooting pages.
Any server-side breakpoints can be incorrect on the first render, causing the image to flash in/out.
Directly adding the media breakpoint with sx fixes this.

Closes: https://github.com/iFixit/ifixit/issues/48975