### PR TITLE
Product List: Use `title` in breadcrumbs, not `h1`

### DIFF
--- a/frontend/templates/product-list/hooks/useProductListBreadcrumbs.ts
+++ b/frontend/templates/product-list/hooks/useProductListBreadcrumbs.ts
@@ -1,5 +1,4 @@
 import { productListPath, storePath } from '@helpers/path-helpers';
-import { getProductListTitle } from '@helpers/product-list-helpers';
 import type { BreadcrumbItem } from '@ifixit/breadcrumbs';
 import { ProductList, ProductListType } from '@models/product-list';
 import { useDevicePartsItemType } from './useDevicePartsItemType';
@@ -27,7 +26,7 @@ export function useProductListBreadcrumbs(
 
    if (productList.type === ProductListType.DeviceParts && itemType) {
       breadcrumbs.push({
-         label: getProductListTitle(productList),
+         label: productList.title,
          url: productListPath(productList),
       });
       breadcrumbs.push({
@@ -35,7 +34,7 @@ export function useProductListBreadcrumbs(
       });
    } else {
       breadcrumbs.push({
-         label: getProductListTitle(productList),
+         label: productList.title,
       });
    }
 


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/50611

Uses the product list title in the breadcrumbs, as opposed to the product list h1.

The h1 value was not intended to be used in breadcrumbs when it was introduced (https://github.com/iFixit/react-commerce/pull/1426).

## QA

- Visit a product list page on the react-commerce preview
- Make sure that the product list `title` is used in the breadcrumbs on all types of product lists, as opposed to the `h1` (as determined in strapi https://breadcrumbs-use-product-list-title.govinor.com/admin)