### PR TITLE
NetSuite: Add new partner codes

### DIFF
--- a/frontend/templates/product/sections/ProductOverviewSection/GenuinePartBanner.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/GenuinePartBanner.tsx
@@ -42,6 +42,24 @@ const partnerCodeToComponentMap: { [key: string]: React.FC } = {
    valve: Valve,
 };
 
+const netsuitePartnerToComponentMap: { [key: string]: React.FC } = {
+   'Genuine Google Pixel Part': Google,
+   'Genuine Crucial Drive': () => <Crucial px="2" />,
+   'Genuine HP Part': () => <Hp py="2" />,
+   'Genuine HTC Vive Part': Vive,
+   'Genuine Lenovo Part': Lenovo,
+   'Genuine Logitech Part': Logitech,
+   'Genuine Micron Drive': () => <Micron px="2" />,
+   'Genuine Microsoft Surface Part': Microsoft,
+   'Genuine Microsoft Surface Tool': Microsoft,
+   'Genuine Motorola Part': Motorola,
+   'Genuine Nokia Part': Nokia,
+   'Genuine Samsung Galaxy Part': Samsung,
+   'Genuine Steam Deck Part': Steam,
+   'Genuine Teenage Engineering Part': TeenageEngineering,
+   'Genuine Valve Index Part': Valve,
+};
+
 export function GenuinePartBanner({ oemPartnership }: GenuinePartBannerProps) {
    const { code, text, url } = oemPartnership;
    // This text is designed to be used as a badge, here we
@@ -51,8 +69,9 @@ export function GenuinePartBanner({ oemPartnership }: GenuinePartBannerProps) {
    );
    const theme = useTheme();
 
-   const hasPartnerLogo = partnerCodeToComponentMap[code] !== undefined;
-   const PartnerLogo = partnerCodeToComponentMap[code];
+   const PartnerLogo =
+      partnerCodeToComponentMap[code] ?? netsuitePartnerToComponentMap[code];
+   const hasPartnerLogo = PartnerLogo !== undefined;
 
    return (
       <Flex


### PR DESCRIPTION
Connects https://github.com/iFixit/ifixit/issues/50282

Adds a map of netsuite partner values to icon components. When we migrate to the NetSuite ERP, we'll no longer have OEM partner codes, just display values.

These partner values come from the proposed values in this [spreadsheet](https://docs.google.com/spreadsheets/d/1R0l4vuSCNepE68od0hsO6gfaxEzzF9U5vjF2U248-1Q/edit#gid=508051636).

## QA

Make sure genuine parts still have the correct partner icon, as on `main`.