### PR TITLE
Remove unused product list image attribute

### DIFF
--- a/frontend/helpers/strapi-helpers.ts
+++ b/frontend/helpers/strapi-helpers.ts
@@ -1,35 +1,3 @@
-import type { UploadFile } from '@lib/strapi-sdk';
-
-export type StrapiImageFormat = 'large' | 'medium' | 'small' | 'thumbnail';
-
-interface Image {
-   url: string;
-   alternativeText: string | null;
-   formats: Record<string, { url: string }>;
-}
-
-export function getImageFromStrapiImage(
-   image: Pick<UploadFile, 'formats' | 'alternativeText' | 'url'>,
-   format?: StrapiImageFormat
-): Image | null {
-   if (image == null) {
-      return null;
-   }
-   const result: Image = {
-      url: `${
-         format && image.formats[format] ? image.formats[format].url : image.url
-      }`,
-      formats: image.formats,
-      alternativeText: null,
-   };
-
-   if (image.alternativeText) {
-      result.alternativeText = image.alternativeText;
-   }
-
-   return result;
-}
-
 export function createSectionId<T extends { __typename: string; id: string }>(
    section: T
 ): string;

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -3030,18 +3030,6 @@ export type FindProductListQuery = {
                   } | null;
                } | null;
             } | null;
