### PR TITLE
Revisionid param: Set to no cache if value is HEAD

### DIFF
--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -30,7 +30,7 @@ export function hasDisableCacheGets(context: GetServerSidePropsContext) {
 }
 
 function getCacheString(options: CacheControlOptions) {
-   if ('disabled' in options && options.disabled) {
+   if ('disabled' in options) {
       return CACHE_CONTROL_DISABLED;
    }
 

--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -30,7 +30,7 @@ export function hasDisableCacheGets(context: GetServerSidePropsContext) {
 }
 
 function getCacheString(options: CacheControlOptions) {
-   if ('forceDisabled' in options && options.forceDisabled) {
+   if ('disabled' in options && options.disabled) {
       return CACHE_CONTROL_DISABLED;
    }
 

--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -16,8 +16,14 @@ export function hasDisableCacheGets(context: GetServerSidePropsContext) {
       return true;
    }
 
-   const disableCacheGets = context.query.disableCacheGets !== undefined;
-   return disableCacheGets;
+   const { disableCacheGets, revisionid } = context.query;
+
+   if (disableCacheGets !== undefined) {
+      return true;
+   }
+
+   const wantsHeadRevision = revisionid?.toString().toUpperCase() === 'HEAD';
+   return wantsHeadRevision;
 }
 
 function getCacheString(options: CacheControlOptions) {

--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -26,14 +26,7 @@ export function hasDisableCacheGets(context: GetServerSidePropsContext) {
       return true;
    }
 
-   const { disableCacheGets, revisionid } = context.query;
-
-   if (disableCacheGets !== undefined) {
-      return true;
-   }
-
-   const wantsHeadRevision = revisionid?.toString().toUpperCase() === 'HEAD';
-   return wantsHeadRevision;
+   return context.query.disableCacheGets !== undefined;
 }
 
 function getCacheString(options: CacheControlOptions) {
@@ -46,7 +39,7 @@ function getCacheString(options: CacheControlOptions) {
    return `public, s-maxage=${maxAgeSeconds}, max-age=${maxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`;
 }
 
-type GetCacheControlOptions = (
+export type GetCacheControlOptions = (
    context: GetServerSidePropsContext
 ) => CacheControlOptions;
 

--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -16,7 +16,7 @@ type CacheControlOptions =
    | EnabledCacheControlOptions
    | DisabledCacheControlOptions;
 
-type withCacheProps = GetCacheControlOptions | CacheControlOptions;
+type WithCacheProps = GetCacheControlOptions | CacheControlOptions;
 
 const CACHE_CONTROL_DISABLED =
    'no-store, no-cache, must-revalidate, stale-if-error=0';
@@ -70,7 +70,7 @@ export const CacheLong: CacheControlOptions = {
    staleWhileRevalidate: Duration(1).day,
 };
 
-export function withCache(props: withCacheProps) {
+export function withCache(props: WithCacheProps) {
    const getCacheControlOptions =
       typeof props === 'function' ? props : () => props;
    return withCacheValue(getCacheControlOptions);

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -1,8 +1,9 @@
 import { AppProviders, AppProvidersProps } from '@components/common';
 import { ALGOLIA_PRODUCT_INDEX_NAME, DEFAULT_STORE_CODE } from '@config/env';
 import {
+   CacheLong,
    hasDisableCacheGets,
-   withCacheLong,
+   withCache,
 } from '@helpers/cache-control-helpers';
 import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
@@ -28,7 +29,7 @@ import { ProductListView } from './ProductListView';
 
 const withMiddleware = compose(
    withLogging<ProductListTemplateProps>,
-   withCacheLong<ProductListTemplateProps>,
+   withCache(CacheLong)<ProductListTemplateProps>,
    withNoindexDevDomains<ProductListTemplateProps>
 );
 

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -1,7 +1,8 @@
 import { DEFAULT_STORE_CODE } from '@config/env';
 import {
+   CacheLong,
    hasDisableCacheGets,
-   withCacheLong,
+   withCache,
 } from '@helpers/cache-control-helpers';
 import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
@@ -15,7 +16,7 @@ import { ProductTemplateProps } from './hooks/useProductTemplateProps';
 
 const withMiddleware = compose(
    withLogging<ProductTemplateProps>,
-   withCacheLong<ProductTemplateProps>,
+   withCache(CacheLong)<ProductTemplateProps>,
    withNoindexDevDomains<ProductTemplateProps>
 );
 

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -13,13 +13,13 @@ import {
    TroubleshootingApiData,
 } from './hooks/useTroubleshootingProps';
 import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
-import { withCacheLong } from '@helpers/cache-control-helpers';
+import { withCache, CacheLong } from '@helpers/cache-control-helpers';
 import compose from 'lodash/flowRight';
 import { ParsedUrlQuery } from 'querystring';
 
 const withMiddleware = compose(
    withLogging<TroubleshootingProps>,
-   withCacheLong<TroubleshootingProps>,
+   withCache(CacheLong)<TroubleshootingProps>,
    withNoindexDevDomains<TroubleshootingProps>
 );
 

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -13,13 +13,28 @@ import {
    TroubleshootingApiData,
 } from './hooks/useTroubleshootingProps';
 import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
-import { withCache, CacheLong } from '@helpers/cache-control-helpers';
+import {
+   withCache,
+   CacheLong,
+   GetCacheControlOptions,
+} from '@helpers/cache-control-helpers';
 import compose from 'lodash/flowRight';
 import { ParsedUrlQuery } from 'querystring';
 
+const CacheOrDisableOnHeadRevision: GetCacheControlOptions = (context) => {
+   const wantsHeadRevision =
+      context.query.revisionid?.toString().toUpperCase() === 'HEAD';
+
+   if (wantsHeadRevision) {
+      return { disabled: true };
+   }
+
+   return CacheLong;
+};
+
 const withMiddleware = compose(
    withLogging<TroubleshootingProps>,
-   withCache(CacheLong)<TroubleshootingProps>,
+   withCache(CacheOrDisableOnHeadRevision)<TroubleshootingProps>,
    withNoindexDevDomains<TroubleshootingProps>
 );
 


### PR DESCRIPTION
This related back to https://github.com/iFixit/ifixit/issues/48965#issue-1823307688

We will want to send editors to this url to bypass vercel's caching
and view the content with the edits immediately.

QA
---

Same as https://github.com/iFixit/react-commerce/pull/1882#issuecomment-1664680136 But ensure `?revisionid=HEAD` also bypasses the cache only on troubleshooting pages

Connects: https://github.com/iFixit/ifixit/issues/48965