### PR TITLE
Vulcan: Refactor `prerenderd` margins

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -78,7 +78,7 @@ const troubleshootingStyles: SystemStyleObject = {
    ...sharedStyles,
 
    '&': {
-      marginTop: { base: 4, sm: 6 },
+      gap: '1em',
    },
 
    '.clearer': {
@@ -90,13 +90,14 @@ const troubleshootingStyles: SystemStyleObject = {
       fontSize: '0',
    },
 
+   // handle the first-child header, which gets .clearer appended
+   '.clearer:not(:first-child) + .headerContainer': {
+      marginTop: { base: 4, sm: 6 },
+   },
+
    '.headerContainer': {
       display: 'flex',
       alignItems: 'baseline',
-
-      _notFirst: {
-         marginTop: { base: 4, sm: 6 },
-      },
 
       '&:hover .selfLink': {
          opacity: '1',
@@ -128,7 +129,7 @@ const troubleshootingStyles: SystemStyleObject = {
          bgColor: 'white',
       },
 
-      '& > p:not(:first-of-type)': {
+      '& > p:not(:first-child)': {
          marginTop: '1em',
       },
    },
@@ -144,7 +145,7 @@ const troubleshootingStyles: SystemStyleObject = {
       lineHeight: '1.38',
       alignSelf: 'stretch',
 
-      _notFirst: {
+      '&:not(:first-child)': {
          marginTop: '1em',
       },
    },

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -849,7 +849,7 @@ function IntroductionSection({
    const { onClick } = useTOCBufferPxScrollOnClick(intro.id);
 
    return (
-      <Box ref={ref} id={intro.id}>
+      <Stack spacing={3} ref={ref} id={intro.id}>
          {intro.heading && (
             <HeadingSelfLink
                fontWeight="semibold"
@@ -863,7 +863,7 @@ function IntroductionSection({
             </HeadingSelfLink>
          )}
          <PrerenderedHTML html={intro.body} template="troubleshooting" />
-      </Box>
+      </Stack>
    );
 }
 
@@ -877,12 +877,12 @@ const ConclusionSection = function ConclusionSectionInner({
    const { onClick } = useTOCBufferPxScrollOnClick(conclusion.id);
 
    return (
-      <Box id={conclusion.id} ref={ref}>
+      <Stack spacing={3} id={conclusion.id} ref={ref}>
          <HeadingSelfLink pt={4} id={conclusion.id} onClick={onClick}>
             {conclusion.heading}
          </HeadingSelfLink>
          <PrerenderedHTML html={conclusion.body} template="troubleshooting" />
-      </Box>
+      </Stack>
    );
 };
 


### PR DESCRIPTION
## Issue

We had a regression in spacing for our `prerendered` containers recently. We're effectively doubling the spacing between the headings and the content.

## QA

<details>
<summary>Before</summary>
<img width="1681" alt="Screenshot 2023-10-18 at 3 09 44 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/d178d81b-058c-4763-9baa-e152b9c1d621">

<img width="1681" alt="Screenshot 2023-10-18 at 3 10 02 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/43e8d363-274c-4f5a-bccd-b2f4532154c7">

</details>

<details>
<summary>After</summary>
<img width="1681" alt="Screenshot 2023-10-18 at 3 27 02 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/eee5395e-44ab-4052-9292-551dfe14b4e7">

<img width="1681" alt="Screenshot 2023-10-18 at 3 25 50 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/26a8e25d-1d52-4c5c-a354-c132b67f440f">

</details>

Closes: https://github.com/iFixit/ifixit/issues/50307