### PR TITLE
Strapi SDK: Regenerate types

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -3356,7 +3356,6 @@ export type FindProductQuery = {
                        } | null;
                     } | null;
                  }
-               | { __typename: 'ComponentProductBitTable' }
                | {
                     __typename: 'ComponentProductBitTable';
                     id: string;


### PR DESCRIPTION
This is the diff from running `pnpm dev`, and allowing codegen to regenerate the types. Followup to https://github.com/iFixit/react-commerce/pull/2076

qa_req 0 as long as the build succeeds