### PR TITLE
Fix troubleshooting page markup error

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -405,12 +405,6 @@ export type ComponentProductListBanner = {
    url: Scalars['String'];
 };
 
-export type ComponentProductListBoostedSearchSkus2 = {
-   __typename?: 'ComponentProductListBoostedSearchSkus2';
-   Sku: Scalars['String'];
-   id: Scalars['ID'];
-};
-
 export type ComponentProductListItemTypeOverride = {
    __typename?: 'ComponentProductListItemTypeOverride';
    description?: Maybe<Scalars['String']>;
@@ -872,7 +866,6 @@ export type GenericMorph =
    | ComponentProductCrossSell
    | ComponentProductDeviceCompatibility
    | ComponentProductListBanner
-   | ComponentProductListBoostedSearchSkus2
    | ComponentProductListItemTypeOverride
    | ComponentProductListLinkedProductListSet
    | ComponentProductListRelatedPosts

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -971,7 +971,7 @@ function RelatedProblems({
                            {displayTitle}
                         </Box>
                         <Text
-                           display={{ base: 'none', xl: 'flex' }}
+                           display={{ base: 'none', xl: '-webkit-box' }}
                            mt={3}
                            noOfLines={4}
                         >

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -972,8 +972,12 @@ function RelatedProblems({
                         <Box fontWeight="semibold" my="auto">
                            {displayTitle}
                         </Box>
-                        <Text display={{ base: 'none', xl: 'flex' }} mt={3}>
-                           <Box noOfLines={4}>{description}</Box>
+                        <Text
+                           display={{ base: 'none', xl: 'flex' }}
+                           mt={3}
+                           noOfLines={4}
+                        >
+                           {description}
                         </Text>
                      </Box>
                   </Flex>


### PR DESCRIPTION
This PR fix a markup nesting issue.
I think it was the reason why Sentry showed an high number of non crash-free sessions recently.

<img width="1121" alt="Screenshot 2023-10-19 at 19 25 39" src="https://github.com/iFixit/react-commerce/assets/7805759/7f4da4b0-a069-4b80-9146-48f051c845ec">

### QA

1. Visit Vercel preview
2. No visible change should be present.
3. As soon as released we should see crash-free sessions going back to normal