### PR TITLE
Vulcan: Show `Causes` list on desktop and mobile

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -234,7 +234,6 @@ const Wiki: NextPageWithLayout<{
                      </VStack>
                   </HStack>
                   <Box
-                     display={{ base: 'default', md: 'none' }}
                      mt="8px"
                      borderBottom="1px"
                      borderColor="gray.300"


### PR DESCRIPTION
I'd not realized that the ToC wasn't shipped yet, so we didn't want to hide the `Causes` list on desktop yet.

## QA Notes
Please confirm that the Causes list is visible on both Desktop and mobile

Closes https://github.com/iFixit/ifixit/issues/49627