### PR TITLE
Tests: Unskip parts-page-navigation.spec.ts

### DIFF
--- a/frontend/tests/playwright/product-list/parts-page-navigation.spec.ts
+++ b/frontend/tests/playwright/product-list/parts-page-navigation.spec.ts
@@ -5,7 +5,7 @@ test.describe('Parts Page Navigation', () => {
       await page.goto('/Parts');
    });
 
-   test.skip('Navigate Through All Device Pages', async ({ page }) => {
+   test('Navigate Through All Device Pages', async ({ page }) => {
       const viewPort = page.viewportSize();
 
       await expect(


### PR DESCRIPTION
## Summary
Previously in CI, and react-commerce vercel deployments, some of the titles and headings on the product list pages were not showing up. 

https://github.com/iFixit/react-commerce/pull/1848 fixed the issue, so we're unskipping the test.

## QA notes
1. Make sure the `parts-page-navigation` CI is passing in CI.
2. Make sure the headings on product list pages are showing up in the vercel deployments, see the examples from [here](https://github.com/iFixit/react-commerce/issues/1844#issuecomment-1646255972). 

closes #1844