### PR TITLE
ProductList: Add Option to Boost Skus

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -241,6 +241,16 @@
          "relation": "manyToMany",
          "target": "api::faq.faq",
          "inversedBy": "product_lists"
+      },
+      "boostedSearchSkus": {
+         "type": "component",
+         "repeatable": true,
+         "pluginOptions": {
+            "i18n": {
+               "localized": true
+            }
+         },
+         "component": "product-list.boosted-search-skus"
       }
    }
 }

--- a/backend/src/components/product-list/boosted-search-skus.json
+++ b/backend/src/components/product-list/boosted-search-skus.json
@@ -1,0 +1,15 @@
+{
+   "collectionName": "components_product_list_boosted_search_skuses",
+   "info": {
+      "displayName": "BoostedSearchSkus",
+      "description": ""
+   },
+   "options": {},
+   "attributes": {
+      "Sku": {
+         "type": "string",
+         "required": true,
+         "unique": true
+      }
+   }
+}

--- a/backend/src/components/product-list/boosted-search-skus.json
+++ b/backend/src/components/product-list/boosted-search-skus.json
@@ -9,7 +9,7 @@
       "Sku": {
          "type": "string",
          "required": true,
-         "unique": true
+         "unique": false
       }
    }
 }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -405,6 +405,28 @@ export type ComponentProductListBanner = {
    url: Scalars['String'];
 };
 
