### PR TITLE
Add return policy value proposition list item

### DIFF
--- a/frontend/components/sections/ServiceValuePropositionSection.tsx
+++ b/frontend/components/sections/ServiceValuePropositionSection.tsx
@@ -1,23 +1,9 @@
-import {
-   Box,
-   Heading,
-   List,
-   ListIcon,
-   ListItem,
-   Stack,
-   Text,
-   VStack,
-} from '@chakra-ui/react';
+import { Box, Heading, Stack, Text, VStack } from '@chakra-ui/react';
 import {
    faBoxCircleCheck as faBoxCircleCheckDuo,
    faRocket as faRocketDuo,
    faShieldCheck as faShieldCheckDuo,
 } from '@fortawesome/pro-duotone-svg-icons';
-import {
-   faBadgeDollar,
-   faRocket,
-   faShieldCheck,
-} from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon, FaIconProps } from '@ifixit/icons';
 import React from 'react';
 
@@ -80,51 +66,6 @@ export function ServiceValuePropositionSection({
    );
 }
 
-export function BuyBoxPropositionSection() {
-   return (
-      <div>
-         <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
-            <ListItem display="flex" alignItems="center">
-               <ListIcon
-                  as={FaIcon}
-                  h="4"
-                  w="5"
-                  mr="1.5"
-                  color="brand.500"
-                  icon={faBadgeDollar}
-               />
-               Purchase with purpose! Repair makes a global impact, reduces
-               e-waste, and saves you money.
-            </ListItem>
-            <ListItem display="flex" alignItems="center">
-               <ListIcon
-                  as={FaIcon}
-                  h="4"
-                  w="5"
-                  mr="1.5"
-                  color="brand.500"
-                  icon={faShieldCheck}
-               />
-               <div>
-                  All our products meet rigorous quality standards and are
-                  backed by industry-leading guarantees.
-               </div>
-            </ListItem>
-            <ListItem display="flex" alignItems="center">
-               <ListIcon
-                  as={FaIcon}
-                  h="4"
-                  w="5"
-                  mr="1.5"
-                  color="brand.500"
-                  icon={faRocket}
-               />
-               Same day shipping if ordered by 1PM Pacific.
-            </ListItem>
-         </List>
-      </div>
-   );
-}
 function ValueProposition({ children }: React.PropsWithChildren<{}>) {
    return (
       <VStack

--- a/frontend/components/ui/Tooltip.tsx
+++ b/frontend/components/ui/Tooltip.tsx
@@ -1,0 +1,39 @@
+import {
+   Popover,
+   PopoverArrow,
+   PopoverBody,
+   PopoverContent,
+   PopoverTrigger,
+} from '@chakra-ui/react';
+import React from 'react';
+
+export interface TooltipProps {
+   trigger: React.ReactNode;
+   content: React.ReactNode;
+}
+
+export function Tooltip({ trigger, content }: TooltipProps) {
+   return (
+      <Popover trigger="hover">
+         <PopoverTrigger>{trigger}</PopoverTrigger>
+         <PopoverContent>
+            <PopoverArrow backgroundColor="gray.800" />
+            <PopoverBody
+               borderRadius="md"
+               backgroundColor="gray.800"
+               color="white"
+               fontSize="13px"
+               sx={{
+                  '& a': {
+                     color: 'white',
+                     fontWeight: 'semibold',
+                     textDecoration: 'underline',
+                  },
+               }}
+            >
+               {content}
+            </PopoverBody>
+         </PopoverContent>
+      </Popover>
+   );
+}

--- a/frontend/templates/product/sections/ProductOverviewSection/AddToCart/ShippingRestrictions.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/AddToCart/ShippingRestrictions.tsx
@@ -1,15 +1,5 @@
-import {
-   Box,
-   Flex,
-   Link,
-   Popover,
-   PopoverArrow,
-   PopoverBody,
-   PopoverContent,
-   PopoverTrigger,
-   StackProps,
-   VStack,
-} from '@chakra-ui/react';
+import { Box, Flex, StackProps, VStack } from '@chakra-ui/react';
+import { Tooltip } from '@components/ui/Tooltip';
 import { faCircleInfo } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon } from '@ifixit/icons';
 
@@ -81,39 +71,30 @@ export function ShippingRestrictions({
                      align="center"
                   >
                      {shippingRestriction.notice}
-                     <Popover trigger="hover">
-                        <PopoverTrigger>
+                     <Tooltip
+                        trigger={
                            <FaIcon
-                              display="block"
                               icon={faCircleInfo}
                               h="4"
-                              m="-1.5"
-                              ml="0"
-                              p="1.5"
+                              mt="1px"
+                              ml="1.5"
                               color="gray.400"
                            />
-                        </PopoverTrigger>
-                        <PopoverContent>
-                           <PopoverArrow backgroundColor="gray.800" />
-                           <PopoverBody
-                              borderRadius="md"
-                              backgroundColor="gray.800"
-                              color="white"
-                              fontSize="13px"
-                           >
+                        }
+                        content={
+                           <>
                               <Box>{shippingRestriction.text}</Box>
                               {shippingRestriction.link && (
-                                 <Link
+                                 <a
                                     href={shippingRestriction.link}
-                                    color="brand.400"
                                     target="_blank"
                                  >
                                     Learn more
-                                 </Link>
+                                 </a>
                               )}
-                           </PopoverBody>
-                        </PopoverContent>
-                     </Popover>
+                           </>
+                        }
+                     />
                   </Flex>
                );
             })}

--- a/frontend/templates/product/sections/ProductOverviewSection/ValuePropositionList.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/ValuePropositionList.tsx
@@ -1,6 +1,5 @@
 import { Box, List, ListIcon, ListItem } from '@chakra-ui/react';
 import { Tooltip } from '@components/ui/Tooltip';
