### PR TITLE
Fix: Ensure we correctly handle no intro

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -110,7 +110,7 @@ const Wiki: NextPageWithLayout<{
 
    const hasRelatedPages = wikiData.linkedProblems.length > 0;
 
-   const firstIntroSection = wikiData.introduction[0];
+   const firstIntroSection = wikiData.introduction[0] || {};
    const otherIntroSections = wikiData.introduction.slice(1);
    const cleanFirstIntroSection = {
       ...firstIntroSection,

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -803,7 +803,7 @@ function AuthorListing({
 }
 
 function IntroductionSections({ introduction }: { introduction: Section[] }) {
-   if (introduction.length < 0) {
+   if (!introduction.length) {
       return null;
    }
 

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -117,7 +117,9 @@ const Wiki: NextPageWithLayout<{
       heading: firstIntroSection.heading || 'Introduction',
       id: firstIntroSection.id || 'introduction',
    };
-   const introSections = [cleanFirstIntroSection, ...otherIntroSections];
+   const introSections = firstIntroSection.body
+      ? [cleanFirstIntroSection, ...otherIntroSections]
+      : wikiData.introduction;
 
    const sections = introSections
       .concat(wikiData.solutions)
@@ -801,6 +803,10 @@ function AuthorListing({
 }
 
 function IntroductionSections({ introduction }: { introduction: Section[] }) {
+   if (introduction.length < 0) {
+      return null;
+   }
+
    return (
       <Stack spacing={6}>
          {introduction.map((intro) => (


### PR DESCRIPTION
wikiData.introduction is undefined
wikiData.introduction[0] is also undefined
We just want to ensure it's an empty section to move on

https://ifixit.slack.com/archives/C90126AN4/p1695319975585399