### PR TITLE
React-commerce: Update jobs page link

### DIFF
--- a/frontend/lib/links.tsx
+++ b/frontend/lib/links.tsx
@@ -14,7 +14,7 @@ const links = {
    ABOUT_US: 'https://www.ifixit.com/Info/index',
    NEWSLETTER: 'https://www.ifixit.com/Newsletter',
    HELP: 'https://help.ifixit.com/',
-   CAREERS: 'https://www.ifixit.com/Info/jobs',
+   CAREERS: 'https://www.ifixit.com/about-us/careers',
    FEEDBACK: 'https://meta.ifixit.com/',
    API: 'https://www.ifixit.com/api/2.0/doc',
    PRESS: 'https://www.ifixit.com/Info/Media',

--- a/frontend/tests/jest/__mocks__/useProductTemplateProps.tsx
+++ b/frontend/tests/jest/__mocks__/useProductTemplateProps.tsx
@@ -301,7 +301,7 @@ export const mockedLayoutProps: Pick<ProductTemplateProps, 'layoutProps'> = {
                   {
                      type: MenuItemType.Link,
                      name: 'Careers',
-                     url: 'https://www.ifixit.com/Info/jobs',
+                     url: 'https://www.ifixit.com/about-us/careers',
                      description: null,
                   },
                   {


### PR DESCRIPTION
## Overview
We are now using a valkyrie page with a new url. This updates the two places in react-commerce code where we link to the jobs page.

## QA
Qa_req 0 - The `links.CAREERS` link is currently unused in react-commerce. The other change is with tests.

Closes https://github.com/iFixit/ifixit/issues/49218 (Part 2 of 2)