### PR TITLE
Vulcan: Sidebar: Update Image Aspect Ratio

### DIFF
--- a/frontend/templates/troubleshooting/Problem.tsx
+++ b/frontend/templates/troubleshooting/Problem.tsx
@@ -42,12 +42,14 @@ export default function ProblemCard({ problem }: { problem: Problem }) {
                outline="1px solid"
                outlineColor="gray.300"
                borderRadius="md"
-               boxSize={{ base: '56px', md: '32px' }}
+               width={{ base: '75px', md: '43px' }}
+               height={{ base: '56px', md: '32px' }}
                mr={2}
+               aspectRatio="4 / 3"
             >
                <Image
                   height="100%"
-                  htmlWidth={56}
+                  htmlWidth={75}
                   htmlHeight={56}
                   objectFit="cover"
                   src={imageUrl}

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -955,13 +955,15 @@ function RelatedProblems({
                      <Image
                         src={imageUrl}
                         alt={displayTitle}
-                        boxSize={{ base: '56px', md: '96px' }}
-                        htmlWidth={96}
-                        htmlHeight={96}
+                        width={{ base: '75px', md: '104px' }}
+                        height={{ base: '56px', md: '78px' }}
+                        htmlWidth={104}
+                        htmlHeight={78}
                         objectFit="cover"
                         borderRadius="md"
                         outline="1px solid"
                         outlineColor="gray.300"
+                        aspectRatio="4 / 3"
                      />
                      <Box display="block" lineHeight="normal">
                         <Box fontWeight="semibold" my="auto">
@@ -972,7 +974,7 @@ function RelatedProblems({
                            mt={3}
                         >
                            <PrerenderedHTML
-                              noOfLines={4}
+                              noOfLines={3}
                               template="troubleshooting"
                               html={description}
                            />

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -1,17 +1,15 @@
-import { DefaultLayout } from '@layouts/default';
-import { DefaultLayoutProps } from '@layouts/default/server';
-import Head from 'next/head';
-import React, { useRef } from 'react';
 import {
-   Avatar,
    Alert,
    AlertIcon,
+   Avatar,
    Box,
    BoxProps,
    Button,
    Flex,
    FlexProps,
+   HStack,
    Heading,
+   HeadingProps,
    IconButton,
    Image,
    Link,
@@ -21,33 +19,25 @@ import {
    MenuItem,
    MenuList,
    Modal,
-   ModalOverlay,
-   ModalContent,
-   ModalHeader,
    ModalBody,
    ModalCloseButton,
-   Stack,
+   ModalContent,
+   ModalHeader,
+   ModalOverlay,
+   SimpleGrid,
    Square,
+   Stack,
    Text,
-   useDisclosure,
    VisuallyHidden,
    chakra,
-   HStack,
-   SimpleGrid,
-   useToken,
-   HeadingProps,
    useBreakpointValue,
+   useDisclosure,
+   useToken,
 } from '@chakra-ui/react';
+import { PixelPing } from '@components/analytics/PixelPing';
 import { PrerenderedHTML } from '@components/common';
-import type {
-   Author,
-   BreadcrumbEntry,
-   Problem,
-   Section,
-   TroubleshootingData,
-} from './hooks/useTroubleshootingProps';
-import SolutionCard from './solution';
-import { FaIcon } from '@ifixit/icons';
+import { ViewStats } from '@components/common/ViewStats';
+import { IntlDate } from '@components/ui/IntlDate';
 import {
    faAngleDown,
    faCircleNodes,
@@ -56,18 +46,28 @@ import {
    faPenToSquare,
 } from '@fortawesome/pro-solid-svg-icons';
 import { BreadCrumbs } from '@ifixit/breadcrumbs';
-import { HeadingSelfLink } from './components/HeadingSelfLink';
+import { FaIcon } from '@ifixit/icons';
+import { DefaultLayout } from '@layouts/default';
+import { DefaultLayoutProps } from '@layouts/default/server';
+import Head from 'next/head';
+import { useRef } from 'react';
 import ProblemCard from './Problem';
-import { PixelPing } from '@components/analytics/PixelPing';
-import { TagManager, GoogleNoScript } from './components/TagManager';
+import { HeadingSelfLink } from './components/HeadingSelfLink';
+import { GoogleNoScript, TagManager } from './components/TagManager';
+import type {
+   Author,
+   BreadcrumbEntry,
+   Problem,
+   Section,
+   TroubleshootingData,
+} from './hooks/useTroubleshootingProps';
+import SolutionCard from './solution';
+import { TOC } from './toc';
 import {
    LinkToTOC,
    TOCContextProvider,
    useTOCBufferPxScrollOnClick,
 } from './tocContext';
-import { TOC } from './toc';
-import { ViewStats } from '@components/common/ViewStats';
-import { IntlDate } from '@components/ui/IntlDate';
 
 const RelatedProblemsRecord = {
    title: 'Related Problems',


### PR DESCRIPTION
## Issue

Update Vulcan sidebar image aspect ratio to match our images. Previously set at 1:1, but images are 4:3.

Mattia may have updates to the design at a later time ([Figma discussion](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9?node-id=201:65526&mode=dev#600241124)), but this resolves the issue for now.

## CR/QA

Verify Image ratio has been updated and looks good on mobile/desktop.

`/Troubleshooting/Mac_Laptop/MacBook+Will+Not+Turn+On/483799`