### PR TITLE
Add generated types

### DIFF
--- a/frontend/codegen/config.ts
+++ b/frontend/codegen/config.ts
@@ -28,6 +28,15 @@ const config: CodegenConfig = {
          config: {
             importFrom: './sdk',
             schema: 'zod',
+            scalarSchemas: {
+               JSON: 'z.unknown()',
+               DateTime: 'z.unknown()',
+               MenuItemsDynamicZoneInput: 'z.unknown()',
+               PageSectionsDynamicZoneInput: 'z.unknown()',
+               ProductSectionsDynamicZoneInput: 'z.unknown()',
+               ProductListItemOverridesDynamicZoneInput: 'z.unknown()',
+               ProductListSectionsDynamicZoneInput: 'z.unknown()',
+            },
          },
       },
       'lib/shopify-storefront-sdk/generated/sdk.ts': {

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -109,6 +109,7 @@ export type BooleanFilterInput = {
    lt?: InputMaybe<Scalars['Boolean']>;
    lte?: InputMaybe<Scalars['Boolean']>;
    ne?: InputMaybe<Scalars['Boolean']>;
+   nei?: InputMaybe<Scalars['Boolean']>;
    not?: InputMaybe<BooleanFilterInput>;
    notContains?: InputMaybe<Scalars['Boolean']>;
    notContainsi?: InputMaybe<Scalars['Boolean']>;
@@ -659,6 +660,7 @@ export type DateTimeFilterInput = {
    lt?: InputMaybe<Scalars['DateTime']>;
    lte?: InputMaybe<Scalars['DateTime']>;
    ne?: InputMaybe<Scalars['DateTime']>;
+   nei?: InputMaybe<Scalars['DateTime']>;
    not?: InputMaybe<DateTimeFilterInput>;
    notContains?: InputMaybe<Scalars['DateTime']>;
    notContainsi?: InputMaybe<Scalars['DateTime']>;
@@ -770,6 +772,7 @@ export type FloatFilterInput = {
    lt?: InputMaybe<Scalars['Float']>;
    lte?: InputMaybe<Scalars['Float']>;
    ne?: InputMaybe<Scalars['Float']>;
+   nei?: InputMaybe<Scalars['Float']>;
    not?: InputMaybe<FloatFilterInput>;
    notContains?: InputMaybe<Scalars['Float']>;
    notContainsi?: InputMaybe<Scalars['Float']>;
@@ -921,6 +924,7 @@ export type IdFilterInput = {
    lt?: InputMaybe<Scalars['ID']>;
    lte?: InputMaybe<Scalars['ID']>;
    ne?: InputMaybe<Scalars['ID']>;
+   nei?: InputMaybe<Scalars['ID']>;
    not?: InputMaybe<IdFilterInput>;
    notContains?: InputMaybe<Scalars['ID']>;
    notContainsi?: InputMaybe<Scalars['ID']>;
@@ -945,6 +949,7 @@ export type IntFilterInput = {
    lt?: InputMaybe<Scalars['Int']>;
    lte?: InputMaybe<Scalars['Int']>;
    ne?: InputMaybe<Scalars['Int']>;
+   nei?: InputMaybe<Scalars['Int']>;
    not?: InputMaybe<IntFilterInput>;
    notContains?: InputMaybe<Scalars['Int']>;
    notContainsi?: InputMaybe<Scalars['Int']>;
@@ -969,6 +974,7 @@ export type JsonFilterInput = {
    lt?: InputMaybe<Scalars['JSON']>;
    lte?: InputMaybe<Scalars['JSON']>;
    ne?: InputMaybe<Scalars['JSON']>;
+   nei?: InputMaybe<Scalars['JSON']>;
    not?: InputMaybe<JsonFilterInput>;
    notContains?: InputMaybe<Scalars['JSON']>;
    notContainsi?: InputMaybe<Scalars['JSON']>;
@@ -2012,6 +2018,7 @@ export type StringFilterInput = {
    lt?: InputMaybe<Scalars['String']>;
    lte?: InputMaybe<Scalars['String']>;
    ne?: InputMaybe<Scalars['String']>;
+   nei?: InputMaybe<Scalars['String']>;
    not?: InputMaybe<StringFilterInput>;
    notContains?: InputMaybe<Scalars['String']>;
    notContainsi?: InputMaybe<Scalars['String']>;

--- a/frontend/lib/strapi-sdk/generated/validation.ts
+++ b/frontend/lib/strapi-sdk/generated/validation.ts
@@ -110,7 +110,7 @@ export function BannerInputSchema(): z.ZodObject<Properties<BannerInput>> {
       description: z.string().nullish(),
       image: z.string().nullish(),
       label: z.string().nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
+      publishedAt: z.unknown().nullish(),
       title: z.string().nullish(),
    });
 }
@@ -132,6 +132,7 @@ export function BooleanFilterInputSchema(): z.ZodObject<
       lt: z.boolean().nullish(),
       lte: z.boolean().nullish(),
       ne: z.boolean().nullish(),
+      nei: z.boolean().nullish(),
       not: z.lazy(() => BooleanFilterInputSchema().nullish()),
       notContains: z.boolean().nullish(),
       notContainsi: z.boolean().nullish(),
@@ -166,7 +167,7 @@ export function CompanyInputSchema(): z.ZodObject<Properties<CompanyInput>> {
    return z.object<Properties<CompanyInput>>({
       logo: z.string().nullish(),
       name: z.string().nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
+      publishedAt: z.unknown().nullish(),
    });
 }
 
@@ -474,27 +475,28 @@ export function DateTimeFilterInputSchema(): z.ZodObject<
    Properties<DateTimeFilterInput>
 > {
    return z.object<Properties<DateTimeFilterInput>>({
-      and: z.array(definedNonNullAnySchema.nullable()).nullish(),
-      between: z.array(definedNonNullAnySchema.nullable()).nullish(),
-      contains: definedNonNullAnySchema.nullish(),
-      containsi: definedNonNullAnySchema.nullish(),
-      endsWith: definedNonNullAnySchema.nullish(),
-      eq: definedNonNullAnySchema.nullish(),
-      eqi: definedNonNullAnySchema.nullish(),
-      gt: definedNonNullAnySchema.nullish(),
-      gte: definedNonNullAnySchema.nullish(),
-      in: z.array(definedNonNullAnySchema.nullable()).nullish(),
-      lt: definedNonNullAnySchema.nullish(),
-      lte: definedNonNullAnySchema.nullish(),
-      ne: definedNonNullAnySchema.nullish(),
+      and: z.array(z.unknown().nullable()).nullish(),
+      between: z.array(z.unknown().nullable()).nullish(),
+      contains: z.unknown().nullish(),
+      containsi: z.unknown().nullish(),
+      endsWith: z.unknown().nullish(),
+      eq: z.unknown().nullish(),
+      eqi: z.unknown().nullish(),
+      gt: z.unknown().nullish(),
+      gte: z.unknown().nullish(),
+      in: z.array(z.unknown().nullable()).nullish(),
+      lt: z.unknown().nullish(),
+      lte: z.unknown().nullish(),
+      ne: z.unknown().nullish(),
+      nei: z.unknown().nullish(),
       not: z.lazy(() => DateTimeFilterInputSchema().nullish()),
-      notContains: definedNonNullAnySchema.nullish(),
-      notContainsi: definedNonNullAnySchema.nullish(),
-      notIn: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      notContains: z.unknown().nullish(),
+      notContainsi: z.unknown().nullish(),
+      notIn: z.array(z.unknown().nullable()).nullish(),
       notNull: z.boolean().nullish(),
       null: z.boolean().nullish(),
-      or: z.array(definedNonNullAnySchema.nullable()).nullish(),
-      startsWith: definedNonNullAnySchema.nullish(),
+      or: z.array(z.unknown().nullable()).nullish(),
+      startsWith: z.unknown().nullish(),
    });
 }
 
@@ -527,7 +529,7 @@ export function FaqFiltersInputSchema(): z.ZodObject<
 export function FaqInputSchema(): z.ZodObject<Properties<FaqInput>> {
    return z.object<Properties<FaqInput>>({
       answer: z.string().nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
+      publishedAt: z.unknown().nullish(),
       question: z.string().nullish(),
    });
 }
@@ -557,6 +559,7 @@ export function FloatFilterInputSchema(): z.ZodObject<
       lt: z.number().nullish(),
       lte: z.number().nullish(),
       ne: z.number().nullish(),
+      nei: z.number().nullish(),
       not: z.lazy(() => FloatFilterInputSchema().nullish()),
       notContains: z.number().nullish(),
       notContainsi: z.number().nullish(),
@@ -573,7 +576,7 @@ export function GlobalInputSchema(): z.ZodObject<Properties<GlobalInput>> {
       newsletterForm: z.lazy(() =>
          ComponentGlobalNewsletterFormInputSchema().nullish()
       ),
-      publishedAt: definedNonNullAnySchema.nullish(),
+      publishedAt: z.unknown().nullish(),
    });
 }
 
@@ -611,6 +614,7 @@ export function IdFilterInputSchema(): z.ZodObject<Properties<IdFilterInput>> {
       lt: z.string().nullish(),
       lte: z.string().nullish(),
       ne: z.string().nullish(),
+      nei: z.string().nullish(),
       not: z.lazy(() => IdFilterInputSchema().nullish()),
       notContains: z.string().nullish(),
       notContainsi: z.string().nullish(),
@@ -639,6 +643,7 @@ export function IntFilterInputSchema(): z.ZodObject<
       lt: z.number().nullish(),
       lte: z.number().nullish(),
       ne: z.number().nullish(),
+      nei: z.number().nullish(),
       not: z.lazy(() => IntFilterInputSchema().nullish()),
       notContains: z.number().nullish(),
       notContainsi: z.number().nullish(),
@@ -654,27 +659,28 @@ export function JsonFilterInputSchema(): z.ZodObject<
    Properties<JsonFilterInput>
 > {
    return z.object<Properties<JsonFilterInput>>({
-      and: z.array(definedNonNullAnySchema.nullable()).nullish(),
-      between: z.array(definedNonNullAnySchema.nullable()).nullish(),
-      contains: definedNonNullAnySchema.nullish(),
-      containsi: definedNonNullAnySchema.nullish(),
-      endsWith: definedNonNullAnySchema.nullish(),
-      eq: definedNonNullAnySchema.nullish(),
-      eqi: definedNonNullAnySchema.nullish(),
-      gt: definedNonNullAnySchema.nullish(),
-      gte: definedNonNullAnySchema.nullish(),
-      in: z.array(definedNonNullAnySchema.nullable()).nullish(),
-      lt: definedNonNullAnySchema.nullish(),
-      lte: definedNonNullAnySchema.nullish(),
-      ne: definedNonNullAnySchema.nullish(),
+      and: z.array(z.unknown().nullable()).nullish(),
+      between: z.array(z.unknown().nullable()).nullish(),
+      contains: z.unknown().nullish(),
+      containsi: z.unknown().nullish(),
+      endsWith: z.unknown().nullish(),
+      eq: z.unknown().nullish(),
+      eqi: z.unknown().nullish(),
+      gt: z.unknown().nullish(),
+      gte: z.unknown().nullish(),
+      in: z.array(z.unknown().nullable()).nullish(),
+      lt: z.unknown().nullish(),
+      lte: z.unknown().nullish(),
+      ne: z.unknown().nullish(),
+      nei: z.unknown().nullish(),
       not: z.lazy(() => JsonFilterInputSchema().nullish()),
-      notContains: definedNonNullAnySchema.nullish(),
-      notContainsi: definedNonNullAnySchema.nullish(),
-      notIn: z.array(definedNonNullAnySchema.nullable()).nullish(),
+      notContains: z.unknown().nullish(),
+      notContainsi: z.unknown().nullish(),
+      notIn: z.array(z.unknown().nullable()).nullish(),
       notNull: z.boolean().nullish(),
       null: z.boolean().nullish(),
-      or: z.array(definedNonNullAnySchema.nullable()).nullish(),
-      startsWith: definedNonNullAnySchema.nullish(),
+      or: z.array(z.unknown().nullable()).nullish(),
+      startsWith: z.unknown().nullish(),
    });
 }
 
@@ -697,8 +703,8 @@ export function MenuFiltersInputSchema(): z.ZodObject<
 
 export function MenuInputSchema(): z.ZodObject<Properties<MenuInput>> {
    return z.object<Properties<MenuInput>>({
-      items: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
+      items: z.array(z.lazy(() => z.unknown())).nullish(),
+      publishedAt: z.unknown().nullish(),
       title: z.string().nullish(),
    });
 }
@@ -724,8 +730,8 @@ export function PageFiltersInputSchema(): z.ZodObject<
 export function PageInputSchema(): z.ZodObject<Properties<PageInput>> {
    return z.object<Properties<PageInput>>({
       path: z.string().nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
-      sections: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
+      publishedAt: z.unknown().nullish(),
+      sections: z.array(z.lazy(() => z.unknown())).nullish(),
       title: z.string().nullish(),
    });
 }
@@ -761,8 +767,8 @@ export function ProductFiltersInputSchema(): z.ZodObject<
 export function ProductInputSchema(): z.ZodObject<Properties<ProductInput>> {
    return z.object<Properties<ProductInput>>({
       handle: z.string().nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
-      sections: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
+      publishedAt: z.unknown().nullish(),
+      sections: z.array(z.lazy(() => z.unknown())).nullish(),
    });
 }
 
@@ -824,14 +830,14 @@ export function ProductListInputSchema(): z.ZodObject<
       heroImage: z.string().nullish(),
       hideFromParent: z.boolean().nullish(),
       image: z.string().nullish(),
-      itemOverrides: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
+      itemOverrides: z.array(z.lazy(() => z.unknown())).nullish(),
       legacyDescription: z.string().nullish(),
       legacyPageId: z.number().nullish(),
       metaDescription: z.string().nullish(),
       metaTitle: z.string().nullish(),
       parent: z.string().nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
-      sections: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
+      publishedAt: z.unknown().nullish(),
+      sections: z.array(z.lazy(() => z.unknown())).nullish(),
       sortPriority: z.number().nullish(),
       tagline: z.string().nullish(),
       title: z.string().nullish(),
@@ -868,7 +874,7 @@ export function SocialPostInputSchema(): z.ZodObject<
    return z.object<Properties<SocialPostInput>>({
       author: z.string().nullish(),
       image: z.string().nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
+      publishedAt: z.unknown().nullish(),
       title: z.string().nullish(),
       url: z.string().nullish(),
    });
@@ -909,7 +915,7 @@ export function StoreInputSchema(): z.ZodObject<Properties<StoreInput>> {
       footer: z.lazy(() => ComponentStoreFooterInputSchema().nullish()),
       header: z.lazy(() => ComponentStoreHeaderInputSchema().nullish()),
       name: z.string().nullish(),
-      publishedAt: definedNonNullAnySchema.nullish(),
+      publishedAt: z.unknown().nullish(),
       shopifySettings: z.lazy(() =>
          ComponentStoreShopifySettingsInputSchema().nullish()
       ),
@@ -937,6 +943,7 @@ export function StringFilterInputSchema(): z.ZodObject<
       lt: z.string().nullish(),
       lte: z.string().nullish(),
       ne: z.string().nullish(),
+      nei: z.string().nullish(),
       not: z.lazy(() => StringFilterInputSchema().nullish()),
       notContains: z.string().nullish(),
       notContainsi: z.string().nullish(),
@@ -990,14 +997,14 @@ export function UploadFileInputSchema(): z.ZodObject<
       ext: z.string().nullish(),
       folder: z.string().nullish(),
       folderPath: z.string().nullish(),
-      formats: definedNonNullAnySchema.nullish(),
+      formats: z.unknown().nullish(),
       hash: z.string().nullish(),
       height: z.number().nullish(),
       mime: z.string().nullish(),
       name: z.string().nullish(),
       previewUrl: z.string().nullish(),
       provider: z.string().nullish(),
-      provider_metadata: definedNonNullAnySchema.nullish(),
+      provider_metadata: z.unknown().nullish(),
       size: z.number().nullish(),
       url: z.string().nullish(),
       width: z.number().nullish(),


### PR DESCRIPTION
In #1869 we upgraded Strapi and apparently some slight api changes have been introduced that trigger the sdk code generation. 

This quick PR is to push these changes into the repo. I've also taken the chance to declare zod schema for unhandled scalars so the next dev cli will not keep showing warnings about unhandled scalars. I'm using `z.unknown()` to preserve the current behaviour.

qa_req 0