### PR TITLE
Next/Sentry: Ignore bad urls from pen testers

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -70,7 +70,7 @@ export function InstantSearchProvider({
             try {
                return new URL(url) as unknown as Location;
             } catch (e) {
-               return new URL(IFIXIT_ORIGIN);
+               return new URL(IFIXIT_ORIGIN) as unknown as Location;
             }
          }
 

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -67,7 +67,11 @@ export function InstantSearchProvider({
    const routerOptions = {
       getLocation() {
          if (typeof window === 'undefined') {
-            return new URL(url) as unknown as Location;
+            try {
+               return new URL(url) as unknown as Location;
+            } catch (e) {
+               return new URL(IFIXIT_ORIGIN);
+            }
          }
 
          return window.location;


### PR DESCRIPTION
See https://ifixit.sentry.io/issues/4511266043/?project=6469069

All the urls are invalid and look like pen testers.

Let's stop hearing about them by bypassing the parsing failure.

Using the origin as the url means the user is show a valid search page still. i.e. we 200 instead of 500.

qa_req 0

Closes #2005