### PR TITLE
Vulcan: Conclusion padding when div is empty

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -172,6 +172,7 @@ const Wiki: NextPageWithLayout<{
                      display={{ base: 'flex', lg: 'grid' }}
                      columnGap={{ lg: 12 }}
                      spacing={4}
+                     height="max-content"
                      sx={{
                         gridTemplateAreas: {
                            lg: `

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -205,7 +205,9 @@ const Wiki: NextPageWithLayout<{
                            </Stack>
                         )}
                      </Stack>
-                     <Conclusion conclusion={filteredConclusions} />
+                     {filteredConclusions.length > 0 && (
+                        <Conclusion conclusion={filteredConclusions} />
+                     )}
                      <RelatedProblemsComponent
                         hasRelatedPages={hasRelatedPages}
                         wikiData={wikiData}


### PR DESCRIPTION
## Issue

We've got an issue where the Conclusion component is rendering empty, but it has a top padding applied, which throws off the UI spacing.

<details>
<img width="1735" alt="Screenshot 2023-11-28 at 2 39 45 PM" src="https://github.com/iFixit/ifixit/assets/1634505/7822df1c-e37a-4e07-a359-7a209a91cdac">

</details>

## CR/QA

`/Troubleshooting/Nintendo_Switch/Will+Not+Turn+On/481634`
`/Troubleshooting/Nest_Cam/Overheating/532364`

<details>
<summary>Post-fix</summary>

<img width="1735" alt="Screenshot 2023-11-28 at 2 52 58 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/9a1bbae6-2f77-4092-bf7c-962d8433ee05">

</details>

Closes https://github.com/iFixit/ifixit/issues/50875