### PR TITLE
CI Fix: Pin Pnpm Version to 8.8.0

### DIFF
--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -6,7 +6,7 @@ runs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2.2.4
         with:
-           version: 8
+           version: 8.8.0
            run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
## Description

The Next.js Bundle Analysis action began failing. @batbattur  discovered that the default pnpm version was bumped to 8.9.0 while the prior version was 8.8.0. 

To address this let's pin the pnpm version to 8.8.0 instead of a just a major semver range of v8.

qa_req 0 CI should pass

**Reference:** https://ifixit.slack.com/archives/C01DBJK0H7U/p1696882385520809