### PR TITLE
Filters: Don't Add "P" URL Param To Links

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/useCreateItemTypeURL.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/useCreateItemTypeURL.tsx
@@ -17,7 +17,9 @@ export function useCreateItemTypeURL() {
          stylizeDeviceItemType(item.value)
       );
       const prefixSegments = segments.slice(0, 2);
-      const search = query ? `?${query}` : '';
+      const params = new URLSearchParams(query);
+      params.delete('p');
+      const search = params.toString() ? `?${params.toString()}` : '';
       return `/${prefixSegments.join('/')}/${itemTypeHandle}${search}`;
    };
 }


### PR DESCRIPTION
## Overview

When someone is on a collection list page that isn't page 1, we append a `p=<pageNumber>` to the filter links. This is unnecessary and potentially detrimental. So lets stop adding that param.

## QA

Make sure collection list filters don't add `p` anymore to their links, even if one a current page where p=<1. 

Make sure this works for mobile and desktop.

You can read more on the issue for more specificity.

Closes: https://github.com/iFixit/ifixit/issues/50411