### PR TITLE
Add related problems count to troubleshooting page

### DIFF
--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -89,6 +89,7 @@ export type TroubleshootingApiData = {
    metaDescription: string;
    metaKeywords: string;
    linkedProblems: Problem[];
+   countOfAssociatedProblems: number;
    mainImageUrl: string;
    mainImageUrlLarge: string;
    category: CategoryInfo;

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -997,8 +997,8 @@ function RelatedProblems({
                         </Text>
                         <Link href={deviceGuideUrl} textColor="brand.500">
                            {countOfAssociatedProblems === 1
-                              ? 'view problem'
-                              : 'view all'}
+                              ? 'View problem'
+                              : 'View all'}
                         </Link>
                      </Flex>
                   )}

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -936,18 +936,14 @@ function RelatedProblems({
             id={RelatedProblemsRecord.uniqueId}
             ref={ref}
             className="sidebar"
-            spacing={{ base: 3, xl: 6 }}
+            spacing={{ base: 4, xl: 6 }}
             width={{ base: '100%' }}
             alignSelf="start"
             fontSize="14px"
             flex={{ xl: '1 0 320px' }}
             mt={{ base: 3, md: 0 }}
          >
-            <Stack
-               className="question"
-               spacing={1.5}
-               display={{ base: 'none', xl: 'flex' }}
-            >
+            <Stack className="question" spacing={1.5} display="flex">
                <Box
                   bgColor="white"
                   border="1px solid"

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -920,7 +920,8 @@ function RelatedProblems({
    wikiData: TroubleshootingData;
    hasRelatedPages?: boolean;
 }) {
-   const { linkedProblems } = wikiData;
+   const { linkedProblems, deviceGuideUrl, countOfAssociatedProblems } =
+      wikiData;
    const { displayTitle, imageUrl, description } = wikiData.category;
 
    const bufferPx = useBreakpointValue({ base: -40, lg: 0 });
@@ -952,6 +953,7 @@ function RelatedProblems({
                   border="1px solid"
                   borderColor="gray.300"
                   borderRadius="md"
+                  overflow="hidden"
                >
                   <Flex gap={2} padding={3}>
                      <Image
@@ -977,6 +979,29 @@ function RelatedProblems({
                         </Text>
                      </Box>
                   </Flex>
+                  {countOfAssociatedProblems && (
+                     <Flex
+                        justifyContent="space-between"
+                        alignItems="center"
+                        w="100%"
+                        h="42px"
+                        padding="12px"
+                        bg="gray.100"
+                        borderTop="1px solid"
+                        borderColor="gray.300"
+                     >
+                        <Text>
+                           {countOfAssociatedProblems === 1
+                              ? '1 Problem'
+                              : countOfAssociatedProblems + ' Problems'}
+                        </Text>
+                        <Link href={deviceGuideUrl} textColor="brand.500">
+                           {countOfAssociatedProblems === 1
+                              ? 'view problem'
+                              : 'view all'}
+                        </Link>
+                     </Flex>
+                  )}
                </Box>
             </Stack>
             {hasRelatedPages && (


### PR DESCRIPTION
## Overview
1. We now have the count of associated problems from the api, so lets add the count and a link to the troubleshooting section of the parent device wiki.
2. This matches the styles in the [figma mockup](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=296-42468&mode=design&t=U0qVoPpyOePi4fOw-0).

## QA
- Make sure the new component matches [the mockup](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=296-42468&mode=design&t=U0qVoPpyOePi4fOw-0). 
- Try it out troubleshooting pages with [zero](http://localhost:3000/Troubleshooting/iPhone_11/Will+Not+Turn+On/478192), one, and [multiple related problems](http://localhost:3000/Troubleshooting/Refrigerator/Compressor+Not+Running/505022).

Closes https://github.com/iFixit/ifixit/issues/50054