### PR TITLE
PPRO: Add Custom Dimension "preferredStore"

### DIFF
--- a/frontend/config/env.ts
+++ b/frontend/config/env.ts
@@ -31,6 +31,8 @@ export const MATOMO_URL = process.env.NEXT_PUBLIC_MATOMO_URL;
 
 export const PIWIK_ID = getPiwikIDForEnv(process.env.NEXT_PUBLIC_PIWIK_ENV);
 
+export const PIWIK_ENV = process.env.NEXT_PUBLIC_PIWIK_ENV;
+
 export const SENTRY_SAMPLING_ENABLED =
    process.env.SENTRY_SAMPLING_ENABLED === 'true';
 

--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -59,6 +59,7 @@ import {
    UserMenuLink,
    WordmarkLink,
 } from '@ifixit/ui';
+import { trackPiwikPreferredStore } from '@ifixit/analytics';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import * as React from 'react';
@@ -74,6 +75,7 @@ const DefaultLayoutComponent = function ({
    globalSettings,
    children,
 }: React.PropsWithChildren<DefaultLayoutProps>) {
+   trackPiwikPreferredStore();
    const { menu } = currentStore.header;
    const mobileSearchInputRef = React.useRef<HTMLInputElement>(null);
    const { adminMessage } = useAppContext();

--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -66,6 +66,7 @@ import * as React from 'react';
 import { CartFooter } from './Footer';
 import { LayoutErrorBoundary } from './LayoutErrorBoundary';
 import type { DefaultLayoutProps } from './server';
+import { PIWIK_ENV } from '@config/env';
 
 const DefaultLayoutComponent = function ({
    title,
@@ -75,7 +76,7 @@ const DefaultLayoutComponent = function ({
    globalSettings,
    children,
 }: React.PropsWithChildren<DefaultLayoutProps>) {
-   trackPiwikPreferredStore();
+   trackPiwikPreferredStore(PIWIK_ENV);
    const { menu } = currentStore.header;
    const mobileSearchInputRef = React.useRef<HTMLInputElement>(null);
    const { adminMessage } = useAppContext();

--- a/packages/analytics/matomo/index.tsx
+++ b/packages/analytics/matomo/index.tsx
@@ -15,10 +15,11 @@ export function trackMatomoPageView(url: string) {
    matomoPush(['trackPageView']);
 }
 
-export function trackPiwikPreferredStore() {
-   if (typeof window !== 'undefined') {
+export function trackPiwikPreferredStore(piwikEnv: string | undefined): void {
+   const dimensionId = getPiwikCustomDimensionsForEnv(piwikEnv);
+   if (typeof window !== 'undefined' && dimensionId) {
       const host = getShopifyStoreDomainFromCurrentURL();
-      matomoPush(['setCustomDimension', 1, host]);
+      matomoPush(['setCustomDimension', dimensionId, host]);
    }
 }
 
@@ -105,4 +106,25 @@ function trackClearCart() {
 
 function trackCartUpdated(grandTotal: Money) {
    matomoPush(['trackEcommerceCartUpdate', grandTotal.amount]);
+}
+
+type PiwikCustomDimensions = {
+   preferredStore: number;
+};
+
+function getPiwikCustomDimensionsForEnv(
+   env: string | undefined
+): PiwikCustomDimensions | null {
+   switch (env) {
+      case 'prod':
+         return {
+            preferredStore: 1,
+         };
+      case 'dev':
+         return {
+            preferredStore: 1,
+         };
+      default:
+         return null;
+   }
 }

--- a/packages/analytics/matomo/index.tsx
+++ b/packages/analytics/matomo/index.tsx
@@ -1,5 +1,9 @@
 import { CartLineItem } from '@ifixit/cart-sdk';
-import { Money, sumMoney } from '@ifixit/helpers';
+import {
+   Money,
+   getShopifyStoreDomainFromCurrentURL,
+   sumMoney,
+} from '@ifixit/helpers';
 import { matomoPush } from './matomoPush';
 
 /**
@@ -9,6 +13,13 @@ export function trackMatomoPageView(url: string) {
    matomoPush(['setCustomUrl', url]);
    matomoPush(['setDocumentTitle', document.title]);
    matomoPush(['trackPageView']);
+}
+
+export function trackPiwikPreferredStore() {
+   if (typeof window !== 'undefined') {
+      const host = getShopifyStoreDomainFromCurrentURL();
+      matomoPush(['setCustomDimension', 1, host]);
+   }
 }
 
 /**

--- a/packages/helpers/index.ts
+++ b/packages/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './generic-helpers';
 export * from './commerce-helpers';
 export * from './product-helpers';
+export * from './shopify-helpers';
 export * from './logger';

--- a/packages/helpers/shopify-helpers.ts
+++ b/packages/helpers/shopify-helpers.ts
@@ -1,0 +1,42 @@
+export function getShopifyStoreDomainFromCurrentURL(): string | null {
+   if (typeof window === 'undefined') return null;
+   const host = window.location.hostname;
+   switch (host) {
+      case 'www.ifixit.com':
+         return 'ifixit-us';
+      case 'australia.ifixit.com':
+         return 'ifixit-australia';
+      case 'canada.ifixit.com':
+         return 'ifixit-canada';
+      case 'store.ifixit.de':
+         return 'ifixit-de';
+      case 'store.ifixit.fr':
+         return 'ifixit-fr';
+      case 'store.ifixit.it':
+         return 'ifixit-it';
+      case 'store.ifixit.co.uk':
+         return 'ifixit-uk';
+      case 'eustore.ifixit.com':
+         return 'ifixit-eu';
+      case 'eustore.ifixit.pro':
+         return 'ifixit-eu-pro';
+      case 'ifixit-dev.myshopify.com':
+         return 'ifixit-dev';
+      case 'store.cominor.com': // not right here'
+         return 'ifixit-test';
+      case 'ifixit-eu-test.myshopify.com':
+         return 'ifixit-eu-test';
+      case 'ifixit-eu-pro-test.myshopify.com':
+         return 'ifixit-eu-pro-test';
+      default:
+         break;
+   }
+   if (
+      host.endsWith('.cominor.com') ||
+      host.endsWith('ifixit.vercel.app') ||
+      host === 'localhost'
+   ) {
+      return 'ifixit-test';
+   }
+   return null;
+}


### PR DESCRIPTION
## Overview

We want to keep track of users preferred Store for their session. We can track that per user sessions by adding a custom dimension, in this case its `preferredStore`, to Piwik. This pull introduces the code to track that dimension in our code for each users session.

## QA

Make sure that users session has the `preferredStore` as a dimension in the analytics.

Connects: #2016