### PR TITLE
Ifixit TroubleShooting API: Encode Parameters

### DIFF
--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/page.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/page.tsx
@@ -53,8 +53,8 @@ async function getTroubleshootingListData(
       origin: ifixitOrigin,
       headers: VarnishBypassHeader,
    });
-
-   const url = `Troubleshooting/Collection/${device}`;
+   const encodedDevice = encodeURIComponent(device);
+   const url = `Troubleshooting/Collection/${encodedDevice}`;
 
    try {
       return await client.get<TroubleshootingListProps>(

--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -55,7 +55,7 @@ export async function fetchMultipleDeviceImages(
    });
    try {
       const result = await client.get(
-         `wikis/topic_images?` + params.toString(),
+         `wikis/topic_images?` + encodeURIComponent(params.toString()),
          'device-images'
       );
       return MultipleDeviceApiResponseSchema.parse(result);

--- a/frontend/templates/troubleshooting/server.tsx
+++ b/frontend/templates/troubleshooting/server.tsx
@@ -75,13 +75,15 @@ function getTroubleshootingApiUrl(
    const wikiname = context.params?.wikiname;
 
    if (wikiname && typeof wikiname === 'string') {
-      return `Troubleshooting/${wikiname}`;
+      const encodedWikiname = encodeURIComponent(wikiname);
+      return `Troubleshooting/${encodedWikiname}`;
    }
 
    const wikiid = context.params?.wikiid;
 
    if (wikiid && typeof wikiid === 'string') {
-      return `Troubleshooting/wikiid/${wikiid}`;
+      const encodedWikiid = encodeURIComponent(wikiid);
+      return `Troubleshooting/wikiid/${encodedWikiid}`;
    }
 
    return null;


### PR DESCRIPTION
## Overview

Before we werent encoding, which was resulting in bad requests that returned the doc endpoint and broke things in react-commerce. Now we encode so we at least hit the expected endpoint and don't redirect.

## QA

You can see the error on `/Troubleshooting/Television/TV+Has+Sound+But+No+Picture/493422` vs `/Troubleshooting/Television/TV+Has+Sound+But+No+Picture/..%2f..%2fpackage.json`. It should no longer 500

Closes: #50760