### PR TITLE
Sentry: Tag production deployment status

### DIFF
--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -58,6 +58,11 @@ export const CACHE_DISABLED = process.env.NEXT_PUBLIC_CACHE_DISABLED === 'true';
 
 export const REDIS_URL = process.env.REDIS_URL;
 
+export const VERCEL_ENV = process.env.NEXT_PUBLIC_VERCEL_ENV;
+
+export const VERCEL_GIT_COMMIT_SHA =
+   process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA;
+
 export const VERCEL_HOST =
    process.env.VERCEL_STABLE_HOST || process.env.VERCEL_URL;
 

--- a/frontend/helpers/vercel-helpers.ts
+++ b/frontend/helpers/vercel-helpers.ts
@@ -4,30 +4,13 @@ export async function isCurrentProductionDeployment() {
    if (!VERCEL_GIT_COMMIT_SHA || VERCEL_ENV !== 'production') {
       return false;
    }
-   const errorMsg = 'Failed to fetch GitHub branch info';
-
-   let res;
-   try {
-      res = await fetch(
-         'https://api.github.com/repos/iFixit/react-commerce/branches/main'
-      );
-   } catch (e) {
-      console.error(errorMsg, e);
-      return false;
-   }
+   const res = await fetch(
+      'https://api.github.com/repos/iFixit/react-commerce/branches/main'
+   );
    if (!res.ok) {
-      console.error(errorMsg, res.status, res.statusText);
-      return false;
+      throw new Error(`Failed to fetch main branch data: ${res.statusText}`);
    }
-
-   let json;
-   try {
-      json = await res.json();
-   } catch (e) {
-      console.error(errorMsg, e);
-      return false;
-   }
-
+   const json = await res.json();
    const currentSha = json.commit.sha;
    return currentSha === VERCEL_GIT_COMMIT_SHA;
 }

--- a/frontend/helpers/vercel-helpers.ts
+++ b/frontend/helpers/vercel-helpers.ts
@@ -1,0 +1,33 @@
+import { VERCEL_ENV, VERCEL_GIT_COMMIT_SHA } from '@config/env';
+
+export async function isCurrentProductionDeployment() {
+   if (!VERCEL_GIT_COMMIT_SHA || VERCEL_ENV !== 'production') {
+      return false;
+   }
+   const errorMsg = 'Failed to fetch GitHub branch info';
+
+   let res;
+   try {
+      res = await fetch(
+         'https://api.github.com/repos/iFixit/react-commerce/branches/main'
+      );
+   } catch (e) {
+      console.error(errorMsg, e);
+      return false;
+   }
+   if (!res.ok) {
+      console.error(errorMsg, res.status, res.statusText);
+      return false;
+   }
+
+   let json;
+   try {
+      json = await res.json();
+   } catch (e) {
+      console.error(errorMsg, e);
+      return false;
+   }
+
+   const currentSha = json.commit.sha;
+   return currentSha === VERCEL_GIT_COMMIT_SHA;
+}

--- a/frontend/helpers/vercel-helpers.ts
+++ b/frontend/helpers/vercel-helpers.ts
@@ -1,16 +1,25 @@
 import { VERCEL_ENV, VERCEL_GIT_COMMIT_SHA } from '@config/env';