+export type ComponentProductListBoostedSearchSkus = {
+   __typename?: 'ComponentProductListBoostedSearchSkus';
+   Sku: Scalars['String'];
+   id: Scalars['ID'];
+};
+
+export type ComponentProductListBoostedSearchSkusFiltersInput = {
+   Sku?: InputMaybe<StringFilterInput>;
+   and?: InputMaybe<
+      Array<InputMaybe<ComponentProductListBoostedSearchSkusFiltersInput>>
+   >;
+   not?: InputMaybe<ComponentProductListBoostedSearchSkusFiltersInput>;
+   or?: InputMaybe<
+      Array<InputMaybe<ComponentProductListBoostedSearchSkusFiltersInput>>
+   >;
+};
+
+export type ComponentProductListBoostedSearchSkusInput = {
+   Sku?: InputMaybe<Scalars['String']>;
+   id?: InputMaybe<Scalars['ID']>;
+};
+
 export type ComponentProductListItemTypeOverride = {
    __typename?: 'ComponentProductListItemTypeOverride';
    description?: Maybe<Scalars['String']>;
@@ -866,6 +888,7 @@ export type GenericMorph =
    | ComponentProductCrossSell
    | ComponentProductDeviceCompatibility
    | ComponentProductListBanner
+   | ComponentProductListBoostedSearchSkus
    | ComponentProductListItemTypeOverride
    | ComponentProductListLinkedProductListSet
    | ComponentProductListRelatedPosts
@@ -1625,6 +1648,9 @@ export type ProductInput = {
 
 export type ProductList = {
    __typename?: 'ProductList';
+   boostedSearchSkus?: Maybe<
+      Array<Maybe<ComponentProductListBoostedSearchSkus>>
+   >;
    brandLogo?: Maybe<UploadFileEntityResponse>;
    brandLogoWidth?: Maybe<Scalars['Int']>;
    children?: Maybe<ProductListRelationResponseCollection>;
@@ -1655,6 +1681,12 @@ export type ProductList = {
    title: Scalars['String'];
    type?: Maybe<Enum_Productlist_Type>;
    updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type ProductListBoostedSearchSkusArgs = {
+   filters?: InputMaybe<ComponentProductListBoostedSearchSkusFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 export type ProductListChildrenArgs = {
@@ -1697,6 +1729,7 @@ export type ProductListEntityResponseCollection = {
 
 export type ProductListFiltersInput = {
    and?: InputMaybe<Array<InputMaybe<ProductListFiltersInput>>>;
+   boostedSearchSkus?: InputMaybe<ComponentProductListBoostedSearchSkusFiltersInput>;
    brandLogoWidth?: InputMaybe<IntFilterInput>;
    children?: InputMaybe<ProductListFiltersInput>;
    createdAt?: InputMaybe<DateTimeFilterInput>;
@@ -1728,6 +1761,9 @@ export type ProductListFiltersInput = {
 };
 
 export type ProductListInput = {
+   boostedSearchSkus?: InputMaybe<
+      Array<InputMaybe<ComponentProductListBoostedSearchSkusInput>>
+   >;
    brandLogo?: InputMaybe<Scalars['ID']>;
    brandLogoWidth?: InputMaybe<Scalars['Int']>;
    children?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -3624,6 +3624,10 @@ export type FindProductListQuery = {
                | { __typename: 'Error' }
                | null
             >;
+            boostedSearchSkus?: Array<{
+               __typename: 'ComponentProductListBoostedSearchSkus';
+               Sku: string;
+            } | null> | null;
             faqs?: {
                __typename?: 'FaqRelationResponseCollection';
                data: Array<{
@@ -3957,6 +3961,10 @@ export type ProductListFieldsFragment = {
       | { __typename: 'Error' }
       | null
    >;
+   boostedSearchSkus?: Array<{
+      __typename: 'ComponentProductListBoostedSearchSkus';
+      Sku: string;
+   } | null> | null;
    faqs?: {
       __typename?: 'FaqRelationResponseCollection';
       data: Array<{
@@ -5965,6 +5973,12 @@ export const ProductListFieldsFragmentDoc = `
       metaDescription
       itemType
       tagline
+    }
+  }
+  boostedSearchSkus {
+    __typename
+    ... on ComponentProductListBoostedSearchSkus {
+      Sku
     }
   }
   faqs {

--- a/frontend/lib/strapi-sdk/generated/validation.ts
+++ b/frontend/lib/strapi-sdk/generated/validation.ts
@@ -14,6 +14,8 @@ import {
    ComponentPageCategoryFiltersInput,
    ComponentPagePressQuoteFiltersInput,
    ComponentPageStatItemFiltersInput,
+   ComponentProductListBoostedSearchSkusFiltersInput,
+   ComponentProductListBoostedSearchSkusInput,
    ComponentSectionQuoteCardFiltersInput,
    ComponentStoreFooterFiltersInput,
    ComponentStoreFooterInput,
@@ -335,6 +337,42 @@ export function ComponentPageStatItemFiltersInputSchema(): z.ZodObject<
          )
          .nullish(),
       value: z.lazy(() => StringFilterInputSchema().nullish()),
+   });
+}
+
+export function ComponentProductListBoostedSearchSkusFiltersInputSchema(): z.ZodObject<
+   Properties<ComponentProductListBoostedSearchSkusFiltersInput>
+> {
+   return z.object<
+      Properties<ComponentProductListBoostedSearchSkusFiltersInput>
+   >({
+      Sku: z.lazy(() => StringFilterInputSchema().nullish()),
+      and: z
+         .array(
+            z.lazy(() =>
+               ComponentProductListBoostedSearchSkusFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+      not: z.lazy(() =>
+         ComponentProductListBoostedSearchSkusFiltersInputSchema().nullish()
+      ),
+      or: z
+         .array(
+            z.lazy(() =>
+               ComponentProductListBoostedSearchSkusFiltersInputSchema().nullable()
+            )
+         )
+         .nullish(),
+   });
+}
+
+export function ComponentProductListBoostedSearchSkusInputSchema(): z.ZodObject<
+   Properties<ComponentProductListBoostedSearchSkusInput>
+> {
+   return z.object<Properties<ComponentProductListBoostedSearchSkusInput>>({
+      Sku: z.string().nullish(),
+      id: z.string().nullish(),
    });
 }
 
@@ -833,6 +871,9 @@ export function ProductListFiltersInputSchema(): z.ZodObject<
       and: z
          .array(z.lazy(() => ProductListFiltersInputSchema().nullable()))
          .nullish(),
+      boostedSearchSkus: z.lazy(() =>
+         ComponentProductListBoostedSearchSkusFiltersInputSchema().nullish()
+      ),
       brandLogoWidth: z.lazy(() => IntFilterInputSchema().nullish()),
       children: z.lazy(() => ProductListFiltersInputSchema().nullish()),
       createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
@@ -872,6 +913,13 @@ export function ProductListInputSchema(): z.ZodObject<
    Properties<ProductListInput>
 > {
    return z.object<Properties<ProductListInput>>({
+      boostedSearchSkus: z
+         .array(
+            z.lazy(() =>
+               ComponentProductListBoostedSearchSkusInputSchema().nullable()
+            )
+         )
+         .nullish(),
       brandLogo: z.string().nullish(),
       brandLogoWidth: z.number().nullish(),
       children: z.array(z.string().nullable()).nullish(),

--- a/frontend/lib/strapi-sdk/operations/findProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/findProductList.graphql
@@ -111,6 +111,12 @@ fragment ProductListFields on ProductList {
          tagline
       }
    }
+   boostedSearchSkus {
+      __typename
+      ... on ComponentProductListBoostedSearchSkus {
+         Sku
+      }
+   }
    faqs {
       data {
          ...FAQFields

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -130,6 +130,9 @@ export async function findProductList(
       wikiInfo: deviceWiki?.info || [],
       isOnStrapi: !!productList,
       itemOverrides: formatItemTypeOverrides(productList?.itemOverrides),
+      boostedSearchSkus: formatBoostedSearchSkus(
+         productList?.boostedSearchSkus
+      ),
    };
 
    return {
@@ -314,6 +317,24 @@ function convertToProductListItemTypeOverrides(
       }
    );
    return filterNullableItems(formatedOverrides);
+}
+
+type ApiProductListBoostedSkus = NonNullable<
+   ProductListFieldsFragment['boostedSearchSkus']
+>[0];
+
+function formatBoostedSearchSkus(
+   boostedSkus: ApiProductListBoostedSkus[] | null | undefined
+): string[] {
+   const formatedBoostedSkus = boostedSkus?.map((boostedSearch) => {
+      if (
+         boostedSearch?.__typename !== 'ComponentProductListBoostedSearchSkus'
+      ) {
+         return null;
+      }
+      return boostedSearch.Sku;
+   });
+   return filterNullableItems(formatedBoostedSkus);
 }
 
 function createPublicAlgoliaKey(appId: string, apiKey: string): string {

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -98,6 +98,7 @@ const BaseProductListSchema = z.object({
    wikiInfo: z.array(WikiInfoEntrySchema),
    isOnStrapi: z.boolean(),
    itemOverrides: ProductListItemTypeOverrideIndexedSchema,
+   boostedSearchSkus: z.array(z.string()),
 });
 export type BaseProductList = z.infer<typeof BaseProductListSchema>;
 

--- a/frontend/templates/product-list/ProductListView.tsx
+++ b/frontend/templates/product-list/ProductListView.tsx
@@ -40,6 +40,10 @@ export function ProductListView({
 
    const currentProductList = itemTypeProductList ?? productList;
 
+   const { boostedSearchSkus } = currentProductList;
+   const optionalFilters = boostedSearchSkus?.map(
+      (sku) => `identifiers:${sku}`
+   );
    if (algoliaSSR) {
       return (
          <>
@@ -47,6 +51,7 @@ export function ProductListView({
                filters={filters}
                hitsPerPage={HITS_PER_PAGE}
                facetingAfterDistinct
+               optionalFilters={optionalFilters}
             />
             <FilterableProductsSection
                productList={currentProductList}
@@ -62,6 +67,7 @@ export function ProductListView({
             filters={filters}
             hitsPerPage={HITS_PER_PAGE}
             facetingAfterDistinct
+            optionalFilters={optionalFilters}
          />
          <MetaTags productList={currentProductList} />
          <SecondaryNavigation productList={productList} />


### PR DESCRIPTION
## Overview

We wanted to be able to highlight some products on product list pages by surfacing or boosting them to the top of the results. This pull allows us to do that by using algolia's optionalFIlters.

## QA

Go to a product list page and find a product that isn't at the top. Grab its sku. Go add that sku to that product list's `boostedSearchSkus` attribute in strapi. Reload the page. The desired product should now be the first thing on the list.

Closes: iFixit/ifixit#50010