### PR TITLE
Vulcan: Blockquote Style Pass

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -112,14 +112,22 @@ const troubleshootingStyles: SystemStyleObject = {
    },
 
    blockquote: {
+      borderColor: 'gray.800',
+      borderLeftWidth: '4px',
+      marginTop: '1em',
+
       '&.featured': {
-         borderColor: '#fe6f15',
-         borderTopWidth: '1px',
-         borderBottomWidth: '1px',
+         borderColor: 'gray.300',
+         borderWidth: '1px',
+         borderLeftWidth: '4px',
+         borderRadius: 'md',
+         padding: 2,
+         color: 'orange.500',
+         bgColor: 'white',
       },
 
-      '& > p': {
-         marginTop: 2,
+      '& > p:not(:first-of-type)': {
+         marginTop: '1em',
       },
    },
 

--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -112,9 +112,10 @@ const troubleshootingStyles: SystemStyleObject = {
    },
 
    blockquote: {
-      borderColor: 'gray.800',
+      borderColor: 'gray.300',
       borderLeftWidth: '4px',
       marginTop: '1em',
+      paddingLeft: '1em',
 
       '&.featured': {
          borderColor: 'gray.300',


### PR DESCRIPTION
## Issue

It looks like we missed porting over the PHP app styles to Vulcan for blockquotes 1:1. Let's get the blockquotes polished up.

## QA

<details>
<summary>After Screenshots</summary>

<img width="1699" alt="Screenshot 2023-10-17 at 10 58 10 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/32bfa3a8-a805-4c24-9cc1-9b3db90b0ec8">

<img width="1699" alt="Screenshot 2023-10-17 at 10 58 34 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/7e217ffa-e88c-4a86-acc9-416838fa8d79">

</details>

Blockquote: `/Troubleshooting/Whirlpool_Refrigerator/Leaking+Water/509236`
Featured Blockquote: `Troubleshooting/Stove/Oven+Not+Turning+On/509246`

Closes https://github.com/iFixit/ifixit/issues/50276