-import { IFIXIT_ORIGIN } from '@config/env';
 import {
    faBadgeDollar,
    faCalendarCheck,
@@ -78,9 +77,7 @@ export function ValuePropositionList() {
                            within 30 days of receipt.
                         </p>
                         <Box mt="3">
-                           <a
-                              href={`${IFIXIT_ORIGIN}/article/49-return-policy`}
-                           >
+                           <a href="https://help.ifixit.com/article/49-return-policy">
                               Initiate a return here
                            </a>
                         </Box>

--- a/frontend/templates/product/sections/ProductOverviewSection/ValuePropositionList.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/ValuePropositionList.tsx
@@ -1,0 +1,94 @@
+import { Box, List, ListIcon, ListItem } from '@chakra-ui/react';
+import { Tooltip } from '@components/ui/Tooltip';
+import { IFIXIT_ORIGIN } from '@config/env';
+import {
+   faBadgeDollar,
+   faCalendarCheck,
+   faCircleInfo,
+   faRocket,
+   faShieldCheck,
+} from '@fortawesome/pro-solid-svg-icons';
+import { FaIcon } from '@ifixit/icons';
+
+export function ValuePropositionList() {
+   return (
+      <div>
+         <List spacing="2.5" fontSize="sm" mt="5" lineHeight="short">
+            <ListItem display="flex" alignItems="center">
+               <ListIcon
+                  as={FaIcon}
+                  h="4"
+                  w="5"
+                  mr="1.5"
+                  color="brand.500"
+                  icon={faBadgeDollar}
+               />
+               Purchase with purpose! Repair makes a global impact, reduces
+               e-waste, and saves you money.
+            </ListItem>
+            <ListItem display="flex" alignItems="center">
+               <ListIcon
+                  as={FaIcon}
+                  h="4"
+                  w="5"
+                  mr="1.5"
+                  color="brand.500"
+                  icon={faShieldCheck}
+               />
+               <div>
+                  All our products meet rigorous quality standards and are
+                  backed by industry-leading guarantees.
+               </div>
+            </ListItem>
+            <ListItem display="flex" alignItems="center">
+               <ListIcon
+                  as={FaIcon}
+                  h="4"
+                  w="5"
+                  mr="1.5"
+                  color="brand.500"
+                  icon={faRocket}
+               />
+               Same day shipping if ordered by 1PM Pacific.
+            </ListItem>
+            <ListItem display="flex" alignItems="center">
+               <ListIcon
+                  as={FaIcon}
+                  h="4"
+                  w="5"
+                  mr="1.5"
+                  color="brand.500"
+                  icon={faCalendarCheck}
+               />
+               <div>30-day returns</div>
+               <Tooltip
+                  trigger={
+                     <FaIcon
+                        icon={faCircleInfo}
+                        h="4"
+                        mt="1px"
+                        ml="1.5"
+                        color="gray.400"
+                     />
+                  }
+                  content={
+                     <Box>
+                        <p>
+                           Your repairs are in good hands! We accept returns
+                           within 30 days of receipt.
+                        </p>
+                        <Box mt="3">
+                           <a
+                              href={`${IFIXIT_ORIGIN}/article/49-return-policy`}
+                           >
+                              Initiate a return here
+                           </a>
+                        </Box>
+                     </Box>
+                  }
+               />
+            </ListItem>
+         </List>
+      </div>
+   );
+}

--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -18,12 +18,13 @@ import {
    Text,
    VStack,
 } from '@chakra-ui/react';
-import { BuyBoxPropositionSection } from '@components/sections/ServiceValuePropositionSection';
+import { PrerenderedHTML } from '@components/common';
 import { faCircleExclamation } from '@fortawesome/pro-solid-svg-icons';
+import { trackGA4ViewItem } from '@ifixit/analytics';
 import { useAppContext } from '@ifixit/app';
 import {
-   isLifetimeWarranty,
    getVariantIdFromVariantURI,
+   isLifetimeWarranty,
 } from '@ifixit/helpers';
 import { FaIcon } from '@ifixit/icons';
 import { ProductVariantPrice, Wrapper } from '@ifixit/ui';
@@ -44,8 +45,7 @@ import { ProductOptions } from './ProductOptions';
 import { ProductRating } from './ProductRating';
 import { ProductVideos } from './ProductVideos';
 import { Prop65Warning } from './Prop65Warning';
-import { trackGA4ViewItem } from '@ifixit/analytics';
-import { PrerenderedHTML } from '@components/common';
+import { ValuePropositionList } from './ValuePropositionList';
 
 export interface ProductOverviewSectionProps {
    product: Product;
@@ -209,7 +209,7 @@ export function ProductOverviewSection({
                   <GenuinePartBanner oemPartnership={product.oemPartnership} />
                )}
 
-               {isForSale && <BuyBoxPropositionSection />}
+               {isForSale && <ValuePropositionList />}
 
                <Accordion
                   defaultIndex={product.isEnabled ? [0, 1] : undefined}


### PR DESCRIPTION
closes https://github.com/iFixit/ifixit/issues/50505

This adds a line item for the return policy in the value proposition list. I took this opportunity to create a component that abstracts the tooltip (that we're using also for shipping restrictions) and re-organize a bit the involved code (the value proposition list component has been moved from the value proposition section to the product overview section where it belongs)

## QA

1. Open a [product page preview](https://react-commerce-git-add-return-policy-value-prop-item-ifixit.vercel.app/products/google-pixel-7-pro-screen-genuine)
2. Verify that the return policy badge is implemented as specified in https://github.com/iFixit/ifixit/issues/50505

cc @ifixitmaxb 