### PR TITLE
HeroSection: Show tagline and description on page 2+ with image

### DIFF
--- a/frontend/templates/product-list/sections/HeroSection.tsx
+++ b/frontend/templates/product-list/sections/HeroSection.tsx
@@ -127,7 +127,7 @@ function HeroTitle({
    children,
    page,
 }: React.PropsWithChildren<{ page: number }>) {
-   // Non-breaking spaces added for all spaces in ` - Page <num>`
+   // Place non-breaking space between 'Page' and page number
    return (
       <Heading
          as="h1"
@@ -137,7 +137,15 @@ function HeroTitle({
          data-testid="hero-title"
       >
          {children}
-         {page > 1 ? ` - Page ${page}` : ''}
+         {page > 1 ? (
+            <>
+               {' - Page'}
+               <span dangerouslySetInnerHTML={{ __html: '&nbsp;' }} />
+               {page}
+            </>
+         ) : (
+            ''
+         )}
       </Heading>
    );
 }

--- a/frontend/templates/product-list/sections/HeroSection.tsx
+++ b/frontend/templates/product-list/sections/HeroSection.tsx
@@ -127,6 +127,7 @@ function HeroTitle({
    children,
    page,
 }: React.PropsWithChildren<{ page: number }>) {
+   // Non-breaking spaces added for all spaces in ` - Page <num>`
    return (
       <Heading
          as="h1"
@@ -136,7 +137,7 @@ function HeroTitle({
          data-testid="hero-title"
       >
          {children}
-         {page > 1 ? ` - Page ${page}` : ''}
+         {page > 1 ? ` - Page ${page}` : ''}
       </Heading>
    );
 }

--- a/frontend/templates/product-list/sections/HeroSection.tsx
+++ b/frontend/templates/product-list/sections/HeroSection.tsx
@@ -82,23 +82,19 @@ export function HeroSection({
                      />
                   )}
                   <HeroTitle page={page}>{title}</HeroTitle>
-                  {isFirstPage && (
-                     <>
-                        {isPresent(tagline) && (
-                           <Text
-                              as="h2"
-                              fontWeight="medium"
-                              data-testid="hero-tagline"
-                           >
-                              {tagline}
-                           </Text>
-                        )}
-                        {isPresent(description) && (
-                           <DescriptionRichText mt="4">
-                              {description}
-                           </DescriptionRichText>
-                        )}
-                     </>
+                  {isPresent(tagline) && (
+                     <Text
+                        as="h2"
+                        fontWeight="medium"
+                        data-testid="hero-tagline"
+                     >
+                        {tagline}
+                     </Text>
+                  )}
+                  {isPresent(description) && (
+                     <DescriptionRichText mt="4">
+                        {description}
+                     </DescriptionRichText>
                   )}
                </Flex>
             </Flex>


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/48955

This change includes:
- Shows the Hero tagline and description on pages 2+ when a backgroundImage is also shown
- If there isn't a backgroundImage, Hero tagline and description won't be shown on pages 2+
- Using non-breaking spaces between the ` - Page <num>`

