### PR TITLE
Product images: use fallback images

### DIFF
--- a/frontend/models/components/image.ts
+++ b/frontend/models/components/image.ts
@@ -12,6 +12,8 @@ export const ImageSchema = z.object({
    thumbnailUrl: z.string().nullable().optional(),
 });
 
+export const ImageAltFallback = '*fallback';
+
 export type Image = z.infer<typeof ImageSchema>;
 
 interface ImageOptions {

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -202,11 +202,11 @@ function imagesFromQueryProduct(
 
 function isGenericOrActiveVariantImage(
    image: ProductVariantImage,
-   variant: ProductVariant[]
+   variants: ProductVariant[]
 ) {
    return (
       image.variantId == null ||
-      variant.some(
+      variants.some(
          (variant) => isActiveVariant(variant) && variant.id === image.variantId
       )
    );

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -46,6 +46,7 @@ import {
 } from './components/product-video';
 import { getProductSections, ProductSectionSchema } from './sections';
 import { ProductDataApiResponse } from '@lib/ifixit-api/productData';
+import { ImageAltFallback } from '@models/components/image';
 
 export type {
    ProductVariant,
@@ -65,6 +66,7 @@ export const ProductSchema = z.object({
    productcode: z.string().optional(),
    tags: z.array(z.string()),
    images: z.array(ProductVariantImageSchema),
+   fallbackImages: z.array(ProductVariantImageSchema),
    options: z.array(ProductOptionSchema),
    variants: z.array(ProductVariantSchema),
    isEnabled: z.boolean(),
@@ -139,6 +141,9 @@ export async function getProduct({
       productcode: parseItemcode(aVariantSku).productcode,
       tags: shopifyProduct.tags,
       images: imagesFromQueryProduct(shopifyProduct, variants),
+      // Images that are relevant for variants that have no images at all
+      // Do not mix these in with variant images nor product group images.
+      fallbackImages: fallbackImagesFromQueryProduct(shopifyProduct),
       options: shopifyProduct.options.map((option) =>
          productOptionFromShopify(
             option,
@@ -182,9 +187,9 @@ function imagesFromQueryProduct(
    variants: ProductVariant[]
 ): ProductVariantImage[] {
    const allImages = filterFalsyItems(
-      queryProduct.images.nodes.map((image) =>
-         getProductVariantImage(queryProduct, image)
-      )
+      queryProduct.images.nodes
+         .filter((image) => image.altText !== ImageAltFallback)
+         .map((image) => getProductVariantImage(queryProduct, image))
    );
 
    const hasActiveVariants = variants.some(isActiveVariant);
@@ -197,6 +202,16 @@ function imagesFromQueryProduct(
 
    return allImages.filter(
       (image) => image.variantId == null || image.variantId === variants[0]?.id
+   );
+}
+
+function fallbackImagesFromQueryProduct(
+   queryProduct: ShopifyProduct
+): ProductVariantImage[] {
+   return filterFalsyItems(
+      queryProduct.images.nodes
+         .filter((image) => image.altText === ImageAltFallback)
+         .map((image) => getProductVariantImage(queryProduct, image))
    );
 }
 

--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -44,7 +44,18 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
       });
    }, [product.images, selectedVariant.id]);
 
-   const allImages = [...genericImages, ...selectedVariantImages];
+   // Fallback images should only be used when there are no others to represent
+   // the variant.
+   const fallbackImages =
+      genericImages.length == 0 && selectedVariantImages.length == 0
+         ? product.fallbackImages
+         : [];
+
+   const allImages = [
+      ...genericImages,
+      ...selectedVariantImages,
+      ...fallbackImages,
+   ];
 
    const priceValidUntil = new Date();
    priceValidUntil.setFullYear(priceValidUntil.getFullYear() + 1);

--- a/frontend/templates/product/MetaTags.tsx
+++ b/frontend/templates/product/MetaTags.tsx
@@ -44,6 +44,8 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
       });
    }, [product.images, selectedVariant.id]);
 
+   const allImages = [...genericImages, ...selectedVariantImages];
+
    const priceValidUntil = new Date();
    priceValidUntil.setFullYear(priceValidUntil.getFullYear() + 1);
 
@@ -102,13 +104,8 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
             ));
          })}
 
