### PR TITLE
Vulcan Hreflangs: Get rendering

### DIFF
--- a/frontend/templates/troubleshooting/components/TagManager.tsx
+++ b/frontend/templates/troubleshooting/components/TagManager.tsx
@@ -1,3 +1,4 @@
+import Head from 'next/head';
 import React from 'react';
 
 // This is public so no need to hide.
@@ -74,9 +75,9 @@ function MatomoScript() {
 
 export function TagManager() {
    return (
-      <>
+      <Head>
          <GoogleScript />
          <MatomoScript />
-      </>
+      </Head>
    );
 }

--- a/frontend/templates/troubleshooting/components/TagManager.tsx
+++ b/frontend/templates/troubleshooting/components/TagManager.tsx
@@ -76,8 +76,8 @@ function MatomoScript() {
 export function TagManager() {
    return (
       <Head>
-         <GoogleScript />
-         <MatomoScript />
+         <GoogleScript key="GoogleScript" />
+         <MatomoScript key="MatomoScript" />
       </Head>
    );
 }

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -110,10 +110,8 @@ const Wiki: NextPageWithLayout<{
                flexShrink="1"
                id="main"
             >
-               <Head>
-                  {metadata}
-                  <HreflangUrls urls={wikiData.hreflangUrls} />
-               </Head>
+               <Head>{metadata}</Head>
+               <HreflangUrls urls={wikiData.hreflangUrls} />
                <HStack
                   spacing={0}
                   mt={{ base: 3, sm: 8 }}
@@ -539,11 +537,11 @@ function NavTabs({
 function HreflangUrls({ urls }: { urls: Record<string, string> }) {
    const hreflangs = Object.entries(urls);
    return (
-      <>
+      <Head>
          {hreflangs.map(([lang, url]) => (
             <link rel="alternate" key={lang} hrefLang={lang} href={url} />
          ))}
-      </>
+      </Head>
    );
 }
 

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -100,6 +100,7 @@ const Wiki: NextPageWithLayout<{
                flexShrink="1"
                id="main"
             >
+               <TagManager />
                <Metadata
                   metaDescription={metaDescription}
                   metaKeywords={metaKeywords}
@@ -558,7 +559,6 @@ function Metadata({
          <meta name="keywords" content={metaKeywords} />
          <meta name="robots" content="index, follow" />,
          <link rel="canonical" href={canonicalUrl} />
-         <TagManager />
       </Head>
    );
 }

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -535,7 +535,12 @@ function HreflangUrls({ urls }: { urls: Record<string, string> }) {
    return (
       <Head>
          {hreflangs.map(([lang, url]) => (
-            <link rel="alternate" key={lang} hrefLang={lang} href={url} />
+            <link
+               rel="alternate"
+               key={`hreflang-${lang}`}
+               hrefLang={lang}
+               href={url}
+            />
          ))}
       </Head>
    );
@@ -554,11 +559,15 @@ function Metadata({
 }) {
    return (
       <Head>
-         <meta name="description" content={metaDescription} />
-         <meta name="title" content={title} />
-         <meta name="keywords" content={metaKeywords} />
-         <meta name="robots" content="index, follow" />,
-         <link rel="canonical" href={canonicalUrl} />
+         <meta
+            key="meta-description"
+            name="description"
+            content={metaDescription}
+         />
+         <meta key="meta-title" name="title" content={title} />
+         <meta key="meta-keywords" name="keywords" content={metaKeywords} />
+         <meta key="meta-robots" name="robots" content="index, follow" />,
+         <link key="canonical" rel="canonical" href={canonicalUrl} />
       </Head>
    );
 }

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -74,16 +74,6 @@ const Wiki: NextPageWithLayout<{
    } = wikiData;
    const { isOpen, onOpen, onClose } = useDisclosure();
    const smBreakpoint = useToken('breakpoints', 'sm');
-   const metadata = (
-      <>
-         <meta name="description" content={metaDescription} />
-         <meta name="title" content={title} />
-         <meta name="keywords" content={metaKeywords} />
-         <meta name="robots" content="index, follow" />,
-         <link rel="canonical" href={canonicalUrl} />
-         <TagManager />
-      </>
-   );
 
    const imageSx: any = {
       display: 'none',
@@ -110,7 +100,12 @@ const Wiki: NextPageWithLayout<{
                flexShrink="1"
                id="main"
             >
-               <Head>{metadata}</Head>
+               <Metadata
+                  metaDescription={metaDescription}
+                  metaKeywords={metaKeywords}
+                  canonicalUrl={canonicalUrl}
+                  title={title}
+               />
                <HreflangUrls urls={wikiData.hreflangUrls} />
                <HStack
                   spacing={0}
@@ -541,6 +536,29 @@ function HreflangUrls({ urls }: { urls: Record<string, string> }) {
          {hreflangs.map(([lang, url]) => (
             <link rel="alternate" key={lang} hrefLang={lang} href={url} />
          ))}
+      </Head>
+   );
+}
+
+function Metadata({
+   metaDescription,
+   title,
+   metaKeywords,
+   canonicalUrl,
+}: {
+   metaDescription: string;
+   title: string;
+   metaKeywords: string;
+   canonicalUrl: string;
+}) {
+   return (
+      <Head>
+         <meta name="description" content={metaDescription} />
+         <meta name="title" content={title} />
+         <meta name="keywords" content={metaKeywords} />
+         <meta name="robots" content="index, follow" />,
+         <link rel="canonical" href={canonicalUrl} />
+         <TagManager />
       </Head>
    );
 }

--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -31,6 +31,40 @@ test.describe('Vulcan Page Content and SEO', () => {
       await expect(canonical).toHaveAttribute('href', /^http/);
    });
 
+   test('HrefLangs are rendered', async ({ page }) => {
+      await page.goto(
+         '/Troubleshooting/Television/TV+Has+Sound+But+No+Picture/493422'
+      );
+      const langsToHrefs = [
+         {
+            lang: 'de',
+            href: 'https://de.www.cominor.com/Wiki/TV_Has_Sound_But_No_Picture',
+         },
+         {
+            lang: 'es',
+            href: 'https://es.www.cominor.com/Wiki/TV_Has_Sound_But_No_Picture',
+         },
+         {
+            lang: 'it',
+            href: 'https://it.www.cominor.com/Wiki/TV_Has_Sound_But_No_Picture',
+         },
+         {
+            lang: 'en',
+            href: 'https://www.cominor.com/Troubleshooting/Television/TV+Has+Sound+But+No+Picture/493422',
+         },
+         {
+            lang: 'x-default',
+            href: 'https://www.cominor.com/Troubleshooting/Television/TV+Has+Sound+But+No+Picture/493422',
+         },
+      ];
+
+      langsToHrefs.forEach(async (langToHref) => {
+         const hrefLang = page.locator(`link[hreflang="${langToHref.lang}"]`);
+         await expect(hrefLang).toHaveAttribute('hreflang', langToHref.lang);
+         await expect(hrefLang).toHaveAttribute('href', langToHref.href);
+      });
+   });
+
    test('Redirect to Canonical URL', async ({ page }) => {
       await page.goto('/Vulcan/Dryer_Not_Spinning');
       expect(page.url()).toMatch(/Not.Spinning/);


### PR DESCRIPTION
The hreflangs component was working as expected. The correct links were rendered,
but when viewing the page no links were actually rendered. It ends up we
are running into an edge case in next/head: vercel/next.js#8384

This commit adds a workaround for this issue which was suggested from the
issue mentioned above.

The fix is to invert the usage such that <Head> is used in your component.
Multiple uses of <Head> will be merged together.

Closes: https://github.com/iFixit/ifixit/issues/48856