### PR TITLE
Vulcan: Change "Ask a question" button text to "Browse our forum"

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -731,7 +731,7 @@ function AnswersCTA({ answersUrl }: { answersUrl: string }) {
             Haven&apos;t found the solution to your problem?
          </chakra.span>
          <Button href={answersUrl} as="a" colorScheme="brand">
-            Ask a question
+            Browse our forum
          </Button>
       </Alert>
    );


### PR DESCRIPTION
Change the text on the button linking to Answers from "Ask a question" to "Browse our forum".

Context: https://github.com/iFixit/ifixit/issues/49125#issuecomment-1668521038

Closes: https://github.com/iFixit/ifixit/issues/49181

