### PR TITLE
Bump E2E workflow timeout from 15 to 20 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ env:
    npm_config_userconfig: './.npmrc'
 jobs:
    playwright-run:
-      timeout-minutes: 15
+      timeout-minutes: 20
       strategy:
          fail-fast: false
          matrix:


### PR DESCRIPTION
## Description

It looks like we've been barely skirting the 15-minute timeout for a while now, where in some cases the timeout is hit. Let's increase the timeout to 20 minutes to give us a bit more breathing room. https://github.com/iFixit/react-commerce/actions/runs/5741240564/job/15561767476

https://app.datadoghq.com/dashboard/3xd-yax-e2h/github-actions?from_ts=1690993556686&to_ts=1690997156686&live=true
![image](https://github.com/iFixit/react-commerce/assets/22064420/87d3a31b-5385-49c3-ba1d-2ab68f9a75fa)

qa_req 0
