### PR TITLE
`?disableCacheGets` on strapi layout data

### DIFF
--- a/frontend/layouts/default/server.ts
+++ b/frontend/layouts/default/server.ts
@@ -4,6 +4,7 @@ import { findStoreByCode, getStoreList } from '@models/store';
 
 type GetLayoutServerSidePropsArgs = {
    storeCode: string;
+   forceMiss?: boolean;
 };
 
 export type DefaultLayoutProps = Awaited<
@@ -14,13 +15,14 @@ export type WithLayoutProps<T> = T & { layoutProps: DefaultLayoutProps };
 
 export async function getLayoutServerSideProps({
    storeCode,
+   forceMiss,
 }: GetLayoutServerSidePropsArgs) {
    const [globalSettings, stores, { shopify, ...currentStore }] =
       await timeAsync('layoutProps', () =>
          Promise.all([
-            getGlobalSettings(),
-            getStoreList(),
-            findStoreByCode(storeCode),
+            getGlobalSettings({ forceMiss }),
+            getStoreList({ forceMiss }),
+            findStoreByCode(storeCode, { forceMiss }),
          ])
       );
    return {

--- a/frontend/lib/cache.ts
+++ b/frontend/lib/cache.ts
@@ -3,14 +3,21 @@ import { timeAsync } from '@ifixit/helpers';
 
 const cacheStore = new LRU({ max: 100 });
 
+type CacheOptions = {
+   ttl: number;
+   forceMiss?: boolean;
+};
+
 export function cache<T>(
    key: string,
    getValue: () => Promise<T>,
-   ttl: number
+   { ttl, forceMiss = false }: CacheOptions
 ): Promise<T> {
-   const fromCache = cacheStore.get(key) as Promise<T> | undefined;
-   if (fromCache !== undefined) {
-      return fromCache;
+   if (!forceMiss) {
+      const fromCache = cacheStore.get(key) as Promise<T> | undefined;
+      if (fromCache !== undefined) {
+         return fromCache;
+      }
    }
    const result = timeAsync(`Cache miss for '${key}'`, getValue);
    cacheStore.set(key, result, { ttl: ttl * 1000 });

--- a/frontend/models/global-settings.ts
+++ b/frontend/models/global-settings.ts
@@ -11,8 +11,17 @@ export interface GlobalSettings {
    };
 }
 
-export async function getGlobalSettings(): Promise<GlobalSettings> {
-   return cache('globalSettings', getGlobalSettingsFromStrapi, 60 * 60);
+type GetGlobalSettingsOptions = {
+   forceMiss?: boolean;
+};
+
+export async function getGlobalSettings({
+   forceMiss,
+}: GetGlobalSettingsOptions = {}): Promise<GlobalSettings> {
+   return cache('globalSettings', getGlobalSettingsFromStrapi, {
+      ttl: 60 * 60,
+      forceMiss,
+   });
 }
 
 async function getGlobalSettingsFromStrapi(): Promise<GlobalSettings> {

--- a/frontend/models/store.ts
+++ b/frontend/models/store.ts
@@ -20,17 +20,23 @@ export type SocialMediaAccounts = Store['socialMediaAccounts'];
 
 export type ShopifySettings = Store['shopify'];
 
+type FindStoreByCodeOptions = {
+   forceMiss?: boolean;
+};
+
 /**
  * Get the store data (header menus, footer menus, etc) from the API.
  * @param {string} code The code of the store
  * @returns The store data.
  */
-export function findStoreByCode(code: string) {
-   return cache(
-      `store-${code}`,
-      () => findStoreByCodeFromStrapi(code),
-      60 * 60
-   );
+export function findStoreByCode(
+   code: string,
+   { forceMiss }: FindStoreByCodeOptions = {}
+) {
+   return cache(`store-${code}`, () => findStoreByCodeFromStrapi(code), {
+      ttl: 60 * 60,
+      forceMiss,
+   });
 }
 
 async function findStoreByCodeFromStrapi(code: string) {
@@ -81,12 +87,21 @@ export interface StoreListItem {
    currency: string;
 }
 
+type GetStoreListOptions = {
+   forceMiss?: boolean;
+};
+
 /**
  * Get the list of stores from the API.
  * @returns A list of store items.
  */
-export function getStoreList(): Promise<StoreListItem[]> {
-   return cache('storeList', getStoreListFromStrapi, 60 * 10);
+export function getStoreList({ forceMiss }: GetStoreListOptions = {}): Promise<
+   StoreListItem[]
+> {
+   return cache('storeList', getStoreListFromStrapi, {
+      ttl: 60 * 10,
+      forceMiss,
+   });
 }
 
 async function getStoreListFromStrapi(): Promise<StoreListItem[]> {

--- a/frontend/templates/page/server.tsx
+++ b/frontend/templates/page/server.tsx
@@ -1,6 +1,7 @@
 import { DEFAULT_STORE_CODE } from '@config/env';
 import { flags } from '@config/flags';
 import { invariant } from '@helpers/application-helpers';
+import { hasDisableCacheGets } from '@helpers/cache-control-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { getLayoutServerSideProps } from '@layouts/default/server';
 import { findPage } from '@models/page/server';
@@ -23,6 +24,7 @@ export const getServerSideProps: GetServerSideProps<PageTemplateProps> = async (
 
    const layoutProps = await getLayoutServerSideProps({
       storeCode: DEFAULT_STORE_CODE,
+      forceMiss: hasDisableCacheGets(context),
    });
    const page = await findPage({
       path,

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -42,16 +42,18 @@ export const getProductListServerSideProps = ({
 }: GetProductListServerSidePropsOptions): GetServerSideProps<ProductListTemplateProps> =>
    withMiddleware(async (context) => {
       const indexName = ALGOLIA_PRODUCT_INDEX_NAME;
+      const forceMiss = hasDisableCacheGets(context);
       const layoutProps: Promise<DefaultLayoutProps> = getLayoutServerSideProps(
          {
             storeCode: DEFAULT_STORE_CODE,
+            forceMiss,
          }
       );
       let productList: ProductList | null;
       let shouldRedirectToCanonical = false;
       let canonicalPath: string | null = null;
       const ifixitOrigin = ifixitOriginFromHost(context);
-      const cacheOptions = { forceMiss: hasDisableCacheGets(context) };
+      const cacheOptions = { forceMiss };
 
       switch (productListType) {
          case ProductListType.AllParts: {

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -23,8 +23,10 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
    withMiddleware(async (context) => {
       const { handle } = context.params || {};
       invariant(typeof handle === 'string', 'handle param is missing');
+      const forceMiss = hasDisableCacheGets(context);
       const { stores, ...otherLayoutProps } = await getLayoutServerSideProps({
          storeCode: DEFAULT_STORE_CODE,
+         forceMiss,
       });
       const ifixitOrigin = ifixitOriginFromHost(context);
       const product = await Product.get(
@@ -33,7 +35,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
             storeCode: DEFAULT_STORE_CODE,
             ifixitOrigin,
          },
-         { forceMiss: hasDisableCacheGets(context) }
+         { forceMiss }
       );
 
       if (product == null) {

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -17,6 +17,7 @@ import {
 } from './hooks/useTroubleshootingProps';
 import { withLogging } from '@helpers/next-helpers';
 import {
+   hasDisableCacheGets,
    withCache,
    CacheLong,
    GetCacheControlOptions,
@@ -93,6 +94,7 @@ export const getServerSideProps: GetServerSideProps<TroubleshootingProps> =
    withMiddleware(async (context) => {
       const layoutProps = await getLayoutServerSideProps({
          storeCode: DEFAULT_STORE_CODE,
+         forceMiss: hasDisableCacheGets(context),
       });
 
       const troubleshootingData = await getTroubleshootingData(context);


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/49358

Forces an LRU cache miss on Strapi layout data (global settings, stores) when the ?disableCacheGets query param is present.

## QA

Make sure the original problem is solved:

> When I made an edit to a footer link in Strapi, the edit didn't immediately show immediately when I used ?disableCacheGets. I refreshed a few times and checked various pages. Some time later the change had applied.

https://force-miss-strapi-layout-cache.govinor.com/admin