### PR TITLE
Set environment for sentry errors

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -27,6 +27,7 @@ Sentry.init({
    sampleRate: 1.0,
    normalizeDepth: 5,
    tracesSampleRate: 0.05,
+   environment: process.env.NODE_ENV,
    // ...
    // Note: if you want to override the automatic release value, do not set a
    // `release` value here - use the environment variable `SENTRY_RELEASE`, so

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -20,6 +20,7 @@ Sentry.init({
          'next.runtime': 'server',
       },
    },
+   environment: process.env.NODE_ENV,
    async beforeSend(event, hint) {
       const ex = hint.originalException;
       if (ex instanceof Error) {


### PR DESCRIPTION
## Why didn't we see an error for [this 500 error?](https://ifixit.slack.com/archives/C90126AN4/p1695319975585399)
There were two reasons we didn’t see the error.
1. The first is that react-commerce errors went to [#errors-store](https://ifixit.slack.com/archives/C03SL3EF40H), but we fixed this by archiving that channel and we now send all react-commerce errors to [#errors](https://ifixit.slack.com/archives/C5BJE8ALF)
2. The second is that we are reporting the environment for 500 errors as ‘development’. Our error reporting only pays attention to ‘production’ environment errors. I’m not sure how Sentry automatically categorizes some errors as development or production, but I do know that we are not specifying the environment in the sentry config ([docs](https://docs.sentry.io/platforms/python/guides/logging/configuration/environments/?original_referrer=https%3A%2F%2Fwww.google.com%2F)).

## The Fix
So, as a solution to #2 above, we should conditionally set the environment based on `NODE_ENV` env variable _and_ change our error reporting to look at **all** environments instead of just production.

## QA
Self QA

Closes https://github.com/iFixit/ifixit/issues/49904