-         {genericImages.length > 0 &&
-            genericImages.map((image) => (
-               <meta key={image.id} property="og:image" content={image.url} />
-            ))}
-
-         {selectedVariantImages.length > 0 &&
-            selectedVariantImages.map((image) => (
+         {allImages.length > 0 &&
+            allImages.map((image) => (
                <meta key={image.id} property="og:image" content={image.url} />
             ))}
 
@@ -147,9 +144,7 @@ export function MetaTags({ product, selectedVariant }: MetaTagsProps) {
                   name: product.vendor || 'iFixit',
                },
                description: shortDescription || '',
-               image: [...genericImages, ...selectedVariantImages].map(
-                  (image) => image.url
-               ),
+               image: allImages.map((image) => image.url),
                mpn: selectedVariant.sku || undefined,
                offers: {
                   '@type': 'Offer',

--- a/frontend/templates/product/sections/ProductOverviewSection/ProductGallery.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/ProductGallery.tsx
@@ -170,9 +170,10 @@ export function ProductGallery({
 
 function useVariantImages(product: Product, variantId: string) {
    return React.useMemo(() => {
-      return product.images.filter(
+      const variantImages = product.images.filter(
          (image) => image.variantId == null || image.variantId === variantId
       );
+      return variantImages.length ? variantImages : product.fallbackImages;
    }, [product, variantId]);
 }
 

--- a/frontend/tests/jest/__mocks__/products/battery.ts
+++ b/frontend/tests/jest/__mocks__/products/battery.ts
@@ -179,6 +179,7 @@ export const mockedBatteryProduct: Product = {
       },
    ],
    images: batteryProductImages,
+   fallbackImages: [],
    options: [
       {
          id: 'gid://shopify/ProductOption/8434015174746',

--- a/frontend/tests/jest/__mocks__/products/generic.ts
+++ b/frontend/tests/jest/__mocks__/products/generic.ts
@@ -265,6 +265,7 @@ export const mockedProduct: Product = {
       'A new replacement 2750 mAh battery compatible with the iPhone 6s Plus. 3.80 Volts (V), 10.45 Watt Hours (Wh). This replacement does not require soldering and is compatible with all iPhone 6s Plus models (not iPhone 6, 6 Plus, or 6s).',
    oemPartnership: null,
    images: productImages,
+   fallbackImages: [],
    options: [
       {
          id: 'gid://shopify/ProductOption/5958025085018',

--- a/frontend/tests/jest/__mocks__/products/part.ts
+++ b/frontend/tests/jest/__mocks__/products/part.ts
@@ -184,6 +184,7 @@ export const mockedPartProduct: Product = {
       },
    ],
    images: partProductImages,
+   fallbackImages: [],
    options: [
       {
          id: 'gid://shopify/ProductOption/8466995773530',

--- a/frontend/tests/jest/__mocks__/products/tool.ts
+++ b/frontend/tests/jest/__mocks__/products/tool.ts
@@ -122,6 +122,7 @@ export const mockedToolProduct: Product = {
       },
    ],
    images: toolProductImages,
+   fallbackImages: [],
    options: [
       {
          id: 'gid://shopify/ProductOption/8433952227418',


### PR DESCRIPTION
Products may now have fallback images (only one right now, but using an
array made integration easier). These are only to be used when a variant
has no other image to represent it. They are identified by (altText ===
'*fallback')

Here we extract them into a new property and make use of them wherever
we are using product.images.

We can't inject copies of these fallback images into product.images
otherwise the gallery would show one copy of the fallback for each
variant that uses it.

fallback images won't always be present and we've dealt with that here.
Our schema validation on the cache should protect us against this
change.

Note: We are filtering out fallback images from the normal
product.images because in that array, variantId === null implies it's
valid for all variants and that's not true for fallback images.

### QA
Hand-edit the images for a product with multiple variants to ensure there are no group-level images and only one variant has images (alt text = sku). Upload a group level image and set the alt text to `*fallback`. When viewing this branch, this image should be used for any variants that don't have images but should not be used for variants that *do* have images.

Connect https://github.com/iFixit/ifixit/issues/49086 and https://github.com/iFixit/ifixit/pull/50859