### PR TITLE
Bit table section backend

### DIFF
--- a/backend/src/api/product/content-types/product/schema.json
+++ b/backend/src/api/product/content-types/product/schema.json
@@ -32,7 +32,8 @@
             "section.lifetime-warranty",
             "section.banner",
             "section.quote",
-            "section.faqs"
+            "section.faqs",
+            "product.bit-table"
          ],
          "required": true
       }

--- a/backend/src/api/screwdriver-bit-type/content-types/screwdriver-bit-type/schema.json
+++ b/backend/src/api/screwdriver-bit-type/content-types/screwdriver-bit-type/schema.json
@@ -1,0 +1,33 @@
+{
+   "kind": "collectionType",
+   "collectionName": "screwdriver_bit_types",
+   "info": {
+      "singularName": "screwdriver-bit-type",
+      "pluralName": "screwdriver-bit-types",
+      "displayName": "ScrewdriverBitType",
+      "description": ""
+   },
+   "options": {
+      "draftAndPublish": false
+   },
+   "pluginOptions": {},
+   "attributes": {
+      "name": {
+         "type": "string",
+         "required": true
+      },
+      "driverSize": {
+         "type": "string",
+         "required": true
+      },
+      "icon": {
+         "type": "media",
+         "multiple": false,
+         "required": true,
+         "allowedTypes": ["images"]
+      },
+      "slug": {
+         "type": "uid"
+      }
+   }
+}

