### PR TITLE
noindex all responses

### DIFF
--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -2,7 +2,6 @@ import { setSentryPageContext } from '@ifixit/sentry';
 import { withTiming } from '@ifixit/helpers';
 import type { GetServerSidePropsMiddleware } from '@lib/next-middleware';
 import * as Sentry from '@sentry/nextjs';
-import { GetServerSidePropsContext } from 'next';
 
 export const withLogging: GetServerSidePropsMiddleware = (next) => {
    return withTiming(`server_side_props`, async (context) => {

--- a/frontend/helpers/next-helpers.ts
+++ b/frontend/helpers/next-helpers.ts
@@ -4,8 +4,6 @@ import type { GetServerSidePropsMiddleware } from '@lib/next-middleware';
 import * as Sentry from '@sentry/nextjs';
 import { GetServerSidePropsContext } from 'next';
 
-const headerAlwaysAddedByCloudfront = 'x-amz-cf-id';
-
 export const withLogging: GetServerSidePropsMiddleware = (next) => {
    return withTiming(`server_side_props`, async (context) => {
       console.log('context.resolvedUrl', context.resolvedUrl);
@@ -25,44 +23,9 @@ export const withLogging: GetServerSidePropsMiddleware = (next) => {
    });
 };
 
-type ContextType = GetServerSidePropsContext;
-
-export type GetRestrictRobots = (
-   context: GetServerSidePropsContext
-) => RestrictRobots | undefined;
-
-enum RestrictRobots {
+export enum RestrictRobots {
    RESTRICT_ALL = 'noindex, nofollow, nosnippet, noarchive, noimageindex',
    RESTRICT_INDEXING = 'noindex, follow, nosnippet, noarchive, noimageindex',
    RESTRICT_FOLLOWING = 'index, nofollow',
    ALLOW_ALL = 'index, follow',
-}
-
-export function withRobotsHeader(
-   getRestrictRobots: GetRestrictRobots
-): GetServerSidePropsMiddleware {
-   return (next) => (context) => {
-      maybeSetRobotsHeader(context, getRestrictRobots);
-      return next(context);
-   };
-}
-
-function maybeSetRobotsHeader(
-   context: ContextType,
-   maybeGetRestrictRobots: GetRestrictRobots
-) {
-   const restrictRobots = maybeGetRestrictRobots(context);
-   if (restrictRobots) {
-      context.res?.setHeader('X-Robots-Tag', restrictRobots);
-   }
-}
-
-export function noindexDevDomains(context: ContextType) {
-   if (!requestFromCloudfront(context)) {
-      return RestrictRobots.RESTRICT_ALL;
-   }
-}
-
-export function requestFromCloudfront(context: ContextType) {
-   return !!context.req.headers[headerAlwaysAddedByCloudfront];
 }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -59,6 +59,23 @@ const moduleExports = {
    env: {
       NEXT_PUBLIC_STRAPI_ORIGIN: strapiOrigin,
    },
+   async headers() {
+      return [
+         {
+            // Nnoindex all responses. Requests to www.ifixit.com that go
+            // through cloudfront will have this header stripped off by a
+            // cloudfront function. This effectively noindexes all vercel urls
+            // that our pages are served from.
+            source: '/:path*',
+            headers: [
+               {
+                  key: 'x-robots-tag',
+                  value: 'noindex, nofollow, nosnippet, noarchive, noimageindex',
+               },
+            ],
+         },
+      ];
+   },
    async rewrites() {
       return [
          {

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -5,11 +5,7 @@ import {
    hasDisableCacheGets,
    withCache,
 } from '@helpers/cache-control-helpers';
-import {
-   noindexDevDomains,
-   withLogging,
-   withRobotsHeader,
-} from '@helpers/next-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import {
    destylizeDeviceItemType,
@@ -33,8 +29,7 @@ import { ProductListView } from './ProductListView';
 
 const withMiddleware = compose(
    withLogging<ProductListTemplateProps>,
-   withCache(CacheLong)<ProductListTemplateProps>,
-   withRobotsHeader(noindexDevDomains)<ProductListTemplateProps>
+   withCache(CacheLong)<ProductListTemplateProps>
 );
 
 type GetProductListServerSidePropsOptions = {

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -4,11 +4,7 @@ import {
    hasDisableCacheGets,
    withCache,
 } from '@helpers/cache-control-helpers';
-import {
-   withLogging,
-   withRobotsHeader,
-   noindexDevDomains,
-} from '@helpers/next-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { invariant } from '@ifixit/helpers';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
@@ -20,8 +16,7 @@ import { ProductTemplateProps } from './hooks/useProductTemplateProps';
 
 const withMiddleware = compose(
    withLogging<ProductTemplateProps>,
-   withCache(CacheLong)<ProductTemplateProps>,
-   withRobotsHeader(noindexDevDomains)<ProductTemplateProps>
+   withCache(CacheLong)<ProductTemplateProps>
 );
 
 export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -15,11 +15,7 @@ import {
    TroubleshootingData,
    TroubleshootingApiData,
 } from './hooks/useTroubleshootingProps';
-import {
-   noindexDevDomains,
-   withLogging,
-   withRobotsHeader,
-} from '@helpers/next-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import {
    withCache,
    CacheLong,
@@ -41,8 +37,7 @@ const CacheOrDisableOnHeadRevision: GetCacheControlOptions = (context) => {
 
 const withMiddleware = compose(
    withLogging<TroubleshootingProps>,
-   withCache(CacheOrDisableOnHeadRevision)<TroubleshootingProps>,
-   withRobotsHeader(noindexDevDomains)<TroubleshootingProps>
+   withCache(CacheOrDisableOnHeadRevision)<TroubleshootingProps>
 );
 
 function rethrowUnless404(e: any) {


### PR DESCRIPTION
@jarstelfox and I discovered this while testing something else and came up with this solution.

The short of it is, since vercel caches responses based on url only (seemingly), we can't have it changing the response based on a header. Currently, we have code here to add a "X-Robots-Tag: noindex" header if there are Cloudfront headers on a request. This works some of the time but we end up caching (and serving) responses generated for the same url, but different sets of headers.

Effectively, the requests from CF and the the requests directly to https://react-commerce-prod.vercel.app share an http cache in vercels CDN. Because of this, we need to not change our vercel responses based on headers as they aren't part of the cache key.

The most straightforward way to disallow indexing on all requests except for those coming through CF is to always add the no-index directive and expicitly have CF remove it from all responses it deals with.

See https://github.com/iFixit/ifixit/pull/49259