### PR TITLE
Add bulk FAQs assignment

### DIFF
--- a/frontend/components/sections/FAQsSection.tsx
+++ b/frontend/components/sections/FAQsSection.tsx
@@ -15,12 +15,13 @@ import { useMemo } from 'react';
 import { SectionDescription } from './SectionDescription';
 import { SectionHeading } from './SectionHeading';
 
-export type FAQsSectionProps = {
+export interface FAQsSectionProps {
    id: string;
    title?: string | null;
    description?: string | null;
    faqs: FAQ[];
-};
+   itemType?: string | null;
+}
 
 const FALLBACK_SECTION_TITLE = 'FAQs';
 
@@ -29,11 +30,16 @@ export function FAQsSection({
    title,
    description,
    faqs,
+   itemType,
 }: FAQsSectionProps) {
    const sectionTitle = isPresent(title) ? title : FALLBACK_SECTION_TITLE;
    const sectionDescription = isPresent(description) ? description : null;
 
-   if (faqs.length === 0) {
+   const filteredFaqs = faqs.filter(
+      (faq) => faq.itemType == null || isSameItemType(faq.itemType, itemType)
+   );
+
+   if (filteredFaqs.length === 0) {
       return null;
    }
 
@@ -53,7 +59,7 @@ export function FAQsSection({
                   )}
                </Box>
                <Accordion defaultIndex={[0]} allowMultiple>
-                  {faqs.map((faq, index) => (
+                  {filteredFaqs.map((faq, index) => (
                      <FAQAccordionItem key={index} faq={faq} />
                   ))}
                </Accordion>
@@ -62,6 +68,16 @@ export function FAQsSection({
       </Box>
    );
 }
+
+const isSameItemType = (
+   a: string | null | undefined,
+   b: string | null | undefined
+) => {
+   if (a == null || b == null) {
+      return a == b;
+   }
+   return a.toLowerCase() === b.toLowerCase();
+};
 
 function FAQAccordionItem({ faq }: { faq: FAQ }) {
    const answerHtml = useMemo(() => markdownToHTML(faq.answer), [faq.answer]);

--- a/frontend/components/sections/FAQsSection.tsx
+++ b/frontend/components/sections/FAQsSection.tsx
@@ -20,7 +20,7 @@ export interface FAQsSectionProps {
    title?: string | null;
    description?: string | null;
    faqs: FAQ[];
-   itemType?: string | null;
+   relevantItemTypes?: string[];
 }
 
 const FALLBACK_SECTION_TITLE = 'FAQs';
@@ -30,16 +30,17 @@ export function FAQsSection({
    title,
    description,
    faqs,
-   itemType,
+   relevantItemTypes = [],
 }: FAQsSectionProps) {
    const sectionTitle = isPresent(title) ? title : FALLBACK_SECTION_TITLE;
    const sectionDescription = isPresent(description) ? description : null;
 
-   const filteredFaqs = faqs.filter(
-      (faq) => faq.itemType == null || isSameItemType(faq.itemType, itemType)
-   );
+   const relevantFaqs = useRelevantFaqs({
+      faqs,
+      relevantItemTypes,
+   });
 
-   if (filteredFaqs.length === 0) {
+   if (relevantFaqs.length === 0) {
       return null;
    }
 
@@ -59,7 +60,7 @@ export function FAQsSection({
                   )}
                </Box>
                <Accordion defaultIndex={[0]} allowMultiple>
-                  {filteredFaqs.map((faq, index) => (
+                  {relevantFaqs.map((faq, index) => (
                      <FAQAccordionItem key={index} faq={faq} />
                   ))}
                </Accordion>
@@ -68,16 +69,6 @@ export function FAQsSection({
       </Box>
    );
 }
-
-const isSameItemType = (
-   a: string | null | undefined,
-   b: string | null | undefined
-) => {
-   if (a == null || b == null) {
-      return a == b;
-   }
-   return a.toLowerCase() === b.toLowerCase();
-};
 
 function FAQAccordionItem({ faq }: { faq: FAQ }) {
    const answerHtml = useMemo(() => markdownToHTML(faq.answer), [faq.answer]);
@@ -117,5 +108,16 @@ function FAQAccordionItem({ faq }: { faq: FAQ }) {
             </>
          )}
       </AccordionItem>
+   );
+}
+
+interface UseRelevantFaqsProps {
+   faqs: FAQ[];
+   relevantItemTypes: string[];
+}
+
+function useRelevantFaqs({ faqs, relevantItemTypes }: UseRelevantFaqsProps) {
+   return faqs.filter(
+      (faq) => faq.itemType == null || relevantItemTypes.includes(faq.itemType)
    );
 }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2628,6 +2628,7 @@ export type FaqFieldsFragment = {
    attributes?: {
       __typename?: 'Faq';
       category?: string | null;
+      item_type?: string | null;
       question: string;
       answer: string;
    } | null;
@@ -3112,6 +3113,7 @@ export type FindProductQuery = {
                           attributes?: {
                              __typename?: 'Faq';
                              category?: string | null;
+                             item_type?: string | null;
                              question: string;
                              answer: string;
                           } | null;
@@ -3300,6 +3302,9 @@ export type FindProductListQuery = {
                                                                            category?:
                                                                               | string
                                                                               | null;
+                                                                           item_type?:
+                                                                              | string
+                                                                              | null;
                                                                            question: string;
                                                                            answer: string;
                                                                         } | null;
@@ -3320,6 +3325,9 @@ export type FindProductListQuery = {
                                                                   category?:
                                                                      | string
                                                                      | null;
+                                                                  item_type?:
+                                                                     | string
+                                                                     | null;
                                                                   question: string;
                                                                   answer: string;
                                                                } | null;
@@ -3338,6 +3346,9 @@ export type FindProductListQuery = {
                                                          category?:
                                                             | string
                                                             | null;
+                                                         item_type?:
+                                                            | string
+                                                            | null;
                                                          question: string;
                                                          answer: string;
                                                       } | null;
@@ -3354,6 +3365,7 @@ export type FindProductListQuery = {
                                              attributes?: {
                                                 __typename?: 'Faq';
                                                 category?: string | null;
+                                                item_type?: string | null;
                                                 question: string;
                                                 answer: string;
                                              } | null;
@@ -3370,6 +3382,7 @@ export type FindProductListQuery = {
                                     attributes?: {
                                        __typename?: 'Faq';
                                        category?: string | null;
+                                       item_type?: string | null;
                                        question: string;
                                        answer: string;
                                     } | null;
@@ -3386,6 +3399,7 @@ export type FindProductListQuery = {
                            attributes?: {
                               __typename?: 'Faq';
                               category?: string | null;
+                              item_type?: string | null;
                               question: string;
                               answer: string;
                            } | null;
@@ -3492,6 +3506,7 @@ export type FindProductListQuery = {
                   attributes?: {
                      __typename?: 'Faq';
                      category?: string | null;
+                     item_type?: string | null;
                      question: string;
                      answer: string;
                   } | null;
@@ -3615,6 +3630,9 @@ export type ProductListFieldsFragment = {
                                                                   category?:
                                                                      | string
                                                                      | null;
+                                                                  item_type?:
+                                                                     | string
+                                                                     | null;
                                                                   question: string;
                                                                   answer: string;
                                                                } | null;
@@ -3633,6 +3651,9 @@ export type ProductListFieldsFragment = {
                                                          category?:
                                                             | string
                                                             | null;
+                                                         item_type?:
+                                                            | string
+                                                            | null;
                                                          question: string;
                                                          answer: string;
                                                       } | null;
@@ -3649,6 +3670,7 @@ export type ProductListFieldsFragment = {
                                              attributes?: {
                                                 __typename?: 'Faq';
                                                 category?: string | null;
+                                                item_type?: string | null;
                                                 question: string;
                                                 answer: string;
                                              } | null;
@@ -3665,6 +3687,7 @@ export type ProductListFieldsFragment = {
                                     attributes?: {
                                        __typename?: 'Faq';
                                        category?: string | null;
+                                       item_type?: string | null;
                                        question: string;
                                        answer: string;
                                     } | null;
@@ -3681,6 +3704,7 @@ export type ProductListFieldsFragment = {
                            attributes?: {
                               __typename?: 'Faq';
                               category?: string | null;
+                              item_type?: string | null;
                               question: string;
                               answer: string;
                            } | null;
@@ -3697,6 +3721,7 @@ export type ProductListFieldsFragment = {
                   attributes?: {
                      __typename?: 'Faq';
                      category?: string | null;
+                     item_type?: string | null;
                      question: string;
                      answer: string;
                   } | null;
@@ -3803,6 +3828,7 @@ export type ProductListFieldsFragment = {
          attributes?: {
             __typename?: 'Faq';
             category?: string | null;
+            item_type?: string | null;
             question: string;
             answer: string;
          } | null;
@@ -3824,6 +3850,7 @@ export type AncestorProductListFieldsFragment = {
          attributes?: {
             __typename?: 'Faq';
             category?: string | null;
+            item_type?: string | null;
             question: string;
             answer: string;
          } | null;
@@ -3958,6 +3985,7 @@ export type FindReusableSectionsQuery = {
                           attributes?: {
                              __typename?: 'Faq';
                              category?: string | null;
+                             item_type?: string | null;
                              question: string;
                              answer: string;
                           } | null;
@@ -4121,6 +4149,7 @@ export type ReusableSectionFieldsFragment = {
                  attributes?: {
                     __typename?: 'Faq';
                     category?: string | null;
+                    item_type?: string | null;
                     question: string;
                     answer: string;
                  } | null;
@@ -5275,6 +5304,7 @@ export type FaQsSectionFieldsFragment = {
          attributes?: {
             __typename?: 'Faq';
             category?: string | null;
+            item_type?: string | null;
             question: string;
             answer: string;
          } | null;
@@ -5634,6 +5664,7 @@ export const FaqFieldsFragmentDoc = `
   id
   attributes {
     category
+    item_type
     question
     answer
   }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2625,7 +2625,12 @@ export type CompanyFieldsFragment = {
 export type FaqFieldsFragment = {
    __typename?: 'FaqEntity';
    id?: string | null;
-   attributes?: { __typename?: 'Faq'; question: string; answer: string } | null;
+   attributes?: {
+      __typename?: 'Faq';
+      category?: string | null;
+      question: string;
+      answer: string;
+   } | null;
 };
 
 export type ImageFieldsFragment = {
@@ -3106,6 +3111,7 @@ export type FindProductQuery = {
                           id?: string | null;
                           attributes?: {
                              __typename?: 'Faq';
+                             category?: string | null;
                              question: string;
                              answer: string;
                           } | null;
@@ -3282,20 +3288,108 @@ export type FindProductListQuery = {
                                                                   deviceTitle?:
                                                                      | string
                                                                      | null;
+                                                                  faqs?: {
+                                                                     __typename?: 'FaqRelationResponseCollection';
+                                                                     data: Array<{
+                                                                        __typename?: 'FaqEntity';
+                                                                        id?:
+                                                                           | string
+                                                                           | null;
+                                                                        attributes?: {
+                                                                           __typename?: 'Faq';
+                                                                           category?:
+                                                                              | string
+                                                                              | null;
+                                                                           question: string;
+                                                                           answer: string;
+                                                                        } | null;
+                                                                     }>;
+                                                                  } | null;
                                                                } | null;
                                                             } | null;
+                                                         } | null;
+                                                         faqs?: {
+                                                            __typename?: 'FaqRelationResponseCollection';
+                                                            data: Array<{
+                                                               __typename?: 'FaqEntity';
+                                                               id?:
+                                                                  | string
+                                                                  | null;
+                                                               attributes?: {
+                                                                  __typename?: 'Faq';
+                                                                  category?:
+                                                                     | string
+                                                                     | null;
+                                                                  question: string;
+                                                                  answer: string;
+                                                               } | null;
+                                                            }>;
                                                          } | null;
                                                       } | null;
                                                    } | null;
                                                 } | null;
+                                                faqs?: {
+                                                   __typename?: 'FaqRelationResponseCollection';
+                                                   data: Array<{
+                                                      __typename?: 'FaqEntity';
+                                                      id?: string | null;
+                                                      attributes?: {
+                                                         __typename?: 'Faq';
+                                                         category?:
+                                                            | string
+                                                            | null;
+                                                         question: string;
+                                                         answer: string;
+                                                      } | null;
+                                                   }>;
+                                                } | null;
                                              } | null;
                                           } | null;
+                                       } | null;
+                                       faqs?: {
+                                          __typename?: 'FaqRelationResponseCollection';
+                                          data: Array<{
+                                             __typename?: 'FaqEntity';
+                                             id?: string | null;
+                                             attributes?: {
+                                                __typename?: 'Faq';
+                                                category?: string | null;
+                                                question: string;
+                                                answer: string;
+                                             } | null;
+                                          }>;
                                        } | null;
                                     } | null;
                                  } | null;
                               } | null;
+                              faqs?: {
+                                 __typename?: 'FaqRelationResponseCollection';
+                                 data: Array<{
+                                    __typename?: 'FaqEntity';
+                                    id?: string | null;
+                                    attributes?: {
+                                       __typename?: 'Faq';
+                                       category?: string | null;
+                                       question: string;
+                                       answer: string;
+                                    } | null;
+                                 }>;
+                              } | null;
                            } | null;
                         } | null;
+                     } | null;
+                     faqs?: {
+                        __typename?: 'FaqRelationResponseCollection';
+                        data: Array<{
+                           __typename?: 'FaqEntity';
+                           id?: string | null;
+                           attributes?: {
+                              __typename?: 'Faq';
+                              category?: string | null;
+                              question: string;
+                              answer: string;
+                           } | null;
+                        }>;
                      } | null;
                   } | null;
                } | null;
@@ -3390,6 +3484,19 @@ export type FindProductListQuery = {
                | { __typename: 'Error' }
                | null
             >;
+            faqs?: {
+               __typename?: 'FaqRelationResponseCollection';
+               data: Array<{
+                  __typename?: 'FaqEntity';
+                  id?: string | null;
+                  attributes?: {
+                     __typename?: 'Faq';
+                     category?: string | null;
+                     question: string;
+                     answer: string;
+                  } | null;
+               }>;
+            } | null;
          } | null;
       }>;
    } | null;
@@ -3496,20 +3603,104 @@ export type ProductListFieldsFragment = {
                                                          deviceTitle?:
                                                             | string
                                                             | null;
+                                                         faqs?: {
+                                                            __typename?: 'FaqRelationResponseCollection';
+                                                            data: Array<{
+                                                               __typename?: 'FaqEntity';
+                                                               id?:
+                                                                  | string
+                                                                  | null;
+                                                               attributes?: {
+                                                                  __typename?: 'Faq';
+                                                                  category?:
+                                                                     | string
+                                                                     | null;
+                                                                  question: string;
+                                                                  answer: string;
+                                                               } | null;
+                                                            }>;
+                                                         } | null;
                                                       } | null;
                                                    } | null;
+                                                } | null;
+                                                faqs?: {
+                                                   __typename?: 'FaqRelationResponseCollection';
+                                                   data: Array<{
+                                                      __typename?: 'FaqEntity';
+                                                      id?: string | null;
+                                                      attributes?: {
+                                                         __typename?: 'Faq';
+                                                         category?:
+                                                            | string
+                                                            | null;
+                                                         question: string;
+                                                         answer: string;
+                                                      } | null;
+                                                   }>;
                                                 } | null;
                                              } | null;
                                           } | null;
                                        } | null;
+                                       faqs?: {
+                                          __typename?: 'FaqRelationResponseCollection';
+                                          data: Array<{
+                                             __typename?: 'FaqEntity';
+                                             id?: string | null;
+                                             attributes?: {
+                                                __typename?: 'Faq';
+                                                category?: string | null;
+                                                question: string;
+                                                answer: string;
+                                             } | null;
+                                          }>;
+                                       } | null;
                                     } | null;
                                  } | null;
+                              } | null;
+                              faqs?: {
+                                 __typename?: 'FaqRelationResponseCollection';
+                                 data: Array<{
+                                    __typename?: 'FaqEntity';
+                                    id?: string | null;
+                                    attributes?: {
+                                       __typename?: 'Faq';
+                                       category?: string | null;
+                                       question: string;
+                                       answer: string;
+                                    } | null;
+                                 }>;
                               } | null;
                            } | null;
                         } | null;
                      } | null;
+                     faqs?: {
+                        __typename?: 'FaqRelationResponseCollection';
+                        data: Array<{
+                           __typename?: 'FaqEntity';
+                           id?: string | null;
+                           attributes?: {
+                              __typename?: 'Faq';
+                              category?: string | null;
+                              question: string;
+                              answer: string;
+                           } | null;
+                        }>;
+                     } | null;
                   } | null;
                } | null;
+            } | null;
+            faqs?: {
+               __typename?: 'FaqRelationResponseCollection';
+               data: Array<{
+                  __typename?: 'FaqEntity';
+                  id?: string | null;
+                  attributes?: {
+                     __typename?: 'Faq';
+                     category?: string | null;
+                     question: string;
+                     answer: string;
+                  } | null;
+               }>;
             } | null;
          } | null;
       } | null;
@@ -3604,6 +3795,19 @@ export type ProductListFieldsFragment = {
       | { __typename: 'Error' }
       | null
    >;
+   faqs?: {
+      __typename?: 'FaqRelationResponseCollection';
+      data: Array<{
+         __typename?: 'FaqEntity';
+         id?: string | null;
+         attributes?: {
+            __typename?: 'Faq';
+            category?: string | null;
+            question: string;
+            answer: string;
+         } | null;
+      }>;
+   } | null;
 };
 
 export type AncestorProductListFieldsFragment = {
@@ -3612,6 +3816,19 @@ export type AncestorProductListFieldsFragment = {
    title: string;
    handle: string;
    deviceTitle?: string | null;
+   faqs?: {
+      __typename?: 'FaqRelationResponseCollection';
+      data: Array<{
+         __typename?: 'FaqEntity';
+         id?: string | null;
+         attributes?: {
+            __typename?: 'Faq';
+            category?: string | null;
+            question: string;
+            answer: string;
+         } | null;
+      }>;
+   } | null;
 };
 
 export type FindReusableSectionsQueryVariables = Exact<{
@@ -3728,7 +3945,25 @@ export type FindReusableSectionsQuery = {
                        }>;
                     } | null;
                  }
-               | { __typename: 'ComponentSectionFaqs' }
+               | {
+                    __typename: 'ComponentSectionFaqs';
+                    id: string;
+                    title?: string | null;
+                    description?: string | null;
+                    faqs?: {
+                       __typename?: 'FaqRelationResponseCollection';
+                       data: Array<{
+                          __typename?: 'FaqEntity';
+                          id?: string | null;
+                          attributes?: {
+                             __typename?: 'Faq';
+                             category?: string | null;
+                             question: string;
+                             answer: string;
+                          } | null;
+                       }>;
+                    } | null;
+                 }
                | {
                     __typename: 'ComponentSectionQuoteGallery';
                     id: string;
@@ -3873,7 +4108,25 @@ export type ReusableSectionFieldsFragment = {
               }>;
            } | null;
         }
-      | { __typename: 'ComponentSectionFaqs' }
+      | {
+           __typename: 'ComponentSectionFaqs';
+           id: string;
+           title?: string | null;
+           description?: string | null;
+           faqs?: {
+              __typename?: 'FaqRelationResponseCollection';
+              data: Array<{
+                 __typename?: 'FaqEntity';
+                 id?: string | null;
+                 attributes?: {
+                    __typename?: 'Faq';
+                    category?: string | null;
+                    question: string;
+                    answer: string;
+                 } | null;
+              }>;
+           } | null;
+        }
       | {
            __typename: 'ComponentSectionQuoteGallery';
            id: string;
@@ -5021,6 +5274,7 @@ export type FaQsSectionFieldsFragment = {
          id?: string | null;
          attributes?: {
             __typename?: 'Faq';
+            category?: string | null;
             question: string;
             answer: string;
          } | null;
@@ -5375,12 +5629,27 @@ export const ImageFieldsFragmentDoc = `
   }
 }
     `;
+export const FaqFieldsFragmentDoc = `
+    fragment FAQFields on FaqEntity {
+  id
+  attributes {
+    category
+    question
+    answer
+  }
+}
+    `;
 export const AncestorProductListFieldsFragmentDoc = `
     fragment AncestorProductListFields on ProductList {
   type
   title
   handle
   deviceTitle
+  faqs {
+    data {
+      ...FAQFields
+    }
+  }
 }
     `;
 export const ProductListBannerSectionFieldsFragmentDoc = `
@@ -5524,6 +5793,11 @@ export const ProductListFieldsFragmentDoc = `
       tagline
     }
   }
+  faqs {
+    data {
+      ...FAQFields
+    }
+  }
 }
     `;
 export const CallToActionFieldsFragmentDoc = `
@@ -5637,6 +5911,18 @@ export const QuoteGallerySectionFieldsFragmentDoc = `
   }
 }
     `;
+export const FaQsSectionFieldsFragmentDoc = `
+    fragment FAQsSectionFields on ComponentSectionFaqs {
+  id
+  title
+  description
+  faqs {
+    data {
+      ...FAQFields
+    }
+  }
+}
+    `;
 export const PlacementFieldsFragmentDoc = `
     fragment PlacementFields on ComponentMiscPlacement {
   showInProductListPages
@@ -5650,6 +5936,7 @@ export const ReusableSectionFieldsFragmentDoc = `
     ...SplitWithImageSectionFields
     ...PressQuotesSectionFields
     ...QuoteGallerySectionFields
+    ...FAQsSectionFields
   }
   placement {
     ...PlacementFields
@@ -5778,27 +6065,6 @@ export const DeviceCompatibilitySectionFieldsFragmentDoc = `
   id
   title
   description
-}
-    `;
-export const FaqFieldsFragmentDoc = `
-    fragment FAQFields on FaqEntity {
-  id
-  attributes {
-    question
-    answer
-  }
-}
-    `;
-export const FaQsSectionFieldsFragmentDoc = `
-    fragment FAQsSectionFields on ComponentSectionFaqs {
-  id
-  title
-  description
-  faqs {
-    data {
-      ...FAQFields
-    }
-  }
 }
     `;
 export const FeaturedProductsSectionFieldsFragmentDoc = `
@@ -6015,6 +6281,7 @@ export const FindProductListDocument = `
     ${ProductListFieldsFragmentDoc}
 ${ImageFieldsFragmentDoc}
 ${AncestorProductListFieldsFragmentDoc}
+${FaqFieldsFragmentDoc}
 ${ProductListBannerSectionFieldsFragmentDoc}
 ${ProductListRelatedPostsSectionFieldsFragmentDoc}
 ${ProductListLinkedProductListSetSectionFieldsFragmentDoc}
@@ -6042,6 +6309,8 @@ ${CompanyFieldsFragmentDoc}
 ${QuoteGallerySectionFieldsFragmentDoc}
 ${QuoteCardFieldsFragmentDoc}
 ${PersonFieldsFragmentDoc}
+${FaQsSectionFieldsFragmentDoc}
+${FaqFieldsFragmentDoc}
 ${PlacementFieldsFragmentDoc}`;
 export const FindStoreDocument = `
     query findStore($filters: StoreFiltersInput) {

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2627,10 +2627,11 @@ export type FaqFieldsFragment = {
    id?: string | null;
    attributes?: {
       __typename?: 'Faq';
-      category?: string | null;
-      item_type?: string | null;
       question: string;
       answer: string;
+      category?: string | null;
+      item_type?: string | null;
+      priority?: number | null;
    } | null;
 };
 
@@ -3112,10 +3113,11 @@ export type FindProductQuery = {
                           id?: string | null;
                           attributes?: {
                              __typename?: 'Faq';
-                             category?: string | null;
-                             item_type?: string | null;
                              question: string;
                              answer: string;
+                             category?: string | null;
+                             item_type?: string | null;
+                             priority?: number | null;
                           } | null;
                        }>;
                     } | null;
@@ -3299,14 +3301,17 @@ export type FindProductListQuery = {
                                                                            | null;
                                                                         attributes?: {
                                                                            __typename?: 'Faq';
+                                                                           question: string;
+                                                                           answer: string;
                                                                            category?:
                                                                               | string
                                                                               | null;
                                                                            item_type?:
                                                                               | string
                                                                               | null;
-                                                                           question: string;
-                                                                           answer: string;
+                                                                           priority?:
+                                                                              | number
+                                                                              | null;
                                                                         } | null;
                                                                      }>;
                                                                   } | null;
@@ -3322,14 +3327,17 @@ export type FindProductListQuery = {
                                                                   | null;
                                                                attributes?: {
                                                                   __typename?: 'Faq';
+                                                                  question: string;
+                                                                  answer: string;
                                                                   category?:
                                                                      | string
                                                                      | null;
                                                                   item_type?:
                                                                      | string
                                                                      | null;
-                                                                  question: string;
-                                                                  answer: string;
+                                                                  priority?:
+                                                                     | number
+                                                                     | null;
                                                                } | null;
                                                             }>;
                                                          } | null;
@@ -3343,14 +3351,17 @@ export type FindProductListQuery = {
                                                       id?: string | null;
                                                       attributes?: {
                                                          __typename?: 'Faq';
+                                                         question: string;
+                                                         answer: string;
                                                          category?:
                                                             | string
                                                             | null;
                                                          item_type?:
                                                             | string
                                                             | null;
-                                                         question: string;
-                                                         answer: string;
+                                                         priority?:
+                                                            | number
+                                                            | null;
                                                       } | null;
                                                    }>;
                                                 } | null;
@@ -3364,10 +3375,11 @@ export type FindProductListQuery = {
                                              id?: string | null;
                                              attributes?: {
                                                 __typename?: 'Faq';
-                                                category?: string | null;
-                                                item_type?: string | null;
                                                 question: string;
                                                 answer: string;
+                                                category?: string | null;
+                                                item_type?: string | null;
+                                                priority?: number | null;
                                              } | null;
                                           }>;
                                        } | null;
@@ -3381,10 +3393,11 @@ export type FindProductListQuery = {
                                     id?: string | null;
                                     attributes?: {
                                        __typename?: 'Faq';
-                                       category?: string | null;
-                                       item_type?: string | null;
                                        question: string;
                                        answer: string;
+                                       category?: string | null;
+                                       item_type?: string | null;
+                                       priority?: number | null;
                                     } | null;
                                  }>;
                               } | null;
@@ -3398,10 +3411,11 @@ export type FindProductListQuery = {
                            id?: string | null;
                            attributes?: {
                               __typename?: 'Faq';
-                              category?: string | null;
-                              item_type?: string | null;
                               question: string;
                               answer: string;
+                              category?: string | null;
+                              item_type?: string | null;
+                              priority?: number | null;
                            } | null;
                         }>;
                      } | null;
@@ -3505,10 +3519,11 @@ export type FindProductListQuery = {
                   id?: string | null;
                   attributes?: {
                      __typename?: 'Faq';
-                     category?: string | null;
-                     item_type?: string | null;
                      question: string;
                      answer: string;
+                     category?: string | null;
+                     item_type?: string | null;
+                     priority?: number | null;
                   } | null;
                }>;
             } | null;
@@ -3627,14 +3642,17 @@ export type ProductListFieldsFragment = {
                                                                   | null;
                                                                attributes?: {
                                                                   __typename?: 'Faq';
+                                                                  question: string;
+                                                                  answer: string;
                                                                   category?:
                                                                      | string
                                                                      | null;
                                                                   item_type?:
                                                                      | string
                                                                      | null;
-                                                                  question: string;
-                                                                  answer: string;
+                                                                  priority?:
+                                                                     | number
+                                                                     | null;
                                                                } | null;
                                                             }>;
                                                          } | null;
@@ -3648,14 +3666,17 @@ export type ProductListFieldsFragment = {
                                                       id?: string | null;
                                                       attributes?: {
                                                          __typename?: 'Faq';
+                                                         question: string;
+                                                         answer: string;
                                                          category?:
                                                             | string
                                                             | null;
                                                          item_type?:
                                                             | string
                                                             | null;
-                                                         question: string;
-                                                         answer: string;
+                                                         priority?:
+                                                            | number
+                                                            | null;
                                                       } | null;
                                                    }>;
                                                 } | null;
@@ -3669,10 +3690,11 @@ export type ProductListFieldsFragment = {
                                              id?: string | null;
                                              attributes?: {
                                                 __typename?: 'Faq';
-                                                category?: string | null;
-                                                item_type?: string | null;
                                                 question: string;
                                                 answer: string;
+                                                category?: string | null;
+                                                item_type?: string | null;
+                                                priority?: number | null;
                                              } | null;
                                           }>;
                                        } | null;
@@ -3686,10 +3708,11 @@ export type ProductListFieldsFragment = {
                                     id?: string | null;
                                     attributes?: {
                                        __typename?: 'Faq';
-                                       category?: string | null;
-                                       item_type?: string | null;
                                        question: string;
                                        answer: string;
+                                       category?: string | null;
+                                       item_type?: string | null;
+                                       priority?: number | null;
                                     } | null;
                                  }>;
                               } | null;
@@ -3703,10 +3726,11 @@ export type ProductListFieldsFragment = {
                            id?: string | null;
                            attributes?: {
                               __typename?: 'Faq';
-                              category?: string | null;
-                              item_type?: string | null;
                               question: string;
                               answer: string;
+                              category?: string | null;
+                              item_type?: string | null;
+                              priority?: number | null;
                            } | null;
                         }>;
                      } | null;
@@ -3720,10 +3744,11 @@ export type ProductListFieldsFragment = {
                   id?: string | null;
                   attributes?: {
                      __typename?: 'Faq';
-                     category?: string | null;
-                     item_type?: string | null;
                      question: string;
                      answer: string;
+                     category?: string | null;
+                     item_type?: string | null;
+                     priority?: number | null;
                   } | null;
                }>;
             } | null;
@@ -3827,10 +3852,11 @@ export type ProductListFieldsFragment = {
          id?: string | null;
          attributes?: {
             __typename?: 'Faq';
-            category?: string | null;
-            item_type?: string | null;
             question: string;
             answer: string;
+            category?: string | null;
+            item_type?: string | null;
+            priority?: number | null;
          } | null;
       }>;
    } | null;
@@ -3849,10 +3875,11 @@ export type AncestorProductListFieldsFragment = {
          id?: string | null;
          attributes?: {
             __typename?: 'Faq';
-            category?: string | null;
-            item_type?: string | null;
             question: string;
             answer: string;
+            category?: string | null;
+            item_type?: string | null;
+            priority?: number | null;
          } | null;
       }>;
    } | null;
@@ -3984,10 +4011,11 @@ export type FindReusableSectionsQuery = {
                           id?: string | null;
                           attributes?: {
                              __typename?: 'Faq';
-                             category?: string | null;
-                             item_type?: string | null;
                              question: string;
                              answer: string;
+                             category?: string | null;
+                             item_type?: string | null;
+                             priority?: number | null;
                           } | null;
                        }>;
                     } | null;
@@ -4148,10 +4176,11 @@ export type ReusableSectionFieldsFragment = {
                  id?: string | null;
                  attributes?: {
                     __typename?: 'Faq';
-                    category?: string | null;
-                    item_type?: string | null;
                     question: string;
                     answer: string;
+                    category?: string | null;
+                    item_type?: string | null;
+                    priority?: number | null;
                  } | null;
               }>;
            } | null;
@@ -5303,10 +5332,11 @@ export type FaQsSectionFieldsFragment = {
          id?: string | null;
          attributes?: {
             __typename?: 'Faq';
-            category?: string | null;
-            item_type?: string | null;
             question: string;
             answer: string;
+            category?: string | null;
+            item_type?: string | null;
+            priority?: number | null;
          } | null;
       }>;
    } | null;
@@ -5663,10 +5693,11 @@ export const FaqFieldsFragmentDoc = `
     fragment FAQFields on FaqEntity {
   id
   attributes {
-    category
-    item_type
     question
     answer
+    category
+    item_type
+    priority
   }
 }
     `;

--- a/frontend/lib/strapi-sdk/operations/FAQFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/FAQFields.fragment.graphql
@@ -1,6 +1,7 @@
 fragment FAQFields on FaqEntity {
    id
    attributes {
+      category
       question
       answer
    }

--- a/frontend/lib/strapi-sdk/operations/components/FAQFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/components/FAQFields.fragment.graphql
@@ -1,9 +1,10 @@
 fragment FAQFields on FaqEntity {
    id
    attributes {
-      category
-      item_type
       question
       answer
+      category
+      item_type
+      priority
    }
 }

--- a/frontend/lib/strapi-sdk/operations/components/FAQFields.fragment.graphql
+++ b/frontend/lib/strapi-sdk/operations/components/FAQFields.fragment.graphql
@@ -2,6 +2,7 @@ fragment FAQFields on FaqEntity {
    id
    attributes {
       category
+      item_type
       question
       answer
    }

--- a/frontend/lib/strapi-sdk/operations/findProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/findProductList.graphql
@@ -111,6 +111,11 @@ fragment ProductListFields on ProductList {
          tagline
       }
    }
+   faqs {
+      data {
+         ...FAQFields
+      }
+   }
 }
 
 fragment AncestorProductListFields on ProductList {
@@ -118,4 +123,9 @@ fragment AncestorProductListFields on ProductList {
    title
    handle
    deviceTitle
+   faqs {
+      data {
+         ...FAQFields
+      }
+   }
 }

--- a/frontend/lib/strapi-sdk/operations/findReusableSections.graphql
+++ b/frontend/lib/strapi-sdk/operations/findReusableSections.graphql
@@ -16,6 +16,7 @@ fragment ReusableSectionFields on ReusableSection {
       ...SplitWithImageSectionFields
       ...PressQuotesSectionFields
       ...QuoteGallerySectionFields
+      ...FAQsSectionFields
    }
    placement {
       ...PlacementFields

--- a/frontend/models/components/faq.ts
+++ b/frontend/models/components/faq.ts
@@ -5,10 +5,11 @@ import { z } from 'zod';
 export type FAQ = z.infer<typeof FAQSchema>;
 
 export const FAQSchema = z.object({
-   category: z.string().nullable(),
-   itemType: z.string().nullable(),
    question: z.string(),
    answer: z.string(),
+   category: z.string().nullable(),
+   itemType: z.string().nullable(),
+   priority: z.number(),
 });
 
 export function faqFromStrapi(
@@ -25,7 +26,13 @@ export function faqFromStrapi(
    return {
       category: isPresent(category) ? category : null,
       itemType: isPresent(itemType) ? itemType : null,
+      priority: fragment?.attributes?.priority ?? 0,
       question,
       answer,
    };
+}
+
+// This sorts FAQs by priority, from highest to lowest.
+export function compareFAQs(a: FAQ, b: FAQ): number {
+   return b.priority - a.priority;
 }

--- a/frontend/models/components/faq.ts
+++ b/frontend/models/components/faq.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 export type FAQ = z.infer<typeof FAQSchema>;
 
 export const FAQSchema = z.object({
+   id: z.string(),
    question: z.string(),
    answer: z.string(),
    category: z.string().nullable(),
@@ -15,15 +16,17 @@ export const FAQSchema = z.object({
 export function faqFromStrapi(
    fragment: FaqFieldsFragment | null | undefined
 ): FAQ | null {
+   const id = fragment?.id;
    const question = fragment?.attributes?.question;
    const answer = fragment?.attributes?.answer;
 
-   if (!isPresent(question) || !isPresent(answer)) return null;
+   if (id == null || !isPresent(question) || !isPresent(answer)) return null;
 
    const category = fragment?.attributes?.category;
    const itemType = fragment?.attributes?.item_type;
 
    return {
+      id,
       category: isPresent(category) ? category : null,
       itemType: isPresent(itemType) ? itemType : null,
       priority: fragment?.attributes?.priority ?? 0,

--- a/frontend/models/components/faq.ts
+++ b/frontend/models/components/faq.ts
@@ -6,6 +6,7 @@ export type FAQ = z.infer<typeof FAQSchema>;
 
 export const FAQSchema = z.object({
    category: z.string().nullable(),
+   itemType: z.string().nullable(),
    question: z.string(),
    answer: z.string(),
 });
@@ -19,8 +20,11 @@ export function faqFromStrapi(
    if (!isPresent(question) || !isPresent(answer)) return null;
 
    const category = fragment?.attributes?.category;
+   const itemType = fragment?.attributes?.item_type;
+
    return {
       category: isPresent(category) ? category : null,
+      itemType: isPresent(itemType) ? itemType : null,
       question,
       answer,
    };

--- a/frontend/models/components/faq.ts
+++ b/frontend/models/components/faq.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 export type FAQ = z.infer<typeof FAQSchema>;
 
 export const FAQSchema = z.object({
+   category: z.string().nullable(),
    question: z.string(),
    answer: z.string(),
 });
@@ -17,7 +18,9 @@ export function faqFromStrapi(
 
    if (!isPresent(question) || !isPresent(answer)) return null;
 
+   const category = fragment?.attributes?.category;
    return {
+      category: isPresent(category) ? category : null,
       question,
       answer,
    };

--- a/frontend/models/product-list/sections/index.ts
+++ b/frontend/models/product-list/sections/index.ts
@@ -31,6 +31,7 @@ import {
    productListChildrenSection,
    ProductListChildrenSectionSchema,
 } from './product-list-children-section';
+import { FAQsSectionSchema } from '@models/sections/faqs-section';
 
 export type ProductListSection = z.infer<typeof ProductListSectionSchema>;
 
@@ -45,6 +46,7 @@ export const ProductListSectionSchema = z.union([
    SplitWithImageSectionSchema,
    QuoteGallerySectionSchema,
    PressQuotesSectionSchema,
+   FAQsSectionSchema,
 ]);
 
 interface ProductListSectionsArgs {

--- a/frontend/models/product-list/sections/reusable-sections.ts
+++ b/frontend/models/product-list/sections/reusable-sections.ts
@@ -6,6 +6,7 @@ import type { ReusableSection } from '@models/reusable-section';
 import { findReusableSections } from '@models/reusable-section/server';
 import type { Dictionary } from 'lodash';
 import keyBy from 'lodash/keyBy';
+import uniqBy from 'lodash/uniqBy';
 
 interface FindProductListReusableSectionsArgs {
    strapiProductList: ProductListFieldsFragment | null | undefined;
@@ -34,6 +35,7 @@ export async function findProductListReusableSections({
                getAncestryFAQsByCategory(strapiProductList);
             const ancestryFaqsWithoutCategory =
                getAncestryFAQsWithoutCategory(strapiProductList);
+
             const sectionFaqsByCategory = keyBy(
                reusableSection.section.faqs.filter(
                   (faq) => faq.category != null
@@ -44,15 +46,21 @@ export async function findProductListReusableSections({
                reusableSection.section.faqs.filter(
                   (faq) => faq.category == null
                );
+
             const allFaqsByCategory = {
                ...ancestryFaqsByCategory,
                ...sectionFaqsByCategory,
             };
-            reusableSection.section.faqs = [
-               ...ancestryFaqsWithoutCategory,
-               ...sectionFaqsWithoutCategory,
-               ...Object.values(allFaqsByCategory),
-            ].sort(compareFAQs);
+
+            reusableSection.section.faqs = uniqBy(
+               [
+                  ...ancestryFaqsWithoutCategory,
+                  ...sectionFaqsWithoutCategory,
+                  ...Object.values(allFaqsByCategory),
+               ],
+               'id'
+            ).sort(compareFAQs);
+
             return reusableSection;
          }
          default:

--- a/frontend/models/product-list/sections/reusable-sections.ts
+++ b/frontend/models/product-list/sections/reusable-sections.ts
@@ -1,7 +1,7 @@
 import { filterFalsyItems } from '@helpers/application-helpers';
 import type { ComponentMiscPlacementFiltersInput } from '@lib/strapi-sdk';
 import { ProductListFieldsFragment } from '@lib/strapi-sdk';
-import { FAQ, faqFromStrapi } from '@models/components/faq';
+import { compareFAQs, FAQ, faqFromStrapi } from '@models/components/faq';
 import type { ReusableSection } from '@models/reusable-section';
 import { findReusableSections } from '@models/reusable-section/server';
 import type { Dictionary } from 'lodash';
@@ -52,7 +52,7 @@ export async function findProductListReusableSections({
                ...ancestryFaqsWithoutCategory,
                ...sectionFaqsWithoutCategory,
                ...Object.values(allFaqsByCategory),
-            ];
+            ].sort(compareFAQs);
             return reusableSection;
          }
          default:

--- a/frontend/models/product-list/sections/reusable-sections.ts
+++ b/frontend/models/product-list/sections/reusable-sections.ts
@@ -1,0 +1,143 @@
+import { filterFalsyItems } from '@helpers/application-helpers';
+import type { ComponentMiscPlacementFiltersInput } from '@lib/strapi-sdk';
+import { ProductListFieldsFragment } from '@lib/strapi-sdk';
+import { FAQ, faqFromStrapi } from '@models/components/faq';
+import type { ReusableSection } from '@models/reusable-section';
+import { findReusableSections } from '@models/reusable-section/server';
+import type { Dictionary } from 'lodash';
+import keyBy from 'lodash/keyBy';
+
+interface FindProductListReusableSectionsArgs {
+   strapiProductList: ProductListFieldsFragment | null | undefined;
+   ancestorHandles: string[];
+}
+
+export async function findProductListReusableSections({
+   strapiProductList,
+   ancestorHandles,
+}: FindProductListReusableSectionsArgs): Promise<ReusableSection[]> {
+   const reusableSections = await findReusableSections({
+      filters: {
+         placement: {
+            or: getPlacementConditions({
+               strapiProductList,
+               ancestorHandles,
+            }),
+         },
+      },
+   });
+
+   return reusableSections.map((reusableSection) => {
+      switch (reusableSection.section.type) {
+         case 'FAQs': {
+            const ancestryFaqsByCategory =
+               getAncestryFAQsByCategory(strapiProductList);
+            const ancestryFaqsWithoutCategory =
+               getAncestryFAQsWithoutCategory(strapiProductList);
+            const sectionFaqsByCategory = keyBy(
+               reusableSection.section.faqs.filter(
+                  (faq) => faq.category != null
+               ),
+               'category'
+            );
+            const sectionFaqsWithoutCategory =
+               reusableSection.section.faqs.filter(
+                  (faq) => faq.category == null
+               );
+            const allFaqsByCategory = {
+               ...ancestryFaqsByCategory,
+               ...sectionFaqsByCategory,
+            };
+            reusableSection.section.faqs = [
+               ...ancestryFaqsWithoutCategory,
+               ...sectionFaqsWithoutCategory,
+               ...Object.values(allFaqsByCategory),
+            ];
+            return reusableSection;
+         }
+         default:
+            return reusableSection;
+      }
+   });
+}
+
+function getPlacementConditions({
+   strapiProductList,
+   ancestorHandles,
+}: FindProductListReusableSectionsArgs): ComponentMiscPlacementFiltersInput[] {
+   const conditions: ComponentMiscPlacementFiltersInput[] = [
+      {
+         showInProductListPages: {
+            eq: 'only descendants',
+         },
+         productLists: {
+            handle: {
+               in: ancestorHandles,
+            },
+         },
+      },
+   ];
+   if (strapiProductList) {
+      conditions.push({
+         showInProductListPages: {
+            eq: 'only selected',
+         },
+         productLists: {
+            handle: {
+               eq: strapiProductList.handle,
+            },
+         },
+      });
+
+      conditions.push({
+         showInProductListPages: {
+            eq: 'selected and descendants',
+         },
+         productLists: {
+            handle: {
+               in: ancestorHandles.concat(strapiProductList.handle),
+            },
+         },
+      });
+   }
+   return conditions;
+}
+
+type ProductListWithFAQs = Pick<ProductListFieldsFragment, 'faqs'> & {
+   parent?: ProductListFieldsFragment['parent'] | null | undefined;
+};
+
+function getAncestryFAQsByCategory(
+   productList: ProductListWithFAQs | null | undefined
+): Dictionary<FAQ> {
+   if (productList == null) {
+      return {};
+   }
+   const ancestryFaqByCategory = getAncestryFAQsByCategory(
+      productList.parent?.data?.attributes
+   );
+
+   const faqs = filterFalsyItems(productList.faqs?.data?.map(faqFromStrapi));
+   const faqsWithCategory = faqs.filter((faq) => faq.category != null);
+
+   return {
+      ...ancestryFaqByCategory,
+      ...keyBy(faqsWithCategory, 'category'),
+   };
+}
+
+function getAncestryFAQsWithoutCategory(
+   productList: ProductListWithFAQs | null | undefined
+): FAQ[] {
+   if (productList == null) {
+      return [];
+   }
+   const ancestryFaqsWithoutCategory = getAncestryFAQsWithoutCategory(
+      productList.parent?.data?.attributes
+   );
+
+   const faqs = filterFalsyItems(productList.faqs?.data?.map(faqFromStrapi));
+   const faqsWithoutCategory = faqs.filter((faq) => faq.category == null);
+
+   return ancestryFaqsWithoutCategory.concat(faqsWithoutCategory);
+}

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -13,7 +13,6 @@ import {
    fetchDeviceWiki,
    fetchMultipleDeviceImages,
 } from '@lib/ifixit-api/devices';
-import type { ComponentMiscPlacementFiltersInput } from '@lib/strapi-sdk';
 import {
    ProductListFieldsFragment,
    ProductListFiltersInput,
@@ -23,14 +22,13 @@ import {
    childImageFromDeviceWiki,
    imageFromStrapi,
 } from '@models/components/image';
-import type { ReusableSection } from '@models/reusable-section';
-import { findReusableSections } from '@models/reusable-section/server';
 import algoliasearch from 'algoliasearch';
 import { createProductListAncestorsFromStrapiOrDeviceWiki } from './component/product-list-ancestor';
 import type { ProductListChild } from './component/product-list-child';
 import { ProductListType } from './component/product-list-type';
 import { productListTypeFromStrapi } from './component/product-list-type.server';
 import { productListSections } from './sections';
+import { findProductListReusableSections } from './sections/reusable-sections';
 import {
    BaseProductList,
    ProductList,
@@ -349,51 +347,4 @@ async function findDevicesWithProducts(devices: string[]) {
       });
       return facets?.device ? facets?.device : {};
    });
-}
-
-interface FindProductListReusableSectionsArgs {
-   strapiProductList: ProductListFieldsFragment | null | undefined;
-   ancestorHandles: string[];
-}
-
-async function findProductListReusableSections({
-   strapiProductList,
-   ancestorHandles,
-}: FindProductListReusableSectionsArgs): Promise<ReusableSection[]> {
-   const conditions: ComponentMiscPlacementFiltersInput[] = [
-      {
-         showInProductListPages: {
-            eq: 'only descendants',
-         },
-         productLists: {
-            handle: {
-               in: ancestorHandles,
-            },
-         },
-      },
-   ];
-   if (strapiProductList) {
-      conditions.push({
-         showInProductListPages: {
-            eq: 'only selected',
-         },
-         productLists: {
-            handle: {
-               eq: strapiProductList.handle,
-            },
-         },
-      });
-
-      conditions.push({
-         showInProductListPages: {
-            eq: 'selected and descendants',
-         },
-         productLists: {
-            handle: {
-               in: ancestorHandles.concat(strapiProductList.handle),
-            },
-         },
-      });
-   }
-   return findReusableSections({ filters: { placement: { or: conditions } } });
 }

--- a/frontend/models/reusable-section/index.ts
+++ b/frontend/models/reusable-section/index.ts
@@ -4,6 +4,7 @@ import { QuoteGallerySectionSchema } from '@models/sections/quote-gallery-sectio
 import { SplitWithImageSectionSchema } from '@models/sections/split-with-image-section';
 import { z } from 'zod';
 import { SectionPlacementSchema } from './components/placement';
+import { FAQsSectionSchema } from '@models/sections/faqs-section';
 
 export type ReusableSection = z.infer<typeof ReusableSectionSchema>;
 
@@ -13,6 +14,7 @@ export const ReusableSectionSchema = z.object({
       SplitWithImageSectionSchema,
       QuoteGallerySectionSchema,
       PressQuotesSectionSchema,
+      FAQsSectionSchema,
    ]),
    placements: z.array(SectionPlacementSchema),
    priority: z.number(),

--- a/frontend/models/reusable-section/server.ts
+++ b/frontend/models/reusable-section/server.ts
@@ -12,6 +12,7 @@ import { quoteGallerySectionFromStrapi } from '@models/sections/quote-gallery-se
 import { splitWithImageSectionFromStrapi } from '@models/sections/split-with-image-section';
 import { ReusableSection } from '.';
 import { getPlacementFromStrapi } from './components/placement';
+import { faqsSectionFromStrapi } from '@models/sections/faqs-section';
 
 export interface FindReusableSectionArgs {
    filters: ReusableSectionFiltersInput;
@@ -61,6 +62,10 @@ function createReusableSectionFromStrapiSection(
       }
       case 'ComponentPagePress': {
          section = pressQuotesSectionFromStrapi(strapiSection, sectionId);
+         break;
+      }
+      case 'ComponentSectionFaqs': {
+         section = faqsSectionFromStrapi(strapiSection, sectionId);
          break;
       }
    }

--- a/frontend/models/sections/faqs-section.ts
+++ b/frontend/models/sections/faqs-section.ts
@@ -20,8 +20,6 @@ export function faqsSectionFromStrapi(
    const strapiFaqs = fragment?.faqs?.data ?? [];
    const faqs = filterFalsyItems(strapiFaqs.map(faqFromStrapi));
 
-   if (faqs.length === 0) return null;
-
    const title = fragment?.title ?? null;
    const description = fragment?.description ?? null;
 

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -7,6 +7,7 @@ import { computeProductListAlgoliaFilterPreset } from '@helpers/product-list-hel
 import type { ProductList } from '@models/product-list';
 import { PressQuotesSection } from '@templates/page/sections/PressQuotesSection';
 import { Configure, useMenu } from 'react-instantsearch';
+import { useDevicePartsItemType } from './hooks/useDevicePartsItemType';
 import { useItemTypeProductList } from './hooks/useItemTypeProductList';
 import { MetaTags } from './MetaTags';
 import { SecondaryNavigation } from './SecondaryNavigation';
@@ -35,6 +36,7 @@ export function ProductListView({
    const filters = computeProductListAlgoliaFilterPreset(productList);
 
    const itemTypeProductList = useItemTypeProductList(productList);
+   const selectedItemType = useDevicePartsItemType(productList);
 
    const currentProductList = itemTypeProductList ?? productList;
 
@@ -182,6 +184,7 @@ export function ProductListView({
                            title={section.title}
                            description={section.description}
                            faqs={section.faqs}
+                           itemType={selectedItemType}
                         />
                      );
                   }

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -7,7 +7,7 @@ import { computeProductListAlgoliaFilterPreset } from '@helpers/product-list-hel
 import type { ProductList } from '@models/product-list';
 import { PressQuotesSection } from '@templates/page/sections/PressQuotesSection';
 import { Configure, useMenu } from 'react-instantsearch';
-import { useDevicePartsItemType } from './hooks/useDevicePartsItemType';
+import { useAvailableItemTypes } from './hooks/useAvailableItemTypes';
 import { useItemTypeProductList } from './hooks/useItemTypeProductList';
 import { MetaTags } from './MetaTags';
 import { SecondaryNavigation } from './SecondaryNavigation';
@@ -36,7 +36,7 @@ export function ProductListView({
    const filters = computeProductListAlgoliaFilterPreset(productList);
 
    const itemTypeProductList = useItemTypeProductList(productList);
-   const selectedItemType = useDevicePartsItemType(productList);
+   const availableItemTypes = useAvailableItemTypes();
 
    const currentProductList = itemTypeProductList ?? productList;
 
@@ -184,7 +184,7 @@ export function ProductListView({
                            title={section.title}
                            description={section.description}
                            faqs={section.faqs}
-                           itemType={selectedItemType}
+                           relevantItemTypes={availableItemTypes}
                         />
                      );
                   }

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -1,4 +1,5 @@
 import { BannersSection } from '@components/sections/BannersSection';
+import { FAQsSection } from '@components/sections/FAQsSection';
 import { LifetimeWarrantySection } from '@components/sections/LifetimeWarrantySection';
 import { QuoteGallerySection } from '@components/sections/QuoteGallerySection';
 import { SplitWithImageContentSection } from '@components/sections/SplitWithImageSection';
@@ -170,6 +171,17 @@ export function ProductListView({
                            description={section.description}
                            callToAction={section.callToAction}
                            quotes={section.quotes}
+                        />
+                     );
+                  }
+                  case 'FAQs': {
+                     return (
+                        <FAQsSection
+                           key={section.id}
+                           id={section.id}
+                           title={section.title}
+                           description={section.description}
+                           faqs={section.faqs}
                         />
                      );
                   }

--- a/frontend/templates/product-list/hooks/useAvailableItemTypes.ts
+++ b/frontend/templates/product-list/hooks/useAvailableItemTypes.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useHits } from 'react-instantsearch-hooks-web';
+import { useHits } from 'react-instantsearch';
 
 export function useAvailableItemTypes() {
    const { results } = useHits();

--- a/frontend/templates/product-list/hooks/useAvailableItemTypes.ts
+++ b/frontend/templates/product-list/hooks/useAvailableItemTypes.ts
@@ -1,0 +1,15 @@
+import { useMemo } from 'react';
+import { useHits } from 'react-instantsearch-hooks-web';
+
+export function useAvailableItemTypes() {
+   const { results } = useHits();
+
+   return useMemo(() => {
+      const itemTypeFacets = results?.hierarchicalFacets.find(
+         (facet) => facet.name === 'facet_tags.Item Type'
+      );
+      if (!itemTypeFacets) return [];
+
+      return itemTypeFacets.data?.map((facet) => facet.name) ?? [];
+   }, [results]);
+}


### PR DESCRIPTION
closes #1940

### Summary

This PR introduces the first iteration of bulk assignment for FAQs. The key features are:

#### FAQ Linking
- An FAQ can be linked to multiple product lists.
  - The FAQ will be visible on every linked product list as well as their descendants, assuming an FAQs section is present. A reusable FAQs section [is already configured in this brannch](https://implement-reusable-faqs.govinor.com/admin/content-manager/collectionType/api::reusable-section.reusable-section/3).

#### FAQ Categories
- FAQs can belong to a category.
  - On each product list, only one FAQ per category is displayed. Descendant FAQs take precedence over ancestor FAQs.
  - All FAQs without a category are displayed.

#### Item Type Filter
- FAQs can be filtered by item type (e.g., "Batteries").
  - If set, the FAQ will be displayed only if the product list contains items of that type (as verified by the presence of the item type in the filter list).

#### Priority
- FAQs can be prioritized.
  - FAQs with higher priority values will appear higher on the list.

### QA Steps

Use both the [Vercel preview](https://react-commerce-git-implement-reusable-faqs-ifixit.vercel.app/Parts) and the [Strapi preview](https://implement-reusable-faqs.govinor.com/admin/content-manager/collectionType/api::faq.faq?page=1&pageSize=10&sort=question:ASC) to verify that the features listed above are correctly implemented.

cc @sterlinghirsh @jeffsnyder 