### PR TITLE
Add unread notifications count

### DIFF
--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -1,3 +1,4 @@
+import { Wordmark20th } from '@assets/svg/files';
 import {
    Alert,
    AlertIcon,
@@ -5,22 +6,32 @@ import {
    Box,
    DrawerCloseButton,
    Flex,
+   Icon,
    MenuDivider,
    MenuGroup,
    MenuList,
    Portal,
-   Icon,
 } from '@chakra-ui/react';
 import { GoogleAnalytics, PiwikPro } from '@components/analytics';
 import { SmartLink } from '@components/ui/SmartLink';
+import { PIWIK_ENV, SHOPIFY_STOREFRONT_VERSION } from '@config/env';
 import {
    faArrowRight,
+   faBell,
+   faBox,
    faMagnifyingGlass,
+   faRightFromBracket,
+   faScrewdriverWrench,
+   faUser,
+   faUsers,
 } from '@fortawesome/pro-solid-svg-icons';
+import {
+   trackPiwikPreferredLanguage,
+   trackPiwikPreferredStore,
+} from '@ifixit/analytics';
 import { useAppContext } from '@ifixit/app';
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';
 import { FaIcon } from '@ifixit/icons';
-import { Wordmark20th } from '@assets/svg/files';
 import type { Menu } from '@ifixit/menu';
 import { ShopifyStorefrontProvider } from '@ifixit/shopify-storefront-client';
 import {
@@ -52,18 +63,14 @@ import {
    NavigationSubmenuName,
    NoUserLink,
    SearchInput,
-   useHeaderContext,
    UserMenu,
    UserMenuButton,
    UserMenuHeading,
+   MenuItemIcon,
    UserMenuLink,
    WordmarkLink,
+   useHeaderContext,
 } from '@ifixit/ui';
-import {
-   trackPiwikPreferredStore,
-   trackPiwikPreferredLanguage,
-} from '@ifixit/analytics';
-import { PIWIK_ENV, SHOPIFY_STOREFRONT_VERSION } from '@config/env';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import * as React from 'react';
@@ -411,37 +418,52 @@ function HeaderUserMenu() {
       return <NoUserLink href={`${appContext.ifixitOrigin}/Login`} />;
    }
 
+   const notificationsCount = user.data.unread_notification_count ?? 0;
+
    return (
       <UserMenu user={user.data}>
-         <UserMenuButton aria-label="Open user menu" />
+         <UserMenuButton
+            aria-label="Open user menu"
+            hasUnreadNotifications={notificationsCount > 0}
+         />
          <Portal>
-            <MenuList>
+            <MenuList minW="240px">
                <UserMenuHeading />
                <MenuDivider />
                <MenuGroup>
                   <UserMenuLink
                      href={`${appContext.ifixitOrigin}/User/Notifications/${user.data.id}/${user.data.username}`}
                   >
-                     Notifications
+                     <Flex justify="space-between" align="center" w="full">
+                        <Flex align="center">
+                           <MenuItemIcon icon={faBell} />
+                           <span>Notifications</span>
+                        </Flex>
+                        <NotificationCountBadge count={notificationsCount} />
+                     </Flex>
                   </UserMenuLink>
                   <UserMenuLink
                      href={`${appContext.ifixitOrigin}/User/${user.data.id}/${user.data.username}`}
                   >
-                     View Profile
+                     <MenuItemIcon icon={faUser} />
+                     <span>View Profile</span>
                   </UserMenuLink>
                   {user.data.teams.length > 0 && (
                      <UserMenuLink href={`${appContext.ifixitOrigin}/Team`}>
-                        My Team
+                        <MenuItemIcon icon={faUsers} />
+                        <span>My Team</span>
                      </UserMenuLink>
                   )}
                   <UserMenuLink href={`${appContext.ifixitOrigin}/User/Orders`}>
-                     Orders
+                     <MenuItemIcon icon={faBox} />
+                     <span>Orders</span>
                   </UserMenuLink>
                   {user.data.links.manage && (
                      <UserMenuLink
                         href={`${appContext.ifixitOrigin}${user.data.links.manage}`}
                      >
-                        Manage
+                        <MenuItemIcon icon={faScrewdriverWrench} />
+                        <span>Manage</span>
                      </UserMenuLink>
                   )}
                </MenuGroup>
@@ -450,12 +472,37 @@ function HeaderUserMenu() {
                   <UserMenuLink
                      href={`${appContext.ifixitOrigin}/Guide/logout`}
                   >
-                     Log Out
+                     <MenuItemIcon icon={faRightFromBracket} />
+                     <span>Log Out</span>
                   </UserMenuLink>
                </MenuGroup>
             </MenuList>
          </Portal>
       </UserMenu>
+   );
+}
+
+interface NotificationCountBadgeProps {
+   count: number;
+}
+
+function NotificationCountBadge({ count }: NotificationCountBadgeProps) {
+   if (count === 0) return null;
+   return (
+      <Flex
+         rounded="full"
+         bgColor="brand.500"
+         h="18px"
+         minW="18px"
+         justify="center"
+         align="center"
+         fontSize="xs"
+         fontWeight="semibold"
+         color="white"
+         p="1"
+      >
+         {count > 100 ? '100+' : count}
+      </Flex>
    );
 }
 

--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -686,6 +686,7 @@ export type CartBuyerIdentityInput = {
     * The rank of the preferences is determined by the order of the addresses in the array. Preferences
     * can be used to populate relevant fields in the checkout flow.
     *
+    * The input must not contain more than `250` values.
     */
    deliveryAddressPreferences?: InputMaybe<Array<DeliveryAddressInput>>;
    /** The email address of the buyer that is interacting with the cart. */
@@ -697,6 +698,7 @@ export type CartBuyerIdentityInput = {
     * Preferences can be used to populate relevant payment fields in the checkout flow.
     *   Accepted value: `["shop_pay"]`.
     *
+    * The input must not contain more than `250` values.
     */
    walletPreferences?: InputMaybe<Array<Scalars['String']>>;
 };
@@ -986,7 +988,11 @@ export type CartFreePaymentMethodInput = {
 
 /** The input fields to create a cart. */
 export type CartInput = {
-   /** An array of key-value pairs that contains additional information about the cart. */
+   /**
+    * An array of key-value pairs that contains additional information about the cart.
+    *
+    * The input must not contain more than `250` values.
+    */
    attributes?: InputMaybe<Array<AttributeInput>>;
    /**
     * The customer associated with the cart. Used to determine [international pricing]
@@ -998,11 +1004,20 @@ export type CartInput = {
    /**
     * The case-insensitive discount codes that the customer added at checkout.
     *
+    * The input must not contain more than `250` values.
     */
    discountCodes?: InputMaybe<Array<Scalars['String']>>;
-   /** A list of merchandise lines to add to the cart. */
+   /**
+    * A list of merchandise lines to add to the cart.
+    *
+    * The input must not contain more than `250` values.
+    */
    lines?: InputMaybe<Array<CartLineInput>>;
-   /** The metafields to associate with this cart. */
+   /**
+    * The metafields to associate with this cart.
+    *
+    * The input must not contain more than `250` values.
+    */
    metafields?: InputMaybe<Array<CartInputMetafieldInput>>;
    /**
     * A note that's associated with the cart. For example, the note can be a personalized message to the buyer.
@@ -1091,7 +1106,11 @@ export type CartLineEstimatedCost = {
 
 /** The input fields to create a merchandise line on a cart. */
 export type CartLineInput = {
-   /** An array of key-value pairs that contains additional information about the merchandise line. */
+   /**
+    * An array of key-value pairs that contains additional information about the merchandise line.
+    *
+    * The input must not contain more than `250` values.
+    */
    attributes?: InputMaybe<Array<AttributeInput>>;
    /** The ID of the merchandise that the buyer intends to purchase. */
    merchandiseId: Scalars['ID'];
@@ -1103,7 +1122,11 @@ export type CartLineInput = {
 
 /** The input fields to update a line item on a cart. */
 export type CartLineUpdateInput = {
-   /** An array of key-value pairs that contains additional information about the merchandise line. */
+   /**
+    * An array of key-value pairs that contains additional information about the merchandise line.
+    *
+    * The input must not contain more than `250` values.
+    */
    attributes?: InputMaybe<Array<AttributeInput>>;
    /** The ID of the merchandise line. */
    id: Scalars['ID'];
@@ -1423,7 +1446,11 @@ export type CheckoutAttributesUpdateV2Input = {
     *
     */
    allowPartialAddresses?: InputMaybe<Scalars['Boolean']>;
-   /** A list of extra information that's added to the checkout. */
+   /**
+    * A list of extra information that's added to the checkout.
+    *
+    * The input must not contain more than `250` values.
+    */
    customAttributes?: InputMaybe<Array<AttributeInput>>;
    /** The text of an optional note that a shop owner can attach to the checkout. */
    note?: InputMaybe<Scalars['String']>;
@@ -1518,11 +1545,19 @@ export type CheckoutCreateInput = {
    allowPartialAddresses?: InputMaybe<Scalars['Boolean']>;
    /** The identity of the customer associated with the checkout. */
    buyerIdentity?: InputMaybe<CheckoutBuyerIdentityInput>;
-   /** A list of extra information that's added to the checkout. */
+   /**
+    * A list of extra information that's added to the checkout.
+    *
+    * The input must not contain more than `250` values.
+    */
    customAttributes?: InputMaybe<Array<AttributeInput>>;
    /** The email with which the customer wants to checkout. */
    email?: InputMaybe<Scalars['String']>;
-   /** A list of line item objects, each one containing information about an item in the checkout. */
+   /**
+    * A list of line item objects, each one containing information about an item in the checkout.
+    *
+    * The input must not contain more than `250` values.
+    */
    lineItems?: InputMaybe<Array<CheckoutLineItemInput>>;
    /** The text of an optional note that a shop owner can attach to the checkout. */
    note?: InputMaybe<Scalars['String']>;
@@ -1789,7 +1824,11 @@ export type CheckoutLineItemEdge = {
 
 /** The input fields to create a line item on a checkout. */
 export type CheckoutLineItemInput = {
-   /** Extra information in the form of an array of Key-Value pairs about the line item. */
+   /**
+    * Extra information in the form of an array of Key-Value pairs about the line item.
+    *
+    * The input must not contain more than `250` values.
+    */
    customAttributes?: InputMaybe<Array<AttributeInput>>;
    /** The quantity of the line item. */
    quantity: Scalars['Int'];
@@ -1799,7 +1838,11 @@ export type CheckoutLineItemInput = {
 
 /** The input fields to update a line item on the checkout. */
 export type CheckoutLineItemUpdateInput = {
-   /** Extra information in the form of an array of Key-Value pairs about the line item. */
+   /**
+    * Extra information in the form of an array of Key-Value pairs about the line item.
+    *
+    * The input must not contain more than `250` values.
+    */
    customAttributes?: InputMaybe<Array<AttributeInput>>;
    /** The ID of the line item. */
    id?: InputMaybe<Scalars['ID']>;

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -24,6 +24,7 @@ const AuthenticatedUserSchema = z.object({
    teams: z.array(z.number()),
    links: z.record(z.any()),
    langid: z.string().optional().nullable(),
+   unread_notification_count: z.number().optional().nullable(),
 });
 
 export function useAuthenticatedUser() {
@@ -74,6 +75,7 @@ const UserApiResponseSchema = z.object({
    teams: z.array(z.number()),
    links: z.record(z.any()),
    langid: z.string().optional().nullable(),
+   unread_notification_count: z.number().optional().nullable(),
 });
 
 async function fetchAuthenticatedUser(
@@ -106,6 +108,7 @@ async function fetchAuthenticatedUser(
       isAdmin: userSchema.data.privileges.includes('Admin'),
       teams: userSchema.data.teams,
       links: userSchema.data.links,
-      langid: userSchema.data?.langid ?? null,
+      langid: userSchema.data.langid ?? null,
+      unread_notification_count: userSchema.data.unread_notification_count,
    };
 }

--- a/packages/ui/cart/drawer/CartDrawerTrigger.tsx
+++ b/packages/ui/cart/drawer/CartDrawerTrigger.tsx
@@ -1,6 +1,7 @@
 import { Box, Circle, IconButton } from '@chakra-ui/react';
 import { faShoppingCart } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon } from '@ifixit/icons';
+import { BlueDot } from '../../misc';
 
 export interface CartDrawerTriggerProps {
    onClick?: () => void;
@@ -29,16 +30,7 @@ export function CartDrawerTrigger({
             data-testid="cart-drawer-open"
          />
          {hasItemsInCart && (
-            <Circle
-               position="absolute"
-               top="0.5"
-               right="2px"
-               size={3}
-               bg="blue.500"
-               borderRadius="full"
-               borderWidth={2}
-               borderColor="gray.900"
-            />
+            <BlueDot position="absolute" top="-2px" right="3px" />
          )}
       </Box>
    );

--- a/packages/ui/header/UserMenu.tsx
+++ b/packages/ui/header/UserMenu.tsx
@@ -1,22 +1,22 @@
 import {
    Avatar,
-   forwardRef,
+   Box,
+   BoxProps,
    Link,
    LinkProps,
    Menu,
    MenuButton,
    MenuButtonProps,
    MenuItem,
-   MenuItemProps,
    MenuProps,
-   StackProps,
    Text,
-   VStack,
 } from '@chakra-ui/react';
 import { faUser } from '@fortawesome/pro-solid-svg-icons';
+import { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
+import { FaIcon } from '@ifixit/icons';
 import * as React from 'react';
 import { usePreloadImage } from '../hooks';
-import { FaIcon } from '@ifixit/icons';
+import { BlueDot } from '../misc';
 
 type UserMenuContext = {
    user: User;
@@ -54,13 +54,17 @@ export const UserMenu = ({ user, ...otherProps }: UserMenuProps) => {
    );
 };
 
-export const UserMenuButton = forwardRef<
-   Omit<MenuButtonProps, 'children'>,
-   'button'
->((props, ref) => {
+interface UserMenuButtonProps extends MenuButtonProps {
+   hasUnreadNotifications?: boolean;
+}
+
+export const UserMenuButton = ({
+   hasUnreadNotifications,
+   ...props
+}: UserMenuButtonProps) => {
    return (
       <MenuButton
-         ref={ref}
+         position="relative"
          borderRadius="full"
          _focus={{
             boxShadow: 'outline',
@@ -69,55 +73,64 @@ export const UserMenuButton = forwardRef<
          {...props}
       >
          <UserAvatar />
+         {hasUnreadNotifications && (
+            <BlueDot position="absolute" top="-2px" right="-2px" />
+         )}
       </MenuButton>
    );
-});
+};
 
-export const UserMenuHeading = forwardRef<Omit<StackProps, 'children'>, 'div'>(
-   (props, ref) => {
-      const { user } = useMenuContext();
-      return (
-         <VStack
-            ref={ref}
-            align="flex-start"
-            px="0.8rem"
-            py="0.4rem"
-            {...props}
-         >
-            <Text color="gray.900" fontWeight="semibold">
-               {user?.username}
-            </Text>
-            {user?.handle && <Text color="gray.700">@{user?.handle}</Text>}
-         </VStack>
-      );
-   }
-);
+export const UserMenuHeading = (props: BoxProps) => {
+   const { user } = useMenuContext();
+   return (
+      <Box px="4" py="2" {...props}>
+         <Text color="gray.900" fontWeight="medium">
+            {user?.username}
+         </Text>
+         {user?.handle && <Text color="gray.500">@{user?.handle}</Text>}
+      </Box>
+   );
+};
 
-export const UserMenuLink = forwardRef<MenuItemProps, 'a'>((props, ref) => {
-   return <MenuItem ref={ref} as="a" fontSize="sm" {...props} />;
-});
+interface UserMenuLinkProps {
+   href: string;
+   children: React.ReactNode;
+}
 
-export const NoUserLink = forwardRef<Omit<LinkProps, 'children'>, 'a'>(
-   (props, ref) => {
-      return (
-         <Link
-            ref={ref}
-            borderRadius="full"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            {...props}
-            h={8}
-            w={8}
-            _hover={{ opacity: '0.7' }}
-            transition="0.3s"
-            aria-label="Login"
-         >
-            <FaIcon icon={faUser} h="5" color="white" />
-         </Link>
-      );
-   }
-);
+export const UserMenuLink = ({ href, children }: UserMenuLinkProps) => {
+   return (
+      <MenuItem as="a" href={href} fontSize="sm" px="4" py="1.5">
+         {children}
+      </MenuItem>
+   );
+};
+
+interface MenuItemIconProps {
+   icon: FontAwesomeIconProps['icon'];
+}
+
+export const MenuItemIcon = ({ icon }: MenuItemIconProps) => {
+   return <FaIcon icon={icon} w="4" color="gray.500" mr="1.5" />;
+};
+
+export const NoUserLink = (props: LinkProps) => {
+   return (
+      <Link
+         borderRadius="full"
+         display="flex"
+         alignItems="center"
+         justifyContent="center"
+         {...props}
+         h={8}
+         w={8}
+         _hover={{ opacity: '0.7' }}
+         transition="0.3s"
+         aria-label="Login"
+      >
+         <FaIcon icon={faUser} h="5" color="white" />
+      </Link>
+   );
+};
 
 function UserAvatar() {
    const { user } = useMenuContext();

--- a/packages/ui/misc/BlueDot.tsx
+++ b/packages/ui/misc/BlueDot.tsx
@@ -1,0 +1,14 @@
+import { Circle, SquareProps } from '@chakra-ui/react';
+
+export function BlueDot(props: SquareProps) {
+   return (
+      <Circle
+         size="3.5"
+         bg="brand.500"
+         borderRadius="full"
+         borderWidth={2}
+         borderColor="gray.900"
+         {...props}
+      />
+   );
+}

--- a/packages/ui/misc/index.ts
+++ b/packages/ui/misc/index.ts
@@ -3,3 +3,4 @@ export * from './Wordmark';
 export * from './Wrapper';
 export * from './ResponsiveImage';
 export * from './IconBadge';
+export * from './BlueDot';


### PR DESCRIPTION
closes https://github.com/iFixit/ifixit/issues/50434

This PR adds an unread notifications count to the user menu avatar and refactors the user menu to match the mockup

<img width="343" alt="Screenshot 2023-11-15 at 09 29 19" src="https://github.com/iFixit/react-commerce/assets/4640135/10057632-08fd-4b25-a6c3-8eb4eccbdfc5">

## QA

1. Open [Vercel preview](https://react-commerce-git-add-unread-notifications-count-ifixit.vercel.app/Parts)
2. As a logged in user, make sure that if you have unread notifications, they show up as a blue dot in the avatar, and the unread notifications count is displayed in the user menu panel
3. Verify that the user menu matches the [mockup](https://www.figma.com/file/sfj6r7Bn6eREMvuqo0f7Du/iFixit---Components?type=design&node-id=3544-10387&mode=dev)