### PR TITLE
Troubleshooting: Split related-problems render on feature flag

### DIFF
--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -10,6 +10,7 @@
                "@ifixit/breadcrumbs",
                "@ifixit/cart-sdk",
                "@ifixit/feature_flags",
+               "@ifixit/react-feature-flags",
                "@ifixit/footer",
                "@ifixit/helpers",
                "@ifixit/icons",

--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -9,6 +9,7 @@
                "@ifixit/auth-sdk",
                "@ifixit/breadcrumbs",
                "@ifixit/cart-sdk",
+               "@ifixit/feature_flags",
                "@ifixit/footer",
                "@ifixit/helpers",
                "@ifixit/icons",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
       "@ifixit/breadcrumbs": "workspace:*",
       "@ifixit/cart-sdk": "workspace:*",
       "@ifixit/eslint-plugin": "workspace:^",
-      "@ifixit/feature_flags": "workspace:*",
+      "@ifixit/react-feature-flags": "workspace:*",
       "@ifixit/footer": "workspace:*",
       "@ifixit/helpers": "workspace:*",
       "@ifixit/icons": "workspace:*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
       "@ifixit/breadcrumbs": "workspace:*",
       "@ifixit/cart-sdk": "workspace:*",
       "@ifixit/eslint-plugin": "workspace:^",
+      "@ifixit/feature_flags": "workspace:*",
       "@ifixit/footer": "workspace:*",
       "@ifixit/helpers": "workspace:*",
       "@ifixit/icons": "workspace:*",

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -51,7 +51,7 @@ import { DefaultLayout } from '@layouts/default';
 import { DefaultLayoutProps } from '@layouts/default/server';
 import Head from 'next/head';
 import { useRef } from 'react';
-import { checkFlag } from '@ifixit/feature_flags';
+import { useFlag } from '@ifixit/react-feature-flags';
 import ProblemCard from './Problem';
 import { HeadingSelfLink } from './components/HeadingSelfLink';
 import { GoogleNoScript, TagManager } from './components/TagManager';