-            image?: {
-               __typename?: 'UploadFileEntityResponse';
-               data?: {
-                  __typename?: 'UploadFileEntity';
-                  attributes?: {
-                     __typename?: 'UploadFile';
-                     alternativeText?: string | null;
-                     url: string;
-                     formats?: any | null;
-                  } | null;
-               } | null;
-            } | null;
             brandLogo?: {
                __typename?: 'UploadFileEntityResponse';
                data?: {
@@ -3247,18 +3235,6 @@ export type ProductListFieldsFragment = {
    forceNoindex?: boolean | null;
    brandLogoWidth?: number | null;
    heroImage?: {
-      __typename?: 'UploadFileEntityResponse';
-      data?: {
-         __typename?: 'UploadFileEntity';
-         attributes?: {
-            __typename?: 'UploadFile';
-            alternativeText?: string | null;
-            url: string;
-            formats?: any | null;
-         } | null;
-      } | null;
-   } | null;
-   image?: {
       __typename?: 'UploadFileEntityResponse';
       data?: {
          __typename?: 'UploadFileEntity';
@@ -4985,9 +4961,6 @@ export const ProductListFieldsFragmentDoc = `
   filters
   forceNoindex
   heroImage {
-    ...ImageFields
-  }
-  image {
     ...ImageFields
   }
   brandLogo {

--- a/frontend/lib/strapi-sdk/operations/findProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/findProductList.graphql
@@ -29,9 +29,6 @@ fragment ProductListFields on ProductList {
    heroImage {
       ...ImageFields
    }
-   image {
-      ...ImageFields
-   }
    brandLogo {
       ...ImageFields
    }

--- a/frontend/models/components/image.ts
+++ b/frontend/models/components/image.ts
@@ -1,6 +1,7 @@
 import type { ImageFieldsFragment } from '@lib/strapi-sdk';
 import type { ImageFieldsFragment as ShopifyImageFields } from '@lib/shopify-storefront-sdk';
 import { z } from 'zod';
+import type { DeviceWiki } from '@lib/ifixit-api/devices';
 
 export const ImageSchema = z.object({
    id: z.string().nullable().optional(),
@@ -58,4 +59,20 @@ export function imageFromShopify(
       width: imageFragment.width,
       url: imageFragment.url,
    };
+}
+
+export function childImageFromDeviceWiki(
+   deviceWiki: DeviceWiki,
+   childDeviceTitle: string
+): Image | null {
+   const child = deviceWiki.children?.find(
+      (c: any) => c.title === childDeviceTitle
+   );
+   if (child?.image?.original) {
+      return {
+         url: child.image.original,
+         altText: null,
+      };
+   }
+   return null;
 }

--- a/frontend/models/product-list/component/product-list-child.ts
+++ b/frontend/models/product-list/component/product-list-child.ts
@@ -1,0 +1,14 @@
+import { ImageSchema } from '@models/components/image';
+import { z } from 'zod';
+import { ProductListTypeSchema } from './product-list-type';
+
+export type ProductListChild = z.infer<typeof ProductListChildSchema>;
+
+export const ProductListChildSchema = z.object({
+   title: z.string(),
+   deviceTitle: z.string().nullable(),
+   handle: z.string(),
+   image: ImageSchema.nullable(),
+   sortPriority: z.number().nullable(),
+   type: ProductListTypeSchema,
+});

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -99,7 +99,6 @@ export async function findProductList(
       filters: productList?.filters ?? null,
       forceNoindex: productList?.forceNoindex ?? null,
       heroImage: imageFromStrapi(productList?.heroImage),
-      image: null,
       brandLogo: imageFromStrapi(productList?.brandLogo, {
          format: 'large',
          width: productList?.brandLogoWidth,

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -106,7 +106,6 @@ const BaseProductListSchema = z.object({
    filters: z.string().nullable(),
    forceNoindex: z.boolean().nullable(),
    heroImage: ImageSchema.nullable(),
-   image: ProductListImageSchema.nullable(),
    brandLogo: ImageSchema.nullable(),
    ancestors: z.array(ProductListAncestorSchema),
    children: z.array(ProductListChildSchema),

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -1,10 +1,8 @@
 import { ImageSchema } from '@models/components/image';
 import { z } from 'zod';
 import { ProductListAncestorSchema } from './component/product-list-ancestor';
-import {
-   ProductListType,
-   ProductListTypeSchema,
-} from './component/product-list-type';
+import { ProductListChildSchema } from './component/product-list-child';
+import { ProductListType } from './component/product-list-type';
 import { ProductListSectionSchema } from './sections';
 
 const PriceTierSchema = z.object({
@@ -44,22 +42,6 @@ const WikiInfoEntrySchema = z.object({
    inheritedFrom: z.string().nullable(),
 });
 export type WikiInfoEntry = z.infer<typeof WikiInfoEntrySchema>;
-
-const ProductListImageSchema = z.object({
-   alternativeText: z.string().nullable(),
-   url: z.string(),
-});
-export type ProductListImage = z.infer<typeof ProductListImageSchema>;
-
-const ProductListChildSchema = z.object({
-   title: z.string(),
-   deviceTitle: z.string().nullable(),
-   handle: z.string(),
-   image: ProductListImageSchema.nullable(),
-   sortPriority: z.number().nullable(),
-   type: ProductListTypeSchema,
-});
-export type ProductListChild = z.infer<typeof ProductListChildSchema>;
 
 const ProductListItemTypeOverrideSchema = z.object({
    itemType: z.string().nullable().optional(),

--- a/frontend/templates/product-list/MetaTags.tsx
+++ b/frontend/templates/product-list/MetaTags.tsx
@@ -44,8 +44,8 @@ export function MetaTags({ productList }: MetaTagsProps) {
          )}
          <meta property="og:type" content="website" />
          <meta property="og:url" content={canonicalUrl} />
-         {productList.image?.url && (
-            <meta property="og:image" content={productList.image.url} />
+         {productList.heroImage?.url && (
+            <meta property="og:image" content={productList.heroImage.url} />
          )}
          <script {...structuredData} />
       </Head>

--- a/frontend/tests/playwright/fixtures/strapi-mocked-queries.ts
+++ b/frontend/tests/playwright/fixtures/strapi-mocked-queries.ts
@@ -24,9 +24,6 @@ export const getProductListMock: FindProductListQuery = {
                heroImage: {
                   data: null,
                },
-               image: {
-                  data: null,
-               },
                brandLogo: {
                   data: null,
                },


### PR DESCRIPTION
closes #1892 

On top of addressing #1892 this PR standardize a couple of images that were not being handled by the image model schema

## QA

1. Open a [product list preview](https://react-commerce-git-remove-unused-product-list-ima-c93abc-ifixit.vercel.app/Parts)
2. Verify that child device images are still being rendered