### PR TITLE
No Index: re-add for all non-cloudfront requests

### DIFF
--- a/frontend/config/constants.ts
+++ b/frontend/config/constants.ts
@@ -1,6 +1,5 @@
 export const PRODUCT_LIST_PAGE_PARAM = 'p';
 export const PRODUCT_LIST_QUERY_PARAM = 'q';
 export const DEFAULT_ANIMATION_DURATION_MS = 300;
-export const PROD_USER_AGENT = 'Amazon CloudFront';
 export const PRODUCT_LIST_MAX_FACET_VALUES_COUNT = 200;
 export const PRODUCT_LIST_DEFAULT_FACET_VALUES_COUNT = 10;

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -57,9 +57,11 @@ function maybeSetRobotsHeader(
 }
 
 export function noindexDevDomains(context: ContextType) {
-   if (context.req.headers['user-agent'] !== PROD_USER_AGENT) {
-      // return RestrictRobots.RESTRICT_ALL;
+   if (!requestFromCloudfront(context)) {
+      return RestrictRobots.RESTRICT_ALL;
    }
+}
 
-   return undefined;
+export function requestFromCloudfront(context: ContextType) {
+   return !!context.req.headers['x-amz-cf-id'];
 }

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -1,9 +1,10 @@
-import { PROD_USER_AGENT } from '@config/constants';
 import { setSentryPageContext } from '@ifixit/sentry';
 import { withTiming } from '@ifixit/helpers';
 import type { GetServerSidePropsMiddleware } from '@lib/next-middleware';
 import * as Sentry from '@sentry/nextjs';
 import { GetServerSidePropsContext } from 'next';
+
+const headerAlwaysAddedByCloudfront = 'x-amz-cf-id';
 
 export const withLogging: GetServerSidePropsMiddleware = (next) => {
    return withTiming(`server_side_props`, async (context) => {
@@ -63,5 +64,5 @@ export function noindexDevDomains(context: ContextType) {
 }
 
 export function requestFromCloudfront(context: ContextType) {
-   return !!context.req.headers['x-amz-cf-id'];
+   return !!context.req.headers[headerAlwaysAddedByCloudfront];
 }


### PR DESCRIPTION
Recently we foudn that we were no-indexing *everything* from next.js accidentally. We quickly removed that entirely:
(https://github.com/iFixit/react-commerce/pull/1901)

Now we re-add the fixed functionality.

Specifically, we want to no-index all responses that come from requests that *are not* being proxied through cloudfront. In other words, we only want www.ifixit.com/* responses to be indexed.

In the case of Troubleshooting pages, this directive conflicts with the html metatag but we've found evidence that google will listen tot he more restricive directive (noindex in this case).