--- a/backend/src/api/screwdriver-bit-type/controllers/screwdriver-bit-type.ts
+++ b/backend/src/api/screwdriver-bit-type/controllers/screwdriver-bit-type.ts
@@ -1,0 +1,9 @@
+/**
+ * screwdriver-bit-type controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController(
+   'api::screwdriver-bit-type.screwdriver-bit-type'
+);

--- a/backend/src/api/screwdriver-bit-type/routes/screwdriver-bit-type.ts
+++ b/backend/src/api/screwdriver-bit-type/routes/screwdriver-bit-type.ts
@@ -1,0 +1,9 @@
+/**
+ * screwdriver-bit-type router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter(
+   'api::screwdriver-bit-type.screwdriver-bit-type'
+);

--- a/backend/src/api/screwdriver-bit-type/services/screwdriver-bit-type.ts
+++ b/backend/src/api/screwdriver-bit-type/services/screwdriver-bit-type.ts
@@ -1,0 +1,9 @@
+/**
+ * screwdriver-bit-type service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService(
+   'api::screwdriver-bit-type.screwdriver-bit-type'
+);

--- a/backend/src/api/screwdriver-bit/content-types/screwdriver-bit/schema.json
+++ b/backend/src/api/screwdriver-bit/content-types/screwdriver-bit/schema.json
@@ -1,0 +1,27 @@
+{
+   "kind": "collectionType",
+   "collectionName": "screwdriver_bits",
+   "info": {
+      "singularName": "screwdriver-bit",
+      "pluralName": "screwdriver-bits",
+      "displayName": "ScrewdriverBit",
+      "description": ""
+   },
+   "options": {
+      "draftAndPublish": false
+   },
+   "pluginOptions": {},
+   "attributes": {
+      "type": {
+         "type": "relation",
+         "relation": "oneToOne",
+         "target": "api::screwdriver-bit-type.screwdriver-bit-type"
+      },
+      "size": {
+         "type": "string"
+      },
+      "slug": {
+         "type": "uid"
+      }
+   }
+}

--- a/backend/src/api/screwdriver-bit/controllers/screwdriver-bit.ts
+++ b/backend/src/api/screwdriver-bit/controllers/screwdriver-bit.ts
@@ -1,0 +1,9 @@
+/**
+ * screwdriver-bit controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController(
+   'api::screwdriver-bit.screwdriver-bit'
+);

--- a/backend/src/api/screwdriver-bit/routes/screwdriver-bit.ts
+++ b/backend/src/api/screwdriver-bit/routes/screwdriver-bit.ts
@@ -1,0 +1,9 @@
+/**
+ * screwdriver-bit router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter(
+   'api::screwdriver-bit.screwdriver-bit'
+);

--- a/backend/src/api/screwdriver-bit/services/screwdriver-bit.ts
+++ b/backend/src/api/screwdriver-bit/services/screwdriver-bit.ts
@@ -1,0 +1,9 @@
+/**
+ * screwdriver-bit service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService(
+   'api::screwdriver-bit.screwdriver-bit'
+);

--- a/backend/src/bootstrap/permissions/config.json
+++ b/backend/src/bootstrap/permissions/config.json
@@ -20,6 +20,10 @@
       "api::faq.faq.findOne",
       "api::faq.faq.find",
       "api::reusable-section.reusable-section.findOne",
-      "api::reusable-section.reusable-section.find"
+      "api::reusable-section.reusable-section.find",
+      "api::screwdriver-bit-type.screwdriver-bit-type.find",
+      "api::screwdriver-bit-type.screwdriver-bit-type.findOne",
+      "api::screwdriver-bit.screwdriver-bit.find",
+      "api::screwdriver-bit.screwdriver-bit.findOne"
    ]
 }

--- a/backend/src/components/product/bit-table.json
+++ b/backend/src/components/product/bit-table.json
@@ -1,0 +1,22 @@
+{
+   "collectionName": "components_product_bit_tables",
+   "info": {
+      "displayName": "bit table",
+      "description": ""
+   },
+   "options": {},
+   "attributes": {
+      "title": {
+         "type": "string",
+         "required": false
+      },
+      "description": {
+         "type": "richtext"
+      },
+      "bits": {
+         "type": "relation",
+         "relation": "oneToMany",
+         "target": "api::screwdriver-bit.screwdriver-bit"
+      }
+   }
+}

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -383,6 +383,20 @@ export type ComponentPageStatsStatsArgs = {
    sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
+export type ComponentProductBitTable = {
+   __typename?: 'ComponentProductBitTable';
+   bits?: Maybe<ScrewdriverBitRelationResponseCollection>;
+   description?: Maybe<Scalars['String']>;
+   id: Scalars['ID'];
+   title?: Maybe<Scalars['String']>;
+};
+
+export type ComponentProductBitTableBitsArgs = {
+   filters?: InputMaybe<ScrewdriverBitFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
 export type ComponentProductCrossSell = {
    __typename?: 'ComponentProductCrossSell';
    id: Scalars['ID'];
@@ -863,6 +877,7 @@ export type GenericMorph =
    | ComponentPageSplitWithImage
    | ComponentPageStatItem
    | ComponentPageStats
+   | ComponentProductBitTable
    | ComponentProductCrossSell
    | ComponentProductDeviceCompatibility
    | ComponentProductListBanner
@@ -895,6 +910,8 @@ export type GenericMorph =
    | ProductList
    | PublisherAction
    | ReusableSection
+   | ScrewdriverBit
+   | ScrewdriverBitType
    | SocialPost
    | Store
    | UploadFile
@@ -1133,6 +1150,8 @@ export type Mutation = {
    createProductListLocalization?: Maybe<ProductListEntityResponse>;
    createPublisherAction?: Maybe<PublisherActionEntityResponse>;
    createReusableSection?: Maybe<ReusableSectionEntityResponse>;
+   createScrewdriverBit?: Maybe<ScrewdriverBitEntityResponse>;
+   createScrewdriverBitType?: Maybe<ScrewdriverBitTypeEntityResponse>;
    createSocialPost?: Maybe<SocialPostEntityResponse>;
    createStore?: Maybe<StoreEntityResponse>;
    createUploadFile?: Maybe<UploadFileEntityResponse>;
@@ -1151,6 +1170,8 @@ export type Mutation = {
    deleteProductList?: Maybe<ProductListEntityResponse>;
    deletePublisherAction?: Maybe<PublisherActionEntityResponse>;
    deleteReusableSection?: Maybe<ReusableSectionEntityResponse>;
+   deleteScrewdriverBit?: Maybe<ScrewdriverBitEntityResponse>;
+   deleteScrewdriverBitType?: Maybe<ScrewdriverBitTypeEntityResponse>;
    deleteSocialPost?: Maybe<SocialPostEntityResponse>;
    deleteStore?: Maybe<StoreEntityResponse>;
    deleteUploadFile?: Maybe<UploadFileEntityResponse>;
@@ -1181,6 +1202,8 @@ export type Mutation = {
    updateProductList?: Maybe<ProductListEntityResponse>;
    updatePublisherAction?: Maybe<PublisherActionEntityResponse>;
    updateReusableSection?: Maybe<ReusableSectionEntityResponse>;
+   updateScrewdriverBit?: Maybe<ScrewdriverBitEntityResponse>;
+   updateScrewdriverBitType?: Maybe<ScrewdriverBitTypeEntityResponse>;
    updateSocialPost?: Maybe<SocialPostEntityResponse>;
    updateStore?: Maybe<StoreEntityResponse>;
    updateUploadFile?: Maybe<UploadFileEntityResponse>;
@@ -1268,6 +1291,14 @@ export type MutationCreateReusableSectionArgs = {
    data: ReusableSectionInput;
 };
 
+export type MutationCreateScrewdriverBitArgs = {
+   data: ScrewdriverBitInput;
+};
+
+export type MutationCreateScrewdriverBitTypeArgs = {
+   data: ScrewdriverBitTypeInput;
+};
+
 export type MutationCreateSocialPostArgs = {
    data: SocialPostInput;
 };
@@ -1333,6 +1364,14 @@ export type MutationDeletePublisherActionArgs = {
 };
 
 export type MutationDeleteReusableSectionArgs = {
+   id: Scalars['ID'];
+};
+
+export type MutationDeleteScrewdriverBitArgs = {
+   id: Scalars['ID'];
+};
+
+export type MutationDeleteScrewdriverBitTypeArgs = {
    id: Scalars['ID'];
 };
 
@@ -1449,6 +1488,16 @@ export type MutationUpdatePublisherActionArgs = {
 
 export type MutationUpdateReusableSectionArgs = {
    data: ReusableSectionInput;
+   id: Scalars['ID'];
+};
+
+export type MutationUpdateScrewdriverBitArgs = {
+   data: ScrewdriverBitInput;
+   id: Scalars['ID'];
+};
+
+export type MutationUpdateScrewdriverBitTypeArgs = {
+   data: ScrewdriverBitTypeInput;
    id: Scalars['ID'];
 };
 
@@ -1784,6 +1833,7 @@ export type ProductListSectionsDynamicZone =
 
 export type ProductSectionsDynamicZone =
    | ComponentPageSplitWithImage
+   | ComponentProductBitTable
    | ComponentProductCrossSell
    | ComponentProductDeviceCompatibility
    | ComponentProductProduct
@@ -1874,6 +1924,10 @@ export type Query = {
    publisherActions?: Maybe<PublisherActionEntityResponseCollection>;
    reusableSection?: Maybe<ReusableSectionEntityResponse>;
    reusableSections?: Maybe<ReusableSectionEntityResponseCollection>;
+   screwdriverBit?: Maybe<ScrewdriverBitEntityResponse>;
+   screwdriverBitType?: Maybe<ScrewdriverBitTypeEntityResponse>;
+   screwdriverBitTypes?: Maybe<ScrewdriverBitTypeEntityResponseCollection>;
+   screwdriverBits?: Maybe<ScrewdriverBitEntityResponseCollection>;
    socialPost?: Maybe<SocialPostEntityResponse>;
    socialPosts?: Maybe<SocialPostEntityResponseCollection>;
    store?: Maybe<StoreEntityResponse>;
@@ -2006,6 +2060,26 @@ export type QueryReusableSectionsArgs = {
    filters?: InputMaybe<ReusableSectionFiltersInput>;
    pagination?: InputMaybe<PaginationArg>;
    publicationState?: InputMaybe<PublicationState>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type QueryScrewdriverBitArgs = {
+   id?: InputMaybe<Scalars['ID']>;
+};
+
+export type QueryScrewdriverBitTypeArgs = {
+   id?: InputMaybe<Scalars['ID']>;
+};
+
+export type QueryScrewdriverBitTypesArgs = {
+   filters?: InputMaybe<ScrewdriverBitTypeFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
+   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type QueryScrewdriverBitsArgs = {
+   filters?: InputMaybe<ScrewdriverBitFiltersInput>;
+   pagination?: InputMaybe<PaginationArg>;
    sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
@@ -2142,6 +2216,101 @@ export type ReusableSectionSectionDynamicZone =
    | ComponentSectionFaqs
    | ComponentSectionQuoteGallery
    | Error;
+
+export type ScrewdriverBit = {
+   __typename?: 'ScrewdriverBit';
+   createdAt?: Maybe<Scalars['DateTime']>;
+   size?: Maybe<Scalars['String']>;
+   slug?: Maybe<Scalars['String']>;
+   type?: Maybe<ScrewdriverBitTypeEntityResponse>;
+   updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type ScrewdriverBitEntity = {
+   __typename?: 'ScrewdriverBitEntity';
+   attributes?: Maybe<ScrewdriverBit>;
+   id?: Maybe<Scalars['ID']>;
+};
+
+export type ScrewdriverBitEntityResponse = {
+   __typename?: 'ScrewdriverBitEntityResponse';
+   data?: Maybe<ScrewdriverBitEntity>;
+};
+
+export type ScrewdriverBitEntityResponseCollection = {
+   __typename?: 'ScrewdriverBitEntityResponseCollection';
+   data: Array<ScrewdriverBitEntity>;
+   meta: ResponseCollectionMeta;
+};
+
+export type ScrewdriverBitFiltersInput = {
+   and?: InputMaybe<Array<InputMaybe<ScrewdriverBitFiltersInput>>>;
+   createdAt?: InputMaybe<DateTimeFilterInput>;
+   id?: InputMaybe<IdFilterInput>;
+   not?: InputMaybe<ScrewdriverBitFiltersInput>;
+   or?: InputMaybe<Array<InputMaybe<ScrewdriverBitFiltersInput>>>;
+   size?: InputMaybe<StringFilterInput>;
+   slug?: InputMaybe<StringFilterInput>;
+   type?: InputMaybe<ScrewdriverBitTypeFiltersInput>;
+   updatedAt?: InputMaybe<DateTimeFilterInput>;
+};
+
+export type ScrewdriverBitInput = {
+   size?: InputMaybe<Scalars['String']>;
+   slug?: InputMaybe<Scalars['String']>;
+   type?: InputMaybe<Scalars['ID']>;
+};
+
+export type ScrewdriverBitRelationResponseCollection = {
+   __typename?: 'ScrewdriverBitRelationResponseCollection';
+   data: Array<ScrewdriverBitEntity>;
+};
+
+export type ScrewdriverBitType = {
+   __typename?: 'ScrewdriverBitType';
+   createdAt?: Maybe<Scalars['DateTime']>;
+   driverSize: Scalars['String'];
+   icon: UploadFileEntityResponse;
+   name: Scalars['String'];
+   slug?: Maybe<Scalars['String']>;
+   updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+export type ScrewdriverBitTypeEntity = {
+   __typename?: 'ScrewdriverBitTypeEntity';
+   attributes?: Maybe<ScrewdriverBitType>;
+   id?: Maybe<Scalars['ID']>;
+};
+
+export type ScrewdriverBitTypeEntityResponse = {
+   __typename?: 'ScrewdriverBitTypeEntityResponse';
+   data?: Maybe<ScrewdriverBitTypeEntity>;
+};
+
+export type ScrewdriverBitTypeEntityResponseCollection = {
+   __typename?: 'ScrewdriverBitTypeEntityResponseCollection';
+   data: Array<ScrewdriverBitTypeEntity>;
+   meta: ResponseCollectionMeta;
+};
+
+export type ScrewdriverBitTypeFiltersInput = {
+   and?: InputMaybe<Array<InputMaybe<ScrewdriverBitTypeFiltersInput>>>;
+   createdAt?: InputMaybe<DateTimeFilterInput>;
+   driverSize?: InputMaybe<StringFilterInput>;
+   id?: InputMaybe<IdFilterInput>;
+   name?: InputMaybe<StringFilterInput>;
+   not?: InputMaybe<ScrewdriverBitTypeFiltersInput>;
+   or?: InputMaybe<Array<InputMaybe<ScrewdriverBitTypeFiltersInput>>>;
+   slug?: InputMaybe<StringFilterInput>;
+   updatedAt?: InputMaybe<DateTimeFilterInput>;
+};
+
+export type ScrewdriverBitTypeInput = {
+   driverSize?: InputMaybe<Scalars['String']>;
+   icon?: InputMaybe<Scalars['ID']>;
+   name?: InputMaybe<Scalars['String']>;
+   slug?: InputMaybe<Scalars['String']>;
+};
 
 export type SocialPost = {
    __typename?: 'SocialPost';
@@ -3132,6 +3301,7 @@ export type FindProductQuery = {
                        } | null;
                     } | null;
                  }
+               | { __typename: 'ComponentProductBitTable' }
                | {
                     __typename: 'ComponentProductCrossSell';
                     id: string;

--- a/frontend/lib/strapi-sdk/generated/validation.ts
+++ b/frontend/lib/strapi-sdk/generated/validation.ts
@@ -53,6 +53,10 @@ import {
    PublisherActionInput,
    ReusableSectionFiltersInput,
    ReusableSectionInput,
+   ScrewdriverBitFiltersInput,
+   ScrewdriverBitInput,
+   ScrewdriverBitTypeFiltersInput,
+   ScrewdriverBitTypeInput,
    SocialPostFiltersInput,
    SocialPostInput,
    StoreFiltersInput,
@@ -978,6 +982,67 @@ export function ReusableSectionInputSchema(): z.ZodObject<
       publishedAt: z.unknown().nullish(),
       section: z.array(z.lazy(() => definedNonNullAnySchema)).nullish(),
       title: z.string().nullish(),
+   });
+}
+
+export function ScrewdriverBitFiltersInputSchema(): z.ZodObject<
+   Properties<ScrewdriverBitFiltersInput>
+> {
+   return z.object<Properties<ScrewdriverBitFiltersInput>>({
+      and: z
+         .array(z.lazy(() => ScrewdriverBitFiltersInputSchema().nullable()))
+         .nullish(),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      not: z.lazy(() => ScrewdriverBitFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => ScrewdriverBitFiltersInputSchema().nullable()))
+         .nullish(),
+      size: z.lazy(() => StringFilterInputSchema().nullish()),
+      slug: z.lazy(() => StringFilterInputSchema().nullish()),
+      type: z.lazy(() => ScrewdriverBitTypeFiltersInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function ScrewdriverBitInputSchema(): z.ZodObject<
+   Properties<ScrewdriverBitInput>
+> {
+   return z.object<Properties<ScrewdriverBitInput>>({
+      size: z.string().nullish(),
+      slug: z.string().nullish(),
+      type: z.string().nullish(),
+   });
+}
+
+export function ScrewdriverBitTypeFiltersInputSchema(): z.ZodObject<
+   Properties<ScrewdriverBitTypeFiltersInput>
+> {
+   return z.object<Properties<ScrewdriverBitTypeFiltersInput>>({
+      and: z
+         .array(z.lazy(() => ScrewdriverBitTypeFiltersInputSchema().nullable()))
+         .nullish(),
+      createdAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+      driverSize: z.lazy(() => StringFilterInputSchema().nullish()),
+      id: z.lazy(() => IdFilterInputSchema().nullish()),
+      name: z.lazy(() => StringFilterInputSchema().nullish()),
+      not: z.lazy(() => ScrewdriverBitTypeFiltersInputSchema().nullish()),
+      or: z
+         .array(z.lazy(() => ScrewdriverBitTypeFiltersInputSchema().nullable()))
+         .nullish(),
+      slug: z.lazy(() => StringFilterInputSchema().nullish()),
+      updatedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
+   });
+}
+
+export function ScrewdriverBitTypeInputSchema(): z.ZodObject<
+   Properties<ScrewdriverBitTypeInput>
+> {
+   return z.object<Properties<ScrewdriverBitTypeInput>>({
+      driverSize: z.string().nullish(),
+      icon: z.string().nullish(),
+      name: z.string().nullish(),
+      slug: z.string().nullish(),
    });
 }
 


### PR DESCRIPTION
Part of https://github.com/iFixit/ifixit/issues/49327

Figma: https://www.figma.com/file/BolmFORO6ZfHXePOSyEGSS/iFixit---Page-sections?type=design&node-id=1766-10708&mode=design&t=z7yor1h57OAQfLpy-0

This PR introduces the backend changes needed to support the bit table section.
A `ScrewdriverBitType` and a `ScrewdriverBit` model are introduced to allow to define bits without having to input data twice.
Slugs are added to both models to allow selection from the referencing strapi entities.
A `BitTable` section then includes the list of bits, and decorate it with a title and a description to compose the page section

### QA

1. Visit Vercel preview
2. Verify that Strapi was restarted correctly with the new models 
3. Verify that the frontend is unchanged and working correctly