### PR TITLE
Productlist Fix: Only show tools on `/Tools/*`

### DIFF
--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -129,17 +129,27 @@ export const getProductListServerSideProps = ({
 
             productList = await timeAsync('findProductList', () =>
                ProductListCache.get(
-                  { filters: { handle: { eqi: handle } }, ifixitOrigin },
+                  {
+                     filters: {
+                        handle: { eqi: handle },
+                        type: { in: ['marketing', 'tools'] },
+                     },
+                     ifixitOrigin,
+                  },
                   cacheOptions
                )
             );
 
-            shouldRedirectToCanonical =
+            const isMarketing = productList?.type === ProductListType.Marketing;
+            const isMiscapitalized =
                typeof productList?.handle === 'string' &&
                productList.handle !== handle;
+            shouldRedirectToCanonical = isMiscapitalized || isMarketing;
             canonicalPath =
                typeof productList?.handle === 'string'
-                  ? `/Tools/${productList.handle}`
+                  ? isMarketing
+                     ? `/Shop/${productList.handle}`
+                     : `/Tools/${productList.handle}`
                   : null;
 
             break;
@@ -155,12 +165,8 @@ export const getProductListServerSideProps = ({
                ProductListCache.get(
                   {
                      filters: {
-                        handle: {
-                           eqi: handle,
-                        },
-                        type: {
-                           eq: 'marketing',
-                        },
+                        handle: { eqi: handle },
+                        type: { eq: 'marketing' },
                      },
                      ifixitOrigin,
                   },


### PR DESCRIPTION
Closes #1911

Fixes a bug where any kind of strapi product list could be viewed on /Tools/*

Slack conversation: https://ifixit.slack.com/archives/C02KMFEHX62/p1691797628050609

## QA

Marketing pages should no longer be viewable on tools urls. For example, `/Shop/Sale` should still exist, but `/Tools/Sale` should now permanently redirect to `/Shop/Sale`. All existing marketing product lists can be viewed in Strapi:

![image](https://github.com/iFixit/react-commerce/assets/52104630/7fb3427f-5e51-4fb2-8cf3-6e0d6e93d6b8)

Additionally, `/Tools/[handle]` should no longer render a page for any valid strapi handle (unless the handle belongs to a tools category or marketing Strapi product list). For example, `/Tools/camera`, `Tools/Parts`, and `/Tools/Tools` should now all 404.