### PR TITLE
Prevent errors from being cached

### DIFF
--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -1,7 +1,7 @@
 import { CACHE_DISABLED } from '@config/env';
 import { GetServerSidePropsMiddleware } from '@lib/next-middleware';
 import { Duration } from '../lib/duration';
-import { GetServerSidePropsContext } from 'next';
+import { GetServerSidePropsContext, NextPageContext } from 'next';
 
 interface EnabledCacheControlOptions {
    sMaxAge: number;
@@ -21,7 +21,9 @@ type WithCacheProps = GetCacheControlOptions | CacheControlOptions;
 export const CACHE_CONTROL_DISABLED =
    'no-store, no-cache, must-revalidate, stale-if-error=0';
 
-export function hasDisableCacheGets(context: GetServerSidePropsContext) {
+export function hasDisableCacheGets(
+   context: GetServerSidePropsContext | NextPageContext
+) {
    if (CACHE_DISABLED) {
       return true;
    }
@@ -39,25 +41,51 @@ function getCacheString(options: CacheControlOptions) {
    return `public, s-maxage=${maxAgeSeconds}, max-age=${maxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`;
 }
 
+type ContextType = GetServerSidePropsContext | NextPageContext;
+
 export type GetCacheControlOptions = (
-   context: GetServerSidePropsContext
+   context: ContextType
 ) => CacheControlOptions;
 
 function withCacheValue(
    getCacheControlOptions: GetCacheControlOptions
 ): GetServerSidePropsMiddleware {
    return (next) => (context) => {
-      const isCacheDisabled = hasDisableCacheGets(context);
-
-      const cacheOptions = isCacheDisabled
-         ? ({ disabled: true } as DisabledCacheControlOptions)
-         : getCacheControlOptions(context);
-
-      const cacheHeaderValue = getCacheString(cacheOptions);
-
-      context.res.setHeader('Cache-Control', cacheHeaderValue);
+      setCache(context, getCacheControlOptions);
       return next(context);
    };
+}
+
+function setCache(
+   context: ContextType,
+   getCacheControlOptions: GetCacheControlOptions
+) {
+   const isCacheDisabled = hasDisableCacheGets(context);
+
+   const cacheOptions = isCacheDisabled
+      ? ({ disabled: true } as DisabledCacheControlOptions)
+      : getCacheControlOptions(context);
+
+   const cacheHeaderValue = getCacheString(cacheOptions);
+   context.res?.setHeader('Cache-Control', cacheHeaderValue);
+}
+
+type GetInitialProps<T> = (context: NextPageContext) => Promise<T>;
+
+export function withInitialCacheValue<T>(
+   func: GetInitialProps<T>,
+   props: WithCacheProps
+) {
+   const getCacheControlOptions =
+      typeof props === 'function' ? props : () => props;
+
+   const wrapped = async (context: NextPageContext) => {
+      setCache(context, getCacheControlOptions);
+
+      return func(context);
+   };
+
+   return wrapped;
 }
 
 export const CacheShort: CacheControlOptions = {

--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -18,7 +18,7 @@ type CacheControlOptions =
 
 type WithCacheProps = GetCacheControlOptions | CacheControlOptions;
 
-export const CACHE_CONTROL_DISABLED =
+const CACHE_CONTROL_DISABLED =
    'no-store, no-cache, must-revalidate, stale-if-error=0';
 
 export function hasDisableCacheGets(

--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -73,19 +73,16 @@ function setCache(
 type GetInitialProps<T> = (context: NextPageContext) => Promise<T>;
 
 export function withInitialCacheValue<T>(
-   func: GetInitialProps<T>,
-   props: WithCacheProps
+   props: WithCacheProps,
+   getInitialProps: GetInitialProps<T>
 ) {
    const getCacheControlOptions =
       typeof props === 'function' ? props : () => props;
 
-   const wrapped = async (context: NextPageContext) => {
+   return async (context: NextPageContext) => {
       setCache(context, getCacheControlOptions);
-
-      return func(context);
+      return getInitialProps(context);
    };
-
-   return wrapped;
 }
 
 export const CacheShort: CacheControlOptions = {

--- a/frontend/helpers/cache-control-helpers.ts
+++ b/frontend/helpers/cache-control-helpers.ts
@@ -18,7 +18,7 @@ type CacheControlOptions =
 
 type WithCacheProps = GetCacheControlOptions | CacheControlOptions;
 
-const CACHE_CONTROL_DISABLED =
+export const CACHE_CONTROL_DISABLED =
    'no-store, no-cache, must-revalidate, stale-if-error=0';
 
 export function hasDisableCacheGets(context: GetServerSidePropsContext) {

--- a/frontend/pages/_error.tsx
+++ b/frontend/pages/_error.tsx
@@ -13,6 +13,7 @@
  *  - https://reactjs.org/docs/error-boundaries.html
  */
 
+import { CACHE_CONTROL_DISABLED } from '@helpers/cache-control-helpers';
 import * as Sentry from '@sentry/nextjs';
 import type { NextPage } from 'next';
 import type { ErrorProps } from 'next/error';
@@ -27,6 +28,8 @@ const CustomErrorComponent: NextPage<ErrorProps> = (props) => {
 };
 
 CustomErrorComponent.getInitialProps = async (contextData) => {
+   contextData.res?.setHeader('Cache-Control', CACHE_CONTROL_DISABLED);
+
    // In case this is running in a serverless function, await this in order to give Sentry
    // time to send the error before the lambda exits
    await Sentry.captureUnderscoreErrorException(contextData);

--- a/frontend/pages/_error.tsx
+++ b/frontend/pages/_error.tsx
@@ -27,6 +27,7 @@ const CustomErrorComponent: NextPage<ErrorProps> = (props) => {
 };
 
 CustomErrorComponent.getInitialProps = withInitialCacheValue<ErrorProps>(
+   { disabled: true },
    async (contextData) => {
       // In case this is running in a serverless function, await this in order to give Sentry
       // time to send the error before the lambda exits
@@ -34,8 +35,7 @@ CustomErrorComponent.getInitialProps = withInitialCacheValue<ErrorProps>(
 
       // This will contain the status code of the response
       return NextErrorComponent.getInitialProps(contextData);
-   },
-   { disabled: true }
+   }
 );
 
 export default CustomErrorComponent;


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/49029

This instructs browsers to not cache 404s and 500s. I think it will also tell cloudfront not to cache 404s for static assets. SSR pages shouldn't be cached by cloudfront anymore https://github.com/iFixit/ifixit/pull/49130).

## QA

Make sure errors still get reported to Sentry. You can test this by running the project locally and throwing an error somewhere in the application code.

We could also check any product, product list, or troubleshooting route that 404s on the previews and make sure the correct `Cache-Control` header is set on the response. (I think this will work based on the [docs](https://nextjs.org/docs/pages/building-your-application/routing/custom-error#more-advanced-error-page-customizing), but perhaps we will have to run the project locally in production mode for this to work correctly).

> pages/_error.js is only used in production. In development you’ll get an error with the call stack to know where the error originated from.