### PR TITLE
Troubleshooting: Part collections card: Remove feature flag

### DIFF
--- a/frontend/templates/troubleshooting/solution.tsx
+++ b/frontend/templates/troubleshooting/solution.tsx
@@ -24,7 +24,6 @@ import {
 } from './Resource';
 import { HeadingSelfLink } from './components/HeadingSelfLink';
 import { LinkToTOC, useTOCBufferPxScrollOnClick } from './tocContext';
-import { useFlag } from '@ifixit/react-feature-flags';
 
 function SolutionHeader({
    index,
@@ -114,11 +113,6 @@ export default function SolutionCard({
 }) {
    const bufferPx = useBreakpointValue({ base: -46, lg: -6 });
    const { ref } = LinkToTOC<HTMLDivElement>(solution.id, bufferPx);
-   const partCollectionLinkCardFlag = useFlag('part-collection-linkcards');
-
-   const partCollections = partCollectionLinkCardFlag
-      ? solution.partCollections
-      : [];
 
    return (
       <Box
@@ -144,7 +138,7 @@ export default function SolutionCard({
                <LinkCards
                   guides={solution.guides}
                   products={solution.products}
-                  partCollections={partCollections}
+                  partCollections={solution.partCollections}
                />
             )}
          </Stack>

--- a/packages/feature_flags/flags.json
+++ b/packages/feature_flags/flags.json
@@ -1,8 +1,5 @@
 {
    "extended-related-problems": {
       "userToggle": true
-   },
-   "part-collection-linkcards": {
-      "userToggle": true
    }
 }


### PR DESCRIPTION
## Overview
Releases the new feature!

## Usage
Part collection link cards can now be added to troubleshooting pages just like linked guides or products. Simply add a link to a part collection, just as https://www.ifixit.com/Parts/iPad/Ports. This should be transformed into the storelink wiki text token, which you can also directly make instead: `[storelink|/Parts/iPad/Ports|iPad Ports]`.

On troubleshooting view, these links are extracted into the new link card component.

## QA
1. Add a part collection link to [a troubleshooting wiki](https://www.cominor.com/Wiki/Edit/iPad_Slow_Charge). This only applies to links starting with `/Parts`.
- Links should be transformed into a token: `https://www.ifixit.com/Parts/iPad/Ports` -> `[storelink|/Parts/iPad/Ports|iPad Ports]`
- Link tokens should be transformed into a storelink token: `[link|/Parts/iPad/Ports|iPad Ports]` -> `[storelink|/Parts/iPad/Ports|iPad Ports]`
2. A part collection link should render as a link card on view of the solution. This should match [the Figma design (parts section)](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=588-33&mode=design&t=JtU8nLVwP7hEDFxn-0).
3. Please check the design across all screen sizes and browsers.

Closes https://github.com/iFixit/ifixit/issues/50601