### PR TITLE
Pagination: Don't Use Search Params On First Page

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/Pagination.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/Pagination.tsx
@@ -30,7 +30,14 @@ export function Pagination(props: PaginationProps) {
    const createPageUrl = (page: number) => {
       const fullUrl = createURL(page - 1);
       const url = new URL(fullUrl);
-      return url.pathname + url.search;
+      const searchParams = new URLSearchParams(url.search);
+      if (page === 1) {
+         searchParams.delete('p');
+      }
+      const search = searchParams.toString()
+         ? `?${searchParams.toString()}`
+         : '';
+      return url.pathname + search;
    };
 
    if (nbPages <= 1) {


### PR DESCRIPTION
## Overview

If pagination page is the first page dont add search params. We don't need p=1 as a url parameter when its the same page as the url by itself. Lets just always use the canonical url.

## QA
You can read the issue and find it pretty straightforward, but basically for pagination on collection list pages we don't need search params for the first page. 

Closes: https://github.com/iFixit/ifixit/issues/50321