### PR TITLE
Vulcan: Problem: Answers CTA last; related problems before device card on mobile

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -22,7 +22,7 @@ export const PrerenderedHTML = forwardRef<PrerenderedHTMLProps, 'div'>(
       return (
          <Box
             ref={ref}
-            className={`prerendered ${className}`}
+            className={className ? `prerendered ${className}` : 'prerendered'}
             sx={styleMap[template]}
             dangerouslySetInnerHTML={{ __html: html }}
             {...others}

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -112,6 +112,7 @@ const Wiki: NextPageWithLayout<{
    const contentContainerRef = useRef<HTMLDivElement>(null);
 
    const tocWidth = '220px';
+   const sidebarWidth = '320px';
 
    const relatedProblemsFlag = useFlag('extended-related-problems');
    const RelatedProblemsComponent = relatedProblemsFlag
@@ -159,7 +160,7 @@ const Wiki: NextPageWithLayout<{
                   listItemProps={{ paddingLeft: { lg: 4 } }}
                   gridArea="toc"
                />
-               <Stack
+               <Flex
                   className="wrapper"
                   gridArea="wrapper"
                   display={{ base: 'block', sm: 'flex' }}
@@ -171,7 +172,6 @@ const Wiki: NextPageWithLayout<{
                   paddingBottom={8}
                   minW={0}
                   marginInline={{ sm: 'auto' }}
-                  spacing={{ base: 4, lg: 12 }}
                   flexWrap={{ base: 'wrap', xl: 'nowrap' }}
                   sx={{
                      '@media (min-width: 1340px) and (max-width: 1719px)': {
@@ -182,35 +182,52 @@ const Wiki: NextPageWithLayout<{
                      },
                   }}
                >
-                  <Stack id="main" spacing={4}>
-                     <TroubleshootingHeading wikiData={wikiData} />
-                     <Causes
-                        introduction={introSections}
-                        solutions={wikiData.solutions}
-                        problems={wikiData.linkedProblems}
-                     />
-                     <Stack className="intro" spacing={6} pt={{ sm: 3 }}>
-                        <IntroductionSections introduction={introSections} />
-                     </Stack>
-                     {wikiData.solutions.length > 0 && (
-                        <Stack spacing={6}>
-                           {wikiData.solutions.map((solution, index) => (
-                              <SolutionCard
-                                 key={solution.heading}
-                                 index={index + 1}
-                                 solution={solution}
-                              />
-                           ))}
+                  <Stack
+                     id="main"
+                     display={{ base: 'flex', lg: 'grid' }}
+                     columnGap={{ lg: 12 }}
+                     spacing={4}
+                     sx={{
+                        gridTemplateAreas: {
+                           lg: `
+                              "Content RelatedProblems"
+                              "Conclusion RelatedProblems"
+                              "AnswersCTA RelatedProblems"
+                           `,
+                        },
+                        gridTemplateColumns: { lg: `1fr ${sidebarWidth}` },
+                     }}
+                  >
+                     <Stack spacing={4} gridArea="Content">
+                        <TroubleshootingHeading wikiData={wikiData} />
+                        <Causes
+                           introduction={introSections}
+                           solutions={wikiData.solutions}
+                           problems={wikiData.linkedProblems}
+                        />
+                        <Stack className="intro" spacing={6} pt={{ sm: 3 }}>
+                           <IntroductionSections introduction={introSections} />
                         </Stack>
-                     )}
+                        {wikiData.solutions.length > 0 && (
+                           <Stack spacing={6}>
+                              {wikiData.solutions.map((solution, index) => (
+                                 <SolutionCard
+                                    key={solution.heading}
+                                    index={index + 1}
+                                    solution={solution}
+                                 />
+                              ))}
+                           </Stack>
+                        )}
+                     </Stack>
+                     <RelatedProblemsComponent
+                        hasRelatedPages={hasRelatedPages}
+                        wikiData={wikiData}
+                     />
                      <Conclusion conclusion={filteredConclusions} />
                      <AnswersCTA answersUrl={wikiData.answersUrl} />
                   </Stack>
-                  <RelatedProblemsComponent
-                     hasRelatedPages={hasRelatedPages}
-                     wikiData={wikiData}
-                  />
-               </Stack>
+               </Flex>
             </Box>
          </TOCContextProvider>
          {viewStats && <ViewStats {...viewStats} />}
@@ -895,7 +912,7 @@ const ConclusionSection = function ConclusionSectionInner({
 
    return (
       <Stack spacing={3} id={conclusion.id} ref={ref}>
-         <HeadingSelfLink pt={4} id={conclusion.id} onClick={onClick}>
+         <HeadingSelfLink id={conclusion.id} onClick={onClick}>
             {conclusion.heading}
          </HeadingSelfLink>
          <PrerenderedHTML html={conclusion.body} template="troubleshooting" />
@@ -905,20 +922,20 @@ const ConclusionSection = function ConclusionSectionInner({
 
 function Conclusion({ conclusion: conclusions }: { conclusion: Section[] }) {
    return (
-      <>
+      <Box gridArea="Conclusion">
          {conclusions.map((conclusion) => (
             <ConclusionSection
                key={conclusion.heading}
                conclusion={conclusion}
             />
          ))}
-      </>
+      </Box>
    );
 }
 
 function AnswersCTA({ answersUrl }: { answersUrl: string }) {
    return (
-      <Alert p={3} fontSize="sm">
+      <Alert p={3} fontSize="sm" gridArea="AnswersCTA">
          <AlertIcon
             color="gray.500"
             alignSelf={{ base: 'start', sm: 'center' }}
@@ -930,7 +947,7 @@ function AnswersCTA({ answersUrl }: { answersUrl: string }) {
             sx={{
                '@media (max-width: 375px)': {
                   flexDirection: 'column',
-                  gap: '6px',
+                  gap: 1.5,
                   alignItems: 'end',
                },
             }}
@@ -972,9 +989,10 @@ function RelatedProblems({
          width={{ base: '100%' }}
          alignSelf="start"
          fontSize="14px"
-         flex={{ xl: '1 0 320px' }}
-         mt={{ base: 3, md: 0 }}
+         pt={4}
+         gridArea="RelatedProblems"
       >
+         {hasRelatedPages && <LinkedProblems problems={linkedProblems} />}
          <DeviceCard
             imageUrl={imageUrl}
             displayTitle={displayTitle}
@@ -982,7 +1000,6 @@ function RelatedProblems({
             countOfAssociatedProblems={countOfAssociatedProblems}
             deviceGuideUrl={deviceGuideUrl}
          />
-         {hasRelatedPages && <LinkedProblems problems={linkedProblems} />}
       </Stack>
    );
 }
@@ -1023,9 +1040,10 @@ function RelatedProblemsV2({
          width={{ base: '100%' }}
          alignSelf="start"
          fontSize="14px"
-         flex={{ xl: '1 0 320px' }}
-         mt={{ base: 3, md: 0 }}
+         pt={4}
+         gridArea="RelatedProblems"
       >
+         {hasRelatedPages && <LinkedProblems problems={uniqProblems} />}
          <DeviceCard
             imageUrl={imageUrl}
             displayTitle={displayTitle}
@@ -1033,7 +1051,6 @@ function RelatedProblemsV2({
             countOfAssociatedProblems={countOfAssociatedProblems}
             deviceGuideUrl={deviceGuideUrl}
          />
-         {hasRelatedPages && <LinkedProblems problems={uniqProblems} />}
       </Stack>
    );
 }
@@ -1052,7 +1069,12 @@ function DeviceCard({
    deviceGuideUrl: string | undefined;
 }) {
    return (
-      <Stack className="question" spacing={1.5} display="flex">
+      <Stack
+         className="question"
+         spacing={1.5}
+         display="flex"
+         order={{ xl: -1 }}
+      >
          <Box
             bgColor="white"
             border="1px solid"
@@ -1064,14 +1086,15 @@ function DeviceCard({
                <Image
                   src={imageUrl}
                   alt={displayTitle}
-                  width={{ base: '75px', md: '104px' }}
-                  height={{ base: '56px', md: '78px' }}
+                  minWidth={{ base: '75px', md: '104px' }}
+                  minHeight={{ base: '56px', md: '78px' }}
                   htmlWidth={104}
                   htmlHeight={78}
                   objectFit="cover"
                   borderRadius="md"
                   outline="1px solid"
                   outlineColor="gray.300"
+                  overflow="hidden"
                   aspectRatio="4 / 3"
                />
                <Box display="block" lineHeight="normal">
@@ -1127,7 +1150,7 @@ function LinkedProblems({ problems }: { problems: Problem[] }) {
          </Heading>
          <SimpleGrid
             className="list"
-            columns={{ base: 1, sm: 2, xl: 1 }}
+            columns={{ base: 1, sm: 2, lg: 1 }}
             spacing={3}
          >
             {problems.map((problem) => (


### PR DESCRIPTION
## Do This

- Always display the Answers CTA last
- On views where the device card and related problems are at the bottom of the page, display the related problems ahead of the device card
  - Device card stays on top in the sidebar, visible at desktop widths

## CR/QA

This is a new grid layout, and the syntax has a bit of a learning curve. If there are any questions, feel free to ping me.

These changes hit all breakpoints.

<details>
<img width="1716" alt="Screenshot 2023-11-16 at 4 32 19 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/598e4c30-4ac9-4793-98a6-5c1c2fe21902">

<img width="1716" alt="Screenshot 2023-11-16 at 4 33 25 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/681fa4d3-7820-473d-8174-478b573f422d">

</details>

Closes https://github.com/iFixit/ifixit/issues/50724