### PR TITLE
FAQ fix: Render markdown

### DIFF
--- a/frontend/components/sections/FAQsSection.tsx
+++ b/frontend/components/sections/FAQsSection.tsx
@@ -2,16 +2,16 @@ import {
    Accordion,
    AccordionButton,
    AccordionItem,
-   AccordionItemProps,
    AccordionPanel,
    Box,
-   forwardRef,
 } from '@chakra-ui/react';
 import { faMinusCircle, faPlusCircle } from '@fortawesome/pro-solid-svg-icons';
+import { markdownToHTML } from '@helpers/ui-helpers';
 import { isPresent } from '@ifixit/helpers';
 import { FaIcon } from '@ifixit/icons';
 import { Wrapper } from '@ifixit/ui';
 import type { FAQ } from '@models/components/faq';
+import { useMemo } from 'react';
 import { SectionDescription } from './SectionDescription';
 import { SectionHeading } from './SectionHeading';
 
@@ -53,49 +53,7 @@ export function FAQsSection({
                   )}
                </Box>
                <Accordion defaultIndex={[0]} allowMultiple>
-                  {faqs.map((faq, index) => {
-                     return (
-                        <FAQAccordionItem key={index}>
-                           {({ isExpanded }) => {
-                              return (
-                                 <>
-                                    <h3>
-                                       <AccordionButton p="4">
-                                          <Box
-                                             flex="1"
-                                             textAlign="left"
-                                             fontWeight="medium"
-                                             color={
-                                                isExpanded
-                                                   ? 'brand.500'
-                                                   : 'gray.900'
-                                             }
-                                          >
-                                             {faq.question}
-                                          </Box>
-                                          <FaIcon
-                                             icon={
-                                                isExpanded
-                                                   ? faMinusCircle
-                                                   : faPlusCircle
-                                             }
-                                             color="gray.400"
-                                          />
-                                       </AccordionButton>
-                                    </h3>
-                                    <AccordionPanel
-                                       pb="5"
-                                       color="gray.700"
-                                       bg="white"
-                                    >
-                                       {faq.answer}
-                                    </AccordionPanel>
-                                 </>
-                              );
-                           }}
-                        </FAQAccordionItem>
-                     );
-                  })}
+                  {faqs.map((faq, index) => FAQAccordionItem({ faq, index }))}
                </Accordion>
             </Box>
          </Wrapper>
@@ -103,17 +61,44 @@ export function FAQsSection({
    );
 }
 
-const FAQAccordionItem = forwardRef<AccordionItemProps, 'div'>((props, ref) => {
+function FAQAccordionItem({ faq, index }: { faq: FAQ; index: number }) {
+   const answerHtml = useMemo(() => markdownToHTML(faq.answer), [faq.answer]);
    return (
       <AccordionItem
-         ref={ref}
+         key={index}
          borderWidth="1px"
          borderColor="gray.300"
          bg="gray.100"
          rounded="md"
          my="4"
          overflow="hidden"
-         {...props}
-      />
+      >
+         {({ isExpanded }) => (
+            <>
+               <h3>
+                  <AccordionButton p="4">
+                     <Box
+                        flex="1"
+                        textAlign="left"
+                        fontWeight="medium"
+                        color={isExpanded ? 'brand.500' : 'gray.900'}
+                     >
+                        {faq.question}
+                     </Box>
+                     <FaIcon
+                        icon={isExpanded ? faMinusCircle : faPlusCircle}
+                        color="gray.400"
+                     />
+                  </AccordionButton>
+               </h3>
+               <AccordionPanel
+                  pb="5"
+                  color="gray.700"
+                  bg="white"
+                  dangerouslySetInnerHTML={{ __html: answerHtml }}
+               />
+            </>
+         )}
+      </AccordionItem>
    );
-});
+}

--- a/frontend/helpers/ui-helpers.ts
+++ b/frontend/helpers/ui-helpers.ts
@@ -1,0 +1,6 @@
+import snarkdown from 'snarkdown';
+
+export function markdownToHTML(markdown: string): string {
+   const preserveNewlines = markdown.trim().replace(/\n/g, '<br />');
+   return snarkdown(preserveNewlines);
+}

--- a/frontend/templates/product-list/sections/HeroSection.tsx
+++ b/frontend/templates/product-list/sections/HeroSection.tsx
@@ -10,12 +10,12 @@ import {
    useDisclosure,
 } from '@chakra-ui/react';
 import { DEFAULT_ANIMATION_DURATION_MS } from '@config/constants';
+import { markdownToHTML } from '@helpers/ui-helpers';
 import { isPresent } from '@ifixit/helpers';
 import { ResponsiveImage, useIsMounted, Wrapper } from '@ifixit/ui';
 import type { Image } from '@models/components/image';
 import * as React from 'react';
 import { usePagination } from 'react-instantsearch-hooks-web';
-import snarkdown from 'snarkdown';
 
 export interface HeroSectionProps {
    title: string;
@@ -200,10 +200,7 @@ type DescriptionRichTextProps = Omit<BoxProps, 'children'> & {
 
 const DescriptionRichText = forwardRef<DescriptionRichTextProps, 'div'>(
    ({ children, ...other }, ref) => {
-      const html = React.useMemo(() => {
-         const preserveNewlines = children.trim().replace(/\n/g, '<br />');
-         return snarkdown(preserveNewlines);
-      }, [children]);
+      const html = React.useMemo(() => markdownToHTML(children), [children]);
 
       return (
          <Box


### PR DESCRIPTION
Slack conversation: https://ifixit.slack.com/archives/C01GMQXJC95/p1692141525169339

This change correctly renders markdown from Strapi FAQ answers on featured product pages.

## Bundle size diff

snarkdown is about 1kb and we import it on the product page in this change, so the +1kb bundle size diff on product pages makes sense.

## QA

Add some markdown syntax to a strapi faq on https://product-page-faq-markdown.govinor.com/admin/content-manager/collectionType/api::faq.faq

Link the faq to a featured product on https://product-page-faq-markdown.govinor.com/admin/content-manager/collectionType/api::product.product

When you visit the featured product page on this preview, you should notice that the markdown text is rendered correctly when the appropriate faq is expanded.