### PR TITLE
Vulcan: Update Related Problems Heading Spacing

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -979,7 +979,7 @@ function RelatedProblems({
                </Box>
             </Stack>
             {hasRelatedPages && (
-               <>
+               <Stack spacing={3}>
                   <Heading
                      as="h3"
                      fontSize={{ base: '20px', md: '24px' }}
@@ -997,7 +997,7 @@ function RelatedProblems({
                         <ProblemCard problem={problem} key={problem.title} />
                      ))}
                   </SimpleGrid>
-               </>
+               </Stack>
             )}
          </Stack>
       </>


### PR DESCRIPTION
## Issue

Mattia updated the design for the Related Problems Heading. Let's update the spacing we have to match.

[figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?node-id=296%3A42472&mode=dev](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?node-id=296%3A42472&mode=dev)

## QA

`/Troubleshooting/Nintendo_Switch/Will+Not+Turn+On/481634`

<details>
<img width="1699" alt="Screenshot 2023-10-16 at 9 01 23 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/4921ef5e-70c4-402f-8304-26e7d141d2e6">

</details>

Closes https://github.com/iFixit/ifixit/issues/50262