### PR TITLE
Add manual noindex to product page

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -8021,6 +8021,7 @@ export type FindProductQuery = {
       descriptionHtml: string;
       tags: Array<string>;
       vendor: string;
+      noindex?: { __typename?: 'Metafield'; value: string } | null;
       rating?: { __typename?: 'Metafield'; value: string } | null;
       reviewsCount?: { __typename?: 'Metafield'; value: string } | null;
       breadcrumbs?: { __typename?: 'Metafield'; value: string } | null;
@@ -8441,6 +8442,9 @@ export const FindProductDocument = `
     handle
     descriptionHtml
     tags
+    noindex: metafield(namespace: "seo", key: "hidden") {
+      value
+    }
     rating: metafield(namespace: "reviews", key: "rating") {
       value
     }

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -5,6 +5,9 @@ query findProduct($handle: String) {
       handle
       descriptionHtml
       tags
+      noindex: metafield(namespace: "seo", key: "hidden") {
+         value
+      }
       rating: metafield(namespace: "reviews", key: "rating") {
          value
       }

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -58,6 +58,7 @@ export const ProductSchema = z.object({
    id: z.string(),
    handle: z.string(),
    title: z.string(),
+   noindex: z.boolean(),
    breadcrumbs: z.array(BreadcrumbSchema),
    descriptionHtml: z.string(),
    iFixitProductId: z.string(),
@@ -125,9 +126,12 @@ export async function getProduct({
       strapiProduct,
    });
 
+   const noindex = shopifyProduct.noindex?.value === '1';
+
    return {
       id: shopifyProduct.id,
       handle: shopifyProduct.handle,
+      noindex,
       title: shopifyProduct.title,
       breadcrumbs,
       descriptionHtml: shopifyProduct.descriptionHtml,

--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -65,7 +65,7 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
          ? 'https://schema.org/InStock'
          : 'https://schema.org/OutOfStock';
 
-   const shouldNoIndex = !product.isEnabled;
+   const shouldNoIndex = !product.isEnabled || product.noindex;
 
    return (
       <Head>

--- a/frontend/tests/jest/__mocks__/products/battery.ts
+++ b/frontend/tests/jest/__mocks__/products/battery.ts
@@ -93,6 +93,7 @@ export const mockedBatteryProduct: Product = {
    id: 'gid://shopify/Product/6556284026970',
    title: 'Moto G7 Play Battery',
    handle: 'moto-g7-play-replacement-battery',
+   noindex: false,
    descriptionHtml:
       "<p>This Moto G7 Play replacement battery is what you need to bring your dead smartphone back to life!</p>\n\n<ul><li>Repair with confidence! iFixit is an authorized Motorola parts reseller.</li></ul>\n\n<p>Battery degradation is an inevitable part of your Android phone's lifespan — extend it with this replacement battery compatible with the Moto G7 Play. If your phone won’t turn on, won’t hold a charge, or you simply experience poor battery life, this replacement battery may be what you need to fix it.</p>",
    tags: [

--- a/frontend/tests/jest/__mocks__/products/generic.ts
+++ b/frontend/tests/jest/__mocks__/products/generic.ts
@@ -184,6 +184,7 @@ export const mockedProduct: Product = {
    id: 'gid://shopify/Product/1231231231231',
    title: 'Mocked Product Title',
    handle: 'iphone-6s-plus-replacement-battery',
+   noindex: false,
    descriptionHtml:
       '<p>This replacement battery is what you need to bring that dead smartphone back to life.</p>\n\n<ul><li>This battery is brand new! Each one has been tested to confirm that there are no cycles on the cell and that the capacity is 95% or higher.</li></ul>',
    tags: [

--- a/frontend/tests/jest/__mocks__/products/part.ts
+++ b/frontend/tests/jest/__mocks__/products/part.ts
@@ -97,6 +97,7 @@ export const mockedPartProduct: Product = {
    id: 'gid://shopify/Product/6581511684186',
    title: 'Galaxy A51 Screen',
    handle: 'galaxy-a51-screen',
+   noindex: false,
    descriptionHtml:
       '<p>This Galaxy A51 replacement screen includes all of the small parts preinstalled in the assembly, saving time and increasing the quality of your repair.</p>\n\n<p>Replace a cracked or scratched front glass panel or malfunctioning AMOLED display on your phone. This screen and digitizer assembly will renew the appearance of your front panel, restore touch function, and eliminate the dead pixels or flickering on an aging display.</p>\n\n<p>This is an aftermarket part. It is not a genuine Samsung part.</p>',
    tags: [

--- a/frontend/tests/jest/__mocks__/products/tool.ts
+++ b/frontend/tests/jest/__mocks__/products/tool.ts
@@ -83,6 +83,7 @@ export const mockedToolProduct: Product = {
    id: 'gid://shopify/Product/6556235071578',
    title: 'Hakko 5B SA Curved Tweezers',
    handle: 'hakko-5b-sa-curved-tweezers',
+   noindex: false,
    descriptionHtml:
       '<p>Very precise fine tipped tweezers for microsoldering and manipulating tiny parts.</p>',
    tags: ['Condition:New', 'Tool', 'Tool Category (Legacy):Soldering & Wiring'],


### PR DESCRIPTION
closes #1780 

We're adding support to manual noindex a product page using the conventional [`seo.hidden`](https://shopify.dev/docs/apps/marketing/seo#step-2-hide-a-resource-from-search-engines-and-sitemaps) Shopify product metafield.

## QA

1. Visit a [product preview page](https://react-commerce-git-add-product-page-noindex-support-ifixit.vercel.app/products/google-pixel-7-pro-screen-genuine) for a product that is indexed
2. Verify that it has no robots meta tags with `noindex,nofollow` content
3. From the [Shopify admin product page](https://admin.shopify.com/store/ifixit-test/products/6856228044890), set `seo.hidden` to 1 to noindex the product and save
    <img width="653" alt="Screenshot 2023-11-07 at 22 16 15" src="https://github.com/iFixit/react-commerce/assets/4640135/faa47a46-ccf3-4320-99e2-7c03c0084d07">

4. Verify that `<meta name="robots" content="noindex,nofollow" />` is present in the `head`

## Post Deploy

Add an integer metafield definition with `seo` namespace and `hidden` key to the US Shopify production store