### PR TITLE
Tests: Drop Firefox from playwright projects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,7 @@ jobs:
       strategy:
          fail-fast: false
          matrix:
-            project:
-               [
-                  'Desktop Chrome',
-                  'Desktop Firefox',
-                  'Mobile Chrome',
-                  'Tablet Chrome',
-               ]
+            project: ['Desktop Chrome', 'Mobile Chrome', 'Tablet Chrome']
       runs-on: ubuntu-latest
       steps:
          - name: Checkout

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -74,13 +74,6 @@ const config: PlaywrightTestConfig = {
             ...devices['Desktop Chrome'],
          },
       }),
-      generateBrowserConfig({
-         name: 'Desktop Firefox',
-         use: {
-            ...devices['Desktop Firefox'],
-         },
-      }),
-
       /* Test against mobile viewports. */
       generateBrowserConfig({
          name: 'Mobile Chrome',
@@ -94,20 +87,6 @@ const config: PlaywrightTestConfig = {
             ...devices['Galaxy Tab S4'],
          },
       }),
-
-      /* Test against branded browsers. */
-      // {
-      //   name: 'Microsoft Edge',
-      //   use: {
-      //     channel: 'msedge',
-      //   },
-      // },
-      // {
-      //   name: 'Google Chrome',
-      //   use: {
-      //     channel: 'chrome',
-      //   },
-      // },
    ],
 
    /* Folder for test artifacts such as screenshots, videos, traces, etc. */


### PR DESCRIPTION
## Summary
Drops `Firefox` from the playwright projects list.

Playwright tests running on `Firefox` take the longest time and usually cause
timeout which leads to failing CI. `Firefox` has been historically slower than `Chrome`
and only `~3.4%` of our users use Firefox, see https://github.com/iFixit/react-commerce/issues/1871#issuecomment-1684389877. 

## QA
- `Desktop Firefox` should no longer be part of `E2E` CI checks. 
- Passing is enough. 

connects #1871 