### PR TITLE
VSCode: Port applicable settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,32 @@
-{}
+{
+   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+   "editor.formatOnSave": false,
+   "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+   },
+   "[javascript][javascriptreact][typescript][typescriptreact]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode",
+      "editor.formatOnSave": true
+   },
+   "eslint.workingDirectories": ["backend", "frontend"],
+   "javascript.updateImportsOnFileMove.enabled": "always",
+   "typescript.updateImportsOnFileMove.enabled": "always",
+   "files.exclude": {
+      "**/.git": true,
+      "**/.svn": true,
+      "**/.hg": true,
+      "**/.DS_Store": true
+   },
+   "search.followSymlinks": false,
+   "git.detectSubmodules": false,
+   "git.enableCommitSigning": true,
+   "git.terminalAuthentication": false,
+   "cSpell.ignoreRegExpList": [
+      "i(F|f)ixit",
+      "(callsite|callsites)",
+      "(doctype|doctypes)",
+      "ubreakit",
+      "\\b\\w*(id|ids)\\b",
+      "\\b\\w*Succeded\\b"
+   ]
+}


### PR DESCRIPTION
## Issue
We've got some useful [default settings in the mono](https://github.com/iFixit/ifixit/blob/master/.vscode/settings.default.json). Let's port over the ones that make sense to commerce.

## CR
Settings that rely on an extension (e.g. [cSpell](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker)) are ignored when the extension isn't installed or disabled.