### PR TITLE
Vulcan: Refactor blockquote styles

### DIFF
--- a/frontend/templates/troubleshooting/prerendered.tsx
+++ b/frontend/templates/troubleshooting/prerendered.tsx
@@ -101,13 +101,11 @@ const renderStyles: SystemStyleObject = {
    },
 
    blockquote: {
-      marginBlock: 5,
-      borderLeftColor: 'gray.200',
-      borderLeftWidth: 1,
-      borderLeftStyle: 'solid',
-      paddingTop: 2,
-      paddingBlock: 0.5,
-      paddingBottom: 3,
+      marginBlock: 6,
+      borderLeft: '1px solid',
+      borderLeftColor: 'gray.300',
+      paddingBlock: '0.25em',
+      paddingInline: '1em',
 
       '&.featured': {
          borderColor: '#fe6f15',


### PR DESCRIPTION
## Issue
Our blockquote styles need some attention. They are really thin, and it's unclear they are a quote without indentation.

## CR/QA
https://me.cominor.com/Troubleshooting/Whirlpool_Refrigerator/Whirlpool+Freezer+Not+Freezing+Ice+Cream/509239

Modified:

- clean up border/padding styles
- increase block padding for clarity
- consistent spacing with other UI page elements

<details>
<summary>Post-fix screenshot</summary>

<img width="1745" alt="Screenshot 2023-07-31 at 5 19 04 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/c75b322f-d6c5-45ef-a715-94e193009809">

</details>


Closes https://github.com/iFixit/ifixit/issues/48985