### PR TITLE
Vulcan: Fix RelatedProblems layout

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -951,7 +951,7 @@ function RelatedProblems({
                   borderRadius="md"
                   overflow="hidden"
                >
-                  <Flex gap={2} padding={3}>
+                  <Flex gap={2} padding={3} align="center">
                      <Image
                         src={imageUrl}
                         alt={displayTitle}
@@ -963,10 +963,7 @@ function RelatedProblems({
                         outline="1px solid"
                         outlineColor="gray.300"
                      />
-                     <Box
-                        display={{ base: 'flex', xl: 'block' }}
-                        lineHeight="normal"
-                     >
+                     <Box display="block" lineHeight="normal">
                         <Box fontWeight="semibold" my="auto">
                            {displayTitle}
                         </Box>
@@ -984,8 +981,7 @@ function RelatedProblems({
                         justifyContent="space-between"
                         alignItems="center"
                         w="100%"
-                        h="42px"
-                        padding="12px"
+                        padding={3}
                         bg="gray.100"
                         borderTop="1px solid"
                         borderColor="gray.300"

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -967,13 +967,12 @@ function RelatedProblems({
                         <Box fontWeight="semibold" my="auto">
                            {displayTitle}
                         </Box>
-                        <Text
-                           display={{ base: 'none', xl: '-webkit-box' }}
+                        <Box
+                           display={{ base: 'none', sm: '-webkit-box' }}
                            mt={3}
-                           noOfLines={4}
                         >
-                           {description}
-                        </Text>
+                           <Text noOfLines={4}>{description}</Text>
+                        </Box>
                      </Box>
                   </Flex>
                   {countOfAssociatedProblems && (


### PR DESCRIPTION
## Issue

There appears to be a Chakra bug or conflict when trying to use `display` and `noOfLines` on a Text component. Resolve this.

Also, below our `desktop-xxl` breakpoint, our `RelatedProblems` layout isn't rendering in a column.

Matches design spec https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?node-id=296%3A44439&mode=dev

## QA

<details>

https://github.com/iFixit/react-commerce/assets/1634505/82f91e1b-ab11-4134-929d-6e0755100256


</details>

`Troubleshooting/iPhone_11/Will+Not+Turn+On/478192`

Closes https://github.com/iFixit/ifixit/issues/50335