### PR TITLE
GA4: set custom dimensions

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -9,7 +9,7 @@ SENTRY_SAMPLING_ENABLED=true
 NEXT_PUBLIC_MATOMO_URL=https://matomo.ubreakit.com
 NEXT_PUBLIC_PIWIK_ENV=none
 NEXT_PUBLIC_GA_KEY=UA-30506-1
-# If we want to test Google Analytics in dev DEBUG should be true and URL should be
+# If we want to test Google Analytics in dev DEBUG should be true, GTAG_ID should be G-5ZXNWJ73GK, and URL should be
 # https://www.google-analytics.com/analytics_debug.js
 NEXT_PUBLIC_GA_DEBUG=
 NEXT_PUBLIC_GA_URL=

--- a/frontend/app/(defaultLayout)/components/IFixitPageFrame.tsx
+++ b/frontend/app/(defaultLayout)/components/IFixitPageFrame.tsx
@@ -89,7 +89,8 @@ export default function IFixitPageFrame({
    const debugMode = Boolean(GA_DEBUG || params?.get('ga4_debug') === 'true');
    React.useEffect(() => {
       setupMinimumGA4(GTAG_ID, debugMode, dimensions);
-   }, [debugMode, dimensions]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+   }, [dimensions]);
 
    return (
       <LayoutErrorBoundary>

--- a/frontend/app/(defaultLayout)/components/IFixitPageFrame.tsx
+++ b/frontend/app/(defaultLayout)/components/IFixitPageFrame.tsx
@@ -89,7 +89,7 @@ export default function IFixitPageFrame({
    const debugMode = Boolean(GA_DEBUG || params?.get('ga4_debug') === 'true');
    React.useEffect(() => {
       setupMinimumGA4(GTAG_ID, debugMode, dimensions);
-   }, [dimensions]);
+   }, [debugMode, dimensions]);
 
    return (
       <LayoutErrorBoundary>

--- a/frontend/app/(defaultLayout)/components/IFixitPageFrame.tsx
+++ b/frontend/app/(defaultLayout)/components/IFixitPageFrame.tsx
@@ -68,7 +68,7 @@ import { CartFooter } from '@layouts/default/Footer';
 import { LayoutErrorBoundary } from '@layouts/default/LayoutErrorBoundary';
 import { Suspense } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { setupMinimumGA4 } from '@ifixit/analytics';
+import { setupMinimumGA4, useGACustomDimensions } from '@ifixit/analytics';
 import { GA_DEBUG, GTAG_ID } from '@config/env';
 import { PiwikPro } from '@components/analytics';
 
@@ -84,9 +84,12 @@ export default function IFixitPageFrame({
    const { adminMessage } = useAppContext();
    const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
    const params = useSearchParams();
+   const dimensions = useGACustomDimensions();
 
    const debugMode = Boolean(GA_DEBUG || params?.get('ga4_debug') === 'true');
-   setupMinimumGA4(GTAG_ID, debugMode);
+   React.useEffect(() => {
+      setupMinimumGA4(GTAG_ID, debugMode, dimensions);
+   }, [dimensions]);
 
    return (
       <LayoutErrorBoundary>

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Script from 'next/script';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { getGACustomDimensions, setupMinimumGA4 } from '@ifixit/analytics';
+import { useGACustomDimensions, setupMinimumGA4 } from '@ifixit/analytics';
 
 declare const ga: (command: string, hitType: string, url?: string) => void;
 
@@ -38,30 +38,19 @@ export function GoogleAnalytics() {
 function GA4() {
    const router = useRouter();
    const { query } = router;
+   const dimensions = useGACustomDimensions();
+
+   console.log('dimensions', dimensions);
 
    const debugMode = GA_DEBUG || query.ga4_debug === 'true';
-   setupMinimumGA4(GTAG_ID, debugMode);
+   React.useEffect(() => {
+      setupMinimumGA4(GTAG_ID, debugMode, dimensions);
+   }, [dimensions]);
    return (
-      <>
-         <Head>
-            <script
-               id="gtag-ga4"
-               dangerouslySetInnerHTML={{
-                  __html: `
-               window.dataLayer = window.dataLayer || [];
-               function gtag(){dataLayer.push(arguments);}
-               gtag('js', new Date());
-               gtag('config', '${GTAG_ID}', ${debugMode} ? { debug_mode: true } : {});
-               gtag('set', 'user_properties', ${getGACustomDimensions()});
-               `,
-               }}
-            />
-         </Head>
-         <Script
-            strategy="afterInteractive"
-            src={`https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`}
-         ></Script>
-      </>
+      <Script
+         strategy="afterInteractive"
+         src={`https://www.googletagmanager.com/gtag/js?id=${GTAG_ID}`}
+      ></Script>
    );
 }
 

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -42,7 +42,8 @@ function GA4() {
    const debugMode = GA_DEBUG || query.ga4_debug === 'true';
    React.useEffect(() => {
       setupMinimumGA4(GTAG_ID, debugMode, dimensions);
-   }, [debugMode, dimensions]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+   }, [dimensions]);
    return (
       <Script
          strategy="afterInteractive"

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import Script from 'next/script';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { getGACustomDimensions, setupMinimumGA4 } from '@ifixit/analytics';
 
 declare const ga: (command: string, hitType: string, url?: string) => void;
 
@@ -39,6 +40,7 @@ function GA4() {
    const { query } = router;
 
    const debugMode = GA_DEBUG || query.ga4_debug === 'true';
+   setupMinimumGA4(GTAG_ID, debugMode);
    return (
       <>
          <Head>

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -52,6 +52,7 @@ function GA4() {
                function gtag(){dataLayer.push(arguments);}
                gtag('js', new Date());
                gtag('config', '${GTAG_ID}', ${debugMode} ? { debug_mode: true } : {});
+               gtag('set', 'user_properties', ${getGACustomDimensions()});
                `,
                }}
             />

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -1,7 +1,6 @@
 import { GA_URL, GTAG_ID, GA_KEY, GA_DEBUG } from '@config/env';
 import * as React from 'react';
 import Script from 'next/script';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useGACustomDimensions, setupMinimumGA4 } from '@ifixit/analytics';
 
@@ -45,7 +44,7 @@ function GA4() {
    const debugMode = GA_DEBUG || query.ga4_debug === 'true';
    React.useEffect(() => {
       setupMinimumGA4(GTAG_ID, debugMode, dimensions);
-   }, [dimensions]);
+   }, [debugMode, dimensions]);
    return (
       <Script
          strategy="afterInteractive"

--- a/frontend/components/analytics/GoogleAnalytics.tsx
+++ b/frontend/components/analytics/GoogleAnalytics.tsx
@@ -39,8 +39,6 @@ function GA4() {
    const { query } = router;
    const dimensions = useGACustomDimensions();
 
-   console.log('dimensions', dimensions);
-
    const debugMode = GA_DEBUG || query.ga4_debug === 'true';
    React.useEffect(() => {
       setupMinimumGA4(GTAG_ID, debugMode, dimensions);

--- a/packages/analytics/google/index.tsx
+++ b/packages/analytics/google/index.tsx
@@ -177,6 +177,6 @@ export function getGACustomDimensions(): GACustomDimensions {
    return {
       preferred_store:
          getShopifyStoreDomainFromCurrentURL() || 'no-store-found',
-      preferred_language: 'DE',
+      preferred_language: 'EN',
    };
 }

--- a/packages/analytics/google/index.tsx
+++ b/packages/analytics/google/index.tsx
@@ -1,7 +1,11 @@
 import { AddToCartInput, CartLineItem } from '@ifixit/cart-sdk';
 import { moneyToNumber, parseItemcode } from '@ifixit/helpers';
 import debounce from 'lodash/debounce';
-import { getShopifyStoreDomainFromCurrentURL } from '@ifixit/helpers';
+import {
+   getShopifyStoreDomainFromCurrentURL,
+   getShopifyLanguageFromCurrentURL,
+} from '@ifixit/helpers';
+import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 
 type GAType = (metric: string, ...args: any) => void;
 type GAProductType = {
@@ -174,9 +178,14 @@ type GACustomDimensions = {
 };
 
 export function getGACustomDimensions(): GACustomDimensions {
+   const preferredLang = useAuthenticatedUser().data?.langid;
+
    return {
       preferred_store:
          getShopifyStoreDomainFromCurrentURL() || 'no-store-found',
-      preferred_language: 'EN',
+      preferred_language:
+         preferredLang?.toUpperCase() ||
+         getShopifyLanguageFromCurrentURL() ||
+         'no-language-found',
    };
 }

--- a/packages/analytics/google/index.tsx
+++ b/packages/analytics/google/index.tsx
@@ -1,6 +1,7 @@
 import { AddToCartInput, CartLineItem } from '@ifixit/cart-sdk';
 import { moneyToNumber, parseItemcode } from '@ifixit/helpers';
 import debounce from 'lodash/debounce';
+import { getShopifyStoreDomainFromCurrentURL } from '@ifixit/helpers';
 
 type GAType = (metric: string, ...args: any) => void;
 type GAProductType = {
@@ -81,6 +82,7 @@ export function setupMinimumGA4(
       window.gtag = windowGtag;
       window.gtag('js', new Date());
       window.gtag('config', GtagID, debugMode ? { debug_mode: true } : {});
+      window.gtag('set', 'user_properties', getGACustomDimensions());
    }
 }
 
@@ -164,4 +166,17 @@ function useGa(): GAType | undefined {
       return undefined;
    }
    return (window as any).ga;
+}
+
+type GACustomDimensions = {
+   preferred_store: string;
+   preferred_language: string;
+};
+
+export function getGACustomDimensions(): GACustomDimensions {
+   return {
+      preferred_store:
+         getShopifyStoreDomainFromCurrentURL() || 'no-store-found',
+      preferred_language: 'DE',
+   };
 }

--- a/packages/analytics/google/index.tsx
+++ b/packages/analytics/google/index.tsx
@@ -79,14 +79,15 @@ function windowGtag() {
 
 export function setupMinimumGA4(
    GtagID: string | undefined,
-   debugMode: boolean
+   debugMode: boolean,
+   dimensions: GACustomDimensions
 ) {
    if (typeof window !== 'undefined' && GtagID) {
       window.dataLayer = window.dataLayer || [];
       window.gtag = windowGtag;
       window.gtag('js', new Date());
       window.gtag('config', GtagID, debugMode ? { debug_mode: true } : {});
-      window.gtag('set', 'user_properties', getGACustomDimensions());
+      window.gtag('set', 'user_properties', dimensions);
    }
 }
 
@@ -177,7 +178,7 @@ type GACustomDimensions = {
    preferred_language: string;
 };
 
-export function getGACustomDimensions(): GACustomDimensions {
+export function useGACustomDimensions(): GACustomDimensions {
    const preferredLang = useAuthenticatedUser().data?.langid;
 
    return {

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -6,7 +6,8 @@
    "license": "MIT",
    "dependencies": {
       "@ifixit/cart-sdk": "workspace:*",
-      "@ifixit/helpers": "workspace:*"
+      "@ifixit/helpers": "workspace:*",
+      "@ifixit/auth-sdk": "workspace:*"
    },
    "devDependencies": {
       "@ifixit/tsconfig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
 
   packages/analytics:
     dependencies:
+      '@ifixit/auth-sdk':
+        specifier: workspace:*
+        version: link:../auth-sdk
       '@ifixit/cart-sdk':
         specifier: workspace:*
         version: link:../cart-sdk


### PR DESCRIPTION
## Overview
Adds the preferred store and preferred language (always english in react-commerce).

## QA
1. Apply this diff _before running `pnpm install:all`_
<details><summary>Diff</summary>
<p>

```diff
NEXT_PUBLIC_GA_KEY=UA-30506-1
 # If we want to test Google Analytics in dev DEBUG should be true, GTAG_ID should be G-5ZXNWJ73GK, and URL should be
 # https://www.google-analytics.com/analytics_debug.js
-NEXT_PUBLIC_GA_DEBUG=
-NEXT_PUBLIC_GA_URL=
-NEXT_PUBLIC_GTAG_ID=
+NEXT_PUBLIC_GA_DEBUG=true
+NEXT_PUBLIC_GA_URL=https://www.google-analytics.com/analytics_debug.js
+NEXT_PUBLIC_GTAG_ID=G-5ZXNWJ73GK
 NEXT_PUBLIC_ALGOLIA_PRODUCT_INDEX_NAME=dev_product_group_en
 NEXT_PUBLIC_DEFAULT_STORE_CODE=test
```

</p>
</details> 

2. Make sure the custom dimensions show up in [GA4 debugger](https://analytics.google.com/analytics/web/#/a30506p383872824/admin/debugview/overview) when an event is fired.
3. The language dimension should now match the language of your logged in user on Cominor.

Closes https://github.com/iFixit/react-commerce/issues/2019
Closes https://github.com/iFixit/react-commerce/issues/2018
Connects https://github.com/iFixit/ifixit/issues/50135