### PR TITLE
Refactor: DisableCacheGets move to cache control middleware

### DIFF
--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -6,25 +6,29 @@ interface CacheControlOptions {
    staleWhileRevalidate: number;
 }
 
-const withCache =
-   (options: CacheControlOptions): GetServerSidePropsMiddleware =>
-   (next) =>
-   (context) => {
-      const maxAgeSeconds = options.sMaxAge / 1000;
-      const staleWhileRevalidateSeconds = options.staleWhileRevalidate / 1000;
-      context.res.setHeader(
-         'Cache-Control',
-         `public, s-maxage=${maxAgeSeconds}, max-age=${maxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`
-      );
+function getCacheString(options: CacheControlOptions) {
+   const maxAgeSeconds = options.sMaxAge / 1000;
+   const staleWhileRevalidateSeconds = options.staleWhileRevalidate / 1000;
+   return `public, s-maxage=${maxAgeSeconds}, max-age=${maxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`;
+}
+
+function withCacheValue(cacheValue: string): GetServerSidePropsMiddleware {
+   return (next) => (context) => {
+      context.res.setHeader('Cache-Control', cacheValue);
       return next(context);
    };
+}
 
-export const withCacheShort = withCacheControl({
-   sMaxAge: Duration(1).second,
-   staleWhileRevalidate: Duration(9).seconds,
-});
+export const withCacheShort = withCacheValue(
+   getCacheString({
+      sMaxAge: Duration(1).second,
+      staleWhileRevalidate: Duration(9).seconds,
+   })
+);
 
-export const withCacheLong = withCacheControl({
-   sMaxAge: Duration(5).minutes,
-   staleWhileRevalidate: Duration(1).day,
-});
+export const withCacheLong = withCacheValue(
+   getCacheString({
+      sMaxAge: Duration(5).minutes,
+      staleWhileRevalidate: Duration(1).day,
+   })
+);

--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -6,7 +6,7 @@ interface CacheControlOptions {
    staleWhileRevalidate: number;
 }
 
-export const withCacheControl =
+const withCache =
    (options: CacheControlOptions): GetServerSidePropsMiddleware =>
    (next) =>
    (context) => {

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -1,5 +1,4 @@
 import { PROD_USER_AGENT } from '@config/constants';
-import { CACHE_DISABLED } from '@config/env';
 import { setSentryPageContext } from '@ifixit/sentry';
 import { withTiming } from '@ifixit/helpers';
 import type { GetServerSidePropsMiddleware } from '@lib/next-middleware';
@@ -18,21 +17,10 @@ export const withLogging: GetServerSidePropsMiddleware = (next) => {
          ...context.params,
          ...context.query,
       });
-      const isCacheDisabled = CACHE_DISABLED || hasDisableCacheGets(context);
-      return next(context)
-         .then((result) => {
-            if (isCacheDisabled) {
-               context.res.setHeader(
-                  'Cache-Control',
-                  'no-store, no-cache, must-revalidate, stale-if-error=0'
-               );
-            }
-            return result;
-         })
-         .catch((err) => {
-            setSentryPageContext(context);
-            throw err;
-         });
+      return next(context).catch((err) => {
+         setSentryPageContext(context);
+         throw err;
+      });
    });
 };
 
@@ -49,7 +37,3 @@ export const withNoindexDevDomains: GetServerSidePropsMiddleware = (next) => {
       return result;
    };
 };
-
-export function hasDisableCacheGets(context: GetServerSidePropsContext) {
-   return context.query.disableCacheGets !== undefined;
-}

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -1,11 +1,10 @@
 import { AppProviders, AppProvidersProps } from '@components/common';
 import { ALGOLIA_PRODUCT_INDEX_NAME, DEFAULT_STORE_CODE } from '@config/env';
-import { withCacheLong } from '@helpers/cache-control-helpers';
 import {
    hasDisableCacheGets,
-   withLogging,
-   withNoindexDevDomains,
-} from '@helpers/next-helpers';
+   withCacheLong,
+} from '@helpers/cache-control-helpers';
+import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import {
    destylizeDeviceItemType,

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -1,10 +1,9 @@
 import { DEFAULT_STORE_CODE } from '@config/env';
-import { withCacheLong } from '@helpers/cache-control-helpers';
 import {
    hasDisableCacheGets,
-   withLogging,
-   withNoindexDevDomains,
-} from '@helpers/next-helpers';
+   withCacheLong,
+} from '@helpers/cache-control-helpers';
+import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { invariant } from '@ifixit/helpers';
 import { urlFromContext } from '@ifixit/helpers/nextjs';


### PR DESCRIPTION
I will want to expand on when the cache is disabled to aid with https://github.com/iFixit/ifixit/issues/48965. However, I noticed the caching behavior was controlled in multiple places. This pull moves the caching to a single middleware.

QA
---

See: https://github.com/iFixit/react-commerce/pull/1882#issuecomment-1664680136