### PR TITLE
PPRO: Add Custom Dimension Tracking for PreferredStore

### DIFF
--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -59,7 +59,10 @@ import {
    UserMenuLink,
    WordmarkLink,
 } from '@ifixit/ui';
-import { trackPiwikPreferredStore } from '@ifixit/analytics';
+import {
+   trackPiwikPreferredStore,
+   trackPiwikPreferredLanguage,
+} from '@ifixit/analytics';
 import { PIWIK_ENV } from '@config/env';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -76,12 +79,14 @@ const DefaultLayoutComponent = function ({
    globalSettings,
    children,
 }: React.PropsWithChildren<DefaultLayoutProps>) {
-   trackPiwikPreferredStore(PIWIK_ENV);
    const { menu } = currentStore.header;
    const mobileSearchInputRef = React.useRef<HTMLInputElement>(null);
    const { adminMessage } = useAppContext();
-   const isAdminUser = useAuthenticatedUser().data?.isAdmin ?? false;
+   const userData = useAuthenticatedUser().data;
+   const isAdminUser = userData?.isAdmin ?? false;
 
+   trackPiwikPreferredStore(PIWIK_ENV);
+   trackPiwikPreferredLanguage(PIWIK_ENV, userData?.langid ?? null);
    return (
       <LayoutErrorBoundary>
          <ShopifyStorefrontProvider

--- a/packages/analytics/piwik/index.tsx
+++ b/packages/analytics/piwik/index.tsx
@@ -2,6 +2,7 @@ import { CartLineItem } from '@ifixit/cart-sdk';
 import {
    Money,
    getShopifyStoreDomainFromCurrentURL,
+   getShopifyLanguageFromCurrentURL,
    sumMoney,
 } from '@ifixit/helpers';
 import { piwikPush } from './piwikPush';
@@ -23,6 +24,22 @@ export function trackPiwikPreferredStore(piwikEnv: string | undefined): void {
          'setCustomDimensionValue',
          customDimensions['preferredStore'],
          host,
+      ]);
+   }
+}
+
+export function trackPiwikPreferredLanguage(
+   piwikEnv: string | undefined,
+   preferredLang: string | null
+): void {
+   const customDimensions = getPiwikCustomDimensionsForEnv(piwikEnv);
+   if (typeof window !== 'undefined' && customDimensions) {
+      const lang =
+         preferredLang?.toUpperCase() ?? getShopifyLanguageFromCurrentURL();
+      piwikPush([
+         'setCustomDimensionValue',
+         customDimensions['preferredLanguage'],
+         lang,
       ]);
    }
 }
@@ -114,6 +131,7 @@ function trackCartUpdated(grandTotal: Money) {
 
 type PiwikCustomDimensions = {
    preferredStore: number;
+   preferredLanguage: number;
 };
 
 function getPiwikCustomDimensionsForEnv(
@@ -123,10 +141,12 @@ function getPiwikCustomDimensionsForEnv(
       case 'prod':
          return {
             preferredStore: 1,
+            preferredLanguage: 2,
          };
       case 'dev':
          return {
             preferredStore: 1,
+            preferredLanguage: 2,
          };
       default:
          return null;

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -22,6 +22,7 @@ const AuthenticatedUserSchema = z.object({
    isAdmin: z.boolean(),
    teams: z.array(z.number()),
    links: z.record(z.any()),
+   langid: z.string().nullable(),
 });
 
 export function useAuthenticatedUser() {
@@ -69,6 +70,7 @@ const UserApiResponseSchema = z.object({
    privileges: z.array(z.string()),
    teams: z.array(z.number()),
    links: z.record(z.any()),
+   langid: z.string().optional().nullable(),
 });
 
 async function fetchAuthenticatedUser(
@@ -87,5 +89,6 @@ async function fetchAuthenticatedUser(
       isAdmin: userSchema.privileges.includes('Admin'),
       teams: userSchema.teams,
       links: userSchema.links,
+      langid: userSchema?.langid ?? null,
    };
 }

--- a/packages/helpers/shopify-helpers.ts
+++ b/packages/helpers/shopify-helpers.ts
@@ -40,3 +40,24 @@ export function getShopifyStoreDomainFromCurrentURL(): string | null {
    }
    return null;
 }
+
+export function getShopifyLanguageFromCurrentURL(): string | null {
+   if (typeof window === 'undefined') return null;
+   const host = window.location.hostname;
+   switch (host) {
+      case 'www.ifixit.com':
+         return 'EN';
+      case 'store.cominor.com':
+         return 'EN';
+      default:
+         break;
+   }
+   if (
+      host.endsWith('.cominor.com') ||
+      host.endsWith('ifixit.vercel.app') ||
+      host === 'localhost'
+   ) {
+      return 'EN';
+   }
+   return null;
+}


### PR DESCRIPTION
## Overview

This pr introduces code to track the preferred store of a user in their piwik session. It first tries to use the users preferred langid from their ifixit account. If there isn't a user for the current session,  it just defaults to the current store's langid (which should always be EN now).

## QA

Make sure the `preferredStore` is correctly logged in piwik. Make sure that it uses the ifixit user's langid if they are logged in, and "EN" if not.

Closes: #2017