### PR TITLE
Log More Info About Unhandled Rejections

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -4,12 +4,16 @@ import '@fortawesome/fontawesome-svg-core/styles.css';
 import { ServerSidePropsProvider } from '@lib/server-side-props';
 import { AppProps } from 'next/app';
 import NextNProgress from 'nextjs-progressbar';
-import { applySentryFetchMiddleware } from '@ifixit/sentry';
+import {
+   applySentryFetchMiddleware,
+   applySentryUnhandledRejectionListener,
+} from '@ifixit/sentry';
 import { useState } from 'react';
 import { Analytics } from '@vercel/analytics/react';
 // Improve FontAwesome integration with Next.js https://fontawesome.com/v5/docs/web/use-with/react#next-js
 config.autoAddCss = false;
 applySentryFetchMiddleware();
+applySentryUnhandledRejectionListener();
 
 type AppPropsWithLayout<P> = AppProps<P> & {
    Component: NextPageWithLayout;

--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -36,6 +36,17 @@ export const applySentryFetchMiddleware = () => {
    }
 };
 
+export const applySentryUnhandledRejectionListener = () => {
+   if (isClientSide) {
+      window.addEventListener('unhandledrejection', (event) => {
+         Sentry.withScope((scope) => {
+            scope.setExtra('promise', event.promise);
+            Sentry.captureException(event.reason);
+         });
+      });
+   }
+};
+
 const withSentry: FetchMiddleware =
    (fetcher, shouldSkipRequest) => async (input, init) => {
       if (shouldSkipRequest?.(input, init)) {


### PR DESCRIPTION
## Overview

We are having a ton of unhandledrejections filling up our sentry logs and the info they have for debugging isn't helpful enough to debug what is going wrong. This should add some more errors to our logs, but will at least we should have better/more specific error data.

## QA

Check if unhandled rejections are being sentry logged now. You can trigger an unhandled rejection easily by inserting the following code into the file `_app.js` in `myApp()`

```tsx
   new Promise((resolve, reject) => {
      reject(new Error("This is a custom error"));
    });      
``` 

Connects: #1913