### PR TITLE
Fix product list title regression

### DIFF
--- a/frontend/templates/product-list/sections/HeroSection.tsx
+++ b/frontend/templates/product-list/sections/HeroSection.tsx
@@ -134,7 +134,6 @@ function HeroTitle({
          size="xl"
          fontSize={{ base: '2xl', md: '3xl' }}
          fontWeight="medium"
-         whiteSpace="nowrap"
          data-testid="hero-title"
       >
          {children}


### PR DESCRIPTION
closes #2050 

## QA

1. Open a vercel [product page preview](https://react-commerce-git-fix-product-list-title-regression-ifixit.vercel.app/Parts/DJI_Phantom_4_Pro_Remote_Controller_with_Built-In_Screen)
2. Verify that the issue described by #2050 is no longer present