### PR TITLE
Worksin: Support passing it via the url

### DIFF
--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -4,7 +4,7 @@ import { getClientOptions } from '@helpers/algolia-helpers';
 import {
    destylizeDeviceItemType,
    destylizeDeviceTitle,
-   destylizeDeviceTitleAndWorksIn,
+   destylizeDeviceTitleAndVariant,
    getFacetWidgetType,
    isValidRefinementListValue,
    stylizeDeviceItemType,
@@ -97,7 +97,7 @@ export function InstantSearchProvider({
          const devicePath = isDevicePartsPage
             ? getDevicePath(deviceHandle, routeState)
             : deviceHandle;
-         const devicePathIsWorksIn =
+         const devicePathHasVariant =
             isDevicePartsPage && devicePath.includes(':');
 
          let path = `/${firstPathSegment}`;
@@ -119,7 +119,7 @@ export function InstantSearchProvider({
             // Item Type is the slug on device pages, not in the query.
             delete filterCopy['facet_tags.Item Type'];
          }
-         if (devicePathIsWorksIn) {
+         if (devicePathHasVariant) {
             delete filterCopy['worksin'];
          }
          const { q, p, filter, ...otherParams } = qsModule.parse(
@@ -156,7 +156,7 @@ export function InstantSearchProvider({
          const deviceHandle = pathParts.length >= 2 ? pathParts[1] : '';
          const itemType = pathParts.length >= 3 ? pathParts[2] : '';
          const isDevicePartsPage = firstPathSegment === 'Parts' && deviceHandle;
-         const deviceHandleIsWorksIn =
+         const devicePathHasVariant =
             isDevicePartsPage && deviceHandle.includes(':');
 
          const { q, p, filter } = qsModule.parse(location.search, {
@@ -199,9 +199,9 @@ export function InstantSearchProvider({
             ).trim();
          }
 
-         if (deviceHandleIsWorksIn) {
+         if (devicePathHasVariant) {
             filterObject['worksin'] =
-               destylizeDeviceTitleAndWorksIn(deviceHandle);
+               destylizeDeviceTitleAndVariant(deviceHandle);
          }
 
          return {
@@ -334,17 +334,17 @@ function getBaseOrigin(location: Location): string {
 }
 
 function getDevicePath(handle: string, routeState: RouteState): string {
-   const [device, worksin] = handle.split(':');
-   const worksinFromRouteState = routeState.filter?.['worksin'];
+   const [device, variant] = handle.split(':');
+   const variantFromRouteState = routeState.filter?.['worksin'];
 
-   if (worksin && !worksinFromRouteState) {
+   if (variant && !variantFromRouteState) {
       return device;
    }
 
-   if (!worksin && worksinFromRouteState) {
+   if (!variant && variantFromRouteState) {
       const title = destylizeDeviceTitle(handle);
-      const newWorksin = worksinFromRouteState.replace(title, '').trim();
-      return `${handle}:${newWorksin}`;
+      const varaintToAdd = variantFromRouteState.replace(title, '').trim();
+      return `${handle}:${varaintToAdd}`;
    }
 
    return handle;

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -3,6 +3,7 @@ import { ALGOLIA_APP_ID, IFIXIT_ORIGIN } from '@config/env';
 import { getClientOptions } from '@helpers/algolia-helpers';
 import {
    destylizeDeviceItemType,
+   destylizeDeviceTitleAndWorksIn,
    getFacetWidgetType,
    isValidRefinementListValue,
    stylizeDeviceItemType,
@@ -92,6 +93,8 @@ export function InstantSearchProvider({
          const firstPathSegment = pathParts.length >= 1 ? pathParts[0] : '';
          const deviceHandle = pathParts.length >= 2 ? pathParts[1] : '';
          const isDevicePartsPage = firstPathSegment === 'Parts' && deviceHandle;
+         const deviceHandleIsWorksIn =
+            isDevicePartsPage && deviceHandle.includes(':');
 
          let path = `/${firstPathSegment}`;
          if (deviceHandle) {
@@ -111,6 +114,9 @@ export function InstantSearchProvider({
          if (isDevicePartsPage) {
             // Item Type is the slug on device pages, not in the query.
             delete filterCopy['facet_tags.Item Type'];
+         }
+         if (deviceHandleIsWorksIn) {
+            delete filterCopy['worksin'];
          }
          const { q, p, filter, ...otherParams } = qsModule.parse(
             location.search,
@@ -146,6 +152,8 @@ export function InstantSearchProvider({
          const deviceHandle = pathParts.length >= 2 ? pathParts[1] : '';
          const itemType = pathParts.length >= 3 ? pathParts[2] : '';
          const isDevicePartsPage = firstPathSegment === 'Parts' && deviceHandle;
+         const deviceHandleIsWorksIn =
+            isDevicePartsPage && deviceHandle.includes(':');
 
          const { q, p, filter } = qsModule.parse(location.search, {
             ignoreQueryPrefix: true,
@@ -185,6 +193,11 @@ export function InstantSearchProvider({
             filterObject['facet_tags.Item Type'] = destylizeDeviceItemType(
                decodeURIComponent(itemType)
             ).trim();
+         }
+
+         if (deviceHandleIsWorksIn) {
+            filterObject['worksin'] =
+               destylizeDeviceTitleAndWorksIn(deviceHandle);
          }
 
          return {

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -3,7 +3,6 @@ import { ALGOLIA_APP_ID, IFIXIT_ORIGIN } from '@config/env';
 import { getClientOptions } from '@helpers/algolia-helpers';
 import {
    destylizeDeviceItemType,
-   destylizeDeviceTitle,
    destylizeDeviceTitleAndVariant,
    getFacetWidgetType,
    isValidRefinementListValue,

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -8,6 +8,7 @@ import {
    getFacetWidgetType,
    isValidRefinementListValue,
    stylizeDeviceItemType,
+   stylizeDeviceTitle,
 } from '@helpers/product-list-helpers';
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { assertNever } from '@ifixit/helpers';
@@ -336,16 +337,14 @@ function getBaseOrigin(location: Location): string {
 
 function getDevicePath(handle: string, routeState: RouteState): string {
    const [device, variant] = handle.split(':');
-   const variantFromRouteState = routeState.filter?.['worksin'];
+   const variantFromRouteState = routeState.filter?.worksin;
 
    if (variant && !variantFromRouteState) {
       return device;
    }
 
    if (!variant && variantFromRouteState) {
-      const title = destylizeDeviceTitle(handle);
-      const varaintToAdd = variantFromRouteState.replace(title, '').trim();
-      return `${handle}:${varaintToAdd}`;
+      return stylizeDeviceTitle(handle, variantFromRouteState);
    }
 
    return handle;

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -200,8 +200,9 @@ export function InstantSearchProvider({
          }
 
          if (devicePathHasVariant) {
-            filterObject['worksin'] =
-               destylizeDeviceTitleAndVariant(deviceHandle);
+            filterObject['worksin'] = destylizeDeviceTitleAndVariant(
+               decodeURIComponent(deviceHandle)
+            );
          }
 
          return {

--- a/frontend/components/common/InstantSearchProvider.tsx
+++ b/frontend/components/common/InstantSearchProvider.tsx
@@ -334,14 +334,14 @@ function getBaseOrigin(location: Location): string {
 }
 
 function getDevicePath(handle: string, routeState: RouteState): string {
-   const [_device, worksin] = handle.split(':');
-   if (worksin) {
-      return handle;
-   }
-
+   const [device, worksin] = handle.split(':');
    const worksinFromRouteState = routeState.filter?.['worksin'];
 
-   if (worksinFromRouteState) {
+   if (worksin && !worksinFromRouteState) {
+      return device;
+   }
+
+   if (!worksin && worksinFromRouteState) {
       const title = destylizeDeviceTitle(handle);
       const newWorksin = worksinFromRouteState.replace(title, '').trim();
       return `${handle}:${newWorksin}`;

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -58,21 +58,21 @@ export function stylizeDeviceItemType(itemType: string): string {
 /**
  * Convert '_' in URL slug to spaces for product list device title
  * If the handle has a : character everything after it is removed.
- * This is to remove the device's worksin from the handle.
+ * This is to remove the device's variant from the handle.
  * Example: "PlayStation_4:CUH-11XXA" becomes "PlayStation 4"
  */
 export function destylizeDeviceTitle(handle: string): string {
-   const [device, _worksin] = handle.split(':');
+   const [device, _variant] = handle.split(':');
    return device.replace(/_/g, ' ');
 }
 
 /**
- * Keeping the device's worksin in the handle.
+ * Keeping the device's variant in the handle.
  * Convert '_' in URL slug to spaces for product list device title
- * Convert ':' in URL slug to spaces for the worksin separator
+ * Convert ':' in URL slug to spaces for the variant separator
  * Example: "PlayStation_4:CUH-11XXA" becomes "PlayStation 4 CUH-11XXA"
  */
-export function destylizeDeviceTitleAndWorksIn(handle: string): string {
+export function destylizeDeviceTitleAndVariant(handle: string): string {
    return handle.replace(/_|:/g, ' ');
 }
 
@@ -81,11 +81,11 @@ export function destylizeDeviceTitleAndWorksIn(handle: string): string {
  */
 export function stylizeDeviceTitle(
    deviceTitle: string,
-   worksin?: string
+   variant?: string
 ): string {
    const urlTitle = deviceTitle.replace(/\s/g, '_');
-   const urlWorksIn = worksin ? `:${worksin}` : '';
-   return urlTitle + urlWorksIn;
+   const urlVariant = variant ? `:${variant}` : '';
+   return urlTitle + urlVariant;
 }
 
 type ProductListTitleAttributes = {

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -57,16 +57,35 @@ export function stylizeDeviceItemType(itemType: string): string {
 
 /**
  * Convert '_' in URL slug to spaces for product list device title
+ * If the handle has a : character everything after it is removed.
+ * This is to remove the device's worksin from the handle.
+ * Example: "PlayStation_4:CUH-11XXA" becomes "PlayStation 4"
  */
 export function destylizeDeviceTitle(handle: string): string {
-   return handle.replace(/_/g, ' ');
+   const [device, _worksin] = handle.split(':');
+   return device.replace(/_/g, ' ');
+}
+
+/**
+ * Keeping the device's worksin in the handle.
+ * Convert '_' in URL slug to spaces for product list device title
+ * Convert ':' in URL slug to spaces for the worksin separator
+ * Example: "PlayStation_4:CUH-11XXA" becomes "PlayStation 4 CUH-11XXA"
+ */
+export function destylizeDeviceTitleAndWorksIn(handle: string): string {
+   return handle.replace(/_|:/g, ' ');
 }
 
 /**
  * Convert to spaces in product list device Title to '_' for URL slug
  */
-export function stylizeDeviceTitle(deviceTitle: string): string {
-   return deviceTitle.replace(/\s/g, '_');
+export function stylizeDeviceTitle(
+   deviceTitle: string,
+   worksin?: string
+): string {
+   const urlTitle = deviceTitle.replace(/\s/g, '_');
+   const urlWorksIn = worksin ? `:${worksin}` : '';
+   return urlTitle + urlWorksIn;
 }
 
 type ProductListTitleAttributes = {

--- a/frontend/helpers/product-list-helpers.ts
+++ b/frontend/helpers/product-list-helpers.ts
@@ -84,8 +84,9 @@ export function stylizeDeviceTitle(
    variant?: string
 ): string {
    const urlTitle = deviceTitle.replace(/\s/g, '_');
-   const urlVariant = variant ? `:${variant}` : '';
-   return urlTitle + urlVariant;
+   const urlVariant = variant?.replace(/\s/g, '_') ?? '';
+   const shortenedVariant = urlVariant.replace(`${urlTitle}_`, '');
+   return shortenedVariant ? `${urlTitle}:${shortenedVariant}` : urlTitle;
 }
 
 type ProductListTitleAttributes = {


### PR DESCRIPTION
I chose not to include it in the query params filter on URL generation

This pull still supports the old URL style as well.

QA
---

The works-in filter should be correct for:
* http://localhost:3000/Parts/PlayStation_4:CUH-11XXA 
* http://localhost:3000/Parts/PlayStation_4?filter%5Bworksin%5D=PlayStation%204%20CUH-11XXA
* http://localhost:3000/Parts/PlayStation_4?filter%5Bfacet_tags.Capacity%5D%5B0%5D=1%20TB 
* http://localhost:3000/Parts/PlayStation_4:CUH-11XXA?filter%5Bfacet_tags.Capacity%5D%5B0%5D=1%20TB
* http://localhost:3000/Parts/PlayStation_4
* http://localhost:3000/Parts/iPod_Mini?filter%5Bworksin%5D=iPod%20Mini%20A1051%202nd%20gen%204%20GB

For clarity both `Parts/PlayStation_4:CUH-11XXA` and `PlayStation_4?filter...` should work. We will prefer the `:` version of the works in value.



Connects: https://github.com/iFixit/ifixit/issues/50436