### PR TITLE
Product page: Compatibility notes api update

### DIFF
--- a/frontend/lib/ifixit-api/productData.ts
+++ b/frontend/lib/ifixit-api/productData.ts
@@ -5,7 +5,7 @@ export type ProductDataApiResponse = {
    variantOptions: {
       [o_code: string]: string[];
    };
-   compatibilityNotes: string | string[];
+   compatibilityNotes: string[];
 };
 
 export async function fetchProductData(

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -72,7 +72,7 @@ export const ProductSchema = z.object({
    productVideos: z.string().nullable(),
    productVideosJson: ProductVideosSchema.nullable(),
    compatibility: ProductDeviceCompatibilitySchema.nullable(),
-   compatibilityNotes: z.union([z.string(), z.array(z.string())]).nullable(),
+   compatibilityNotes: z.array(z.string()).nullable(),
    metaTitle: z.string().nullable(),
    shortDescription: z.string().nullable(),
    reviews: ProductReviewsSchema.nullable(),

--- a/frontend/templates/product/sections/CompatibilityNotesSection/index.tsx
+++ b/frontend/templates/product/sections/CompatibilityNotesSection/index.tsx
@@ -1,34 +1,17 @@
 import { Box, Heading } from '@chakra-ui/react';
 import { Wrapper } from '@ifixit/ui';
-import type { Product } from '@pages/api/nextjs/cache/product';
 
 export type CompatibilityNotesSectionProps = {
-   compatibilityNotes?: Product['compatibilityNotes'];
+   compatibilityNotes: string[];
 };
 
-const MAX_DEFAULT_VISIBLE_DEVICES = 10;
-
-export function splitCompatibilityNotes({
-   compatibilityNotes,
-}: CompatibilityNotesSectionProps) {
-   let devices;
-   if (Array.isArray(compatibilityNotes)) {
-      devices = compatibilityNotes;
-   } else {
-      devices = compatibilityNotes?.trim().split(/\r?\n/) ?? [];
-      devices = devices.map((device) => device.trim()).filter(Boolean);
-   }
-   const visibleDevices = devices.slice(0, MAX_DEFAULT_VISIBLE_DEVICES);
-   const hiddenDevices = devices.slice(MAX_DEFAULT_VISIBLE_DEVICES);
-   return [visibleDevices, hiddenDevices];
-}
+export const MAX_VISIBLE_DEVICES = 10;
 
 export function CompatibilityNotesSection({
    compatibilityNotes,
 }: CompatibilityNotesSectionProps) {
-   const [visibleDevices, hiddenDevices] = splitCompatibilityNotes({
-      compatibilityNotes,
-   });
+   const visibleDevices = compatibilityNotes.slice(0, MAX_VISIBLE_DEVICES);
+   const hiddenDevices = compatibilityNotes.slice(MAX_VISIBLE_DEVICES);
    return compatibilityNotes && visibleDevices.length > 0 ? (
       <Box as="section" id="compatibility" py="16" fontSize="sm">
          <Wrapper>

--- a/frontend/templates/product/sections/ProductOverviewSection/CompatibilityNotes.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/CompatibilityNotes.tsx
@@ -5,19 +5,17 @@ import {
    AccordionPanel,
    Box,
 } from '@chakra-ui/react';
-import type { Product } from '@pages/api/nextjs/cache/product';
-import React from 'react';
-import { splitCompatibilityNotes } from '../CompatibilityNotesSection';
+import { MAX_VISIBLE_DEVICES } from '../CompatibilityNotesSection';
 
 export type CompatibilityNotesProps = {
-   product: Product;
+   compatibilityNotes: string[];
 };
 
-export function CompatibilityNotes({ product }: CompatibilityNotesProps) {
-   const compatibilityNotes = product.compatibilityNotes;
-   const [visibleDevices, hiddenDevices] = splitCompatibilityNotes({
-      compatibilityNotes,
-   });
+export function CompatibilityNotes({
+   compatibilityNotes,
+}: CompatibilityNotesProps) {
+   const visibleDevices = compatibilityNotes.slice(0, MAX_VISIBLE_DEVICES);
+   const hiddenDevices = compatibilityNotes.slice(MAX_VISIBLE_DEVICES);
    return (
       <Box px={2}>
          <Box pb={5}>{visibleDevices.join(', ')}</Box>

--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -225,7 +225,9 @@ export function ProductOverviewSection({
                               Compatibility Notes
                            </CustomAccordionButton>
                            <CustomAccordionPanel data-testid="product-compatibility-dropdown">
-                              <CompatibilityNotes product={product} />
+                              <CompatibilityNotes
+                                 compatibilityNotes={product.compatibilityNotes}
+                              />
                            </CustomAccordionPanel>
                         </>
                      ) : (


### PR DESCRIPTION
Connects https://github.com/iFixit/ifixit/issues/49081

Now that the iFixit product api only returns an array of compatibility note device strings, we can narrow our types.

## QA

Make sure the compatibility notes section works the same as on `main`.

Here is a product that has compatibility notes: https://www.cominor.com/products/ice-bucket-assembly-da97-14504c

There are many products without them