### PR TITLE
Vulcan: Answers CTA: Copy is too long on mobile

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -901,14 +901,28 @@ function Conclusion({ conclusion: conclusions }: { conclusion: Section[] }) {
 
 function AnswersCTA({ answersUrl }: { answersUrl: string }) {
    return (
-      <Alert p={3} mt={4}>
+      <Alert p={3}>
          <AlertIcon color="gray.500" />
-         <chakra.span pr={3} mr="auto">
-            Haven&apos;t found the solution to your problem?
-         </chakra.span>
-         <Button href={answersUrl} as="a" colorScheme="brand">
-            Browse our forum
-         </Button>
+         <Flex
+            align="center"
+            sx={{
+               '@media (max-width: 374px)': {
+                  flexDirection: 'column',
+                  gap: '8px',
+
+                  a: {
+                     width: '100%',
+                  },
+               },
+            }}
+         >
+            <chakra.span pr={3} mr="auto">
+               Haven&apos;t found the solution to your problem?
+            </chakra.span>
+            <Button href={answersUrl} as="a" colorScheme="brand">
+               Browse our forum
+            </Button>
+         </Flex>
       </Alert>
    );
 }

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -901,25 +901,27 @@ function Conclusion({ conclusion: conclusions }: { conclusion: Section[] }) {
 
 function AnswersCTA({ answersUrl }: { answersUrl: string }) {
    return (
-      <Alert p={3}>
-         <AlertIcon color="gray.500" />
+      <Alert p={3} fontSize="sm">
+         <AlertIcon
+            color="gray.500"
+            alignSelf={{ base: 'start', sm: 'center' }}
+         />
          <Flex
             align="center"
+            flex="auto"
+            justify="space-between"
             sx={{
-               '@media (max-width: 374px)': {
+               '@media (max-width: 375px)': {
                   flexDirection: 'column',
-                  gap: '8px',
-
-                  a: {
-                     width: '100%',
-                  },
+                  gap: '6px',
+                  alignItems: 'end',
                },
             }}
          >
-            <chakra.span pr={3} mr="auto">
+            <chakra.span>
                Haven&apos;t found the solution to your problem?
             </chakra.span>
-            <Button href={answersUrl} as="a" colorScheme="brand">
+            <Button href={answersUrl} as="a" colorScheme="brand" ml={3}>
                Browse our forum
             </Button>
          </Flex>


### PR DESCRIPTION
## Issue

We don't have enough space to render the Figma layout on small mobile devices:

![image](https://github.com/iFixit/react-commerce/assets/1634505/45a19c90-1f29-407d-8652-ba8760489f01)

## Solution

Switch the layout to a column when viewport is less than 375px:

![image](https://github.com/iFixit/react-commerce/assets/1634505/80466574-6965-4fef-a83e-ca706bb2bc58)

## CR/QA

`Troubleshooting/Whirlpool_Washing_Machine/Whirlpool+Washer+Not+Spinning/506149#Section_Additional_Information`

Closes https://github.com/iFixit/ifixit/issues/50591