### PR TITLE
Vulcan: Fix First Steps Spacing

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -802,11 +802,11 @@ function AuthorListing({
 
 function IntroductionSections({ introduction }: { introduction: Section[] }) {
    return (
-      <>
+      <Stack spacing={6}>
          {introduction.map((intro) => (
             <IntroductionSection key={intro.heading} intro={intro} mt={0} />
          ))}
-      </>
+      </Stack>
    );
 }
 


### PR DESCRIPTION
## Issue

Fix whitespace between the bottom of the Introduction section and the "First Steps" heading.

## Result

<details>
<img width="1726" alt="Screenshot 2023-09-21 at 10 42 43 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/ab5927f4-462a-4a91-ba67-082431c71f84">
</details>

## CR/QA

`Troubleshooting/Google_Phone/Google+Pixel+Overheating/479437`

Closes https://github.com/iFixit/ifixit/issues/49892