### PR TITLE
Vulcan: Redirect sitemap for `/Troubleshooting`

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -97,6 +97,11 @@ const moduleExports = {
             permanent: true,
          },
          {
+            source: '/Troubleshooting/sitemap.xml',
+            destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/sitemap/troubleshooting.xml`,
+            permanent: true,
+         },
+         {
             source: '/products/pro-tech-toolkit',
             destination: `${process.env.NEXT_PUBLIC_IFIXIT_ORIGIN}/Store/Tools/Pro-Tech-Toolkit/IF145-307`,
             permanent: false,


### PR DESCRIPTION
We want the troubleshooting sitemap to be visible under the `/Troubleshooting` path. Because we send all traffic for the `/Troubleshooting` path to NextJS, we need to implement the redirect here.

## QA Notes
See the issue for the path that should work.

Closes https://github.com/iFixit/ifixit/issues/48979