### PR TITLE
Product page: Fix compatibility notes count

### DIFF
--- a/frontend/lib/ifixit-api/productData.ts
+++ b/frontend/lib/ifixit-api/productData.ts
@@ -5,7 +5,7 @@ export type ProductDataApiResponse = {
    variantOptions: {
       [o_code: string]: string[];
    };
-   compatibilityNotes: string;
+   compatibilityNotes: string | string[];
 };
 
 export async function fetchProductData(

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -72,7 +72,7 @@ export const ProductSchema = z.object({
    productVideos: z.string().nullable(),
    productVideosJson: ProductVideosSchema.nullable(),
    compatibility: ProductDeviceCompatibilitySchema.nullable(),
-   compatibilityNotes: z.string().nullable(),
+   compatibilityNotes: z.union([z.string(), z.array(z.string())]).nullable(),
    metaTitle: z.string().nullable(),
    shortDescription: z.string().nullable(),
    reviews: ProductReviewsSchema.nullable(),

--- a/frontend/templates/product/sections/CompatibilityNotesSection/index.tsx
+++ b/frontend/templates/product/sections/CompatibilityNotesSection/index.tsx
@@ -11,12 +11,15 @@ const MAX_DEFAULT_VISIBLE_DEVICES = 10;
 export function splitCompatibilityNotes({
    compatibilityNotes,
 }: CompatibilityNotesSectionProps) {
-   let devices = compatibilityNotes?.trim().split(/\r?\n/) ?? [];
-   devices = devices.map((device) => device.trim()).filter(Boolean);
-   const visibleDevices = devices
-      .slice(0, MAX_DEFAULT_VISIBLE_DEVICES)
-      .join(', ');
-   const hiddenDevices = devices.slice(MAX_DEFAULT_VISIBLE_DEVICES).join(', ');
+   let devices;
+   if (Array.isArray(compatibilityNotes)) {
+      devices = compatibilityNotes;
+   } else {
+      devices = compatibilityNotes?.trim().split(/\r?\n/) ?? [];
+      devices = devices.map((device) => device.trim()).filter(Boolean);
+   }
+   const visibleDevices = devices.slice(0, MAX_DEFAULT_VISIBLE_DEVICES);
+   const hiddenDevices = devices.slice(MAX_DEFAULT_VISIBLE_DEVICES);
    return [visibleDevices, hiddenDevices];
 }
 
@@ -40,14 +43,12 @@ export function CompatibilityNotesSection({
                Compatibility Notes
             </Heading>
             <Box p={2}>
-               {'Compatible with: ' + visibleDevices}
+               {`Compatible with: ${visibleDevices.join(', ')}`}
                {hiddenDevices && (
                   <Box p={2}>
                      <details>
-                        <summary>
-                           {'Show ' + hiddenDevices.length + ' more'}
-                        </summary>
-                        <Box>{hiddenDevices}</Box>
+                        <summary>{`Show ${hiddenDevices.length} more`}</summary>
+                        <Box>{hiddenDevices.join(', ')}</Box>
                      </details>
                   </Box>
                )}

--- a/frontend/templates/product/sections/ProductOverviewSection/CompatibilityNotes.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/CompatibilityNotes.tsx
@@ -20,7 +20,7 @@ export function CompatibilityNotes({ product }: CompatibilityNotesProps) {
    });
    return (
       <Box px={2}>
-         <Box pb={5}>{visibleDevices}</Box>
+         <Box pb={5}>{visibleDevices.join(', ')}</Box>
          <AccordionItem hidden={!hiddenDevices.length}>
             <AccordionButton py="5" px="1.5">
                <Box
@@ -30,11 +30,11 @@ export function CompatibilityNotes({ product }: CompatibilityNotesProps) {
                   fontWeight="semibold"
                   fontSize="sm"
                >
-                  {'Show ' + hiddenDevices.length + ' more'}
+                  {`Show ${hiddenDevices.length} more`}
                </Box>
                <AccordionIcon />
             </AccordionButton>
-            <AccordionPanel p={2}>{hiddenDevices}</AccordionPanel>
+            <AccordionPanel p={2}>{hiddenDevices.join(', ')}</AccordionPanel>
          </AccordionItem>
       </Box>
    );


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/49081

Fixes the product page to show the count of compatible devices instead of the count of the characters.

Also adds support for receiving a list of devices from the api, instead of a string of devices delimited by newlines. I'd like to make an API change to use this data format so we don't have to do parsing on the frontend.

## QA

Visit https://www.cominor.com/products/ice-bucket-assembly-da97-14504c

(cominor api url https://www.cominor.com/api/2.0/store/product/ice-bucket-assembly-da97-14504c)

The text should say 297 more devices, not 5773.

![image](https://github.com/iFixit/react-commerce/assets/52104630/2963fe8a-208e-454b-a719-07c4f96b004f)

![image](https://github.com/iFixit/react-commerce/assets/52104630/b7852eca-3c1c-43de-aa2f-ac7a811eb610)
