### PR TITLE
Vulcan: Fix mobile content overflowing the viewport

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -41,6 +41,7 @@ const sharedStyles: SystemStyleObject = {
    },
 
    pre: {
+      marginTop: '1em',
       paddingInline: 1,
       maxWidth: '100%',
       overflow: 'auto',

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -152,6 +152,8 @@ const Wiki: NextPageWithLayout<{
                />
                <Stack
                   className="wrapper"
+                  gridArea="wrapper"
+                  display={{ base: 'block', sm: 'flex' }}
                   direction={{ base: 'column', xl: 'row' }}
                   fontSize="md"
                   maxW="1280px"
@@ -159,10 +161,9 @@ const Wiki: NextPageWithLayout<{
                   paddingX={{ base: 4, sm: 8 }}
                   paddingBottom={8}
                   minW={0}
-                  marginInline="auto"
+                  marginInline={{ sm: 'auto' }}
                   spacing={{ base: 4, lg: 12 }}
                   flexWrap={{ base: 'wrap', xl: 'nowrap' }}
-                  gridArea="wrapper"
                >
                   <Stack id="main" spacing={4}>
                      <TroubleshootingHeading wikiData={wikiData} />
@@ -171,7 +172,7 @@ const Wiki: NextPageWithLayout<{
                         solutions={wikiData.solutions}
                         problems={wikiData.linkedProblems}
                      />
-                     <Stack className="intro" spacing={6} pt={3}>
+                     <Stack className="intro" spacing={6} pt={{ sm: 3 }}>
                         <IntroductionSections introduction={introSections} />
                      </Stack>
                      {wikiData.solutions.length > 0 && (


### PR DESCRIPTION
## Issue

We have viewport overflow on mobile, narrowed down to the `pre` element.

## CR

- issue was in the parent display
- add top margin to separate from surrounding content

## QA

`/Troubleshooting/Whirlpool_Refrigerator/Making+Humming+Noise/509241#Section_Faulty_Compressor_Components`

<details>
<summary>Before/After Screenshots</summary>

<img width="1699" alt="Screenshot 2023-10-17 at 11 26 43 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/91198d31-3f29-41cc-a9e8-545ed732c1ea">

<img width="1699" alt="Screenshot 2023-10-17 at 11 16 48 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/ff2dc9d7-144f-4a5b-b751-5f3533b9b73d">

</details>

Closes https://github.com/iFixit/ifixit/issues/50246