### PR TITLE
Sentry/index Exports All of SentryErrorIntegration

### DIFF
--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/nextjs';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { GetServerSidePropsContext } from 'next';
 import { Scope } from '@sentry/nextjs';
-import { SentryErrorIntegration as Integration } from './SentryErrorIntegration';
-export { Integration as SentryErrorIntegration };
+
+export * from './SentryErrorIntegration';
 
 type Fetcher = typeof fetch;
 


### PR DESCRIPTION
## Overview

While deving I kept seeing the following in my console

```
instrument.js:123 ./sentry.client.config.ts
Attempted import error: 'SentryErrorIntegration' is not exported from '@ifixit/sentry' (imported as 'SentryErrorIntegration').
```

So this fixes that.

## QA

The above import error shouldn't show up anymore.

@jarstelfox Is this ok? Or am i missing something?
qa_req 0