### PR TITLE
Add placement fields to Strapi FAQ

### DIFF
--- a/backend/src/api/faq/content-types/faq/schema.json
+++ b/backend/src/api/faq/content-types/faq/schema.json
@@ -4,7 +4,8 @@
    "info": {
       "singularName": "faq",
       "pluralName": "faqs",
-      "displayName": "FAQ"
+      "displayName": "FAQ",
+      "description": ""
    },
    "options": {
       "draftAndPublish": true
@@ -18,6 +19,16 @@
       "answer": {
          "type": "richtext",
          "required": true
+      },
+      "category": {
+         "type": "string",
+         "required": false
+      },
+      "product_lists": {
+         "type": "relation",
+         "relation": "manyToMany",
+         "target": "api::product-list.product-list",
+         "mappedBy": "faqs"
       }
    }
 }

--- a/backend/src/api/faq/content-types/faq/schema.json
+++ b/backend/src/api/faq/content-types/faq/schema.json
@@ -32,6 +32,9 @@
       },
       "item_type": {
          "type": "string"
+      },
+      "priority": {
+         "type": "integer"
       }
    }
 }

--- a/backend/src/api/faq/content-types/faq/schema.json
+++ b/backend/src/api/faq/content-types/faq/schema.json
@@ -29,6 +29,9 @@
          "relation": "manyToMany",
          "target": "api::product-list.product-list",
          "mappedBy": "faqs"
+      },
+      "item_type": {
+         "type": "string"
       }
    }
 }

--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -235,6 +235,12 @@
          "type": "dynamiczone",
          "components": ["product-list.item-type-override"],
          "required": true
+      },
+      "faqs": {
+         "type": "relation",
+         "relation": "manyToMany",
+         "target": "api::faq.faq",
+         "inversedBy": "product_lists"
       }
    }
 }

--- a/backend/src/api/reusable-section/content-types/reusable-section/schema.json
+++ b/backend/src/api/reusable-section/content-types/reusable-section/schema.json
@@ -41,7 +41,8 @@
             "section.banner",
             "page.split-with-image",
             "page.press",
