### PR TITLE
Vulcan: Fix numbered list clipping

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -2,7 +2,7 @@
 // is broken up into `shared`, `troubleshooting`, and `commerce` variables to control what
 // is included, and where via the styleMap.
 
-import { Box, SystemStyleObject, forwardRef, BoxProps } from '@chakra-ui/react';
+import { Box, BoxProps, SystemStyleObject, forwardRef } from '@chakra-ui/react';
 import 'lite-youtube-embed/src/lite-yt-embed.css';
 import { useEffect } from 'react';
 
@@ -179,7 +179,6 @@ const troubleshootingStyles: SystemStyleObject = {
    'ul, ol': {
       marginTop: '1em',
       marginInlineStart: '1em',
-      overflowX: 'auto', // clear child media floats
       paddingInlineStart: 'calc(1em + 2px)',
 
       li: {
@@ -300,6 +299,10 @@ const troubleshootingStyles: SystemStyleObject = {
       marginTop: { base: 4, sm: 6 },
       minWidth: 'min-content', // narrow image text-wrap fix
       width: 'fit-content',
+
+      '& + ul, & + ol': {
+         overflowX: 'auto', // clear sibling lists
+      },
 
       '&.imageBox_center': {
          marginInline: 'auto',


### PR DESCRIPTION
## Issue

We have clipping on our ordered lists on mobile: https://www.ifixit.com/Troubleshooting/iPhone/Will+Not+Connect+to+WiFi/481127

<details>
<summary>Screenshot</summary>

![image](https://github.com/iFixit/ifixit/assets/89873512/164f5db8-dde5-4527-8e7d-590176c38f4a)

</details> 

[Slack thread](https://ifixit.slack.com/archives/CDFNZ4N4A/p1697855660963489)

## CR/QA

Primary issue observed at `/Troubleshooting/iPhone/Will+Not+Connect+to+WiFi/481127`

We'll need to keep Desktop in mind as well for regressions, but since this is more targeted than the previous application, I don't expect any.

Closes https://github.com/iFixit/ifixit/issues/50343