### PR TITLE
Vulcan: Update Causes introduction icon

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -50,7 +50,7 @@ import {
    faAngleDown,
    faCircleNodes,
    faClockRotateLeft,
-   faInfoCircle,
+   faList,
    faPenToSquare,
 } from '@fortawesome/pro-solid-svg-icons';
 import { BreadCrumbs } from '@ifixit/breadcrumbs';
@@ -321,7 +321,7 @@ function TableOfContents({
                      borderRadius="md"
                      mr={2}
                   >
-                     <FaIcon icon={faInfoCircle} color="brand.500" />
+                     <FaIcon icon={faList} color="brand.500" />
                   </Square>
                   <Box as="span">Introduction</Box>
                </Link>


### PR DESCRIPTION
## Issue
Update the Causes introduction icon from `InfoCircle` to `List`

[Figma link](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=201-65621&mode=design&t=qzcftwURjqxSnmrO-0)

<details>
<summary>Post-update</summary>
<img width="1817" alt="Screenshot 2023-09-06 at 12 44 07 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/ad6f0ff5-4e25-476a-a89d-db5cadeff369">

</details>

## QA

Test on `Troubleshooting/Nintendo_Switch/Will+Not+Turn+On/481634`

Closes https://github.com/iFixit/ifixit/issues/49674