### PR TITLE
ifixit-api-client: Use peer version of `@ifixit/sentry`

### DIFF
--- a/packages/ifixit-api-client/package.json
+++ b/packages/ifixit-api-client/package.json
@@ -6,8 +6,7 @@
    "license": "MIT",
    "dependencies": {
       "@ifixit/app": "workspace:*",
-      "@ifixit/helpers": "workspace:*",
-      "@ifixit/sentry": "workspace:*"
+      "@ifixit/helpers": "workspace:*"
    },
    "devDependencies": {
       "@ifixit/tsconfig": "workspace:*",
@@ -17,7 +16,8 @@
       "typescript": "5.2.2"
    },
    "peerDependencies": {
-      "react": "18.2.0"
+      "react": "18.2.0",
+      "@ifixit/sentry": "workspace:*"
    },
    "scripts": {
       "build": "",


### PR DESCRIPTION
This gives us a way to easily get access to the `@ifixit/sentry` version that's being used, rather than needing to override a dependency of a dependency to configure that version.

qa_req 0
As long as this builds, it shouldn't affect functionality, as we're already using `@ifixit/sentry` in `frontend`.

CC @jarstelfox
Connects https://github.com/iFixit/ifixit/issues/50513
