### PR TITLE
Troubleshooting: Show Related Problems appropriately

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -72,7 +72,12 @@ const Wiki: NextPageWithLayout<{
       (conclusion) => conclusion.heading !== 'Related Pages'
    );
 
-   const hasRelatedPages = wikiData.linkedProblems.length > 0;
+   const relatedProblemsFlag = useFlag('extended-related-problems');
+
+   const relatedProblemsLength =
+      wikiData.linkedProblems.length +
+      (relatedProblemsFlag ? wikiData.relatedProblems.length : 0);
+   const hasRelatedPages = relatedProblemsLength > 0;
 
    const firstIntroSection = wikiData.introduction[0] || {};
    const otherIntroSections = wikiData.introduction.slice(1);
@@ -99,7 +104,6 @@ const Wiki: NextPageWithLayout<{
    const tocWidth = '220px';
    const sidebarWidth = '320px';
 
-   const relatedProblemsFlag = useFlag('extended-related-problems');
    const RelatedProblemsComponent = relatedProblemsFlag
       ? RelatedProblemsV2
       : RelatedProblems;


### PR DESCRIPTION
When we have the `extended-related-problems` flag enabled, we have extra
problems potentially included in the `Related Problems` list
(confusingly, these come from the `relatedProblems` key and are added to
the existing `linkedProblems` list). This ensures that we update the
`hasRelatedPages` boolean to accurately reflect the state of the
`Related Problems` section.

## QA Notes
Check that adding `#enable-extended-related-problems` to a troubleshooting page URL results in the extended related-problems section showing up.