-            "section.quote-gallery"
+            "section.quote-gallery",
+            "section.faqs"
          ],
          "required": true,
          "max": 1,

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -748,10 +748,21 @@ export type Error = {
 export type Faq = {
    __typename?: 'Faq';
    answer: Scalars['String'];
+   category?: Maybe<Scalars['String']>;
    createdAt?: Maybe<Scalars['DateTime']>;
+   item_type?: Maybe<Scalars['String']>;
+   priority?: Maybe<Scalars['Int']>;
+   product_lists?: Maybe<ProductListRelationResponseCollection>;
    publishedAt?: Maybe<Scalars['DateTime']>;
    question: Scalars['String'];
    updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type FaqProduct_ListsArgs = {
+   filters?: InputMaybe<ProductListFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
+   publicationState?: InputMaybe<PublicationState>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type FaqEntity = {
@@ -774,10 +785,14 @@ export type FaqEntityResponseCollection = {
 export type FaqFiltersInput = {
    and?: InputMaybe<Array<InputMaybe<FaqFiltersInput>>>;
    answer?: InputMaybe<StringFilterInput>;
+   category?: InputMaybe<StringFilterInput>;
    createdAt?: InputMaybe<DateTimeFilterInput>;
    id?: InputMaybe<IdFilterInput>;
+   item_type?: InputMaybe<StringFilterInput>;
    not?: InputMaybe<FaqFiltersInput>;
    or?: InputMaybe<Array<InputMaybe<FaqFiltersInput>>>;
+   priority?: InputMaybe<IntFilterInput>;
+   product_lists?: InputMaybe<ProductListFiltersInput>;
    publishedAt?: InputMaybe<DateTimeFilterInput>;
    question?: InputMaybe<StringFilterInput>;
    updatedAt?: InputMaybe<DateTimeFilterInput>;
@@ -785,6 +800,10 @@ export type FaqFiltersInput = {
 
 export type FaqInput = {
    answer?: InputMaybe<Scalars['String']>;
+   category?: InputMaybe<Scalars['String']>;
+   item_type?: InputMaybe<Scalars['String']>;
+   priority?: InputMaybe<Scalars['Int']>;
+   product_lists?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
    publishedAt?: InputMaybe<Scalars['DateTime']>;
    question?: InputMaybe<Scalars['String']>;
 };
@@ -1596,6 +1615,7 @@ export type ProductList = {
    defaultShowAllChildrenOnLgSizes?: Maybe<Scalars['Boolean']>;
    description: Scalars['String'];
    deviceTitle?: Maybe<Scalars['String']>;
+   faqs?: Maybe<FaqRelationResponseCollection>;
    filters?: Maybe<Scalars['String']>;
    forceNoindex?: Maybe<Scalars['Boolean']>;
    h1?: Maybe<Scalars['String']>;
@@ -1622,6 +1642,13 @@ export type ProductList = {
 
 export type ProductListChildrenArgs = {
    filters?: InputMaybe<ProductListFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
+   publicationState?: InputMaybe<PublicationState>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type ProductListFaqsArgs = {
+   filters?: InputMaybe<FaqFiltersInput>;
    pagination?: InputMaybe<PaginationArg>;
    publicationState?: InputMaybe<PublicationState>;
    sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
@@ -1659,6 +1686,7 @@ export type ProductListFiltersInput = {
    defaultShowAllChildrenOnLgSizes?: InputMaybe<BooleanFilterInput>;
    description?: InputMaybe<StringFilterInput>;
    deviceTitle?: InputMaybe<StringFilterInput>;
+   faqs?: InputMaybe<FaqFiltersInput>;
    filters?: InputMaybe<StringFilterInput>;
    forceNoindex?: InputMaybe<BooleanFilterInput>;
    h1?: InputMaybe<StringFilterInput>;
@@ -1689,6 +1717,7 @@ export type ProductListInput = {
    defaultShowAllChildrenOnLgSizes?: InputMaybe<Scalars['Boolean']>;
    description?: InputMaybe<Scalars['String']>;
    deviceTitle?: InputMaybe<Scalars['String']>;
+   faqs?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
    filters?: InputMaybe<Scalars['String']>;
    forceNoindex?: InputMaybe<Scalars['Boolean']>;
    h1?: InputMaybe<Scalars['String']>;
@@ -2025,6 +2054,7 @@ export type ReusableSectionSectionDynamicZone =
    | ComponentPagePress
    | ComponentPageSplitWithImage
    | ComponentSectionBanner
+   | ComponentSectionFaqs
    | ComponentSectionQuoteGallery
    | Error;
 
@@ -3698,6 +3728,7 @@ export type FindReusableSectionsQuery = {
                        }>;
                     } | null;
                  }
+               | { __typename: 'ComponentSectionFaqs' }
                | {
                     __typename: 'ComponentSectionQuoteGallery';
                     id: string;
@@ -3842,6 +3873,7 @@ export type ReusableSectionFieldsFragment = {
               }>;
            } | null;
         }
+      | { __typename: 'ComponentSectionFaqs' }
       | {
            __typename: 'ComponentSectionQuoteGallery';
            id: string;

--- a/frontend/lib/strapi-sdk/generated/validation.ts
+++ b/frontend/lib/strapi-sdk/generated/validation.ts
@@ -560,10 +560,14 @@ export function FaqFiltersInputSchema(): z.ZodObject<
    return z.object<Properties<FaqFiltersInput>>({
       and: z.array(z.lazy(() => FaqFiltersInputSchema().nullable())).nullish(),
       answer: z.lazy(() => StringFilterInputSchema().nullish()),
+      category: z.lazy(() => StringFilterInputSchema().nullish()),
       createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
       id: z.lazy(() => IdFilterInputSchema().nullish()),
+      item_type: z.lazy(() => StringFilterInputSchema().nullish()),
       not: z.lazy(() => FaqFiltersInputSchema().nullish()),
       or: z.array(z.lazy(() => FaqFiltersInputSchema().nullable())).nullish(),
+      priority: z.lazy(() => IntFilterInputSchema().nullish()),
+      product_lists: z.lazy(() => ProductListFiltersInputSchema().nullish()),
       publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
       question: z.lazy(() => StringFilterInputSchema().nullish()),
       updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
@@ -573,6 +577,10 @@ export function FaqFiltersInputSchema(): z.ZodObject<
 export function FaqInputSchema(): z.ZodObject<Properties<FaqInput>> {
    return z.object<Properties<FaqInput>>({
       answer: z.string().nullish(),
+      category: z.string().nullish(),
+      item_type: z.string().nullish(),
+      priority: z.number().nullish(),
+      product_lists: z.array(z.string().nullable()).nullish(),
       publishedAt: z.unknown().nullish(),
       question: z.string().nullish(),
    });
@@ -831,6 +839,7 @@ export function ProductListFiltersInputSchema(): z.ZodObject<
       ),
       description: z.lazy(() => StringFilterInputSchema().nullish()),
       deviceTitle: z.lazy(() => StringFilterInputSchema().nullish()),
+      faqs: z.lazy(() => FaqFiltersInputSchema().nullish()),
       filters: z.lazy(() => StringFilterInputSchema().nullish()),
       forceNoindex: z.lazy(() => BooleanFilterInputSchema().nullish()),
       h1: z.lazy(() => StringFilterInputSchema().nullish()),
@@ -867,6 +876,7 @@ export function ProductListInputSchema(): z.ZodObject<
       defaultShowAllChildrenOnLgSizes: z.boolean().nullish(),
       description: z.string().nullish(),
       deviceTitle: z.string().nullish(),
+      faqs: z.array(z.string().nullable()).nullish(),
       filters: z.string().nullish(),
       forceNoindex: z.boolean().nullish(),
       h1: z.string().nullish(),


### PR DESCRIPTION
Part of #1940 
qa_req 0

This PR expands the Strapi FAQ collection type with the fields that are necessary to accomplish an MVP for #772.
Allowing complex filtering capabilities to determine whether an FAQ should be visible or not in a product list is tricky and can result in a complex interface for the editors. 
We've explored many solutions and during last week iOP meeting we agreed on getting started with a simple version that only allows to apply an item type filter (e.g. an FAQ that only applies to "Batteries"). This will help us ship an initial implementation and iterate afterward on filtering capabilities as needed.

