### PR TITLE
Vulcan: Sidebar: Design tweaks for new image aspect ratios

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -951,7 +951,7 @@ function RelatedProblems({
                   borderRadius="md"
                   overflow="hidden"
                >
-                  <Flex gap={2} padding={3} align="center">
+                  <Flex gap={2} padding={3}>
                      <Image
                         src={imageUrl}
                         alt={displayTitle}
@@ -971,10 +971,10 @@ function RelatedProblems({
                         </Box>
                         <Box
                            display={{ base: 'none', sm: '-webkit-box' }}
-                           mt={3}
+                           mt={1}
                         >
                            <PrerenderedHTML
-                              noOfLines={3}
+                              noOfLines={4}
                               template="troubleshooting"
                               html={description}
                            />


### PR DESCRIPTION
## Issue

Mattia updated the design for the Problem sidebar: https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=201-65526&mode=design#600241124

Let's update to match.

## CR/QA

<details>
Figma:
<img width="1681" alt="Screenshot 2023-11-08 at 1 00 11 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/aefff681-0ba2-4d4a-9f0f-4938f5a23f1b">

Current branch:
<img width="1681" alt="Screenshot 2023-11-08 at 12 57 52 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/78cabcae-8f40-4239-9533-f543e33bf728">

</details>

`Troubleshooting/Garbage_Disposal/Hums/491105#Section_Jammed_Motor`