### PR TITLE
Add page template meta tags

### DIFF
--- a/frontend/helpers/metadata-helpers.ts
+++ b/frontend/helpers/metadata-helpers.ts
@@ -1,0 +1,9 @@
+const META_TITLE_SUFFIX = ' | iFixit';
+
+export function metaTitleWithSuffix(metaTitle: string) {
+   const rawMetaTitle = metaTitle.trim();
+
+   if (rawMetaTitle.endsWith(META_TITLE_SUFFIX)) return rawMetaTitle;
+
+   return `${rawMetaTitle}${META_TITLE_SUFFIX}`;
+}

--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -1,12 +1,12 @@
-import { SentryError } from '@ifixit/sentry';
 import { IFIXIT_ORIGIN } from '@config/env';
 import { invariant } from '@ifixit/helpers';
+import { SentryError } from '@ifixit/sentry';
 import type { Product } from '@models/product';
 import { ProductList, ProductListType } from '@models/product-list';
+import type { IncomingHttpHeaders } from 'http';
 import { GetServerSidePropsContext } from 'next';
 import { getProductIdFromGlobalId } from './product-helpers';
 import { stylizeDeviceTitle } from './product-list-helpers';
-import { IncomingHttpHeaders } from 'http';
 
 export function productPath(handle: string) {
    return `/products/${handle}`;
@@ -150,4 +150,8 @@ export function getiFixitOriginFromHost(headers: Headers) {
 
 export function ifixitOriginWithSubdomain(subdomain: string) {
    return IFIXIT_ORIGIN.replace(/(^https:\/\/)www/, `$1${subdomain}`);
+}
+
+export function joinPaths(...paths: string[]) {
+   return paths.map((path) => path.replace(/^\/|\/$/g, '')).join('/');
 }

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -2815,6 +2815,8 @@ export type FindPageQuery = {
             __typename?: 'Page';
             path: string;
             title: string;
+            metaTitle?: string | null;
+            metaDescription?: string | null;
             sections: Array<
                | {
                     __typename: 'ComponentPageBrowse';
@@ -6338,6 +6340,8 @@ export const FindPageDocument = `
       attributes {
         path
         title
+        metaTitle
+        metaDescription
         sections {
           __typename
           ...HeroSectionFields

--- a/frontend/lib/strapi-sdk/operations/findPage.graphql
+++ b/frontend/lib/strapi-sdk/operations/findPage.graphql
@@ -12,6 +12,8 @@ query findPage(
          attributes {
             path
             title
+            metaTitle
+            metaDescription
             sections {
                __typename
                ...HeroSectionFields

--- a/frontend/models/page/index.ts
+++ b/frontend/models/page/index.ts
@@ -30,5 +30,7 @@ export type Page = z.infer<typeof PageSchema>;
 export const PageSchema = z.object({
    path: z.string(),
    title: z.string(),
+   metaTitle: z.string().nullable(),
+   metaDescription: z.string().nullable(),
    sections: z.array(PageSectionSchema),
 });

--- a/frontend/models/page/server.ts
+++ b/frontend/models/page/server.ts
@@ -1,5 +1,6 @@
 import { filterNullableItems } from '@helpers/application-helpers';
 import { createSectionId } from '@helpers/strapi-helpers';
+import { presence, timeAsync } from '@ifixit/helpers';
 import { FindPageQuery, strapi } from '@lib/strapi-sdk';
 import { bannersSectionFromStrapi } from '@models/sections/banners-section';
 import { featuredProductsSectionFromStrapi } from '@models/sections/featured-products-section';
@@ -8,10 +9,9 @@ import { quoteGallerySectionFromStrapi } from '@models/sections/quote-gallery-se
 import { socialGallerySectionFromStrapi } from '@models/sections/social-gallery-section';
 import { splitWithImageSectionFromStrapi } from '@models/sections/split-with-image-section';
 import type { Page, PageSection } from '.';
+import { pressQuotesSectionFromStrapi } from '../sections/press-quotes-section';
 import { browseSectionFromStrapi } from './sections/browse-section';
 import { heroSectionFromStrapi } from './sections/hero-section';
-import { pressQuotesSectionFromStrapi } from '../sections/press-quotes-section';
-import { timeAsync } from '@ifixit/helpers';
 
 interface FindPageArgs {
    path: string;
@@ -89,6 +89,8 @@ export async function findPage({ path }: FindPageArgs): Promise<Page | null> {
    return {
       path: page.path,
       title: page.title,
+      metaTitle: presence(page.metaTitle),
+      metaDescription: presence(page.metaDescription),
       sections,
    };
 }

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -6,7 +6,7 @@ import {
 import { escapeFilterValue, getClientOptions } from '@helpers/algolia-helpers';
 import { filterNullableItems } from '@helpers/application-helpers';
 import { getProductListTitle } from '@helpers/product-list-helpers';
-import { presentOrNull, timeAsync } from '@ifixit/helpers';
+import { presence, timeAsync } from '@ifixit/helpers';
 import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
 import {
    DeviceWiki,
@@ -102,13 +102,13 @@ export async function findProductList(
    const baseProductList: BaseProductList = {
       id,
       title,
-      h1: presentOrNull(productList?.h1),
+      h1: presence(productList?.h1),
       handle,
       deviceTitle,
-      tagline: presentOrNull(productList?.tagline),
+      tagline: presence(productList?.tagline),
       description,
-      metaDescription: presentOrNull(productList?.metaDescription),
-      metaTitle: presentOrNull(productList?.metaTitle),
+      metaDescription: presence(productList?.metaDescription),
+      metaTitle: presence(productList?.metaTitle),
       defaultShowAllChildrenOnLgSizes:
          productList?.defaultShowAllChildrenOnLgSizes ?? null,
       filters: productList?.filters ?? null,

--- a/frontend/templates/page/index.tsx
+++ b/frontend/templates/page/index.tsx
@@ -12,6 +12,7 @@ import {
    PageTemplateProps,
    usePageTemplateProps,
 } from './hooks/usePageTemplateProps';
+import { MetaTags } from './meta-tags';
 import { BrowseSection } from './sections/BrowseSection';
 import { HeroSection } from './sections/HeroSection';
 import { PressQuotesSection } from './sections/PressQuotesSection';
@@ -19,98 +20,103 @@ import { PressQuotesSection } from './sections/PressQuotesSection';
 const PageTemplate: NextPageWithLayout<PageTemplateProps> = () => {
    const { page } = usePageTemplateProps();
    return (
-      <Box>
-         {page.sections.map((section) => {
-            switch (section.type) {
-               case 'Hero': {
-                  return <HeroSection key={section.id} data={section} />;
+      <>
+         <MetaTags page={page} />
+         <Box>
+            {page.sections.map((section) => {
+               switch (section.type) {
+                  case 'Hero': {
+                     return <HeroSection key={section.id} data={section} />;
+                  }
+                  case 'Browse': {
+                     return <BrowseSection key={section.id} data={section} />;
+                  }
+                  case 'IFixitStats': {
+                     return (
+                        <IFixitStatsSection key={section.id} data={section} />
+                     );
+                  }
+                  case 'SplitWithImage': {
+                     return (
+                        <SplitWithImageContentSection
+                           key={section.id}
+                           id={section.id}
+                           title={section.title}
+                           description={section.description}
+                           image={section.image}
+                           imagePosition={section.imagePosition}
+                           callToAction={section.callToAction}
+                        />
+                     );
+                  }
+                  case 'PressQuotes': {
+                     return (
+                        <PressQuotesSection
+                           key={section.id}
+                           title={section.title}
+                           description={section.description}
+                           callToAction={section.callToAction}
+                           quotes={section.quotes}
+                        />
+                     );
+                  }
+                  case 'FeaturedProducts': {
+                     return (
+                        <FeaturedProductsSection
+                           key={section.id}
+                           id={section.id}
+                           title={section.title}
+                           description={section.description}
+                           background={section.background}
+                           products={section.products}
+                        />
+                     );
+                  }
+                  case 'SocialGallery': {
+                     return (
+                        <SocialGallerySection
+                           key={section.id}
+                           title={section.title}
+                           description={section.description}
+                           posts={section.posts}
+                        />
+                     );
+                  }
+                  case 'LifetimeWarranty': {
+                     return (
+                        <LifetimeWarrantySection
+                           key={section.id}
+                           title={section.title}
+                           description={section.description}
+                        />
+                     );
+                  }
+                  case 'Banners': {
+                     return (
+                        <BannersSection
+                           key={section.id}
+                           id={section.id}
+                           banners={section.banners}
+                        />
+                     );
+                  }
+                  case 'QuoteGallery': {
+                     return (
+                        <QuoteGallerySection
+                           key={section.id}
+                           id={section.id}
+                           title={section.title}
+                           description={section.description}
+                           quotes={section.quotes}
+                        />
+                     );
+                  }
+                  default:
+                     return assertNever(section);
                }
-               case 'Browse': {
-                  return <BrowseSection key={section.id} data={section} />;
-               }
-               case 'IFixitStats': {
-                  return <IFixitStatsSection key={section.id} data={section} />;
-               }
-               case 'SplitWithImage': {
-                  return (
-                     <SplitWithImageContentSection
-                        key={section.id}
-                        id={section.id}
-                        title={section.title}
-                        description={section.description}
-                        image={section.image}
-                        imagePosition={section.imagePosition}
-                        callToAction={section.callToAction}
-                     />
-                  );
-               }
-               case 'PressQuotes': {
-                  return (
-                     <PressQuotesSection
-                        key={section.id}
-                        title={section.title}
-                        description={section.description}
-                        callToAction={section.callToAction}
-                        quotes={section.quotes}
-                     />
-                  );
-               }
-               case 'FeaturedProducts': {
-                  return (
-                     <FeaturedProductsSection
-                        key={section.id}
-                        id={section.id}
-                        title={section.title}
-                        description={section.description}
-                        background={section.background}
-                        products={section.products}
-                     />
-                  );
-               }
-               case 'SocialGallery': {
-                  return (
-                     <SocialGallerySection
-                        key={section.id}
-                        title={section.title}
-                        description={section.description}
-                        posts={section.posts}
-                     />
-                  );
-               }
-               case 'LifetimeWarranty': {
-                  return (
-                     <LifetimeWarrantySection
-                        key={section.id}
-                        title={section.title}
-                        description={section.description}
-                     />
-                  );
-               }
-               case 'Banners': {
-                  return (
-                     <BannersSection
-                        key={section.id}
-                        id={section.id}
-                        banners={section.banners}
-                     />
-                  );
-               }
-               case 'QuoteGallery': {
-                  return (
-                     <QuoteGallerySection
-                        key={section.id}
-                        id={section.id}
-                        title={section.title}
-                        description={section.description}
-                        quotes={section.quotes}
-                     />
-                  );
-               }
-               default:
-                  return assertNever(section);
-            }
-         })}
-      </Box>
+            })}
+         </Box>
+      </>
    );
 };
 

--- a/frontend/templates/page/meta-tags.tsx
+++ b/frontend/templates/page/meta-tags.tsx
@@ -1,0 +1,48 @@
+import { IFIXIT_ORIGIN } from '@config/env';
+import { metaTitleWithSuffix } from '@helpers/metadata-helpers';
+import { joinPaths } from '@helpers/path-helpers';
+import type { Page } from '@models/page';
+import Head from 'next/head';
+
+interface MetaTagsProps {
+   page: Page;
+}
+
+export function MetaTags({ page }: MetaTagsProps) {
+   const ogImage = findOgImage(page);
+   console.log('ogImage', ogImage);
+   return (
+      <>
+         <Head>
+            {page.metaTitle && (
+               <>
+                  <title>{metaTitleWithSuffix(page.metaTitle)}</title>
+                  <meta name="og:title" content={page.metaTitle} />
+               </>
+            )}
+            {page.metaDescription && (
+               <meta name="description" content={page.metaDescription} />
+            )}
+            <meta name="og:type" content="website" />
+            <meta name="og:url" content={joinPaths(IFIXIT_ORIGIN, page.path)} />
+            {ogImage && <meta name="og:image" content={ogImage} />}
+         </Head>
+      </>
+   );
+}
+
+function findOgImage(page: Page) {
+   for (const section of page.sections) {
+      switch (section.type) {
+         case 'Hero': {
+            if (section.image?.url) return section.image.url;
+            break;
+         }
+         case 'Browse': {
+            if (section.image?.url) return section.image.url;
+            break;
+         }
+      }
+   }
+   return null;
+}

--- a/frontend/templates/page/meta-tags.tsx
+++ b/frontend/templates/page/meta-tags.tsx
@@ -10,7 +10,6 @@ interface MetaTagsProps {
 
 export function MetaTags({ page }: MetaTagsProps) {
    const ogImage = findOgImage(page);
-   console.log('ogImage', ogImage);
    return (
       <>
          <Head>

--- a/frontend/templates/product-list/MetaTags.tsx
+++ b/frontend/templates/product-list/MetaTags.tsx
@@ -1,4 +1,5 @@
 import { PRODUCT_LIST_PAGE_PARAM } from '@config/constants';
+import { metaTitleWithSuffix } from '@helpers/metadata-helpers';
 import { productListPath } from '@helpers/path-helpers';
 import { stylizeDeviceItemType } from '@helpers/product-list-helpers';
 import { useAppContext } from '@ifixit/app';
@@ -49,8 +50,6 @@ export function MetaTags({ productList }: MetaTagsProps) {
    );
 }
 
-const META_TITLE_SUFFIX = ' | iFixit';
-
 function useMetaTitle(productList: ProductList): string {
    const pagination = usePagination();
 
@@ -60,9 +59,7 @@ function useMetaTitle(productList: ProductList): string {
 
    let metaTitle = productList.metaTitle ?? productList.title;
 
-   if (!metaTitle.trim().endsWith(META_TITLE_SUFFIX)) {
-      metaTitle += META_TITLE_SUFFIX;
-   }
+   metaTitle = metaTitleWithSuffix(metaTitle);
 
    if (metaTitle && !isFiltered && page > 1) {
       metaTitle += ` - Page ${page}`;

--- a/frontend/templates/product-list/hooks/useItemTypeProductList.ts
+++ b/frontend/templates/product-list/hooks/useItemTypeProductList.ts
@@ -1,4 +1,4 @@
-import { presentOrNull } from '@ifixit/helpers';
+import { presence } from '@ifixit/helpers';
 import { ProductList, ProductListType } from '@models/product-list';
 import { useDevicePartsItemType } from './useDevicePartsItemType';
 
@@ -25,35 +25,35 @@ export function useItemTypeProductList(productList: ProductList) {
       };
    }
 
-   const overrideTitle = presentOrNull(
+   const overrideTitle = presence(
       replacePlaceholders(
          overrides?.title ?? allItemTypesOverrides?.title,
          replacements
       )
    );
 
-   const overrideMetaTitle = presentOrNull(
+   const overrideMetaTitle = presence(
       replacePlaceholders(
          overrides?.metaTitle ?? allItemTypesOverrides?.metaTitle,
          replacements
       )
    );
 
-   const overrideDescription = presentOrNull(
+   const overrideDescription = presence(
       replacePlaceholders(
          overrides?.description ?? allItemTypesOverrides?.description,
          replacements
       )
    );
 
-   const overrideMetaDescription = presentOrNull(
+   const overrideMetaDescription = presence(
       replacePlaceholders(
          overrides?.metaDescription ?? allItemTypesOverrides?.metaDescription,
          replacements
       )
    );
 
-   const overrideTagline = presentOrNull(
+   const overrideTagline = presence(
       replacePlaceholders(
          overrides?.tagline ?? allItemTypesOverrides?.tagline,
          replacements

--- a/packages/helpers/generic-helpers.ts
+++ b/packages/helpers/generic-helpers.ts
@@ -92,7 +92,7 @@ export function isPresent(text: string | null | undefined): text is string {
    return typeof text === 'string' && text.length > 0;
 }
 
-export function presentOrNull(text: string | null | undefined): string | null {
+export function presence(text: string | null | undefined): string | null {
    return isPresent(text) ? text : null;
 }
 


### PR DESCRIPTION
closes https://github.com/iFixit/ifixit/issues/50536

## QA

1. Open [Strapi Govinor preview](https://add-page-template-metatags.govinor.com/admin/content-manager/collectionType/api::page.page/2?plugins[i18n][locale]=en)
2. Change store home page meta title and description
3. Verify that the [store home page preview](https://react-commerce-git-add-page-template-metatags-ifixit.vercel.app/Store) has page title and meta tags (title, description and `og`) that reflect what's been set in Strapi