### PR TITLE
Drop dropshipping check for value proposition

### DIFF
--- a/frontend/components/sections/ServiceValuePropositionSection.tsx
+++ b/frontend/components/sections/ServiceValuePropositionSection.tsx
@@ -19,17 +19,14 @@ import {
    faShieldCheck,
 } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon, FaIconProps } from '@ifixit/icons';
-import type { ProductVariant } from '@models/product';
 import React from 'react';
 
 export interface ServiceValuePropositionSectionProps {
    id: string;
-   selectedVariant: ProductVariant;
 }
 
 export function ServiceValuePropositionSection({
    id,
-   selectedVariant,
 }: ServiceValuePropositionSectionProps) {
    return (
       <Box as="section" id={id}>
@@ -73,25 +70,17 @@ export function ServiceValuePropositionSection({
                   backed by industry-leading guarantees.
                </Text>
             </ValueProposition>
-            {!isDropshipped(selectedVariant) && (
-               <ValueProposition>
-                  <ValuePropositionIcon icon={faRocketDuo} />
-                  <Text fontWeight="semibold">Fast shipping</Text>
-                  <Text>Same day shipping if ordered by 1PM Pacific.</Text>
-               </ValueProposition>
-            )}
+            <ValueProposition>
+               <ValuePropositionIcon icon={faRocketDuo} />
+               <Text fontWeight="semibold">Fast shipping</Text>
+               <Text>Same day shipping if ordered by 1PM Pacific.</Text>
+            </ValueProposition>
          </Stack>
       </Box>
    );
 }
 
-export type BuyBoxPropositionSectionProps = {
-   selectedVariant: ProductVariant;
-};
-
-export function BuyBoxPropositionSection({
-   selectedVariant,
-}: BuyBoxPropositionSectionProps) {
+export function BuyBoxPropositionSection() {
    return (
       <div>
          <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
@@ -121,19 +110,17 @@ export function BuyBoxPropositionSection({
                   backed by industry-leading guarantees.
                </div>
             </ListItem>
-            {!isDropshipped(selectedVariant) && (
-               <ListItem display="flex" alignItems="center">
-                  <ListIcon
-                     as={FaIcon}
-                     h="4"
-                     w="5"
-                     mr="1.5"
-                     color="brand.500"
-                     icon={faRocket}
-                  />
-                  Same day shipping if ordered by 1PM Pacific.
-               </ListItem>
-            )}
+            <ListItem display="flex" alignItems="center">
+               <ListIcon
+                  as={FaIcon}
+                  h="4"
+                  w="5"
+                  mr="1.5"
+                  color="brand.500"
+                  icon={faRocket}
+               />
+               Same day shipping if ordered by 1PM Pacific.
+            </ListItem>
          </List>
       </div>
    );
@@ -154,8 +141,3 @@ function ValueProposition({ children }: React.PropsWithChildren<{}>) {
 const ValuePropositionIcon = ({ icon, ...props }: FaIconProps) => {
    return <FaIcon icon={icon} h="8" color="brand.500" {...props} />;
 };
-
-function isDropshipped(variant: ProductVariant) {
-   const restrictions = variant.shippingRestrictions;
-   return restrictions && restrictions.includes('fulfilled_via_dropshipping');
-}

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -153,7 +153,6 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
                         <ServiceValuePropositionSection
                            key={section.id}
                            id={section.id}
-                           selectedVariant={selectedVariant}
                         />
                      );
                   }

--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -187,9 +187,7 @@ export function ProductOverviewSection({
                   <GenuinePartBanner oemPartnership={product.oemPartnership} />
                )}
 
-               {isForSale && (
-                  <BuyBoxPropositionSection selectedVariant={selectedVariant} />
-               )}
+               {isForSale && <BuyBoxPropositionSection />}
 
                <Accordion
                   defaultIndex={product.isEnabled ? [0, 1] : undefined}


### PR DESCRIPTION
closes #1969 

I left the `1PM` note as suggested by @sterlinghirsh [comment](https://github.com/iFixit/react-commerce/issues/1969#issuecomment-1716625196)

## QA

1. Open [Vercel Preview](https://react-commerce-3q1bj2i2g-ifixit.vercel.app/products/asus-c302ca-laptop-battery) for a product shipped by Encompass
2. Verify that "Same day shipping if ordered by 1PM Pacific" value proposition is present

