### PR TITLE
Fix Safari 13.1 Bugs

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -286,7 +286,10 @@ const troubleshootingStyles: SystemStyleObject = {
 
       video: {
          position: 'absolute',
-         inset: 0,
+         top: '0',
+         right: '0',
+         bottom: '0',
+         left: '0',
       },
    },
 

--- a/frontend/components/sections/BannersSection/SingleBanner.tsx
+++ b/frontend/components/sections/BannersSection/SingleBanner.tsx
@@ -18,10 +18,20 @@ export function SingleBanner({ id, banner }: SingleBannerProps) {
             position="absolute"
             bgGradient="linear(to-r, blackAlpha.600 50%, blackAlpha.400)"
             zIndex={-1}
-            inset="0"
+            top="0"
+            right="0"
+            bottom="0"
+            left="0"
          />
          {banner.image && (
-            <Box position="absolute" zIndex={-2} inset="0">
+            <Box
+               position="absolute"
+               zIndex={-2}
+               top="0"
+               right="0"
+               bottom="0"
+               left="0"
+            >
                <ResponsiveImage
                   src={banner.image.url}
                   alt=""

--- a/frontend/components/sections/LifetimeWarrantySection.tsx
+++ b/frontend/components/sections/LifetimeWarrantySection.tsx
@@ -76,7 +76,7 @@ export function LifetimeWarrantySection({
 function BackgroundImage() {
    return (
       <>
-         <Box position="absolute" inset="0">
+         <Box position="absolute" top="0" right="0" bottom="0" left="0">
             <Image
                alt=""
                src={backgroundImage}
@@ -88,7 +88,10 @@ function BackgroundImage() {
          </Box>
          <Box
             position="absolute"
-            inset="0"
+            top="0"
+            right="0"
+            bottom="0"
+            left="0"
             bgGradient="linear(to-r, blackAlpha.600, blackAlpha.400)"
          />
       </>

--- a/packages/ui/cart/drawer/CartDrawerTrigger.tsx
+++ b/packages/ui/cart/drawer/CartDrawerTrigger.tsx
@@ -28,6 +28,7 @@ export function CartDrawerTrigger({
                bg: 'gray.900',
             }}
             data-testid="cart-drawer-open"
+            border="0"
          />
          {hasItemsInCart && (
             <BlueDot position="absolute" top="-2px" right="3px" />

--- a/packages/ui/header/NavigationMenu.tsx
+++ b/packages/ui/header/NavigationMenu.tsx
@@ -64,6 +64,8 @@ export const NavigationMenuButton = forwardRef<FlexProps, 'button'>(
             fontSize="sm"
             fontWeight="semibold"
             borderRadius="md"
+            border="0"
+            color="white"
             _focus={{
                boxShadow: 'outline',
                outline: 'none',
@@ -90,6 +92,7 @@ export const NavigationSubmenu = forwardRef<FlexProps, 'ul'>(
             transform="translateY(100%)"
             display="none"
             bg="gray.800"
+            margin="0"
             {...otherProps}
          >
             {children}

--- a/packages/ui/header/NavigationMenu.tsx
+++ b/packages/ui/header/NavigationMenu.tsx
@@ -19,7 +19,7 @@ export const NavigationMenu = forwardRef<BoxProps, 'nav'>(
             display={{ base: 'none', lg: 'block' }}
             {...otherProps}
          >
-            <Flex as="ul" role="menubar" h="full" position="relative">
+            <Flex as="ul" role="menubar" h="full" position="relative" m="0">
                {children}
             </Flex>
          </Box>
@@ -92,7 +92,6 @@ export const NavigationSubmenu = forwardRef<FlexProps, 'ul'>(
             transform="translateY(100%)"
             display="none"
             bg="gray.800"
-            margin="0"
             {...otherProps}
          >
             {children}

--- a/packages/ui/theme/styles.ts
+++ b/packages/ui/theme/styles.ts
@@ -12,5 +12,8 @@ export const styles: ThemeOverride['styles'] = {
          backgroundColor: 'blueGray.50',
          fontSize: 'md', // set cascading font-size at body, leave html at 16px to preserve rem
       },
+      img: {
+         maxWidth: '100%', // Images won't overflow their container
+      },
    },
 };


### PR DESCRIPTION
## Issue

These popped up while doing some testing. Let's take care of the low-level UI bugs, so our friends stuck on older Safari versions can at least use the site.

## CR/QA

Fixes the following issues:

<details>
<summary>Header styling</summary>
<img width="1716" alt="Screenshot 2023-11-20 at 2 55 05 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/32bcd742-2c1a-462c-9c4a-a946b3c55e80">

<img width="1716" alt="Screenshot 2023-11-20 at 3 07 44 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/b3bcc1d7-391a-4d3a-bcd3-9e76ef6631ac">

</details>


<details>
<summary>Limit image width to their container</summary>
<img width="1716" alt="Screenshot 2023-11-20 at 2 55 19 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/733596dc-a413-4b15-96af-c9fd23859b4b">

<img width="1716" alt="Screenshot 2023-11-20 at 3 07 53 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/99632d35-7022-47d4-bcf6-2e5530c59f63">

</details>


<details>
<summary>Replace inset="0" usage</summary>
<img width="1716" alt="Screenshot 2023-11-20 at 2 55 26 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/11c7d8f7-5471-4eaf-b4a3-8a6d2f1e50d6">

<img width="1716" alt="Screenshot 2023-11-20 at 3 08 10 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/d3035b78-41bb-4a31-8ed9-3c74a8bb4551">

</details>
