### PR TITLE
Robots Header: Stop no-indexing in prod

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -3,7 +3,7 @@ import { setSentryPageContext } from '@ifixit/sentry';
 import { withTiming } from '@ifixit/helpers';
 import type { GetServerSidePropsMiddleware } from '@lib/next-middleware';
 import * as Sentry from '@sentry/nextjs';
-import { GetServerSidePropsContext, NextPageContext } from 'next';
+import { GetServerSidePropsContext } from 'next';
 
 export const withLogging: GetServerSidePropsMiddleware = (next) => {
    return withTiming(`server_side_props`, async (context) => {

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -60,4 +60,6 @@ export function noindexDevDomains(context: ContextType) {
    if (context.req.headers['user-agent'] !== PROD_USER_AGENT) {
       // return RestrictRobots.RESTRICT_ALL;
    }
+
+   return undefined;
 }

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -58,6 +58,6 @@ function maybeSetRobotsHeader(
 
 export function noindexDevDomains(context: ContextType) {
    if (context.req.headers['user-agent'] !== PROD_USER_AGENT) {
-      return RestrictRobots.RESTRICT_ALL;
+      // return RestrictRobots.RESTRICT_ALL;
    }
 }

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -5,7 +5,11 @@ import {
    hasDisableCacheGets,
    withCache,
 } from '@helpers/cache-control-helpers';
-import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
+import {
+   noindexDevDomains,
+   withLogging,
+   withRobotsHeader,
+} from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import {
    destylizeDeviceItemType,
@@ -30,7 +34,7 @@ import { ProductListView } from './ProductListView';
 const withMiddleware = compose(
    withLogging<ProductListTemplateProps>,
    withCache(CacheLong)<ProductListTemplateProps>,
-   withNoindexDevDomains<ProductListTemplateProps>
+   withRobotsHeader(noindexDevDomains)<ProductListTemplateProps>
 );
 
 type GetProductListServerSidePropsOptions = {

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -4,7 +4,11 @@ import {
    hasDisableCacheGets,
    withCache,
 } from '@helpers/cache-control-helpers';
-import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
+import {
+   withLogging,
+   withRobotsHeader,
+   noindexDevDomains,
+} from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { invariant } from '@ifixit/helpers';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
@@ -17,7 +21,7 @@ import { ProductTemplateProps } from './hooks/useProductTemplateProps';
 const withMiddleware = compose(
    withLogging<ProductTemplateProps>,
    withCache(CacheLong)<ProductTemplateProps>,
-   withNoindexDevDomains<ProductTemplateProps>
+   withRobotsHeader(noindexDevDomains)<ProductTemplateProps>
 );
 
 export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -15,7 +15,11 @@ import {
    TroubleshootingData,
    TroubleshootingApiData,
 } from './hooks/useTroubleshootingProps';
-import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
+import {
+   noindexDevDomains,
+   withLogging,
+   withRobotsHeader,
+} from '@helpers/next-helpers';
 import {
    withCache,
    CacheLong,
@@ -38,7 +42,7 @@ const CacheOrDisableOnHeadRevision: GetCacheControlOptions = (context) => {
 const withMiddleware = compose(
    withLogging<TroubleshootingProps>,
    withCache(CacheOrDisableOnHeadRevision)<TroubleshootingProps>,
-   withNoindexDevDomains<TroubleshootingProps>
+   withRobotsHeader(noindexDevDomains)<TroubleshootingProps>
 );
 
 function rethrowUnless404(e: any) {


### PR DESCRIPTION
We think the recent proxying change that sends *all* client headers through to the origin may have resulted in the user-agent no longer being `Amazon Cloudfront`. Thus we are now no-indexing all of prod :-(