### PR TITLE
Minicart: Use retail discount from api

### DIFF
--- a/packages/cart-sdk/hooks/use-cart.ts
+++ b/packages/cart-sdk/hooks/use-cart.ts
@@ -37,8 +37,8 @@ function isValidCartPayload(data: any): data is CartAPIResponse {
 function createCart(input: APICart): Cart {
    const lineItems = input.products.map<CartLineItem>((product) => {
       const priceAmount = parseFloat(product.subPrice);
-      const singleItemDiscount = product.discount
-         ? parseFloat(product.discount)
+      const singleItemDiscount = product.retailDiscount
+         ? parseFloat(product.retailDiscount)
          : 0;
       const price: Money = {
          amount: priceAmount,

--- a/packages/cart-sdk/types.ts
+++ b/packages/cart-sdk/types.ts
@@ -92,6 +92,7 @@ export interface APICartProduct {
    maxToAdd: number;
    name: string;
    quantity: number;
+   retailDiscount: string;
    subPrice: string;
    subPriceStr: string;
    subTotal: string;


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/45708

The retail discount is a new field that factors in the retail (aka compare at) price when it is set, otherwise it is the same as the `discount` field.

## QA

Test all combinations of discounts and make sure that the Next.js product page, the Next.js cart drawer, and checkout all align with each other (except for employee discounts, which only appear in checkout).

You can edit a product in akeneo.cominor.com to change it's price and retail (aka "compare at") price, as well as price tier overrides. Default pro percent off discounts are defined in `ifixit_cart.customer_discounts`, and apply to products when "Reseller Discount" is enabled in Akeneo.