### PR TITLE
Quick Fix: Verdaccio Token CLI Warnings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@ shamefully-hoist=true
 always-auth=false
 strict-peer-dependencies=false
 registry=https://verdaccio.ubreakit.com
-//verdaccio.ubreakit.com/:_authToken=${VERDACCIO_AUTH_TOKEN}
+//verdaccio.ubreakit.com/:_authToken=$VERDACCIO_AUTH_TOKEN

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,3 +1,3 @@
 always-auth=false
 registry=https://verdaccio.ubreakit.com
-//verdaccio.ubreakit.com/:_authToken=${VERDACCIO_AUTH_TOKEN}
+//verdaccio.ubreakit.com/:_authToken=$VERDACCIO_AUTH_TOKEN


### PR DESCRIPTION
## Issue

I noticed these warnings and did a quick search on Phind. One of the last recommendations was to remove the curly braces around the variable name. 

> When using environment variables in the .npmrc file, make sure to use the variable name without curly braces. For example, use `$NPM_TOKEN` instead of `${NPM_TOKEN}`. [stackoverflow.com](https://stackoverflow.com/questions/55543361/npm-config-file-not-reading-environment-variables)

I tried it. It worked.

## Details

<details>
<summary>Before</summary>

<img width="1557" alt="Screenshot 2023-09-26 at 8 11 18 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/61d1c014-451b-475f-9695-ae71c723e28f">

</details>

<details>
<summary>After</summary>
<img width="1557" alt="Screenshot 2023-09-26 at 8 11 57 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/0ab319ee-5920-452b-81e1-99d53dad18db">

</details>