### PR TITLE
iFixit API: Force no caching

### DIFF
--- a/packages/ifixit-api-client/index.tsx
+++ b/packages/ifixit-api-client/index.tsx
@@ -85,7 +85,7 @@ export class IFixitAPIClient {
                credentials: 'include',
                ...init,
                headers: headers,
-               cache: 'no-cache',
+               cache: 'no-store',
             })
       );
       if (!response.ok) {

--- a/packages/ifixit-api-client/index.tsx
+++ b/packages/ifixit-api-client/index.tsx
@@ -85,6 +85,7 @@ export class IFixitAPIClient {
                credentials: 'include',
                ...init,
                headers: headers,
+               cache: 'no-cache',
             })
       );
       if (!response.ok) {


### PR DESCRIPTION
OMG Next overrides fetch and defaults to caching:
https://nextjs.org/docs/app/api-reference/functions/fetch

Worst of all, they drop many of the configuration values.

As far as Danny and I could tell we would want the mdn value of "default" but Next does not support this value.

We basically get "on or off" and "For how long?" as a global cache even between deployments on vercel.

Lastly we may need to discuss overriding fetch globally in next to avoid this problem in other places.

CC @danielbeardsley 