### PR TITLE
Revert ProductOverviewSection th style removal

### DIFF
--- a/frontend/templates/product/sections/ProductOverviewSection/index.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/index.tsx
@@ -468,6 +468,9 @@ function WikiHtmlAccordianItem({
                      tbody: {
                         w: 'full',
                      },
+                     th: {
+                        textAlign: 'left',
+                     },
                      tr: {
                         display: 'flex',
                         flexDirection: 'column',


### PR DESCRIPTION
## Issue

Patches regression from https://github.com/iFixit/react-commerce/commit/786f8841480ce2c424a1de344deeb712c06129a6#diff-4ba9a3ed2b1b0f257b259b4f1882666fed795caf6983cdc11995b6253d79a824L456-L458

## CR/QA

Make sure `th` text is left aligned in Specifications accordion:

https://react-commerce-prod-git-revert-productoverviewsec-b28102-ifixit.vercel.app/products/google-pixel-7-pro-screen-genuine

`products/google-pixel-7-pro-screen-genuine`

<img width="1681" alt="Screenshot 2023-11-13 at 9 32 13 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/ecb94a11-0ee9-475d-b30e-a4e9cb5d0961">
