### PR TITLE
Shopping Cart: Add cart-view page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+   "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/frontend/pages/Cart/view.tsx
+++ b/frontend/pages/Cart/view.tsx
@@ -1,0 +1,2 @@
+export { default } from '@templates/cart';
+export { getServerSideProps } from '@templates/cart/server';

--- a/frontend/templates/cart/index.tsx
+++ b/frontend/templates/cart/index.tsx
@@ -4,40 +4,14 @@ import { DefaultLayout } from '@layouts/default';
 import * as React from 'react';
 import { useCart } from '@ifixit/cart-sdk';
 import { ViewCartTemplateProps, useViewCartProps } from './useViewCartProps';
-import { Heading, Box } from '@chakra-ui/react';
-import { CartLineItem } from '@ifixit/cart-sdk';
+import { Box } from '@chakra-ui/react';
+// import { CartLineItem } from '@ifixit/cart-sdk';
 import { Wrapper } from '@ifixit/ui';
+import { ShoppingCart } from '@ifixit/ui';
 
 const ViewCartTemplate: NextPageWithLayout<ViewCartTemplateProps> = () => {
-   return (
-      <Wrapper>
-         <Heading>Shopping Cart</Heading>
-         <CartContents />
-      </Wrapper>
-   );
+   return <ShoppingCart />;
 };
