### PR TITLE
Add feature flag package

### DIFF
--- a/packages/feature_flags/README.md
+++ b/packages/feature_flags/README.md
@@ -1,0 +1,49 @@
+This is a very basic feature-flag system. It is designed to meet several constraints:
+
+1. Extremely lightweight. We don't want any extra requests to determine if flags
+   are enabled or disabled.
+2. Persistent enabling/disabling of flags for users. Ideally, we'd support
+   flipping flags by userid, but that currently would require an additional
+   server request, which we're avoiding (see 1). So we support local-storage as
+   a next-best option. Perhaps cookies will someday be a better approach.
+3. Compatibility with PHP. We want to be able to easily integrate this into our
+   PHP code. This requires two things:
+   1. No dependencies on NextJS-specific features. This is why we choose to
+      have all the feature-flag code be client-side in NextJS.
+   2. A flag format which is visible to PHP: This drives the decision to store
+      flags in JSON format.
+
+## Usage
+
+### Adding a feature flag
+
+Add feature flags to `flags.json`. If you get the schema wrong, `index.ts` will
+have type errors. The valid schema is kept in `flag_schema.ts`.
+
+### Reading a feature flag
+
+Use the `checkFlag` function from `index.ts`. It should have types such that it
+will only accept keys for flags which actually exist.
+
+## Design Rationale
+
+I chose not to use cookies due to the additional complexity they add. Local
+Storage is really easy to use, and for our initial version should do just what
+we need.
+
+I discovered that TypeScript is totally able to typecheck the flags JSON file.
+We're taking advantage of that by assigning the imported JSON file to a constant
+with the schema type; the assignment fails if the JSON doesn't match the
+required schema.
+
+## Future Work
+
+-  Add a function to set a feature flag on the user's browser.
+-  Add a page on the site which exposes all the user-configurable feature flags
+   and allows the user to click the ones they want to set.
+   -  Maybe use a GET param or something to set the flag in the user's browser, so
+      there can be one-link flag setting options.
+-  Add support for other parameters of interest when configuring flags.
+-  Add a function for the PHP side which copies flags from Local Storage into
+   PHP-compatible query parameters. This will make it possible to use the flags
+   server-side.

--- a/packages/feature_flags/flag_schema.ts
+++ b/packages/feature_flags/flag_schema.ts
@@ -1,0 +1,15 @@
+/**
+ * The list of feature flags which can be enabled/disabled.
+ */
+export type FlagList = Record<string, FlagSettings>;
+
+/**
+ * If true/false, the flag is enabled or disabled globally. If a
+ * FlagSettingsObject, the flag is enabled or disabled according to the
+ * configuration in the object.
+ */
+export type FlagSettings = boolean | FlagSettingsObject;
+
+export interface FlagSettingsObject {
+   userToggle: boolean;
+}

--- a/packages/feature_flags/flags.json
+++ b/packages/feature_flags/flags.json
@@ -1,0 +1,5 @@
+{
+   "extended-related-problems": {
+      "userToggle": true
+   }
+}

--- a/packages/feature_flags/index.ts
+++ b/packages/feature_flags/index.ts
@@ -14,7 +14,7 @@ export function checkFlag(flagName: keyof typeof raw_flags) {
 
    if (typeof flagValue === 'object') {
       if (flagValue.userToggle) {
-         return localStorage.getItem(enableFlag) === 'true';
+         return window?.localStorage?.getItem(enableFlag) === 'true';
       }
    }
 

--- a/packages/feature_flags/index.ts
+++ b/packages/feature_flags/index.ts
@@ -1,0 +1,35 @@
+import * as raw_flags from './flags.json';
+import type { FlagList as FormalFlagList } from './flag_schema';
+
+export const flags: FormalFlagList = raw_flags;
+
+export function checkFlag(flagName: keyof typeof raw_flags) {
+   const flagValue = flags[flagName];
+
+   if (flagValue === true) {
+      return true;
+   }
+
+   const enableFlag = 'enable-' + flagName;
+
+   if (typeof flagValue === 'object') {
+      if (flagValue.userToggle) {
+         return localStorage.getItem(enableFlag) === 'true';
+      }
+   }
+
+   // Check if there's a hash enabling the flag
+   if (getHashBoolean(enableFlag)) {
+      return true;
+   }
+
+   return false;
+}
+
+function getHashBoolean(param: string): boolean {
+   const hash = window?.location?.hash;
+   if (!hash) {
+      return false;
+   }
+   return hash.indexOf(param) !== -1;
+}

--- a/packages/feature_flags/package.json
+++ b/packages/feature_flags/package.json
@@ -1,0 +1,19 @@
+{
+   "name": "@ifixit/feature_flags",
+   "version": "0.0.0",
+   "main": "./index.ts",
+   "types": "./index.ts",
+   "license": "MIT",
+   "exports": {
+      ".": "./index.ts"
+   },
+   "devDependencies": {
+      "@ifixit/tsconfig": "workspace:*",
+      "typescript": "5.2.2"
+   },
+   "scripts": {
+      "build": "",
+      "clean": "",
+      "type-check": "tsc --pretty --noEmit"
+   }
+}

--- a/packages/feature_flags/tsconfig.json
+++ b/packages/feature_flags/tsconfig.json
@@ -1,0 +1,8 @@
+{
+   "extends": "@ifixit/tsconfig/base.json",
+   "include": ["."],
+   "exclude": ["dist", "build", "node_modules"],
+   "compilerOptions": {
+      "resolveJsonModule": true
+   }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,15 @@ importers:
 
   packages/eslint: {}
 
+  packages/feature_flags:
+    devDependencies:
+      '@ifixit/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
   packages/footer:
     dependencies:
       '@chakra-ui/react':


### PR DESCRIPTION
This is an attempt at an ultra-simple feature flag package which could be used across the monorepo and this NextJS repo.

See the readme for rationale and design notes.

The goal is to add a minimal package which we can use to consistently have feature flags available.

qa_req 0
This code is unused.

Connects https://github.com/iFixit/ifixit/issues/50604
