### PR TITLE
Parts Collection Feature Flag: Don't mutate the server response

### DIFF
--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -116,7 +116,7 @@ export default function SolutionCard({
    const { ref } = LinkToTOC<HTMLDivElement>(solution.id, bufferPx);
    const partCollectionLinkCardFlag = useFlag('part-collection-linkcards');
 
-   solution.partCollections = partCollectionLinkCardFlag
+   const partCollections = partCollectionLinkCardFlag
       ? solution.partCollections
       : [];
 
@@ -144,7 +144,7 @@ export default function SolutionCard({
                <LinkCards
                   guides={solution.guides}
                   products={solution.products}
-                  partCollections={solution.partCollections}
+                  partCollections={partCollections}
                />
             )}
          </Stack>


### PR DESCRIPTION
1. This code is being SSR'ed without the feature flag. That mutates the solutions array and sets the parts collection to an empty array.
2. Then when the client passes the feature flag, it sets the partsCollection array to the empty array of solutions.partsCollection that we just mutated.
3. Setting this to a const instead of mutating the original array fixes the issue.

Qa_req 0 - this is still behind the feature flag.

Connects https://github.com/iFixit/ifixit/issues/50601