### PR TITLE
notifyWhenSkuInStock: Add a nicer error handler

### DIFF
--- a/packages/ifixit-api-client/index.tsx
+++ b/packages/ifixit-api-client/index.tsx
@@ -25,45 +25,49 @@ export class IFixitAPIClient {
    async get<Data = unknown>(
       endpoint: string,
       statName: string,
-      init?: RequestInit
+      init?: RequestInit,
+      processRequest = this.processRequest
    ): Promise<Data> {
       return this.fetch(endpoint, statName, {
          ...init,
          method: 'GET',
-      });
+      }).then(processRequest);
    }
 
    async post<Data = unknown>(
       endpoint: string,
       statName: string,
-      init?: RequestInit
+      init?: RequestInit,
+      processRequest = this.processRequest
    ): Promise<Data> {
       return this.fetch(endpoint, statName, {
          ...init,
          method: 'POST',
-      });
+      }).then(processRequest);
    }
 
    async put<Data = unknown>(
       endpoint: string,
       statName: string,
-      init?: RequestInit
+      init?: RequestInit,
+      processRequest = this.processRequest
    ): Promise<Data> {
       return this.fetch(endpoint, statName, {
          ...init,
          method: 'PUT',
-      });
+      }).then(processRequest);
    }
 
    async delete<Data = unknown>(
       endpoint: string,
       statName: string,
-      init?: RequestInit
+      init?: RequestInit,
+      processRequest = this.processRequest
    ): Promise<Data> {
       return this.fetch(endpoint, statName, {
          ...init,
          method: 'DELETE',
-      });
+      }).then(processRequest);
    }
 
    async fetch(endpoint: string, statName: string, init?: RequestInit) {
@@ -86,17 +90,26 @@ export class IFixitAPIClient {
                headers: headers,
             })
       );
+
+      warnIfNotBypassed(headers, response);
+      return response;
+   }
+
+   processRequest = (response: Response) => {
       if (!response.ok) {
          throw new Error(response.statusText);
       }
 
-      warnIfNotBypassed(headers, response);
+      return this.jsonOrNull(response);
+   };
 
+   jsonOrNull = (response: Response) => {
       if (response.headers.get('Content-Type') === 'application/json') {
          return response.json();
       }
+
       return null;
-   }
+   };
 }
 
 function warnIfNotBypassed(requestHeaders: Headers, response: Response): void {


### PR DESCRIPTION
See: https://ifixit.slack.com/archives/C90126AN4/p1697489648458609

We had hid the response status away from devs in favor of a decent
default implementation.

Sometimes we may want to vary from the default implementation of throwing if not a 200
and instead, handle error codes ourselves.

QA
---

Check the notifyWhenSkuInStock input with `something@something` without a `.com`

Closes: https://github.com/iFixit/ifixit/issues/50266