### PR TITLE
Troubleshooting: Bypass varnish always

### DIFF
--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -1,6 +1,9 @@
 import { DEFAULT_STORE_CODE } from '@config/env';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
-import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
+import {
+   IFixitAPIClient,
+   VarnishBypassHeader,
+} from '@ifixit/ifixit-api-client';
 import { getLayoutServerSideProps } from '@layouts/default/server';
 import {
    GetServerSideProps,
@@ -51,7 +54,10 @@ async function getTroubleshootingData(
    context: GetServerSidePropsContext<ParsedUrlQuery, PreviewData>
 ): Promise<TroubleshootingApiData | null> {
    const ifixitOrigin = ifixitOriginFromHost(context);
-   const client = new IFixitAPIClient({ origin: ifixitOrigin });
+   const client = new IFixitAPIClient({
+      origin: ifixitOrigin,
+      headers: VarnishBypassHeader,
+   });
 
    const url = getTroubleshootingApiUrl(context);
    if (!url) {

--- a/packages/ifixit-api-client/index.tsx
+++ b/packages/ifixit-api-client/index.tsx
@@ -5,14 +5,21 @@ import * as React from 'react';
 export interface ClientOptions {
    origin: string;
    version?: string;
+   headers?: HeadersInit;
 }
+
+export const VarnishBypassHeader = { 'Nextjs-Bypass-Varnish': '1' };
+
 export class IFixitAPIClient {
    origin: string;
    version: string;
 
+   headers: HeadersInit;
+
    constructor(readonly options: ClientOptions) {
       this.origin = options.origin;
       this.version = options.version ?? '2.0';
+      this.headers = options.headers ?? {};
    }
 
    async get<Data = unknown>(
@@ -65,26 +72,53 @@ export class IFixitAPIClient {
          ? { Authorization: `PSK ${pskToken}` }
          : {};
       const url = `${this.origin}/api/${this.version}/${endpoint}`;
+      const headers = {
+         ...authHeader,
+         ...this.headers,
+         ...init?.headers,
+      };
       const response = await timeAsync(
          `ifixit-api.${init?.method?.toLowerCase() || 'get'}.${statName}`,
          () =>
             fetch(url, {
                credentials: 'include',
                ...init,
-               headers: {
-                  ...authHeader,
-                  ...init?.headers,
-               },
+               headers: headers,
             })
       );
       if (!response.ok) {
          throw new Error(response.statusText);
       }
+
+      warnIfNotBypassed(headers, response);
+
       if (response.headers.get('Content-Type') === 'application/json') {
          return response.json();
       }
       return null;
    }
+}
+
+function warnIfNotBypassed(headers: HeadersInit, response: Response): void {
+   const key = Object.keys(VarnishBypassHeader)[0];
+   const bypassed = headers.hasOwnProperty(key);
+   if (!bypassed) {
+      return;
+   }
+
+   const responseReason = response.headers.get('X-varnish-reason');
+   const responseBypassed = responseReason === 'nextjs_bypass_varnish_header';
+   if (responseBypassed) {
+      return;
+   }
+
+   console.warn(
+      `Varnish bypass requested, but didn't bypass for ${truncate(
+         response.url,
+         100
+      )}!`,
+      `${key}: ${responseReason}`
+   );
 }
 
 /**


### PR DESCRIPTION
This commit adds a header which we will use to bypass varnish

As an added measure I added a nice bit of logging.

QA
---

* Make an edit to a vulcan page
* Visit the page without `?revisionid=HEAD`
* Ensure the latest changes show up

Connects: https://github.com/iFixit/ifixit/issues/48965