+import { cache } from '@lib/cache';
 
 export async function isCurrentProductionDeployment() {
    if (!VERCEL_GIT_COMMIT_SHA || VERCEL_ENV !== 'production') {
       return false;
    }
+   const sha = await cache('get-main-commit-sha', getMainCommitSha, {
+      ttl: 300,
+   });
+   return sha === VERCEL_GIT_COMMIT_SHA;
+}
+
+async function getMainCommitSha(): Promise<string> {
    const res = await fetch(
       'https://api.github.com/repos/iFixit/react-commerce/branches/main'
    );
    if (!res.ok) {
-      throw new Error(`Failed to fetch main branch data: ${res.statusText}`);
+      throw new Error(
+         `Failed to fetch main branch data: ${res.status} ${res.statusText}`
+      );
    }
    const json = await res.json();
-   const currentSha = json.commit.sha;
-   return currentSha === VERCEL_GIT_COMMIT_SHA;
+   return json.commit.sha;
 }

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -10,8 +10,15 @@ const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
    async beforeSend(event) {
-      const current_production = await isCurrentProductionDeployment();
-      event.tags = { ...event.tags, current_production };
+      try {
+         const current_production = await isCurrentProductionDeployment();
+         event.tags = { ...event.tags, current_production };
+      } catch (e) {
+         event.extra = {
+            ...event.extra,
+            'Exception Checking Production Deployment': e,
+         };
+      }
       return event;
    },
    dsn: SENTRY_DSN,

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -2,12 +2,18 @@
 // The config you add here will be used whenever a page is visited.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
 import * as Sentry from '@sentry/nextjs';
 import { BrowserTracing } from '@sentry/browser';
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
+   async beforeSend(event) {
+      const current_production = await isCurrentProductionDeployment();
+      event.tags = { ...event.tags, current_production };
+      return event;
+   },
    dsn: SENTRY_DSN,
    integrations: [new BrowserTracing()],
    sampleRate: 1.0,

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -14,6 +14,7 @@ Sentry.init({
          const current_production = await isCurrentProductionDeployment();
          event.tags = { ...event.tags, current_production };
       } catch (e) {
+         event.tags = { ...event.tags, before_send_error: true };
          event.extra = {
             ...event.extra,
             'Exception Checking Production Deployment': e,

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -5,8 +5,15 @@ const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
    async beforeSend(event) {
-      const current_production = await isCurrentProductionDeployment();
-      event.tags = { ...event.tags, current_production };
+      try {
+         const current_production = await isCurrentProductionDeployment();
+         event.tags = { ...event.tags, current_production };
+      } catch (e) {
+         event.extra = {
+            ...event.extra,
+            'Exception Checking Production Deployment': e,
+         };
+      }
       return event;
    },
    dsn: SENTRY_DSN,

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -1,8 +1,14 @@
+import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
 import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
 Sentry.init({
+   async beforeSend(event) {
+      const current_production = await isCurrentProductionDeployment();
+      event.tags = { ...event.tags, current_production };
+      return event;
+   },
    dsn: SENTRY_DSN,
    initialScope: {
       tags: {

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -9,6 +9,7 @@ Sentry.init({
          const current_production = await isCurrentProductionDeployment();
          event.tags = { ...event.tags, current_production };
       } catch (e) {
+         event.tags = { ...event.tags, before_send_error: true };
          event.extra = {
             ...event.extra,
             'Exception Checking Production Deployment': e,

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -32,6 +32,7 @@ Sentry.init({
          const current_production = await isCurrentProductionDeployment();
          event.tags = { ...event.tags, current_production };
       } catch (e) {
+         event.tags = { ...event.tags, before_send_error: true };
          event.extra = {
             ...event.extra,
             'Exception Checking Production Deployment': e,

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -2,6 +2,7 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
+import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
 import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
@@ -19,7 +20,7 @@ Sentry.init({
          'next.runtime': 'server',
       },
    },
-   beforeSend(event, hint) {
+   async beforeSend(event, hint) {
       const ex = hint.originalException;
       if (ex instanceof Error) {
          // Happens when receiving a bad url that fails to decode
@@ -27,6 +28,8 @@ Sentry.init({
             return null;
          }
       }
+      const current_production = await isCurrentProductionDeployment();
+      event.tags = { ...event.tags, current_production };
       return event;
    },
 });

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -28,8 +28,15 @@ Sentry.init({
             return null;
          }
       }
-      const current_production = await isCurrentProductionDeployment();
-      event.tags = { ...event.tags, current_production };
+      try {
+         const current_production = await isCurrentProductionDeployment();
+         event.tags = { ...event.tags, current_production };
+      } catch (e) {
+         event.extra = {
+            ...event.extra,
+            'Exception Checking Production Deployment': e,
+         };
+      }
       return event;
    },
 });


### PR DESCRIPTION
Closes #1942

Adds a boolean tag (`current_production`) to all Sentry events indicating whether the deployment is the current production deployment.

## QA

Throw an error somewhere in local dev. Make sure the new tag (`current_production`) shows up in Sentry. It should be `false` for local dev.