### PR TITLE
Use bundle add to cart for cross sell items

### DIFF
--- a/frontend/templates/product/sections/ProductOverviewSection/CrossSell/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/CrossSell/index.tsx
@@ -63,7 +63,11 @@ export function CrossSell({ product, selectedVariant }: CrossSellProps) {
          >
             {availableForSaleVariants.map((variant) => {
                return (
-                  <CrossSellItem key={variant.id} productPreview={variant} />
+                  <CrossSellItem
+                     key={variant.id}
+                     productPreview={variant}
+                     selectedVariant={selectedVariant}
+                  />
                );
             })}
          </VStack>
@@ -73,17 +77,29 @@ export function CrossSell({ product, selectedVariant }: CrossSellProps) {
 
 interface CrossSellItemProps {
    productPreview: ProductPreviewWithCartDetails;
+   selectedVariant: ProductVariant;
 }
 
-function CrossSellItem({ productPreview }: CrossSellItemProps) {
+function CrossSellItem({
+   productPreview,
+   selectedVariant,
+}: CrossSellItemProps) {
    const addToCart = useAddToCart('Frequently Bought Together');
    const withUserPrice = useWithUserPrice();
    const drawer = useCartDrawer();
 
    const handleAddToCart = () => {
+      if (selectedVariant.sku == null) {
+         console.error(`Variant ${selectedVariant.id} has no SKU`);
+         return;
+      }
+
       addToCart.mutate({
-         type: 'product',
-         product: createCartLineItem(withUserPrice(productPreview)),
+         type: 'bundle',
+         bundle: {
+            currentItemCode: selectedVariant.sku,
+            items: [createCartLineItem(withUserPrice(productPreview))],
+         },
       });
       drawer.onOpen(event, true);
       trackGA4AddToCart({


### PR DESCRIPTION
closes #1910 

Let's fix how we record "frequently bought together" add to cart event. Switching to using the add bundle function of the cart sdk should do the trick.

@addison-grant This PR should fix Piwik tracking. I saw that the GA4 cart tracking has been added recently, is it working as intended? If not I can look into it in another pull.

## QA

Not sure how to QA this, @masonmcelvain do we have a way to test Piwik event tracking in staging environments?
Since we're not tracking events correctly for this anyway, I think it's also fine to merge this and see if newer events in production are correct.