### PR TITLE
Simplify FaIcon types

### DIFF
--- a/packages/icons/misc/FaIcon.tsx
+++ b/packages/icons/misc/FaIcon.tsx
@@ -1,14 +1,15 @@
+import type * as React from 'react';
 import { ChakraComponent, ChakraProps, chakra } from '@chakra-ui/react';
 import {
    FontAwesomeIcon,
    FontAwesomeIconProps,
 } from '@fortawesome/react-fontawesome';
 
-export type FaIconProps = ChakraProps & FontAwesomeIconProps;
-
 export const FaIcon = chakra(FontAwesomeIcon, {
    baseStyle: {
       display: 'flex',
       alignItems: 'center',
    },
-}) as ChakraComponent<typeof FontAwesomeIcon, FontAwesomeIconProps>;
+});
+
+export type FaIconProps = React.ComponentProps<typeof FaIcon>;


### PR DESCRIPTION
FaIcon had its types changed and a cast added as part of the TS 5 upgrade. (fe1ebadfb0109db9e65205da3b07e413a8a042c7). This removes some of the changes, in an attempt to support the full range of possible types which the `color` prop supports (e.g., ResponsiveArray types).

qa_req 0
This only affects types, so no QA should be needed.