### PR TITLE
User SDK: Don't validate null user data

### DIFF
--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -80,6 +80,9 @@ async function fetchAuthenticatedUser(
    apiClient: IFixitAPIClient
 ): Promise<User | null> {
    const payload = await apiClient.get('user', 'user');
+   if (payload == null) {
+      return null;
+   }
    const userSchema = UserApiResponseSchema.safeParse(payload);
    if (!userSchema.success) {
       Sentry.captureMessage('User schema parsing failed', {


### PR DESCRIPTION
We got thousands of sentry events overnight notifying us that the value "null" failed the user schema validation. Let's bail early with no validation in that case.

Slack: https://ifixit.slack.com/archives/C04C05FA3EH/p1698329545488009

Sentry: https://ifixit.sentry.io/share/issue/d7d55c09325f4e55880ffdeea3c7e202/

Followup to: https://github.com/iFixit/react-commerce/pull/2038

qa_req 0 when this deploys, we can validate that it's working be observing whether the sentry events start trending down