-
-function CartContents() {
-   const cart = useCart();
-   if (!cart.isLoading && !cart.data) {
-      return <EmptyCart />;
-   }
-   return (
-      <Box>
-         {cart.data?.lineItems.map((item) => (
-            <LineItem key={item.itemcode} lineItem={item} />
-         ))}
-      </Box>
-   );
-}
-
-function EmptyCart() {
-   return <Box>Your cart is empty</Box>;
-}
-
-function LineItem({ lineItem: CartLineItem }) {
-   return <Box>{CartLineItem.itemcode}</Box>;
-}
 
 ViewCartTemplate.getLayout = function getLayout(page, pageProps) {
    return <DefaultLayout {...pageProps.layoutProps}>{page}</DefaultLayout>;

--- a/frontend/templates/cart/index.tsx
+++ b/frontend/templates/cart/index.tsx
@@ -4,12 +4,40 @@ import { DefaultLayout } from '@layouts/default';
 import * as React from 'react';
 import { useCart } from '@ifixit/cart-sdk';
 import { ViewCartTemplateProps, useViewCartProps } from './useViewCartProps';
+import { Heading, Box } from '@chakra-ui/react';
+import { CartLineItem } from '@ifixit/cart-sdk';
+import { Wrapper } from '@ifixit/ui';
 
 const ViewCartTemplate: NextPageWithLayout<ViewCartTemplateProps> = () => {
-   const { cart } = useCart();
-
-   return <React.Fragment>Empty Cart</React.Fragment>;
+   return (
+      <Wrapper>
+         <Heading>Shopping Cart</Heading>
+         <CartContents />
+      </Wrapper>
+   );
 };
+
+function CartContents() {
+   const cart = useCart();
+   if (!cart.isLoading && !cart.data) {
+      return <EmptyCart />;
+   }
+   return (
+      <Box>
+         {cart.data?.lineItems.map((item) => (
+            <LineItem key={item.itemcode} lineItem={item} />
+         ))}
+      </Box>
+   );
+}
+
+function EmptyCart() {
+   return <Box>Your cart is empty</Box>;
+}
+
+function LineItem({ lineItem: CartLineItem }) {
+   return <Box>{CartLineItem.itemcode}</Box>;
+}
 
 ViewCartTemplate.getLayout = function getLayout(page, pageProps) {
    return <DefaultLayout {...pageProps.layoutProps}>{page}</DefaultLayout>;

--- a/frontend/templates/cart/index.tsx
+++ b/frontend/templates/cart/index.tsx
@@ -1,0 +1,18 @@
+// import { Box, Flex } from '@chakra-ui/react';
+import { useAuthenticatedUser } from '@ifixit/auth-sdk';
+import { DefaultLayout } from '@layouts/default';
+import * as React from 'react';
+import { useCart } from '@ifixit/cart-sdk';
+import { ViewCartTemplateProps, useViewCartProps } from './useViewCartProps';
+
+const ViewCartTemplate: NextPageWithLayout<ViewCartTemplateProps> = () => {
+   const { cart } = useCart();
+
+   return <React.Fragment>Empty Cart</React.Fragment>;
+};
+
+ViewCartTemplate.getLayout = function getLayout(page, pageProps) {
+   return <DefaultLayout {...pageProps.layoutProps}>{page}</DefaultLayout>;
+};
+
+export default ViewCartTemplate;

--- a/frontend/templates/cart/index.tsx
+++ b/frontend/templates/cart/index.tsx
@@ -1,12 +1,6 @@
-// import { Box, Flex } from '@chakra-ui/react';
-import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { DefaultLayout } from '@layouts/default';
 import * as React from 'react';
-import { useCart } from '@ifixit/cart-sdk';
-import { ViewCartTemplateProps, useViewCartProps } from './useViewCartProps';
-import { Box } from '@chakra-ui/react';
-// import { CartLineItem } from '@ifixit/cart-sdk';
-import { Wrapper } from '@ifixit/ui';
+import { ViewCartTemplateProps } from './useViewCartProps';
 import { ShoppingCart } from '@ifixit/ui';
 
 const ViewCartTemplate: NextPageWithLayout<ViewCartTemplateProps> = () => {

--- a/frontend/templates/cart/server.tsx
+++ b/frontend/templates/cart/server.tsx
@@ -1,9 +1,5 @@
 import { DEFAULT_STORE_CODE } from '@config/env';
-import {
-   CacheLong,
-   hasDisableCacheGets,
-   withCache,
-} from '@helpers/cache-control-helpers';
+import { CacheLong, withCache } from '@helpers/cache-control-helpers';
 import { withLogging } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { getLayoutServerSideProps } from '@layouts/default/server';

--- a/frontend/templates/cart/server.tsx
+++ b/frontend/templates/cart/server.tsx
@@ -1,0 +1,32 @@
+import { DEFAULT_STORE_CODE } from '@config/env';
+import { withCacheLong } from '@helpers/cache-control-helpers';
+import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
+import { ifixitOriginFromHost } from '@helpers/path-helpers';
+import { getLayoutServerSideProps } from '@layouts/default/server';
+import compose from 'lodash/flowRight';
+import { GetServerSideProps } from 'next';
+import { ViewCartTemplateProps } from './useViewCartProps';
+
+const withMiddleware = compose(
+   withLogging<ViewCartTemplateProps>,
+   withCacheLong<ViewCartTemplateProps>,
+   withNoindexDevDomains<ViewCartTemplateProps>
+);
+
+export const getServerSideProps: GetServerSideProps<ViewCartTemplateProps> =
+   withMiddleware(async (context) => {
+      const layoutProps = await getLayoutServerSideProps({
+         storeCode: DEFAULT_STORE_CODE,
+      });
+      const ifixitOrigin = ifixitOriginFromHost(context);
+
+      const pageProps: ViewCartTemplateProps = {
+         layoutProps: layoutProps,
+         appProps: {
+            ifixitOrigin: ifixitOrigin,
+         },
+      };
+      return {
+         props: pageProps,
+      };
+   });

--- a/frontend/templates/cart/server.tsx
+++ b/frontend/templates/cart/server.tsx
@@ -1,6 +1,10 @@
 import { DEFAULT_STORE_CODE } from '@config/env';
-import { withCacheLong } from '@helpers/cache-control-helpers';
-import { withLogging, withNoindexDevDomains } from '@helpers/next-helpers';
+import {
+   CacheLong,
+   hasDisableCacheGets,
+   withCache,
+} from '@helpers/cache-control-helpers';
+import { withLogging } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { getLayoutServerSideProps } from '@layouts/default/server';
 import compose from 'lodash/flowRight';
@@ -9,8 +13,7 @@ import { ViewCartTemplateProps } from './useViewCartProps';
 
 const withMiddleware = compose(
    withLogging<ViewCartTemplateProps>,
-   withCacheLong<ViewCartTemplateProps>,
-   withNoindexDevDomains<ViewCartTemplateProps>
+   withCache(CacheLong)<ViewCartTemplateProps>
 );
 
 export const getServerSideProps: GetServerSideProps<ViewCartTemplateProps> =

--- a/frontend/templates/cart/useViewCartProps.ts
+++ b/frontend/templates/cart/useViewCartProps.ts
@@ -1,0 +1,8 @@
+import { WithProvidersProps } from '@components/common';
+import type { WithLayoutProps } from '@layouts/default/server';
+import { useServerSideProps } from '@lib/server-side-props';
+
+export type ViewCartTemplateProps = WithProvidersProps<WithLayoutProps<{}>>;
+
+export const useViewCartProps = () =>
+   useServerSideProps<ViewCartTemplateProps>();

--- a/packages/cart-sdk/hooks/use-cart.ts
+++ b/packages/cart-sdk/hooks/use-cart.ts
@@ -6,6 +6,7 @@ import {
 } from '@ifixit/helpers';
 import { useIFixitApiClient } from '@ifixit/ifixit-api-client';
 import { useIsMutating, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import {
    APICart,
    Cart,
@@ -33,6 +34,26 @@ export function useCart() {
       enabled: !isMutating,
    });
    return query;
+}
+
+export function extractCrossSells(cart: Cart | null | undefined) {
+   return useMemo(
+      () =>
+         cart
+            ? cart.crossSellProducts
+                 .filter((item) => {
+                    const isAlreadyInCart =
+                       item &&
+                       cart.lineItems.find(
+                          (lineItem) => lineItem.itemcode === item.itemcode
+                       );
+                    if (isAlreadyInCart) return null;
+                    return item;
+                 })
+                 .sort((a, b) => a.handle.localeCompare(b.handle))
+            : [],
+      [cart]
+   );
 }
 
 function isValidCartPayload(data: any): data is CartAPIResponse {

--- a/packages/cart-sdk/hooks/use-cart.ts
+++ b/packages/cart-sdk/hooks/use-cart.ts
@@ -36,7 +36,9 @@ export function useCart() {
    return query;
 }
 
-export function extractCrossSells(cart: Cart | null | undefined) {
+export function useCrossSells() {
+   const cartQuery = useCart();
+   const cart = cartQuery.data;
    return useMemo(
       () =>
          cart

--- a/packages/cart-sdk/index.tsx
+++ b/packages/cart-sdk/index.tsx
@@ -1,4 +1,4 @@
-export { useCart } from './hooks/use-cart';
+export { useCart, extractCrossSells } from './hooks/use-cart';
 export { useUpdateLineItemQuantity } from './hooks/use-update-line-item-quantity';
 export { useAddToCart } from './hooks/use-add-to-cart';
 export type { AddToCartInput } from './hooks/use-add-to-cart';

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -139,7 +139,13 @@ export function CartDrawer() {
                                  />
                               )}
                            </Box>
-                           <CrossSell />
+                           <Box
+                              px="3"
+                              py="1.5"
+                              data-testid="cart-drawer-x-sell-items"
+                           >
+                              <CrossSell />
+                           </Box>
                         </>
                      )}
                      <Fade

--- a/packages/ui/cart/drawer/CrossSell.tsx
+++ b/packages/ui/cart/drawer/CrossSell.tsx
@@ -11,16 +11,15 @@ export function CrossSell() {
    const hasItemsInCart = cart.data?.hasItemsInCart ?? false;
 
    return (
-      <Box px="3" py="1.5" data-testid="cart-drawer-x-sell-items">
-         {hasItemsInCart && (
-            <AnimatedList
-               items={crossSellItems}
-               getItemId={(item) => item.itemcode}
-               renderItem={(item) => {
-                  return <CrossSellItem item={item} my="1.5" />;
-               }}
-            />
-         )}
-      </Box>
+      (hasItemsInCart && (
+         <AnimatedList
+            items={crossSellItems}
+            getItemId={(item) => item.itemcode}
+            renderItem={(item) => {
+               return <CrossSellItem item={item} my="1.5" />;
+            }}
+         />
+      )) ||
+      null
    );
 }

--- a/packages/ui/cart/drawer/CrossSell.tsx
+++ b/packages/ui/cart/drawer/CrossSell.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@chakra-ui/react';
-import { useCart } from '@ifixit/cart-sdk';
+import { useCart, extractCrossSells } from '@ifixit/cart-sdk';
 import * as React from 'react';
 import { AnimatedList } from '../../animations';
 import { CrossSellItem } from './CrossSellItem';
@@ -7,22 +7,7 @@ import { CrossSellItem } from './CrossSellItem';
 export function CrossSell() {
    const cart = useCart();
 
-   const crossSellItems = React.useMemo(() => {
-      const crossSells =
-         cart.data?.crossSellProducts
-            .filter((item) => {
-               const isAlreadyInCart =
-                  item &&
-                  cart.data?.lineItems.find(
-                     (lineItem) => lineItem.itemcode === item.itemcode
-                  );
-               if (isAlreadyInCart) return null;
-               return item;
-            })
-            .sort((a, b) => a.handle.localeCompare(b.handle)) ?? [];
-      return crossSells;
-   }, [cart.data]);
-
+   const crossSellItems = extractCrossSells(cart);
    const hasItemsInCart = cart.data?.hasItemsInCart ?? false;
 
    return (

--- a/packages/ui/cart/drawer/CrossSell.tsx
+++ b/packages/ui/cart/drawer/CrossSell.tsx
@@ -7,7 +7,7 @@ import { CrossSellItem } from './CrossSellItem';
 export function CrossSell() {
    const cart = useCart();
 
-   const crossSellItems = extractCrossSells(cart);
+   const crossSellItems = extractCrossSells(cart.data);
    const hasItemsInCart = cart.data?.hasItemsInCart ?? false;
 
    return (

--- a/packages/ui/cart/drawer/CrossSell.tsx
+++ b/packages/ui/cart/drawer/CrossSell.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@chakra-ui/react';
-import { useCart, extractCrossSells } from '@ifixit/cart-sdk';
+import { useCart, useCrossSells } from '@ifixit/cart-sdk';
 import * as React from 'react';
 import { AnimatedList } from '../../animations';
 import { CrossSellItem } from './CrossSellItem';
@@ -7,7 +7,7 @@ import { CrossSellItem } from './CrossSellItem';
 export function CrossSell() {
    const cart = useCart();
 
-   const crossSellItems = extractCrossSells(cart.data);
+   const crossSellItems = useCrossSells();
    const hasItemsInCart = cart.data?.hasItemsInCart ?? false;
 
    return (

--- a/packages/ui/cart/index.ts
+++ b/packages/ui/cart/index.ts
@@ -1,2 +1,3 @@
+export * from './view/ShoppingCart';
 export * from './drawer/CartDrawer';
 export * from './drawer/hooks/useCartDrawer';

--- a/packages/ui/cart/view/CartEmptyState.tsx
+++ b/packages/ui/cart/view/CartEmptyState.tsx
@@ -2,24 +2,15 @@ import { Button, Circle, Text, VStack } from '@chakra-ui/react';
 import { faCartCircleExclamation } from '@fortawesome/pro-duotone-svg-icons';
 import { FaIcon } from '@ifixit/icons';
 
-export interface CartEmptyStateProps {
-   onClose: () => void;
-}
+export interface CartEmptyStateProps {}
 
-export function CartEmptyState({ onClose }: CartEmptyStateProps) {
+export function CartEmptyState({}: CartEmptyStateProps) {
    return (
       <VStack spacing="5" p="5">
          <Circle size="72px" bg="brand.100">
             <FaIcon icon={faCartCircleExclamation} h="8" color="blue.ifixit" />
          </Circle>
          <Text>Your cart is empty</Text>
-         <Button
-            colorScheme="blue"
-            onClick={onClose}
-            data-testid="back-to-shopping"
-         >
-            Back to shopping
-         </Button>
       </VStack>
    );
 }

--- a/packages/ui/cart/view/CartEmptyState.tsx
+++ b/packages/ui/cart/view/CartEmptyState.tsx
@@ -1,0 +1,25 @@
+import { Button, Circle, Text, VStack } from '@chakra-ui/react';
+import { faCartCircleExclamation } from '@fortawesome/pro-duotone-svg-icons';
+import { FaIcon } from '@ifixit/icons';
+
+export interface CartEmptyStateProps {
+   onClose: () => void;
+}
+
+export function CartEmptyState({ onClose }: CartEmptyStateProps) {
+   return (
+      <VStack spacing="5" p="5">
+         <Circle size="72px" bg="brand.100">
+            <FaIcon icon={faCartCircleExclamation} h="8" color="blue.ifixit" />
+         </Circle>
+         <Text>Your cart is empty</Text>
+         <Button
+            colorScheme="blue"
+            onClick={onClose}
+            data-testid="back-to-shopping"
+         >
+            Back to shopping
+         </Button>
+      </VStack>
+   );
+}

--- a/packages/ui/cart/view/CartLineItem.tsx
+++ b/packages/ui/cart/view/CartLineItem.tsx
@@ -102,10 +102,10 @@ export function CartLineItem({ lineItem }: CartLineItemProps) {
             >
                {lineItem.name}
             </Link>
-            <Text color="gray.500" fontSize="sm">
+            <Text color="gray.500" fontSize="sm" fontFamily="mono">
                {lineItem.itemcode}
             </Text>
-            <Text color="gray.500" fontSize="sm">
+            <Text pb="2" pt="1" color="gray.500" fontSize="sm">
                {lineItem.variantTitle}
             </Text>
             <HStack borderColor="gray.300" borderWidth="1px" borderRadius="md">

--- a/packages/ui/cart/view/CartLineItem.tsx
+++ b/packages/ui/cart/view/CartLineItem.tsx
@@ -84,100 +84,81 @@ export function CartLineItem({ lineItem }: CartLineItemProps) {
    };
 
    return (
-      <Flex direction="column" w="full" p="3" bgColor="white">
-         <Flex w="full" justify="space-between" align="flex-start">
-            <HStack spacing="3" align="flex-start">
-               <CartLineItemImage src={lineItem.imageSrc} alt={lineItem.name} />
-               <Box>
-                  <VStack align="flex-start">
-                     <Flex direction="column">
-                        <Link
-                           href={`${appContext.ifixitOrigin}/Store/Product/${lineItem.itemcode}`}
-                           isExternal
-                           fontWeight="semibold"
-                           fontSize="sm"
-                           borderRadius="sm"
-                        >
-                           {lineItem.name}
-                        </Link>
-                        <Text color="gray.500" fontSize="sm">
-                           {lineItem.itemcode}
-                        </Text>
-                        <Text color="gray.500" fontSize="sm">
-                           {lineItem.variantTitle}
-                        </Text>
-                     </Flex>
-                     <HStack
-                        borderColor="gray.300"
-                        borderWidth="1px"
-                        borderRadius="md"
-                     >
-                        <IconButton
-                           aria-label="Decrease quantity by one"
-                           variant="ghost"
-                           color="gray.500"
-                           icon={
-                              <FaIcon
-                                 icon={faCircleMinus}
-                                 h="4"
-                                 color="gray.400"
-                              />
-                           }
-                           size="xs"
-                           disabled={lineItem.quantity <= 1}
-                           onClick={decrementQuantity}
-                           data-testid="cart-drawer-decrease-quantity"
-                        />
-                        <Text
-                           color="gray.800"
-                           fontSize="xs"
-                           data-testid="cart-drawer-quantity"
-                        >
-                           {lineItem.quantity}
-                        </Text>
-                        <IconButton
-                           aria-label="Increase quantity by one"
-                           variant="ghost"
-                           color="gray.500"
-                           icon={
-                              <FaIcon
-                                 icon={faCirclePlus}
-                                 h="4"
-                                 color="gray.400"
-                              />
-                           }
-                           size="xs"
-                           disabled={
-                              lineItem.maxToAdd != null &&
-                              lineItem.quantity >= lineItem.maxToAdd
-                           }
-                           onClick={incrementQuantity}
-                           data-testid="cart-drawer-increase-quantity"
-                        />
-                     </HStack>
-                     <Collapse
-                        in={updateLineItemQuantity.isError}
-                        animateOpacity
-                     >
-                        <Alert
-                           status="error"
-                           bg="transparent"
-                           textColor="red.500"
-                           fontSize="sm"
-                           p="0"
-                        >
-                           <FaIcon
-                              icon={faCircleExclamation}
-                              h="4"
-                              mr="1.5"
-                              color="red.500"
-                           />
-                           Unable to update quantity.
-                        </Alert>
-                     </Collapse>
-                  </VStack>
-               </Box>
+      <HStack
+         w="full"
+         justify="space-between"
+         p="3"
+         spacing="3"
+         align="stretch"
+      >
+         <CartLineItemImage src={lineItem.imageSrc} alt={lineItem.name} />
+         <VStack align="flex-start" spacing="0" flexGrow="1">
+            <Link
+               href={`${appContext.ifixitOrigin}/Store/Product/${lineItem.itemcode}`}
+               isExternal
+               fontWeight="semibold"
+               fontSize="sm"
+               borderRadius="sm"
+            >
+               {lineItem.name}
+            </Link>
+            <Text color="gray.500" fontSize="sm">
+               {lineItem.itemcode}
+            </Text>
+            <Text color="gray.500" fontSize="sm">
+               {lineItem.variantTitle}
+            </Text>
+            <HStack borderColor="gray.300" borderWidth="1px" borderRadius="md">
+               <IconButton
+                  aria-label="Decrease quantity by one"
+                  variant="ghost"
+                  color="gray.500"
+                  icon={<FaIcon icon={faCircleMinus} h="4" color="gray.400" />}
+                  size="xs"
+                  disabled={lineItem.quantity <= 1}
+                  onClick={decrementQuantity}
+                  data-testid="cart-drawer-decrease-quantity"
+               />
+               <Text
+                  color="gray.800"
+                  fontSize="xs"
+                  data-testid="cart-drawer-quantity"
+               >
+                  {lineItem.quantity}
+               </Text>
+               <IconButton
+                  aria-label="Increase quantity by one"
+                  variant="ghost"
+                  color="gray.500"
+                  icon={<FaIcon icon={faCirclePlus} h="4" color="gray.400" />}
+                  size="xs"
+                  disabled={
+                     lineItem.maxToAdd != null &&
+                     lineItem.quantity >= lineItem.maxToAdd
+                  }
+                  onClick={incrementQuantity}
+                  data-testid="cart-drawer-increase-quantity"
+               />
             </HStack>
+            <Collapse in={updateLineItemQuantity.isError} animateOpacity>
+               <Alert
+                  status="error"
+                  bg="transparent"
+                  textColor="red.500"
+                  fontSize="sm"
+                  p="0"
+               >
+                  <FaIcon
+                     icon={faCircleExclamation}
+                     h="4"
+                     mr="1.5"
+                     color="red.500"
+                  />
+                  Unable to update quantity.
+               </Alert>
+            </Collapse>
+         </VStack>
+         <VStack justify="space-between" align="flex-end">
             <Box>
                <IconButton
                   bg="transparent"
@@ -191,8 +172,6 @@ export function CartLineItem({ lineItem }: CartLineItemProps) {
                   data-testid="cart-drawer-remove-item"
                />
             </Box>
-         </Flex>
-         <Box alignSelf="flex-end">
             <ProductVariantPrice
                price={multiplyMoney(lineItem.price, lineItem.quantity)}
                compareAtPrice={
@@ -203,7 +182,7 @@ export function CartLineItem({ lineItem }: CartLineItemProps) {
                direction="column-reverse"
                size="small"
             />
-         </Box>
-      </Flex>
+         </VStack>
+      </HStack>
    );
 }

--- a/packages/ui/cart/view/CartLineItem.tsx
+++ b/packages/ui/cart/view/CartLineItem.tsx
@@ -1,0 +1,209 @@
+import {
+   Alert,
+   Box,
+   Collapse,
+   Flex,
+   HStack,
+   IconButton,
+   Link,
+   Text,
+   useToast,
+   VStack,
+} from '@chakra-ui/react';
+import {
+   faCircleExclamation,
+   faCircleMinus,
+   faCirclePlus,
+   faTrash,
+} from '@fortawesome/pro-solid-svg-icons';
+import { useAppContext } from '@ifixit/app';
+import {
+   CartLineItem as LineItem,
+   useRemoveLineItem,
+   useUpdateLineItemQuantity,
+} from '@ifixit/cart-sdk';
+import { multiplyMoney } from '@ifixit/helpers';
+import { FaIcon } from '@ifixit/icons';
+import * as React from 'react';
+import { ProductVariantPrice } from '../../commerce';
+import { CartLineItemImage } from './CartLineItemImage';
+
+interface CartLineItemProps {
+   lineItem: LineItem;
+}
+
+export function CartLineItem({ lineItem }: CartLineItemProps) {
+   const appContext = useAppContext();
+   const toast = useToast();
+   const removeLineItem = useRemoveLineItem();
+   const updateLineItemQuantity = useUpdateLineItemQuantity();
+
+   React.useEffect(() => {
+      if (updateLineItemQuantity.isError) {
+         const id = setTimeout(() => {
+            updateLineItemQuantity.reset();
+         }, 3000);
+         return () => clearTimeout(id);
+      }
+   }, [updateLineItemQuantity.isError, updateLineItemQuantity.reset]);
+
+   React.useEffect(() => {
+      if (removeLineItem.isError) {
+         toast.closeAll();
+         toast({
+            status: 'error',
+            title: 'Unable to remove product',
+            description:
+               'Please try again. If the problem persists contact us.',
+            duration: 5000,
+            isClosable: true,
+            variant: 'subtle',
+            position: 'bottom-right',
+         });
+      }
+   }, [removeLineItem.isError]);
+
+   const incrementQuantity = () => {
+      updateLineItemQuantity.mutate({
+         itemcode: lineItem.itemcode,
+         quantity: 1,
+      });
+   };
+
+   const decrementQuantity = () => {
+      updateLineItemQuantity.mutate({
+         itemcode: lineItem.itemcode,
+         quantity: -1,
+      });
+   };
+
+   const handleRemoveLineItem = () => {
+      removeLineItem.mutate({
+         itemcode: lineItem.itemcode,
+      });
+   };
+
+   return (
+      <Flex direction="column" w="full" p="3" bgColor="white">
+         <Flex w="full" justify="space-between" align="flex-start">
+            <HStack spacing="3" align="flex-start">
+               <CartLineItemImage src={lineItem.imageSrc} alt={lineItem.name} />
+               <Box>
+                  <VStack align="flex-start">
+                     <Flex direction="column">
+                        <Link
+                           href={`${appContext.ifixitOrigin}/Store/Product/${lineItem.itemcode}`}
+                           isExternal
+                           fontWeight="semibold"
+                           fontSize="sm"
+                           borderRadius="sm"
+                        >
+                           {lineItem.name}
+                        </Link>
+                        <Text color="gray.500" fontSize="sm">
+                           {lineItem.itemcode}
+                        </Text>
+                        <Text color="gray.500" fontSize="sm">
+                           {lineItem.variantTitle}
+                        </Text>
+                     </Flex>
+                     <HStack
+                        borderColor="gray.300"
+                        borderWidth="1px"
+                        borderRadius="md"
+                     >
+                        <IconButton
+                           aria-label="Decrease quantity by one"
+                           variant="ghost"
+                           color="gray.500"
+                           icon={
+                              <FaIcon
+                                 icon={faCircleMinus}
+                                 h="4"
+                                 color="gray.400"
+                              />
+                           }
+                           size="xs"
+                           disabled={lineItem.quantity <= 1}
+                           onClick={decrementQuantity}
+                           data-testid="cart-drawer-decrease-quantity"
+                        />
+                        <Text
+                           color="gray.800"
+                           fontSize="xs"
+                           data-testid="cart-drawer-quantity"
+                        >
+                           {lineItem.quantity}
+                        </Text>
+                        <IconButton
+                           aria-label="Increase quantity by one"
+                           variant="ghost"
+                           color="gray.500"
+                           icon={
+                              <FaIcon
+                                 icon={faCirclePlus}
+                                 h="4"
+                                 color="gray.400"
+                              />
+                           }
+                           size="xs"
+                           disabled={
+                              lineItem.maxToAdd != null &&
+                              lineItem.quantity >= lineItem.maxToAdd
+                           }
+                           onClick={incrementQuantity}
+                           data-testid="cart-drawer-increase-quantity"
+                        />
+                     </HStack>
+                     <Collapse
+                        in={updateLineItemQuantity.isError}
+                        animateOpacity
+                     >
+                        <Alert
+                           status="error"
+                           bg="transparent"
+                           textColor="red.500"
+                           fontSize="sm"
+                           p="0"
+                        >
+                           <FaIcon
+                              icon={faCircleExclamation}
+                              h="4"
+                              mr="1.5"
+                              color="red.500"
+                           />
+                           Unable to update quantity.
+                        </Alert>
+                     </Collapse>
+                  </VStack>
+               </Box>
+            </HStack>
+            <Box>
+               <IconButton
+                  bg="transparent"
+                  _hover={{ bg: 'gray.100', color: 'gray.400' }}
+                  aria-label={`Remove ${lineItem.name} from cart`}
+                  _active={{ bg: 'gray.200' }}
+                  color="gray.300"
+                  icon={<FaIcon icon={faTrash} h="4" />}
+                  size="xs"
+                  onClick={handleRemoveLineItem}
+                  data-testid="cart-drawer-remove-item"
+               />
+            </Box>
+         </Flex>
+         <Box alignSelf="flex-end">
+            <ProductVariantPrice
+               price={multiplyMoney(lineItem.price, lineItem.quantity)}
+               compareAtPrice={
+                  lineItem.compareAtPrice == null
+                     ? null
+                     : multiplyMoney(lineItem.compareAtPrice, lineItem.quantity)
+               }
+               direction="column-reverse"
+               size="small"
+            />
+         </Box>
+      </Flex>
+   );
+}

--- a/packages/ui/cart/view/CartLineItemImage.tsx
+++ b/packages/ui/cart/view/CartLineItemImage.tsx
@@ -11,7 +11,7 @@ interface CartLineItemImageProps {
 export function CartLineItemImage({ src, alt }: CartLineItemImageProps) {
    return (
       <Box
-         boxSize="16"
+         boxSize="74px"
          position="relative"
          borderColor="gray.300"
          borderWidth="1px"
@@ -24,8 +24,8 @@ export function CartLineItemImage({ src, alt }: CartLineItemImageProps) {
                src={src}
                alt={alt || ''}
                priority
-               height={62}
-               width={62}
+               height={72}
+               width={72}
                style={{
                   objectFit: 'cover',
                }}

--- a/packages/ui/cart/view/CartLineItemImage.tsx
+++ b/packages/ui/cart/view/CartLineItemImage.tsx
@@ -1,0 +1,45 @@
+import { Box, Center } from '@chakra-ui/react';
+import { faImage } from '@fortawesome/pro-duotone-svg-icons';
+import { FaIcon } from '@ifixit/icons';
+import { ResponsiveImage } from '../../misc';
+
+interface CartLineItemImageProps {
+   src?: string | null;
+   alt?: string;
+}
+
+export function CartLineItemImage({ src, alt }: CartLineItemImageProps) {
+   return (
+      <Box
+         boxSize="16"
+         position="relative"
+         borderColor="gray.300"
+         borderWidth="1px"
+         borderRadius="md"
+         overflow="hidden"
+         flexShrink={0}
+      >
+         {src ? (
+            <ResponsiveImage
+               src={src}
+               alt={alt || ''}
+               priority
+               height={62}
+               width={62}
+               style={{
+                  objectFit: 'cover',
+               }}
+            />
+         ) : (
+            <Center bgColor="gray.100" h="full">
+               <FaIcon
+                  icon={faImage}
+                  color="gray.500"
+                  h="6"
+                  transition="color 300ms"
+               />
+            </Center>
+         )}
+      </Box>
+   );
+}

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -30,14 +30,17 @@ import { ShoppingCartTotals } from './ShoppingCartTotals';
 type CartQuery = ReturnType<typeof useCart>;
 
 export function ShoppingCart() {
+   const checkout = useCheckout();
    return (
       <Flex py="16" width="full" maxWidth="6xl" margin="auto">
          <Box pr="20" flexGrow="1">
             <ShoppingCartItems />
          </Box>
-         <Box width="sm">
+         <Flex direction="column" width="sm" gap="5">
             <ShoppingCartTotals />
-         </Box>
+            <CheckoutError error={checkout.error} onDismiss={checkout.reset} />
+            <CompleteOrderButton checkout={checkout} />
+         </Flex>
       </Flex>
    );
 }
@@ -46,7 +49,6 @@ export function ShoppingCartItems() {
    const appContext = useAppContext();
    const isMounted = useIsMountedState();
    const cart = useCart();
-   const checkout = useCheckout();
    const isCartEmpty = cart.isFetched && !cart.data?.hasItemsInCart;
 
    return (
@@ -85,23 +87,26 @@ export function ShoppingCartItems() {
          >
             <CartEmptyState />
          </Fade>
-
-         <Slide show={cart.data?.hasItemsInCart}>
-            <CheckoutError error={checkout.error} onDismiss={checkout.reset} />
-            <Box w="full">
-               <SimpleGrid columns={2} spacing="2.5" w="full">
-                  <Button
-                     colorScheme="blue"
-                     disabled={!cart.data?.hasItemsInCart}
-                     isLoading={checkout.isRedirecting}
-                     onClick={checkout.redirectToCheckout}
-                  >
-                     Checkout
-                  </Button>
-               </SimpleGrid>
-            </Box>
-         </Slide>
       </VStack>
+   );
+}
+
+function CompleteOrderButton({
+   checkout,
+}: {
+   checkout: ReturnType<typeof useCheckout>;
+}) {
+   const cart = useCart();
+   return (
+      <Button
+         w="full"
+         colorScheme="blue"
+         disabled={!cart.data?.hasItemsInCart}
+         isLoading={checkout.isRedirecting}
+         onClick={checkout.redirectToCheckout}
+      >
+         Complete Order
+      </Button>
    );
 }
 

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -66,7 +66,6 @@ export function ShoppingCartItems() {
                <Card data-testid="cart-drawer-line-items">
                   {cart.data && (
                      <AnimatedList
-                        debug="LINE ITEMS"
                         items={cart.data.lineItems}
                         getItemId={(item) => item.itemcode}
                         renderItem={(item) => {

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -56,26 +56,7 @@ export function ShoppingCartItems() {
    return (
       <VStack spacing="5">
          <CartHeading cart={cart} />
-         {cart.isError && (
-            <Alert
-               status="error"
-               variant="subtle"
-               flexDirection="column"
-               alignItems="center"
-               justifyContent="center"
-               textAlign="center"
-               height="200px"
-            >
-               <FaIcon icon={faCircleExclamation} h="10" color="red.500" />
-               <AlertTitle mt={4} mb={1} fontSize="lg">
-                  Unable to fetch the cart
-               </AlertTitle>
-               <AlertDescription maxWidth="sm">
-                  Please try to reload the page. If the problem persists, please
-                  contact us.
-               </AlertDescription>
-            </Alert>
-         )}
+         <CartAlert cart={cart} />
          {cart.data?.hasItemsInCart && (
             <>
                <Card data-testid="cart-drawer-line-items">
@@ -184,6 +165,29 @@ function CartHeading({ cart }: { cart: CartQuery }) {
          )}
       </HStack>
    );
+}
+
+function CartAlert({ cart }: { cart: CartQuery }) {
+   return cart.isError ? (
+      <Alert
+         status="error"
+         variant="subtle"
+         flexDirection="column"
+         alignItems="center"
+         justifyContent="center"
+         textAlign="center"
+         height="200px"
+      >
+         <FaIcon icon={faCircleExclamation} h="10" color="red.500" />
+         <AlertTitle mt={4} mb={1} fontSize="lg">
+            Unable to fetch the cart
+         </AlertTitle>
+         <AlertDescription maxWidth="sm">
+            Please try to reload the page. If the problem persists, please
+            contact us.
+         </AlertDescription>
+      </Alert>
+   ) : null;
 }
 
 interface CheckoutErrorProps {

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -5,6 +5,7 @@ import {
    Badge,
    Box,
    Button,
+   Card,
    CloseButton,
    Divider,
    Flex,
@@ -12,6 +13,7 @@ import {
    HStack,
    SimpleGrid,
    Skeleton,
+   Spacer,
    Spinner,
    Text,
 } from '@chakra-ui/react';
@@ -26,8 +28,22 @@ import { useIsMountedState } from '../../hooks';
 import { CartEmptyState } from './CartEmptyState';
 import { CartLineItem } from './CartLineItem';
 import { CrossSell } from '../drawer/CrossSell';
+import { ShoppingCartTotals } from './ShoppingCartTotals';
 
 export function ShoppingCart() {
+   return (
+      <Flex py="16" gap="80px" maxWidth="5xl" margin="auto">
+         <Box>
+            <ShoppingCartItems />
+         </Box>
+         <Box width="md">
+            <ShoppingCartTotals />
+         </Box>
+      </Flex>
+   );
+}
+
+export function ShoppingCartItems() {
    const appContext = useAppContext();
    const isMounted = useIsMountedState();
    const cart = useCart();
@@ -37,9 +53,7 @@ export function ShoppingCart() {
    return (
       <>
          <HStack align="center">
-            <Heading size="sm" lineHeight="normal">
-               Cart
-            </Heading>
+            <Heading size="xl">Shopping cart</Heading>
             {(cart.data != null || !cart.isError) && (
                <Badge
                   borderRadius="full"
@@ -71,23 +85,19 @@ export function ShoppingCart() {
                textAlign="center"
                height="200px"
             >
-               <FaIcon
-                  icon={faCircleExclamation}
-                  h="10"
-                  color="red.500"
-               />
+               <FaIcon icon={faCircleExclamation} h="10" color="red.500" />
                <AlertTitle mt={4} mb={1} fontSize="lg">
                   Unable to fetch the cart
                </AlertTitle>
                <AlertDescription maxWidth="sm">
-                  Please try to reload the page. If the problem
-                  persists, please contact us.
+                  Please try to reload the page. If the problem persists, please
+                  contact us.
                </AlertDescription>
             </Alert>
          )}
          {cart.data?.hasItemsInCart && (
             <>
-               <Box data-testid="cart-drawer-line-items">
+               <Card data-testid="cart-drawer-line-items">
                   {cart.data && (
                      <AnimatedList
                         debug="LINE ITEMS"
@@ -103,7 +113,7 @@ export function ShoppingCart() {
                         }}
                      />
                   )}
-               </Box>
+               </Card>
                <CrossSell />
             </>
          )}
@@ -119,10 +129,7 @@ export function ShoppingCart() {
          </Fade>
 
          <Slide show={cart.data?.hasItemsInCart}>
-            <CheckoutError
-               error={checkout.error}
-               onDismiss={checkout.reset}
-            />
+            <CheckoutError error={checkout.error} onDismiss={checkout.reset} />
             <Box w="full">
                <Collapse show={!cart.isError} mb="3">
                   <Flex w="full" justify="space-between">
@@ -138,18 +145,13 @@ export function ShoppingCart() {
                                  lineHeight="1em"
                                  fontWeight="bold"
                               >
-                                 {formatMoney(
-                                    cart.data.totals.price
-                                 )}
+                                 {formatMoney(cart.data.totals.price)}
                               </Text>
                               {cart.data.totals.discount &&
-                                 cart.data.totals.discount.amount >
-                                 0 && (
+                                 cart.data.totals.discount.amount > 0 && (
                                     <Text color="gray.500">
                                        You saved{' '}
-                                       {formatMoney(
-                                          cart.data.totals.discount
-                                       )}
+                                       {formatMoney(cart.data.totals.discount)}
                                     </Text>
                                  )}
                            </>

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -12,16 +12,12 @@ import {
    Heading,
    HStack,
    SimpleGrid,
-   Skeleton,
-   Spacer,
    Spinner,
-   Text,
    VStack,
 } from '@chakra-ui/react';
 import { faCircleExclamation } from '@fortawesome/pro-solid-svg-icons';
 import { useAppContext } from '@ifixit/app';
 import { CartError, useCart, useCheckout } from '@ifixit/cart-sdk';
-import { formatMoney } from '@ifixit/helpers';
 import { FaIcon } from '@ifixit/icons';
 import * as React from 'react';
 import { AnimatedList, Collapse, Slide, Fade } from '../../animations';
@@ -54,7 +50,7 @@ export function ShoppingCartItems() {
    const isCartEmpty = cart.isFetched && !cart.data?.hasItemsInCart;
 
    return (
-      <VStack spacing="5">
+      <Flex direction="column" spacing="5">
          <CartHeading cart={cart} />
          <CartAlert cart={cart} />
          {cart.data?.hasItemsInCart && (
@@ -105,7 +101,7 @@ export function ShoppingCartItems() {
                </SimpleGrid>
             </Box>
          </Slide>
-      </VStack>
+      </Flex>
    );
 }
 

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -141,7 +141,7 @@ export function ShoppingCartItems() {
 
 function CartHeading({ cart }: { cart: CartQuery }) {
    return (
-      <HStack align="center">
+      <HStack align="center" w="full">
          <Heading size="xl">Shopping cart</Heading>
          {(cart.data != null || !cart.isError) && (
             <Badge

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -83,14 +83,7 @@ export function ShoppingCartItems() {
                <CrossSell />
             </>
          )}
-         <Fade
-            show={isCartEmpty}
-            disableExitAnimation
-            position="absolute"
-            w="full"
-            top="0"
-            left="0"
-         >
+         <Fade show={isCartEmpty} disableExitAnimation w="full">
             <CartEmptyState />
          </Fade>
       </VStack>
@@ -122,26 +115,27 @@ function CartHeading({ cart }: { cart: CartQuery }) {
    return (
       <HStack align="center" w="full">
          <Heading size="xl">Shopping cart</Heading>
-         {(cart.data != null || !cart.isError) && (
-            <Badge
-               borderRadius="full"
-               variant="subtle"
-               colorScheme="gray"
-               boxSize="6"
-               display="flex"
-               alignItems="center"
-               justifyContent="center"
-               bg="gray.100"
-               color="gray.400"
-               data-testid="cart-drawer-item-count"
-            >
-               {cart.isLoading ? (
-                  <Spinner size="xs" />
-               ) : (
-                  cart.data?.totals.itemsCount ?? 0
-               )}
-            </Badge>
-         )}
+         {(cart.data != null || !cart.isError) &&
+            cart.data?.totals.itemsCount !== 0 && (
+               <Badge
+                  borderRadius="full"
+                  variant="subtle"
+                  colorScheme="gray"
+                  boxSize="6"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  bg="gray.100"
+                  color="gray.400"
+                  data-testid="cart-drawer-item-count"
+               >
+                  {cart.isLoading ? (
+                     <Spinner size="xs" />
+                  ) : (
+                     cart.data?.totals.itemsCount ?? 0
+                  )}
+               </Badge>
+            )}
       </HStack>
    );
 }

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -1,0 +1,280 @@
+import {
+   Alert,
+   AlertDescription,
+   AlertTitle,
+   Badge,
+   Box,
+   Button,
+   CloseButton,
+   Divider,
+   Drawer,
+   DrawerBody,
+   DrawerCloseButton,
+   DrawerContent,
+   DrawerFooter,
+   DrawerHeader,
+   DrawerOverlay,
+   Flex,
+   Heading,
+   HStack,
+   SimpleGrid,
+   Skeleton,
+   Spinner,
+   Text,
+} from '@chakra-ui/react';
+import { faCircleExclamation } from '@fortawesome/pro-solid-svg-icons';
+import { useAppContext } from '@ifixit/app';
+import { CartError, useCart, useCheckout } from '@ifixit/cart-sdk';
+import { formatMoney } from '@ifixit/helpers';
+import { FaIcon } from '@ifixit/icons';
+import * as React from 'react';
+import { AnimatedList, Collapse, Slide, Fade } from '../../animations';
+import { useIsMountedState } from '../../hooks';
+import { CartDrawerTrigger } from './CartDrawerTrigger';
+import { CartEmptyState } from './CartEmptyState';
+import { CartLineItem } from './CartLineItem';
+import { CrossSell } from './CrossSell';
+import { useCartDrawer } from './hooks/useCartDrawer';
+
+export function CartDrawer() {
+   const appContext = useAppContext();
+   const { isOpen, onOpen, onClose, onViewCart } = useCartDrawer();
+   const isMounted = useIsMountedState();
+   const cart = useCart();
+   const checkout = useCheckout();
+   const isCartEmpty = cart.isFetched && !cart.data?.hasItemsInCart;
+
+   return (
+      <>
+         <CartDrawerTrigger
+            onClick={onOpen}
+            hasItemsInCart={cart.data?.hasItemsInCart}
+         />
+         {isMounted && (
+            <Drawer
+               isOpen={isOpen}
+               placement="right"
+               onClose={onClose}
+               size="sm"
+            >
+               <DrawerOverlay />
+               <DrawerContent color="gray.800" data-testid="cart-drawer">
+                  <DrawerHeader borderBottomWidth="1px" position="relative">
+                     <DrawerCloseButton
+                        top="50%"
+                        transform="translateY(-50%)"
+                        data-testid="cart-drawer-close"
+                     />
+                     <HStack align="center">
+                        <Heading size="sm" lineHeight="normal">
+                           Cart
+                        </Heading>
+                        {(cart.data != null || !cart.isError) && (
+                           <Badge
+                              borderRadius="full"
+                              variant="subtle"
+                              colorScheme="gray"
+                              boxSize="6"
+                              display="flex"
+                              alignItems="center"
+                              justifyContent="center"
+                              bg="gray.100"
+                              color="gray.400"
+                              data-testid="cart-drawer-item-count"
+                           >
+                              {cart.isLoading ? (
+                                 <Spinner size="xs" />
+                              ) : (
+                                 cart.data?.totals.itemsCount ?? 0
+                              )}
+                           </Badge>
+                        )}
+                     </HStack>
+                  </DrawerHeader>
+
+                  <DrawerBody
+                     p="0"
+                     data-testid="cart-drawer-body"
+                     position="relative"
+                  >
+                     {cart.isError && (
+                        <Alert
+                           status="error"
+                           variant="subtle"
+                           flexDirection="column"
+                           alignItems="center"
+                           justifyContent="center"
+                           textAlign="center"
+                           height="200px"
+                        >
+                           <FaIcon
+                              icon={faCircleExclamation}
+                              h="10"
+                              color="red.500"
+                           />
+                           <AlertTitle mt={4} mb={1} fontSize="lg">
+                              Unable to fetch the cart
+                           </AlertTitle>
+                           <AlertDescription maxWidth="sm">
+                              Please try to reload the page. If the problem
+                              persists, please contact us.
+                           </AlertDescription>
+                        </Alert>
+                     )}
+                     {cart.data?.hasItemsInCart && (
+                        <>
+                           <Box data-testid="cart-drawer-line-items">
+                              {cart.data && (
+                                 <AnimatedList
+                                    debug="LINE ITEMS"
+                                    items={cart.data.lineItems}
+                                    getItemId={(item) => item.itemcode}
+                                    renderItem={(item) => {
+                                       return (
+                                          <>
+                                             <CartLineItem lineItem={item} />
+                                             <Divider borderColor="chakra-border-color" />
+                                          </>
+                                       );
+                                    }}
+                                 />
+                              )}
+                           </Box>
+                           <CrossSell />
+                        </>
+                     )}
+                     <Fade
+                        show={isCartEmpty}
+                        disableExitAnimation
+                        position="absolute"
+                        w="full"
+                        top="0"
+                        left="0"
+                     >
+                        <CartEmptyState onClose={onClose} />
+                     </Fade>
+                  </DrawerBody>
+
+                  <Slide show={cart.data?.hasItemsInCart}>
+                     <CheckoutError
+                        error={checkout.error}
+                        onDismiss={checkout.reset}
+                     />
+                     <DrawerFooter borderTopWidth="1px">
+                        <Box w="full">
+                           <Collapse show={!cart.isError} mb="3">
+                              <Flex w="full" justify="space-between">
+                                 <Text fontSize="sm" fontWeight="bold">
+                                    Total
+                                 </Text>
+                                 <Flex direction="column" align="flex-end">
+                                    {cart.data && !cart.isRefetching ? (
+                                       <>
+                                          <Text
+                                             color="brand.500"
+                                             fontSize="xl"
+                                             lineHeight="1em"
+                                             fontWeight="bold"
+                                          >
+                                             {formatMoney(
+                                                cart.data.totals.price
+                                             )}
+                                          </Text>
+                                          {cart.data.totals.discount &&
+                                             cart.data.totals.discount.amount >
+                                                0 && (
+                                                <Text color="gray.500">
+                                                   You saved{' '}
+                                                   {formatMoney(
+                                                      cart.data.totals.discount
+                                                   )}
+                                                </Text>
+                                             )}
+                                       </>
+                                    ) : (
+                                       <Skeleton h="20px" w="80px" />
+                                    )}
+                                 </Flex>
+                              </Flex>
+                           </Collapse>
+                           <SimpleGrid columns={2} spacing="2.5" w="full">
+                              <Button
+                                 as="a"
+                                 href={`${appContext.ifixitOrigin}/cart/view`}
+                                 variant="outline"
+                                 onClick={onViewCart}
+                              >
+                                 View cart
+                              </Button>
+                              <Button
+                                 colorScheme="blue"
+                                 disabled={!cart.data?.hasItemsInCart}
+                                 isLoading={checkout.isRedirecting}
+                                 onClick={checkout.redirectToCheckout}
+                              >
+                                 Checkout
+                              </Button>
+                           </SimpleGrid>
+                        </Box>
+                     </DrawerFooter>
+                  </Slide>
+               </DrawerContent>
+            </Drawer>
+         )}
+      </>
+   );
+}
+
+interface CheckoutErrorProps {
+   error: CartError | null;
+   onDismiss: () => void;
+}
+
+function CheckoutError({ error, onDismiss }: CheckoutErrorProps) {
+   let checkoutError: React.ReactNode | null = null;
+
+   switch (error) {
+      case CartError.EmptyCart:
+         checkoutError = 'Your cart is empty';
+      case CartError.UnknownError:
+         checkoutError = (
+            <>
+               Checkout unavailable. Please contact{' '}
+               <a href="mailto:support@ifixit.com">support@ifixit.com</a>
+            </>
+         );
+   }
+
+   React.useEffect(() => {
+      if (checkoutError) {
+         const id = setTimeout(onDismiss, 5000);
+         return () => clearTimeout(id);
+      }
+   }, [checkoutError, onDismiss]);
+
+   return (
+      <Collapse show={checkoutError != null}>
+         <Box p="3">
+            <Alert status="error">
+               <FaIcon
+                  icon={faCircleExclamation}
+                  h="4"
+                  mt="0.5"
+                  mr="2.5"
+                  color="red.500"
+               />
+               <Box flexGrow={1}>
+                  <AlertDescription>{checkoutError}</AlertDescription>
+               </Box>
+               <CloseButton
+                  alignSelf="flex-start"
+                  position="relative"
+                  right={-1}
+                  top={-1}
+                  onClick={onDismiss}
+               />
+            </Alert>
+         </Box>
+      </Collapse>
+   );
+}

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -16,6 +16,7 @@ import {
    Spacer,
    Spinner,
    Text,
+   VStack,
 } from '@chakra-ui/react';
 import { faCircleExclamation } from '@fortawesome/pro-solid-svg-icons';
 import { useAppContext } from '@ifixit/app';
@@ -32,8 +33,8 @@ import { ShoppingCartTotals } from './ShoppingCartTotals';
 
 export function ShoppingCart() {
    return (
-      <Flex py="16" gap="80px" maxWidth="5xl" margin="auto">
-         <Box>
+      <Flex py="16" maxWidth="5xl" margin="auto">
+         <Box pr="20">
             <ShoppingCartItems />
          </Box>
          <Box width="md">
@@ -51,7 +52,7 @@ export function ShoppingCartItems() {
    const isCartEmpty = cart.isFetched && !cart.data?.hasItemsInCart;
 
    return (
-      <>
+      <VStack spacing="5">
          <HStack align="center">
             <Heading size="xl">Shopping cart</Heading>
             {(cart.data != null || !cart.isError) && (
@@ -173,7 +174,7 @@ export function ShoppingCartItems() {
                </SimpleGrid>
             </Box>
          </Slide>
-      </>
+      </VStack>
    );
 }
 

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -93,36 +93,6 @@ export function ShoppingCartItems() {
          <Slide show={cart.data?.hasItemsInCart}>
             <CheckoutError error={checkout.error} onDismiss={checkout.reset} />
             <Box w="full">
-               <Collapse show={!cart.isError} mb="3">
-                  <Flex w="full" justify="space-between">
-                     <Text fontSize="sm" fontWeight="bold">
-                        Total
-                     </Text>
-                     <Flex direction="column" align="flex-end">
-                        {cart.data && !cart.isRefetching ? (
-                           <>
-                              <Text
-                                 color="brand.500"
-                                 fontSize="xl"
-                                 lineHeight="1em"
-                                 fontWeight="bold"
-                              >
-                                 {formatMoney(cart.data.totals.price)}
-                              </Text>
-                              {cart.data.totals.discount &&
-                                 cart.data.totals.discount.amount > 0 && (
-                                    <Text color="gray.500">
-                                       You saved{' '}
-                                       {formatMoney(cart.data.totals.discount)}
-                                    </Text>
-                                 )}
-                           </>
-                        ) : (
-                           <Skeleton h="20px" w="80px" />
-                        )}
-                     </Flex>
-                  </Flex>
-               </Collapse>
                <SimpleGrid columns={2} spacing="2.5" w="full">
                   <Button
                      colorScheme="blue"

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -101,6 +101,8 @@ function CompleteOrderButton({
       <Button
          w="full"
          colorScheme="blue"
+         py="4"
+         height="auto"
          disabled={!cart.data?.hasItemsInCart}
          isLoading={checkout.isRedirecting}
          onClick={checkout.redirectToCheckout}

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -31,11 +31,11 @@ type CartQuery = ReturnType<typeof useCart>;
 
 export function ShoppingCart() {
    return (
-      <Flex py="16" maxWidth="5xl" margin="auto">
-         <Box pr="20">
+      <Flex py="16" width="full" maxWidth="5xl" margin="auto">
+         <Box pr="20" flexGrow="1">
             <ShoppingCartItems />
          </Box>
-         <Box width="lg">
+         <Box width="sm">
             <ShoppingCartTotals />
          </Box>
       </Flex>
@@ -50,7 +50,7 @@ export function ShoppingCartItems() {
    const isCartEmpty = cart.isFetched && !cart.data?.hasItemsInCart;
 
    return (
-      <Flex direction="column" spacing="5">
+      <VStack w="full" align="left" spacing="5">
          <CartHeading cart={cart} />
          <CartAlert cart={cart} />
          {cart.data?.hasItemsInCart && (
@@ -101,7 +101,7 @@ export function ShoppingCartItems() {
                </SimpleGrid>
             </Box>
          </Slide>
-      </Flex>
+      </VStack>
    );
 }
 

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -39,7 +39,7 @@ export function ShoppingCart() {
          <Box pr="20">
             <ShoppingCartItems />
          </Box>
-         <Box width="md">
+         <Box width="lg">
             <ShoppingCartTotals />
          </Box>
       </Flex>

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -31,7 +31,7 @@ type CartQuery = ReturnType<typeof useCart>;
 
 export function ShoppingCart() {
    return (
-      <Flex py="16" width="full" maxWidth="5xl" margin="auto">
+      <Flex py="16" width="full" maxWidth="6xl" margin="auto">
          <Box pr="20" flexGrow="1">
             <ShoppingCartItems />
          </Box>

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -7,13 +7,6 @@ import {
    Button,
    CloseButton,
    Divider,
-   Drawer,
-   DrawerBody,
-   DrawerCloseButton,
-   DrawerContent,
-   DrawerFooter,
-   DrawerHeader,
-   DrawerOverlay,
    Flex,
    Heading,
    HStack,
@@ -30,15 +23,12 @@ import { FaIcon } from '@ifixit/icons';
 import * as React from 'react';
 import { AnimatedList, Collapse, Slide, Fade } from '../../animations';
 import { useIsMountedState } from '../../hooks';
-import { CartDrawerTrigger } from './CartDrawerTrigger';
 import { CartEmptyState } from './CartEmptyState';
 import { CartLineItem } from './CartLineItem';
-import { CrossSell } from './CrossSell';
-import { useCartDrawer } from './hooks/useCartDrawer';
+import { CrossSell } from '../drawer/CrossSell';
 
-export function CartDrawer() {
+export function ShoppingCart() {
    const appContext = useAppContext();
-   const { isOpen, onOpen, onClose, onViewCart } = useCartDrawer();
    const isMounted = useIsMountedState();
    const cart = useCart();
    const checkout = useCheckout();
@@ -46,181 +36,141 @@ export function CartDrawer() {
 
    return (
       <>
-         <CartDrawerTrigger
-            onClick={onOpen}
-            hasItemsInCart={cart.data?.hasItemsInCart}
-         />
-         {isMounted && (
-            <Drawer
-               isOpen={isOpen}
-               placement="right"
-               onClose={onClose}
-               size="sm"
+         <HStack align="center">
+            <Heading size="sm" lineHeight="normal">
+               Cart
+            </Heading>
+            {(cart.data != null || !cart.isError) && (
+               <Badge
+                  borderRadius="full"
+                  variant="subtle"
+                  colorScheme="gray"
+                  boxSize="6"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  bg="gray.100"
+                  color="gray.400"
+                  data-testid="cart-drawer-item-count"
+               >
+                  {cart.isLoading ? (
+                     <Spinner size="xs" />
+                  ) : (
+                     cart.data?.totals.itemsCount ?? 0
+                  )}
+               </Badge>
+            )}
+         </HStack>
+         {cart.isError && (
+            <Alert
+               status="error"
+               variant="subtle"
+               flexDirection="column"
+               alignItems="center"
+               justifyContent="center"
+               textAlign="center"
+               height="200px"
             >
-               <DrawerOverlay />
-               <DrawerContent color="gray.800" data-testid="cart-drawer">
-                  <DrawerHeader borderBottomWidth="1px" position="relative">
-                     <DrawerCloseButton
-                        top="50%"
-                        transform="translateY(-50%)"
-                        data-testid="cart-drawer-close"
-                     />
-                     <HStack align="center">
-                        <Heading size="sm" lineHeight="normal">
-                           Cart
-                        </Heading>
-                        {(cart.data != null || !cart.isError) && (
-                           <Badge
-                              borderRadius="full"
-                              variant="subtle"
-                              colorScheme="gray"
-                              boxSize="6"
-                              display="flex"
-                              alignItems="center"
-                              justifyContent="center"
-                              bg="gray.100"
-                              color="gray.400"
-                              data-testid="cart-drawer-item-count"
-                           >
-                              {cart.isLoading ? (
-                                 <Spinner size="xs" />
-                              ) : (
-                                 cart.data?.totals.itemsCount ?? 0
-                              )}
-                           </Badge>
-                        )}
-                     </HStack>
-                  </DrawerHeader>
-
-                  <DrawerBody
-                     p="0"
-                     data-testid="cart-drawer-body"
-                     position="relative"
-                  >
-                     {cart.isError && (
-                        <Alert
-                           status="error"
-                           variant="subtle"
-                           flexDirection="column"
-                           alignItems="center"
-                           justifyContent="center"
-                           textAlign="center"
-                           height="200px"
-                        >
-                           <FaIcon
-                              icon={faCircleExclamation}
-                              h="10"
-                              color="red.500"
-                           />
-                           <AlertTitle mt={4} mb={1} fontSize="lg">
-                              Unable to fetch the cart
-                           </AlertTitle>
-                           <AlertDescription maxWidth="sm">
-                              Please try to reload the page. If the problem
-                              persists, please contact us.
-                           </AlertDescription>
-                        </Alert>
-                     )}
-                     {cart.data?.hasItemsInCart && (
-                        <>
-                           <Box data-testid="cart-drawer-line-items">
-                              {cart.data && (
-                                 <AnimatedList
-                                    debug="LINE ITEMS"
-                                    items={cart.data.lineItems}
-                                    getItemId={(item) => item.itemcode}
-                                    renderItem={(item) => {
-                                       return (
-                                          <>
-                                             <CartLineItem lineItem={item} />
-                                             <Divider borderColor="chakra-border-color" />
-                                          </>
-                                       );
-                                    }}
-                                 />
-                              )}
-                           </Box>
-                           <CrossSell />
-                        </>
-                     )}
-                     <Fade
-                        show={isCartEmpty}
-                        disableExitAnimation
-                        position="absolute"
-                        w="full"
-                        top="0"
-                        left="0"
-                     >
-                        <CartEmptyState onClose={onClose} />
-                     </Fade>
-                  </DrawerBody>
-
-                  <Slide show={cart.data?.hasItemsInCart}>
-                     <CheckoutError
-                        error={checkout.error}
-                        onDismiss={checkout.reset}
-                     />
-                     <DrawerFooter borderTopWidth="1px">
-                        <Box w="full">
-                           <Collapse show={!cart.isError} mb="3">
-                              <Flex w="full" justify="space-between">
-                                 <Text fontSize="sm" fontWeight="bold">
-                                    Total
-                                 </Text>
-                                 <Flex direction="column" align="flex-end">
-                                    {cart.data && !cart.isRefetching ? (
-                                       <>
-                                          <Text
-                                             color="brand.500"
-                                             fontSize="xl"
-                                             lineHeight="1em"
-                                             fontWeight="bold"
-                                          >
-                                             {formatMoney(
-                                                cart.data.totals.price
-                                             )}
-                                          </Text>
-                                          {cart.data.totals.discount &&
-                                             cart.data.totals.discount.amount >
-                                                0 && (
-                                                <Text color="gray.500">
-                                                   You saved{' '}
-                                                   {formatMoney(
-                                                      cart.data.totals.discount
-                                                   )}
-                                                </Text>
-                                             )}
-                                       </>
-                                    ) : (
-                                       <Skeleton h="20px" w="80px" />
-                                    )}
-                                 </Flex>
-                              </Flex>
-                           </Collapse>
-                           <SimpleGrid columns={2} spacing="2.5" w="full">
-                              <Button
-                                 as="a"
-                                 href={`${appContext.ifixitOrigin}/cart/view`}
-                                 variant="outline"
-                                 onClick={onViewCart}
-                              >
-                                 View cart
-                              </Button>
-                              <Button
-                                 colorScheme="blue"
-                                 disabled={!cart.data?.hasItemsInCart}
-                                 isLoading={checkout.isRedirecting}
-                                 onClick={checkout.redirectToCheckout}
-                              >
-                                 Checkout
-                              </Button>
-                           </SimpleGrid>
-                        </Box>
-                     </DrawerFooter>
-                  </Slide>
-               </DrawerContent>
-            </Drawer>
+               <FaIcon
+                  icon={faCircleExclamation}
+                  h="10"
+                  color="red.500"
+               />
+               <AlertTitle mt={4} mb={1} fontSize="lg">
+                  Unable to fetch the cart
+               </AlertTitle>
+               <AlertDescription maxWidth="sm">
+                  Please try to reload the page. If the problem
+                  persists, please contact us.
+               </AlertDescription>
+            </Alert>
          )}
+         {cart.data?.hasItemsInCart && (
+            <>
+               <Box data-testid="cart-drawer-line-items">
+                  {cart.data && (
+                     <AnimatedList
+                        debug="LINE ITEMS"
+                        items={cart.data.lineItems}
+                        getItemId={(item) => item.itemcode}
+                        renderItem={(item) => {
+                           return (
+                              <>
+                                 <CartLineItem lineItem={item} />
+                                 <Divider borderColor="chakra-border-color" />
+                              </>
+                           );
+                        }}
+                     />
+                  )}
+               </Box>
+               <CrossSell />
+            </>
+         )}
+         <Fade
+            show={isCartEmpty}
+            disableExitAnimation
+            position="absolute"
+            w="full"
+            top="0"
+            left="0"
+         >
+            <CartEmptyState />
+         </Fade>
+
+         <Slide show={cart.data?.hasItemsInCart}>
+            <CheckoutError
+               error={checkout.error}
+               onDismiss={checkout.reset}
+            />
+            <Box w="full">
+               <Collapse show={!cart.isError} mb="3">
+                  <Flex w="full" justify="space-between">
+                     <Text fontSize="sm" fontWeight="bold">
+                        Total
+                     </Text>
+                     <Flex direction="column" align="flex-end">
+                        {cart.data && !cart.isRefetching ? (
+                           <>
+                              <Text
+                                 color="brand.500"
+                                 fontSize="xl"
+                                 lineHeight="1em"
+                                 fontWeight="bold"
+                              >
+                                 {formatMoney(
+                                    cart.data.totals.price
+                                 )}
+                              </Text>
+                              {cart.data.totals.discount &&
+                                 cart.data.totals.discount.amount >
+                                 0 && (
+                                    <Text color="gray.500">
+                                       You saved{' '}
+                                       {formatMoney(
+                                          cart.data.totals.discount
+                                       )}
+                                    </Text>
+                                 )}
+                           </>
+                        ) : (
+                           <Skeleton h="20px" w="80px" />
+                        )}
+                     </Flex>
+                  </Flex>
+               </Collapse>
+               <SimpleGrid columns={2} spacing="2.5" w="full">
+                  <Button
+                     colorScheme="blue"
+                     disabled={!cart.data?.hasItemsInCart}
+                     isLoading={checkout.isRedirecting}
+                     onClick={checkout.redirectToCheckout}
+                  >
+                     Checkout
+                  </Button>
+               </SimpleGrid>
+            </Box>
+         </Slide>
       </>
    );
 }

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -31,6 +31,8 @@ import { CartLineItem } from './CartLineItem';
 import { CrossSell } from '../drawer/CrossSell';
 import { ShoppingCartTotals } from './ShoppingCartTotals';
 
+type CartQuery = ReturnType<typeof useCart>;
+
 export function ShoppingCart() {
    return (
       <Flex py="16" maxWidth="5xl" margin="auto">
@@ -53,29 +55,7 @@ export function ShoppingCartItems() {
 
    return (
       <VStack spacing="5">
-         <HStack align="center">
-            <Heading size="xl">Shopping cart</Heading>
-            {(cart.data != null || !cart.isError) && (
-               <Badge
-                  borderRadius="full"
-                  variant="subtle"
-                  colorScheme="gray"
-                  boxSize="6"
-                  display="flex"
-                  alignItems="center"
-                  justifyContent="center"
-                  bg="gray.100"
-                  color="gray.400"
-                  data-testid="cart-drawer-item-count"
-               >
-                  {cart.isLoading ? (
-                     <Spinner size="xs" />
-                  ) : (
-                     cart.data?.totals.itemsCount ?? 0
-                  )}
-               </Badge>
-            )}
-         </HStack>
+         <CartHeading cart={cart} />
          {cart.isError && (
             <Alert
                status="error"
@@ -175,6 +155,34 @@ export function ShoppingCartItems() {
             </Box>
          </Slide>
       </VStack>
+   );
+}
+
+function CartHeading({ cart }: { cart: CartQuery }) {
+   return (
+      <HStack align="center">
+         <Heading size="xl">Shopping cart</Heading>
+         {(cart.data != null || !cart.isError) && (
+            <Badge
+               borderRadius="full"
+               variant="subtle"
+               colorScheme="gray"
+               boxSize="6"
+               display="flex"
+               alignItems="center"
+               justifyContent="center"
+               bg="gray.100"
+               color="gray.400"
+               data-testid="cart-drawer-item-count"
+            >
+               {cart.isLoading ? (
+                  <Spinner size="xs" />
+               ) : (
+                  cart.data?.totals.itemsCount ?? 0
+               )}
+            </Badge>
+         )}
+      </HStack>
    );
 }
 

--- a/packages/ui/cart/view/ShoppingCart.tsx
+++ b/packages/ui/cart/view/ShoppingCart.tsx
@@ -32,11 +32,17 @@ type CartQuery = ReturnType<typeof useCart>;
 export function ShoppingCart() {
    const checkout = useCheckout();
    return (
-      <Flex py="16" width="full" maxWidth="6xl" margin="auto">
-         <Box pr="20" flexGrow="1">
+      <Flex
+         direction={{ base: 'column', lg: 'row' }}
+         p={{ base: 3, md: 10, lg: 16 }}
+         width="full"
+         maxWidth="6xl"
+         margin="auto"
+      >
+         <Box pr={{ base: '0', lg: '20' }} flexGrow="1">
             <ShoppingCartItems />
          </Box>
-         <Flex direction="column" width="sm" gap="5">
+         <Flex direction="column" width={{ base: 'full', lg: 'sm' }} gap="5">
             <ShoppingCartTotals />
             <CheckoutError error={checkout.error} onDismiss={checkout.reset} />
             <CompleteOrderButton checkout={checkout} />
@@ -107,7 +113,7 @@ function CompleteOrderButton({
          isLoading={checkout.isRedirecting}
          onClick={checkout.redirectToCheckout}
       >
-         Complete Order
+         Complete order
       </Button>
    );
 }

--- a/packages/ui/cart/view/ShoppingCartTotals.tsx
+++ b/packages/ui/cart/view/ShoppingCartTotals.tsx
@@ -1,11 +1,113 @@
-import { Card, CardBody, CardHeader } from '@chakra-ui/react';
+import {
+   Card,
+   CardBody,
+   CardHeader,
+   VStack,
+   Flex,
+   Box,
+   Spinner,
+   Spacer,
+   Text,
+} from '@chakra-ui/react';
+import { useCart } from '@ifixit/cart-sdk';
+import { formatMoney } from '@ifixit/helpers';
 import * as React from 'react';
 
 export function ShoppingCartTotals() {
+   const { data, isLoading } = useCart();
+   if (!isLoading && !data) {
+      return null;
+   }
    return (
       <Card>
-         <CardHeader textAlign="center">Summary</CardHeader>
-         <CardBody>Some totals</CardBody>
+         <CardHeader
+            p="5"
+            borderBottom="1px solid"
+            borderBottomColor="gray.300"
+            color="gray.800"
+            fontWeight="700"
+            textAlign="center"
+         >
+            Summary
+         </CardHeader>
+         <CardBody>
+            {isLoading ? (
+               <Spinner />
+            ) : data ? (
+               <>
+                  <VStack spacing="4" fontSize="sm">
+                     <VStack w="100%" lineHeight="normal" spacing="3" mb="2">
+                        <Flex
+                           justify="space-between"
+                           w="100%"
+                           alignItems="center"
+                        >
+                           <Box textAlign="left" color="gray.600">
+                              Subtotal
+                           </Box>
+                           <Box
+                              textAlign="right"
+                              color="gray.800"
+                              fontWeight="700"
+                           >
+                              {formatMoney(
+                                 data.totals.compareAtPrice || data.totals.price
+                              )}
+                           </Box>
+                        </Flex>
+                        {data.totals.discount?.amount && (
+                           <Flex
+                              justify="space-between"
+                              w="100%"
+                              color="brand.500"
+                              alignItems="center"
+                           >
+                              <Box textAlign="left">You saved</Box>
+                              <Box textAlign="right" fontWeight="700">
+                                 {formatMoney(data.totals.discount)}
+                              </Box>
+                           </Flex>
+                        )}
+                        <Flex
+                           justify="space-between"
+                           w="100%"
+                           fontSize="sm"
+                           alignItems="center"
+                        >
+                           <Box textAlign="left" color="gray.600">
+                              Shipping
+                           </Box>
+                           <Box
+                              textAlign="right"
+                              color="gray.800"
+                              fontWeight="700"
+                           >
+                              Calculated at next step
+                           </Box>
+                        </Flex>
+                     </VStack>
+                     <Spacer
+                        borderBottom="1px solid"
+                        borderBottomColor="gray.300"
+                     />
+                     <Flex
+                        justify="space-between"
+                        w="100%"
+                        fontSize="sm"
+                        fontWeight="700"
+                        alignItems="center"
+                     >
+                        <Box textAlign="left" color="gray.600">
+                           Total
+                        </Box>
+                        <Box textAlign="right" color="brand.500" fontSize="2xl">
+                           {formatMoney(data.totals.price)}
+                        </Box>
+                     </Flex>
+                  </VStack>
+               </>
+            ) : null}
+         </CardBody>
       </Card>
    );
 }

--- a/packages/ui/cart/view/ShoppingCartTotals.tsx
+++ b/packages/ui/cart/view/ShoppingCartTotals.tsx
@@ -1,0 +1,11 @@
+import { Card, CardBody, CardHeader } from '@chakra-ui/react';
+import * as React from 'react';
+
+export function ShoppingCartTotals() {
+   return (
+      <Card>
+         <CardHeader textAlign="center">Summary</CardHeader>
+         <CardBody>Some totals</CardBody>
+      </Card>
+   );
+}


### PR DESCRIPTION
Create most of the cart view page according to the figma design.

This started as copying the CartDrawer (re-copied this morning) and modifying it as needed to match the figma. I also extracted a few bits that weren't likely to change.

I've opted in many cases to copy the functionality because keeping one component that can work in both places would require compromising on styling a fair amount, or increase complexity (adding a page and drawer mode).

### Features

* Cart contents
* Summary / totals
* Checkout button
* Cross sell (borrowed component from Drawer)
* Cart Alerts

This is missing some of the sections from the design and I imagine those will come as future pulls but I want to get this in the code base now as the `CartDrawer` continues to evolve.

Connect iFixit/ifixit#48798