### PR TITLE
ProductList: Add Optional Filters To Backend

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -241,6 +241,14 @@
          "relation": "manyToMany",
          "target": "api::faq.faq",
          "inversedBy": "product_lists"
+      },
+      "optionalFilters": {
+         "pluginOptions": {
+            "i18n": {
+               "localized": true
+            }
+         },
+         "type": "text"
       }
    }
 }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -1647,6 +1647,7 @@ export type ProductList = {
    localizations?: Maybe<ProductListRelationResponseCollection>;
    metaDescription?: Maybe<Scalars['String']>;
    metaTitle?: Maybe<Scalars['String']>;
+   optionalFilters?: Maybe<Scalars['String']>;
    parent?: Maybe<ProductListEntityResponse>;
    publishedAt?: Maybe<Scalars['DateTime']>;
    sections: Array<Maybe<ProductListSectionsDynamicZone>>;
@@ -1717,6 +1718,7 @@ export type ProductListFiltersInput = {
    metaDescription?: InputMaybe<StringFilterInput>;
    metaTitle?: InputMaybe<StringFilterInput>;
    not?: InputMaybe<ProductListFiltersInput>;
+   optionalFilters?: InputMaybe<StringFilterInput>;
    or?: InputMaybe<Array<InputMaybe<ProductListFiltersInput>>>;
    parent?: InputMaybe<ProductListFiltersInput>;
    publishedAt?: InputMaybe<DateTimeFilterInput>;
@@ -1749,6 +1751,7 @@ export type ProductListInput = {
    legacyPageId?: InputMaybe<Scalars['Int']>;
    metaDescription?: InputMaybe<Scalars['String']>;
    metaTitle?: InputMaybe<Scalars['String']>;
+   optionalFilters?: InputMaybe<Scalars['String']>;
    parent?: InputMaybe<Scalars['ID']>;
    publishedAt?: InputMaybe<Scalars['DateTime']>;
    sections?: InputMaybe<Array<Scalars['ProductListSectionsDynamicZoneInput']>>;

--- a/frontend/lib/strapi-sdk/generated/validation.ts
+++ b/frontend/lib/strapi-sdk/generated/validation.ts
@@ -855,6 +855,7 @@ export function ProductListFiltersInputSchema(): z.ZodObject<
       metaDescription: z.lazy(() => StringFilterInputSchema().nullish()),
       metaTitle: z.lazy(() => StringFilterInputSchema().nullish()),
       not: z.lazy(() => ProductListFiltersInputSchema().nullish()),
+      optionalFilters: z.lazy(() => StringFilterInputSchema().nullish()),
       or: z
          .array(z.lazy(() => ProductListFiltersInputSchema().nullable()))
          .nullish(),
@@ -891,6 +892,7 @@ export function ProductListInputSchema(): z.ZodObject<
       legacyPageId: z.number().nullish(),
       metaDescription: z.string().nullish(),
       metaTitle: z.string().nullish(),
+      optionalFilters: z.string().nullish(),
       parent: z.string().nullish(),
       publishedAt: z.unknown().nullish(),
       sections: z.array(z.lazy(() => z.unknown())).nullish(),


### PR DESCRIPTION
## Overview

We wanted to be able to highlight some products on product list pages by surfacing or boosting them to the top of the results. This pull allows us to do that by using algolia's optionalFIlters.

These are the required strapi backend changes to facilitate that.
## QA 

To product list pages still work?

Connects: #2014 
Closes: https://github.com/iFixit/ifixit/issues/50010