### PR TITLE
Fix prerendered html component ref

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -2,9 +2,34 @@
 // is broken up into `shared`, `troubleshooting`, and `commerce` variables to control what
 // is included, and where via the styleMap.
 
-import { useEffect } from 'react';
-import { Box, chakra, SystemStyleObject } from '@chakra-ui/react';
+import { Box, SystemStyleObject, forwardRef } from '@chakra-ui/react';
 import 'lite-youtube-embed/src/lite-yt-embed.css';
+import { useEffect } from 'react';
+
+interface PrerenderedHTMLProps {
+   html: string;
+   template: 'troubleshooting' | 'commerce';
+   className?: string;
+}
+
+export const PrerenderedHTML = forwardRef<PrerenderedHTMLProps, 'div'>(
+   function PrerenderedHTML({ html, template, className }, ref) {
+      useEffect(() => {
+         if (template === 'troubleshooting') {
+            import('lite-youtube-embed');
+         }
+      }, [template]);
+
+      return (
+         <Box
+            ref={ref}
+            className={`prerendered ${className}`}
+            sx={styleMap[template]}
+            dangerouslySetInnerHTML={{ __html: html }}
+         />
+      );
+   }
+);
 
 const constrainStandardWidth = '282px'; // pulled from PHP app for legacy image sizing
 
@@ -372,27 +397,3 @@ const styleMap = {
    troubleshooting: troubleshootingStyles,
    commerce: commerceStyles,
 };
-
-export const PrerenderedHTML = chakra(function Prerendered({
-   html,
-   template,
-   className,
-}: {
-   html: string;
-   template: 'troubleshooting' | 'commerce';
-   className?: string;
-}) {
-   useEffect(() => {
-      if (template === 'troubleshooting') {
-         import('lite-youtube-embed');
-      }
-   }, [template]);
-
-   return (
-      <Box
-         className={`prerendered ${className}`}
-         sx={styleMap[template]}
-         dangerouslySetInnerHTML={{ __html: html }}
-      />
-   );
-});

--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -2,18 +2,17 @@
 // is broken up into `shared`, `troubleshooting`, and `commerce` variables to control what
 // is included, and where via the styleMap.
 
-import { Box, SystemStyleObject, forwardRef } from '@chakra-ui/react';
+import { Box, SystemStyleObject, forwardRef, BoxProps } from '@chakra-ui/react';
 import 'lite-youtube-embed/src/lite-yt-embed.css';
 import { useEffect } from 'react';
 
-interface PrerenderedHTMLProps {
+type PrerenderedHTMLProps = BoxProps & {
    html: string;
    template: 'troubleshooting' | 'commerce';
-   className?: string;
-}
+};
 
 export const PrerenderedHTML = forwardRef<PrerenderedHTMLProps, 'div'>(
-   function PrerenderedHTML({ html, template, className }, ref) {
+   function PrerenderedHTML({ html, template, className, ...others }, ref) {
       useEffect(() => {
          if (template === 'troubleshooting') {
             import('lite-youtube-embed');
@@ -26,6 +25,7 @@ export const PrerenderedHTML = forwardRef<PrerenderedHTMLProps, 'div'>(
             className={`prerendered ${className}`}
             sx={styleMap[template]}
             dangerouslySetInnerHTML={{ __html: html }}
+            {...others}
          />
       );
    }


### PR DESCRIPTION
This fixes a regression introduced by #1946 where the rich text component has been replaced with one that does not support refs:

![Screenshot 2023-10-23 at 16 42 00](https://github.com/iFixit/react-commerce/assets/4640135/b75cfcfd-b826-4a81-a19f-bafe7648e070)

This adds refs support to the `PrerenderedHTML` component

## QA

Verify that rich text is still correctly rendered (check product list page hero description, or look at wiki text in troubleshooting pages)