@@ -110,7 +110,8 @@ const Wiki: NextPageWithLayout<{
 
    const contentContainerRef = useRef<HTMLDivElement>(null);
 
-   const RelatedProblemsComponent = checkFlag('extended-related-problems')
+   const relatedProblemsFlag = useFlag('extended-related-problems');
+   const RelatedProblemsComponent = relatedProblemsFlag
       ? RelatedProblemsV2
       : RelatedProblems;
 

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -51,6 +51,7 @@ import { DefaultLayout } from '@layouts/default';
 import { DefaultLayoutProps } from '@layouts/default/server';
 import Head from 'next/head';
 import { useRef } from 'react';
+import { checkFlag } from '@ifixit/feature_flags';
 import ProblemCard from './Problem';
 import { HeadingSelfLink } from './components/HeadingSelfLink';
 import { GoogleNoScript, TagManager } from './components/TagManager';
@@ -108,6 +109,10 @@ const Wiki: NextPageWithLayout<{
       .filter((tocItem) => tocItem.title);
 
    const contentContainerRef = useRef<HTMLDivElement>(null);
+
+   const RelatedProblemsComponent = checkFlag('extended-related-problems')
+      ? RelatedProblemsV2
+      : RelatedProblems;
 
    return (
       <>
@@ -189,7 +194,7 @@ const Wiki: NextPageWithLayout<{
                      <Conclusion conclusion={filteredConclusions} />
                      <AnswersCTA answersUrl={wikiData.answersUrl} />
                   </Stack>
-                  <RelatedProblems
+                  <RelatedProblemsComponent
                      hasRelatedPages={hasRelatedPages}
                      wikiData={wikiData}
                   />
@@ -930,6 +935,49 @@ function AnswersCTA({ answersUrl }: { answersUrl: string }) {
 }
 
 function RelatedProblems({
+   wikiData,
+   hasRelatedPages,
+}: {
+   wikiData: TroubleshootingData;
+   hasRelatedPages?: boolean;
+}) {
+   const { linkedProblems, deviceGuideUrl, countOfAssociatedProblems } =
+      wikiData;
+   const { displayTitle, imageUrl, description } = wikiData.category;
+
+   const bufferPx = useBreakpointValue({ base: -40, lg: 0 });
+   const { ref } = LinkToTOC<HTMLHeadingElement>(
+      RelatedProblemsRecord.uniqueId,
+      bufferPx
+   );
+
+   return (
+      <>
+         <Stack
+            id={RelatedProblemsRecord.uniqueId}
+            ref={ref}
+            className="sidebar"
+            spacing={{ base: 4, xl: 6 }}
+            width={{ base: '100%' }}
+            alignSelf="start"
+            fontSize="14px"
+            flex={{ xl: '1 0 320px' }}
+            mt={{ base: 3, md: 0 }}
+         >
+            <DeviceCard
+               imageUrl={imageUrl}
+               displayTitle={displayTitle}
+               description={description}
+               countOfAssociatedProblems={countOfAssociatedProblems}
+               deviceGuideUrl={deviceGuideUrl}
+            />
+            {hasRelatedPages && <LinkedProblems problems={linkedProblems} />}
+         </Stack>
+      </>
+   );
+}
+
+function RelatedProblemsV2({
    wikiData,
    hasRelatedPages,
 }: {

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -999,6 +999,7 @@ function RelatedProblemsV2({
          <Stack
             id={RelatedProblemsRecord.uniqueId}
             ref={ref}
+            data-test="related-problems-v2"
             className="sidebar"
             spacing={{ base: 4, xl: 6 }}
             width={{ base: '100%' }}

--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -8,6 +8,29 @@ test.describe('Troubleshooting Page Content and SEO', () => {
       ).toBeVisible();
    });
 
+   test('Related Problems hidden by feature flag', async ({ page }) => {
+      await page.goto('/Troubleshooting/Dryer/Not+Spinning/478872');
+      // Select the element with the ID 'related-problems'
+      const element = await page.locator('#related-problems');
+
+      // Assert that the element's 'data-test' attribute is 'related-problems-v2'
+      await expect(element).not.toHaveAttribute(
+         'data-test',
+         'related-problems-v2'
+      );
+   });
+
+   test('Related Problems visible behind feature flag', async ({ page }) => {
+      await page.goto(
+         '/Troubleshooting/Dryer/Not+Spinning/478872#enable-extended-related-problems'
+      );
+      // Select the element with the ID 'related-problems'
+      const element = await page.locator('#related-problems');
+
+      // Assert that the element's 'data-test' attribute is 'related-problems-v2'
+      await expect(element).toHaveAttribute('data-test', 'related-problems-v2');
+   });
+
    test('Loads By Wikiid Successfully', async ({ page }) => {
       await page.goto('/Troubleshooting/Dryer/Making%20Loud%20Noise/479415');
       await expect(

--- a/frontend/tests/playwright/troubleshooting/loading.spec.ts
+++ b/frontend/tests/playwright/troubleshooting/loading.spec.ts
@@ -13,7 +13,7 @@ test.describe('Troubleshooting Page Content and SEO', () => {
       // Select the element with the ID 'related-problems'
       const element = await page.locator('#related-problems');
 
-      // Assert that the element's 'data-test' attribute is 'related-problems-v2'
+      // Assert that the element's 'data-test' attribute is not 'related-problems-v2'
       await expect(element).not.toHaveAttribute(
          'data-test',
          'related-problems-v2'

--- a/packages/feature_flags/index.ts
+++ b/packages/feature_flags/index.ts
@@ -14,7 +14,9 @@ export function checkFlag(flagName: keyof typeof raw_flags) {
 
    if (typeof flagValue === 'object') {
       if (flagValue.userToggle && typeof localStorage !== 'undefined') {
-         return localStorage?.getItem(enableFlag) === 'true';
+         if (localStorage?.getItem(enableFlag) === 'true') {
+            return true;
+         }
       }
    }
 

--- a/packages/feature_flags/index.ts
+++ b/packages/feature_flags/index.ts
@@ -2,8 +2,9 @@ import * as raw_flags from './flags.json';
 import type { FlagList as FormalFlagList } from './flag_schema';
 
 export const flags: FormalFlagList = raw_flags;
+export type FlagKey = keyof typeof raw_flags;
 
-export function checkFlag(flagName: keyof typeof raw_flags) {
+export function checkFlag(flagName: FlagKey) {
    const flagValue = flags[flagName];
 
    if (flagValue === true) {

--- a/packages/feature_flags/index.ts
+++ b/packages/feature_flags/index.ts
@@ -13,8 +13,8 @@ export function checkFlag(flagName: keyof typeof raw_flags) {
    const enableFlag = 'enable-' + flagName;
 
    if (typeof flagValue === 'object') {
-      if (flagValue.userToggle) {
-         return window?.localStorage?.getItem(enableFlag) === 'true';
+      if (flagValue.userToggle && typeof localStorage !== 'undefined') {
+         return localStorage?.getItem(enableFlag) === 'true';
       }
    }
 
@@ -27,6 +27,10 @@ export function checkFlag(flagName: keyof typeof raw_flags) {
 }
 
 function getHashBoolean(param: string): boolean {
+   if (typeof window === 'undefined') {
+      return false;
+   }
+
    const hash = window?.location?.hash;
    if (!hash) {
       return false;

--- a/packages/react-feature-flags/README.md
+++ b/packages/react-feature-flags/README.md
@@ -1,0 +1,13 @@
+This is a React wrapper for the feature flag system in @ifixit/feature_flags.
+It's designed to ensure that the server and client rendering line up as much as
+possible.
+
+## Usage
+
+Import `useFlag` from this package. Use it in a component like so:
+
+```ts
+const flag = useFlag('flagname');
+```
+
+Only valid flag names will typecheck; to add a flag, see the docs for @ifixit/feature_flags

--- a/packages/react-feature-flags/index.ts
+++ b/packages/react-feature-flags/index.ts
@@ -1,0 +1,10 @@
+import { FlagKey, checkFlag } from '@ifixit/feature_flags';
+import { useEffect, useState } from 'react';
+
+export function useFlag(flagName: FlagKey) {
+   const [flag, setFlag] = useState(false);
+   useEffect(() => {
+      setFlag(checkFlag(flagName));
+   });
+   return flag;
+}

--- a/packages/react-feature-flags/package.json
+++ b/packages/react-feature-flags/package.json
@@ -1,0 +1,25 @@
+{
+   "name": "@ifixit/react-feature-flags",
+   "version": "0.0.0",
+   "main": "./index.ts",
+   "types": "./index.ts",
+   "license": "MIT",
+   "exports": {
+      ".": "./index.ts"
+   },
+   "devDependencies": {
+      "@ifixit/tsconfig": "workspace:*",
+      "typescript": "5.2.2"
+   },
+   "peerDependencies": {
+      "react": "^18.0.0"
+   },
+   "dependencies": {
+      "@ifixit/feature_flags": "workspace:*"
+   },
+   "scripts": {
+      "build": "",
+      "clean": "",
+      "type-check": "tsc --pretty --noEmit"
+   }
+}

--- a/packages/react-feature-flags/tsconfig.json
+++ b/packages/react-feature-flags/tsconfig.json
@@ -1,0 +1,8 @@
+{
+   "extends": "@ifixit/tsconfig/base.json",
+   "include": ["."],
+   "exclude": ["dist", "build", "node_modules"],
+   "compilerOptions": {
+      "resolveJsonModule": true
+   }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       '@ifixit/eslint-plugin':
         specifier: workspace:^
         version: link:../packages/eslint
+      '@ifixit/feature_flags':
+        specifier: workspace:*
+        version: link:../packages/feature_flags
       '@ifixit/footer':
         specifier: workspace:*
         version: link:../packages/footer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,9 +82,6 @@ importers:
       '@ifixit/eslint-plugin':
         specifier: workspace:^
         version: link:../packages/eslint
-      '@ifixit/feature_flags':
-        specifier: workspace:*
-        version: link:../packages/feature_flags
       '@ifixit/footer':
         specifier: workspace:*
         version: link:../packages/footer
@@ -106,6 +103,9 @@ importers:
       '@ifixit/newsletter-sdk':
         specifier: workspace:*
         version: link:../packages/newsletter-sdk
+      '@ifixit/react-feature-flags':
+        specifier: workspace:*
+        version: link:../packages/react-feature-flags
       '@ifixit/sentry':
         specifier: workspace:*
         version: link:../packages/sentry

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -737,6 +737,22 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/react-feature-flags:
+    dependencies:
+      '@ifixit/feature_flags':
+        specifier: workspace:*
+        version: link:../feature_flags
+      react:
+        specifier: ^18.0.0
+        version: 18.2.0
+    devDependencies:
+      '@ifixit/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
   packages/sentry:
     dependencies:
       '@ifixit/helpers':


### PR DESCRIPTION
This adds a second component for the related-problems change and 
 ensures we're not accidentally exposing our new component to the world. It should be pretty hard to mess up, because it checks that the test attribute doesn't exist without the feature flag and does exist with the feature flag.

qa_req 0
There's a test for this!