### PR TITLE
Shopify outage: Ensure we get sentry pings

### DIFF
--- a/frontend/lib/swr-cache/index.ts
+++ b/frontend/lib/swr-cache/index.ts
@@ -212,7 +212,7 @@ export const withCache = <
          return res.status(200).json({ success: true });
       } catch (error) {
          logger.error(printError(error));
-         return res.status(500).json({ success: false });
+         throw error;
       }
    };
 

--- a/frontend/tests/jest/tests/sentry.test.tsx
+++ b/frontend/tests/jest/tests/sentry.test.tsx
@@ -1,0 +1,52 @@
+import {
+   SentryDetails,
+   SentryError,
+   injectSentryErrorHandler,
+} from '@ifixit/sentry';
+import * as Sentry from '@sentry/nextjs';
+
+describe('Sentry beforeSend', () => {
+   it('should add extra information to the event', () => {
+      const mockBeforeSend = initSentry();
+      const sentryDetails: SentryDetails = {
+         contexts: {
+            contextName: {
+               contextItem1: 'contextItem1',
+               contextObj: {
+                  name: 'contextObj',
+               },
+            },
+         },
+         tags: {
+            tag1: 'Hello',
+            tag2: 'Goodbye',
+         },
+      };
+      Sentry.captureException(new SentryError('message', sentryDetails));
+
+      expect(mockBeforeSend).toHaveBeenCalledTimes(1);
+
+      const event = mockBeforeSend.mock.calls[0][0];
+
+      expect(event.contexts).toMatchObject(sentryDetails.contexts || {});
+      expect(event.tags).toMatchObject(sentryDetails.tags || {});
+   });
+});
+
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+function initSentry() {
+   const mockBeforeSend = jest.fn();
+
+   Sentry.init({
+      sampleRate: 1,
+      dsn: SENTRY_DSN,
+      beforeSend: (event) => {
+         mockBeforeSend(event);
+         return null;
+      },
+   });
+
+   injectSentryErrorHandler();
+
+   return mockBeforeSend;
+}

--- a/frontend/tests/jest/tests/shopify-storefront-sdk.test.tsx
+++ b/frontend/tests/jest/tests/shopify-storefront-sdk.test.tsx
@@ -42,7 +42,7 @@ describe('getServerShopifyStorefrontSdk', () => {
          await storefront.findProduct({
             handle: 'test-handle',
          });
-         fail('Expected error to be thrown');
+         expect(true).toBe('Expected error to be thrown');
       } catch (error) {
          expect(error).toBeInstanceOf(SentryError);
          expect((error as SentryError).sentryDetails).toEqual({

--- a/frontend/tests/jest/tests/shopify-storefront-sdk.test.tsx
+++ b/frontend/tests/jest/tests/shopify-storefront-sdk.test.tsx
@@ -13,8 +13,10 @@ describe('getServerShopifyStorefrontSdk', () => {
       (global as any).fetch = mockFetch;
 
       const mockResponse: Partial<Response> = {
-         ok: false,
-         statusText: 'Not Found',
+         url: 'https://test.myshopify.com/api/graphql',
+         ok: true,
+         statusText: 'success',
+         status: 200,
          json: async () => ({
             errors: [
                {
@@ -34,8 +36,13 @@ describe('getServerShopifyStorefrontSdk', () => {
          storefrontDelegateToken: 'test_token',
       };
 
+      const storefront = getServerShopifyStorefrontSdk(shop);
+
       try {
-         await getServerShopifyStorefrontSdk(shop);
+         await storefront.findProduct({
+            handle: 'test-handle',
+         });
+         fail('Expected error to be thrown');
       } catch (error) {
          expect(error).toBeInstanceOf(SentryError);
          expect((error as SentryError).sentryDetails).toEqual({
@@ -56,9 +63,9 @@ describe('getServerShopifyStorefrontSdk', () => {
                },
             },
             tags: {
-               request_url: expect.any(String),
-               request_status: '404',
-               request_status_text: 'Not Found',
+               request_url: 'https://test.myshopify.com/api/graphql',
+               request_status: '200',
+               request_status_text: 'success',
             },
          });
       }

--- a/frontend/tests/jest/tests/shopify-storefront-sdk.test.tsx
+++ b/frontend/tests/jest/tests/shopify-storefront-sdk.test.tsx
@@ -1,0 +1,66 @@
+import { SentryError } from '@ifixit/sentry';
+import {
+   getServerShopifyStorefrontSdk,
+   ShopCredentials,
+} from '../../../lib/shopify-storefront-sdk/index';
+import { Response } from 'node-fetch';
+
+jest.mock('node-fetch');
+
+describe('getServerShopifyStorefrontSdk', () => {
+   it('throws a SentryError when fetch result has errors', async () => {
+      const mockFetch = jest.fn();
+      (global as any).fetch = mockFetch;
+
+      const mockResponse: Partial<Response> = {
+         ok: false,
+         statusText: 'Not Found',
+         json: async () => ({
+            errors: [
+               {
+                  message: 'Error message',
+                  extensions: {
+                     code: 'ERROR_CODE',
+                  },
+               },
+            ],
+         }),
+      };
+
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const shop: ShopCredentials = {
+         shopDomain: 'test.myshopify.com',
+         storefrontDelegateToken: 'test_token',
+      };
+
+      try {
+         await getServerShopifyStorefrontSdk(shop);
+      } catch (error) {
+         expect(error).toBeInstanceOf(SentryError);
+         expect((error as SentryError).sentryDetails).toEqual({
+            contexts: {
+               graphql_response: {
+                  errors: [
+                     {
+                        message: 'Error message',
+                        extensions: {
+                           code: 'ERROR_CODE',
+                        },
+                     },
+                  ],
+               },
+               body: {
+                  query: expect.any(String),
+                  variables: expect.any(Object),
+               },
+            },
+            tags: {
+               request_url: expect.any(String),
+               request_status: '404',
+               request_status_text: 'Not Found',
+            },
+         });
+      }
+   });
+});

--- a/frontend/tests/jest/tests/withCache.test.tsx
+++ b/frontend/tests/jest/tests/withCache.test.tsx
@@ -1,0 +1,37 @@
+import { SentryError } from '@ifixit/sentry';
+import { withCache } from '@lib/swr-cache';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+
+jest.mock('node-fetch');
+
+describe('withCache', () => {
+   it('bubbles up thrown errors', async () => {
+      const getHandler = async () => {
+         const req = {
+            body: '',
+         } as NextApiRequest;
+         const res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockResolvedValue({}),
+         } as unknown as NextApiResponse;
+         const handler = withCache({
+            endpoint: 'https://test.myshopify.com/api/graphql',
+            statName: 'test_stat_name',
+            variablesSchema: z.any(),
+            valueSchema: z.any(),
+            getFreshValue() {
+               throw new SentryError('Expected error!');
+            },
+         });
+         return await handler(req, res);
+      };
+
+      try {
+         await getHandler();
+         expect(true).toBe('Expected error to be thrown');
+      } catch (error) {
+         expect(error).toBeInstanceOf(SentryError);
+      }
+   });
+});


### PR DESCRIPTION
I was pretty sure we should get data in Sentry, but just in case I started some tests.

qa_req 0

Closes: https://github.com/iFixit/ifixit/issues/50607