### PR TITLE
Improve hello world app router

### DIFF
--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/Header.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/Header.tsx
@@ -2,11 +2,10 @@
 
 import { Heading } from '@chakra-ui/react';
 
-export type TemplateProps = {
+export type HeaderProps = {
    device: string;
 };
 
-export default function PageTemplate(props: TemplateProps) {
-   const { device } = props;
+export default function Header({ device }: HeaderProps) {
    return <Heading>Device: {device}</Heading>;
 }

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/ServerHeader.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/ServerHeader.tsx
@@ -1,0 +1,7 @@
+export type ServerHeaderProps = {
+   device: string;
+};
+
+export default function ServerHeader({ device }: ServerHeaderProps) {
+   return <span>Device: {device}</span>;
+}

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/page.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/page.tsx
@@ -1,10 +1,11 @@
-import { Metadata } from 'next';
-import PageTemplate from './components/pageTemplate';
-import { RestrictRobots } from '@helpers/next-helpers';
-import { notFound } from 'next/navigation';
 import { flags } from '@config/flags';
+import { RestrictRobots } from '@helpers/next-helpers';
 import { getiFixitOrigin } from '@helpers/path-helpers';
+import { Metadata } from 'next';
 import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
+import Header from './components/Header';
+import ServerHeader from './components/ServerHeader';
 
 export type PageParams = {
    device: string;
@@ -19,7 +20,12 @@ export default function Page({ params, searchParams }: PageProps) {
    ensureFlag();
 
    const pageProps = getPageProps({ params, searchParams });
-   return <PageTemplate {...pageProps} />;
+   return (
+      <>
+         <Header {...pageProps} />
+         <ServerHeader {...pageProps} />
+      </>
+   );
 }
 
 function ensureFlag() {

--- a/frontend/app/(defaultLayout)/components/GoogleAnalytics.tsx
+++ b/frontend/app/(defaultLayout)/components/GoogleAnalytics.tsx
@@ -1,7 +1,7 @@
-import { GA_URL, GA_KEY, GA_DEBUG, GTAG_ID } from '@config/env';
-import * as React from 'react';
-import Script from 'next/script';
+import { GA_DEBUG, GA_KEY, GA_URL, GTAG_ID } from '@config/env';
 import { usePathname, useSearchParams } from 'next/navigation';
+import Script from 'next/script';
+import * as React from 'react';
 
 declare const ga: (command: string, hitType: string, url?: string) => void;
 

--- a/frontend/app/(defaultLayout)/components/IFixitPageFrame.tsx
+++ b/frontend/app/(defaultLayout)/components/IFixitPageFrame.tsx
@@ -14,8 +14,8 @@ import {
    MenuList,
    Portal,
 } from '@chakra-ui/react';
-import { Matomo } from './components/Matomo';
-import { GoogleAnalytics } from './components/GoogleAnalytics';
+import { Matomo } from './Matomo';
+import { GoogleAnalytics } from './GoogleAnalytics';
 import { SmartLink } from '@components/ui/SmartLink';
 import {
    faArrowRight,
@@ -69,7 +69,7 @@ import { LayoutErrorBoundary } from '@layouts/default/LayoutErrorBoundary';
 import { Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 
-export default function DefaultLayout({
+export default function IFixitPageFrame({
    stores,
    currentStore,
    shopifyCredentials,

--- a/frontend/app/(defaultLayout)/components/Matomo.tsx
+++ b/frontend/app/(defaultLayout)/components/Matomo.tsx
@@ -1,8 +1,8 @@
 import { MATOMO_URL } from '@config/env';
-import * as React from 'react';
-import Script from 'next/script';
 import { trackMatomoPageView } from '@ifixit/analytics';
 import { usePathname, useSearchParams } from 'next/navigation';
+import Script from 'next/script';
+import * as React from 'react';
 
 export function Matomo() {
    const pathname = usePathname();

--- a/frontend/app/(defaultLayout)/layout.tsx
+++ b/frontend/app/(defaultLayout)/layout.tsx
@@ -1,12 +1,10 @@
-'use client';
-
-import { AppProviders } from '@components/common';
+import { AppProviders } from '@components/common/AppProviders';
 import { DEFAULT_STORE_CODE } from '@config/env';
-import DefaultLayout from './iFixitHeaderFooter';
 import { getLayoutServerSideProps } from '@layouts/default/server';
 import { ReactNode } from 'react';
+import IFixitPageFrame from './components/IFixitPageFrame';
 
-export default async function iFixitHeaderFooterLayout({
+export default async function DefaultLayout({
    children,
 }: {
    children: ReactNode;
@@ -19,7 +17,7 @@ export default async function iFixitHeaderFooterLayout({
 
    return (
       <AppProviders>
-         <DefaultLayout {...layoutProps}>{children}</DefaultLayout>
+         <IFixitPageFrame {...layoutProps}>{children}</IFixitPageFrame>
       </AppProviders>
    );
 }

--- a/frontend/app/(defaultLayout)/not-found.tsx
+++ b/frontend/app/(defaultLayout)/not-found.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Center, Divider, Heading, Text, VStack } from '@chakra-ui/react';
-import DefaultLayout from './iFixitHeaderFooter';
-import { DEFAULT_STORE_CODE } from '@config/env';
 import { AppProviders } from '@components/common/AppProviders';
+import { DEFAULT_STORE_CODE } from '@config/env';
 import { getLayoutServerSideProps } from '@layouts/default/server';
+import IFixitPageFrame from './components/IFixitPageFrame';
 
 export default async function NotFound() {
    const layoutPropsPromise = getLayoutServerSideProps({
@@ -15,7 +15,7 @@ export default async function NotFound() {
 
    return (
       <AppProviders>
-         <DefaultLayout {...layoutProps}>
+         <IFixitPageFrame {...layoutProps}>
             <Center
                flexGrow={1}
                paddingTop="16px"
@@ -50,7 +50,7 @@ export default async function NotFound() {
                   </Text>
                </VStack>
             </Center>
-         </DefaultLayout>
+         </IFixitPageFrame>
       </AppProviders>
    );
 }


### PR DESCRIPTION
This PR moves from the previous hello-world-app-router one (https://github.com/iFixit/react-commerce/pull/1950) and:

- removes the 'use client' directive inside `(defaultLayout)/layout.tsx` since that was meant to be a server component
- explicitly mark the page.tsx as an async server component, since there we will need to perform data fetching
- refactor a bit the file structure

qa_req 0