### PR TITLE
Product List: Add black friday hreflangs

### DIFF
--- a/frontend/seo/product-list/hreflangs.ts
+++ b/frontend/seo/product-list/hreflangs.ts
@@ -115,6 +115,7 @@ const usHreflangsPaths = {
    macbook: 'Parts/MacBook',
    'apple-macbook-parts': 'Parts/Mac_Laptop',
    parts: 'Parts',
+   'black-friday-deals': 'Shop/Black_Friday',
 };
 
 const euHreflangPaths: Partial<Record<Collection, string>> = {


### PR DESCRIPTION
Satisfies https://github.com/iFixit/ifixit/issues/50809 for the headless store

## QA

Make sure that `/Shop/Black_Friday` has only the hreflangs in the parent issue, and make sure other pages don't.