### PR TITLE
Get Edit Review Links To Link Directly To Review

### DIFF
--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -223,7 +223,8 @@ function ProductReviewLineItem({ review }: ProductReviewLineItemProps) {
    const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
    const appContext = useAppContext();
 
-   const reviewItemCode = getItemCodeFromSku(review.sku);
+   const sku = review.sku ?? '';
+   const reviewItemCode = getItemCodeFromSku(sku);
    return (
       <Box
          py="6"
@@ -231,7 +232,7 @@ function ProductReviewLineItem({ review }: ProductReviewLineItemProps) {
          borderColor="gray.200"
          data-testid="product-review-line-item"
       >
-         {isAdminUser && (
+         {isAdminUser && sku && (
             <Button
                variant="link"
                as={Link}

--- a/frontend/templates/product/sections/ProductReviewsSection/index.tsx
+++ b/frontend/templates/product/sections/ProductReviewsSection/index.tsx
@@ -19,7 +19,7 @@ import { Rating } from '@components/ui';
 import { faStar } from '@fortawesome/pro-duotone-svg-icons';
 import { faPenToSquare, faShieldCheck } from '@fortawesome/pro-solid-svg-icons';
 import { useAppContext } from '@ifixit/app';
-import { isPresent } from '@ifixit/helpers';
+import { isPresent, getItemCodeFromSku } from '@ifixit/helpers';
 import { FaIcon } from '@ifixit/icons';
 import { Wrapper } from '@ifixit/ui';
 import type { Product, ProductVariant } from '@models/product';
@@ -223,6 +223,7 @@ function ProductReviewLineItem({ review }: ProductReviewLineItemProps) {
    const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
    const appContext = useAppContext();
 
+   const reviewItemCode = getItemCodeFromSku(review.sku);
    return (
       <Box
          py="6"
@@ -243,7 +244,7 @@ function ProductReviewLineItem({ review }: ProductReviewLineItemProps) {
                color="brand.500"
                textAlign="center"
                paddingBottom="10px"
-               href={`${appContext.ifixitOrigin}/User/Reviews/${review.sku}?userid=${review.author?.userid}`}
+               href={`${appContext.ifixitOrigin}/User/Reviews/${reviewItemCode}?userid=${review.author?.userid}`}
             >
                Edit
             </Button>

--- a/packages/helpers/product-helpers.ts
+++ b/packages/helpers/product-helpers.ts
@@ -22,6 +22,10 @@ export function getProductVariantSku(itemcode: string): string {
    return itemcode.replace(/\D/g, '');
 }
 
+export function getItemCodeFromSku(sku: string): string {
+   return `IF${sku.replace(/(.{3})/g, '$1-')}`;
+}
+
 export function parseItemcode(itemcode: string) {
    let matches = itemcode.match(ITEMCODE_RE);
    return matches


### PR DESCRIPTION
## Overview

We weren't using the whole sku just the itemcode in the link. This meant that the links weren't working as intended. We now use the full sku in the links to link directly to the desired review.

## QA

Do reviews `edit` links for admins now directly link to the review?

Closes: #1500 