### PR TITLE
Vulcan: Add parts collection Link Card

### DIFF
--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -188,6 +188,7 @@ function hasKey<O extends Object>(obj: O, key: PropertyKey): key is keyof O {
 
 function Resource({
    title,
+   showStackedImages,
    imageUrl,
    timeRequired,
    difficulty,
@@ -198,6 +199,7 @@ function Resource({
    children,
 }: React.PropsWithChildren<{
    title: string;
+   showStackedImages?: boolean;
    imageUrl?: string | null;
    introduction?: string | null;
    timeRequired?: string;
@@ -219,7 +221,31 @@ function Resource({
 
    return (
       <ResourceBox>
-         {imageUrl && (
+         {imageUrl && showStackedImages && (
+            <Box position="relative" mr={2}>
+               <Image
+                  boxSize="64px"
+                  outline="1px solid"
+                  outlineColor="gray.300"
+                  borderRadius="md"
+                  objectFit="cover"
+                  alt={title}
+                  src={imageUrl}
+                  position="relative"
+                  zIndex="1"
+               />
+               <Box
+                  boxSize="64px"
+                  outline="1px solid"
+                  outlineColor="gray.300"
+                  borderRadius="md"
+                  position="absolute"
+                  top="0"
+                  transform="rotate(6deg)"
+               />
+            </Box>
+         )}
+         {imageUrl && !showStackedImages && (
             <Image
                boxSize="64px"
                outline="1px solid"

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -21,7 +21,11 @@ import { PrerenderedHTML } from '@components/common';
 import { DifficultyThemeLookup, GuideDifficultyNames } from './DifficultyBadge';
 import { Rating } from '@components/ui';
 import { Money, formatMoney, shouldShowProductRating } from '@ifixit/helpers';
-import { SectionProduct, SectionGuide } from './hooks/useTroubleshootingProps';
+import {
+   SectionProduct,
+   SectionGuide,
+   SectionPartCollection,
+} from './hooks/useTroubleshootingProps';
 
 export function GuideResource({ guide }: { guide: SectionGuide }) {
    return (

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -77,8 +77,6 @@ export function PartCollectionResource({
 }) {
    const { title, url, description, imageUrl } = partCollection;
 
-   console.log('rendering part collection: ' + partCollection);
-
    return (
       <Resource
          href={url}
@@ -232,6 +230,7 @@ function Resource({
                outlineColor="gray.300"
             >
                {showStackedImages && (
+                  // Renders an empty box to fake the stacked image effect
                   <Box
                      width="100%"
                      height="100%"

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -204,7 +204,7 @@ function Resource({
    difficulty?: string;
    spacing: SystemProps['margin'];
    href: string;
-   showBuyButton?: boolean;
+   showBuyButton?: string | boolean;
    openInNewTab?: boolean;
 }>) {
    const difficultyTheme =
@@ -214,6 +214,8 @@ function Resource({
    const { themeColor, iconColor, icon } = difficultyTheme;
    const breakpoint = useBreakpoint();
    const isMobile = breakpoint === 'base';
+   const buyButtonText =
+      typeof showBuyButton === 'string' ? showBuyButton : 'Buy';
 
    return (
       <ResourceBox>
@@ -274,7 +276,7 @@ function Resource({
                buttonSize="xs"
                openInNewTab={false}
                url={href}
-               buyButtonText="Buy"
+               buyButtonText={buyButtonText}
             />
          )}
          {!isMobile && showBuyButton && (
@@ -283,7 +285,7 @@ function Resource({
                buttonSize="sm"
                openInNewTab={openInNewTab}
                url={href}
-               buyButtonText="Buy"
+               buyButtonText={buyButtonText}
             />
          )}
       </ResourceBox>

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -70,6 +70,32 @@ export function ProductResource({ product }: { product: SectionProduct }) {
    );
 }
 
+export function PartCollectionResource({
+   partCollection,
+}: {
+   partCollection: SectionPartCollection;
+}) {
+   const { title, url, description, imageUrl } = partCollection;
+
+   console.log('rendering part collection: ' + partCollection);
+
+   return (
+      <Resource
+         href={url}
+         title={title}
+         imageUrl={imageUrl}
+         spacing={1}
+         showBuyButton={'Find Your Parts'}
+         openInNewTab={true}
+         showStackedImages={true}
+      >
+         <Text color="gray.600" fontSize="12px">
+            {description}
+         </Text>
+      </Resource>
+   );
+}
+
 function ResourceProductRating({ product }: { product: SectionProduct }) {
    if (!shouldShowProductRating(product.reviews)) {
       return null;

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -221,41 +221,39 @@ function Resource({
 
    return (
       <ResourceBox>
-         {imageUrl && showStackedImages && (
-            <Box position="relative" mr={2}>
+         {imageUrl && (
+            <Box
+               position="relative"
+               mr={2}
+               boxSize="64px"
+               minWidth="64px"
+               borderRadius="md"
+               outline="1px solid"
+               outlineColor="gray.300"
+            >
+               {showStackedImages && (
+                  <Box
+                     width="100%"
+                     height="100%"
+                     borderRadius="inherit"
+                     outline="inherit"
+                     outlineColor="inherit"
+                     position="absolute"
+                     top="0"
+                     transform="rotate(6deg)"
+                  />
+               )}
                <Image
-                  boxSize="64px"
-                  outline="1px solid"
-                  outlineColor="gray.300"
-                  borderRadius="md"
+                  outline="inherit"
+                  outlineColor="inherit"
+                  borderRadius="inherit"
                   objectFit="cover"
                   alt={title}
                   src={imageUrl}
                   position="relative"
                   zIndex="1"
                />
-               <Box
-                  boxSize="64px"
-                  outline="1px solid"
-                  outlineColor="gray.300"
-                  borderRadius="md"
-                  position="absolute"
-                  top="0"
-                  transform="rotate(6deg)"
-               />
             </Box>
-         )}
-         {imageUrl && !showStackedImages && (
-            <Image
-               boxSize="64px"
-               outline="1px solid"
-               outlineColor="gray.300"
-               borderRadius="md"
-               objectFit="cover"
-               alt={title}
-               src={imageUrl}
-               mr={2}
-            />
          )}
          <Stack
             justify="flex-start"

--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -26,6 +26,14 @@ export type Problem = {
 export type ApiSolutionSection = Section & {
    guides: SectionGuide[];
    products: SectionProduct[];
+   partCollections: SectionPartCollection[];
+};
+
+export type SectionPartCollection = {
+   title: string;
+   url: string;
+   description: string;
+   imageUrl: string;
 };
 
 export type SectionProduct = {

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -17,7 +17,11 @@ import {
    SectionPartCollection,
 } from './hooks/useTroubleshootingProps';
 import { PrerenderedHTML } from '@components/common';
-import { GuideResource, ProductResource } from './Resource';
+import {
+   GuideResource,
+   ProductResource,
+   PartCollectionResource,
+} from './Resource';
 import { HeadingSelfLink } from './components/HeadingSelfLink';
 import { LinkToTOC, useTOCBufferPxScrollOnClick } from './tocContext';
 
@@ -128,10 +132,13 @@ export default function SolutionCard({
                title={solution.heading}
             />
             <SolutionTexts body={solution.body} />
-            {(solution.guides.length > 0 || solution.products.length > 0) && (
+            {(solution.guides.length > 0 ||
+               solution.products.length > 0 ||
+               solution.partCollections.length > 0) && (
                <LinkCards
                   guides={solution.guides}
                   products={solution.products}
+                  partCollections={solution.partCollections}
                />
             )}
          </Stack>
@@ -142,8 +149,13 @@ export default function SolutionCard({
 function LinkCards({
    guides,
    products,
+   partCollections,
    ...props
-}: { guides: SectionGuide[]; products: SectionProduct[] } & BoxProps) {
+}: {
+   guides: SectionGuide[];
+   products: SectionProduct[];
+   partCollections: SectionPartCollection[];
+} & BoxProps) {
    const uniqueGuides = guides.filter(
       (guide, index) =>
          guides.findIndex((g) => g.guideid === guide.guideid) === index
@@ -156,6 +168,14 @@ function LinkCards({
          {products.map((product: SectionProduct, index) => (
             <ProductResource key={index} product={product} />
          ))}
+         {partCollections.map(
+            (partCollection: SectionPartCollection, index) => (
+               <PartCollectionResource
+                  key={index}
+                  partCollection={partCollection}
+               />
+            )
+         )}
       </VStack>
    );
 }

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -113,6 +113,7 @@ export default function SolutionCard({
 }) {
    const bufferPx = useBreakpointValue({ base: -46, lg: -6 });
    const { ref } = LinkToTOC<HTMLDivElement>(solution.id, bufferPx);
+   solution.partCollections = [];
 
    return (
       <Box

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -14,6 +14,7 @@ import {
    SectionGuide,
    SectionProduct,
    SolutionSection,
+   SectionPartCollection,
 } from './hooks/useTroubleshootingProps';
 import { PrerenderedHTML } from '@components/common';
 import { GuideResource, ProductResource } from './Resource';

--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -166,13 +166,13 @@ function LinkCards({
          {uniqueGuides.map((guide: SectionGuide) => (
             <GuideResource key={guide.guideid} guide={guide} />
          ))}
-         {products.map((product: SectionProduct, index) => (
-            <ProductResource key={index} product={product} />
+         {products.map((product: SectionProduct, productsIndex) => (
+            <ProductResource key={productsIndex} product={product} />
          ))}
          {partCollections.map(
-            (partCollection: SectionPartCollection, index) => (
+            (partCollection: SectionPartCollection, partCollectionsIndex) => (
                <PartCollectionResource
-                  key={index}
+                  key={partCollectionsIndex}
                   partCollection={partCollection}
                />
             )


### PR DESCRIPTION
## Overview
Implements the [figma design](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=588-33&mode=design&t=zRnaaF8j4VA0y902-0) for part collections linked in vulcan pages.

## QA
Qa_req 0 - This component will not render currently.

Connect to https://github.com/iFixit/ifixit/issues/50601