### PR TITLE
Product List: Add default H1 override

### DIFF
--- a/frontend/templates/product-list/hooks/useItemTypeProductList.ts
+++ b/frontend/templates/product-list/hooks/useItemTypeProductList.ts
@@ -21,6 +21,7 @@ export function useItemTypeProductList(productList: ProductList) {
    if (!hasItemTypeOverrides) {
       return {
          ...productList,
+         h1: getDefaultH1Override(productList, selectedItemType),
          title: getDefaultTitleOverride(productList, selectedItemType),
       };
    }
@@ -66,7 +67,7 @@ export function useItemTypeProductList(productList: ProductList) {
          overrideTitle ??
          getDefaultTitleOverride(productList, selectedItemType),
       metaTitle: overrideMetaTitle ?? productList.metaTitle,
-      h1: overrideTitle ?? productList.h1,
+      h1: overrideTitle ?? getDefaultH1Override(productList, selectedItemType),
       description: overrideDescription,
       metaDescription: overrideMetaDescription,
       tagline: overrideTagline,
@@ -94,4 +95,13 @@ function getDefaultTitleOverride(
       return productList.title;
 
    return `${productList.title.replace(/parts$/i, '').trim()} ${itemType}`;
+}
+
+function getDefaultH1Override(
+   productList: ProductList,
+   itemType: string
+): string | null {
+   if (!productList.h1) return null;
+   if (productList.type !== ProductListType.DeviceParts) return productList.h1;
+   return `${productList.h1.replace(/parts$/i, '').trim()} ${itemType}`;
 }


### PR DESCRIPTION
## Problem

Original report in Slack: https://ifixit.slack.com/archives/C02KMFEHX62/p1700521827373909

Wrong H1:

![image](https://github.com/iFixit/react-commerce/assets/52104630/3b3276d9-97f9-46b7-af8b-e633436d9119)
https://www.ifixit.com/Parts/Samsung_Galaxy_S21/Batteries

Correct H1:

![image](https://github.com/iFixit/react-commerce/assets/52104630/aff4ace0-b992-454e-8f37-eaff1b7b7ee6)
https://www.ifixit.com/Parts/Google_Pixel_4a/Batteries

## Fix

I noticed that the Samsung Strapi product list had an H1 set, while the Google Pixel Strapi page did not. When there are no item type overrides, the code picks a default title but not a default H1. This change picks a default H1.
