### PR TITLE
Only show compatibility notes when length > 0

### DIFF
--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -185,7 +185,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                      );
                   }
                   case 'DeviceCompatibility':
-                     return product.compatibilityNotes ? (
+                     return product.compatibilityNotes?.length ? (
                         <CompatibilityNotesSection
                            key={section.id}
                            compatibilityNotes={product.compatibilityNotes}

--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -219,7 +219,7 @@ export function ProductOverviewSection({
                         product.compatibility.devices.length <= 0
                      }
                   >
-                     {product.compatibilityNotes ? (
+                     {product.compatibilityNotes?.length ? (
                         <>
                            <CustomAccordionButton>
                               Compatibility Notes


### PR DESCRIPTION
We were always showing compatibility notes, even when empty.

This shows as an empty compatibility notes section on any product where compatibility notes isn't set, like most of them.

https://www.ifixit.com/products/iphone-x-replacement-battery

![image](https://github.com/iFixit/react-commerce/assets/589425/b6c426c4-d72d-4ceb-a115-4a28c4401337)

Connects https://github.com/iFixit/ifixit/issues/49081
