### PR TITLE
Troubleshooting: Use deviceTroubleshootingUrl for "View all" link

### DIFF
--- a/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
+++ b/frontend/templates/troubleshooting/hooks/useTroubleshootingProps.tsx
@@ -88,6 +88,7 @@ export type TroubleshootingApiData = {
    answersUrl: string;
    viewStats?: ViewStatsProps;
    deviceGuideUrl?: string;
+   deviceTroubleshootingUrl?: string;
    devicePartsUrl?: string;
    canonicalUrl: string;
    lastUpdatedDate: number;

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -699,8 +699,11 @@ function RelatedProblems({
    wikiData: TroubleshootingData;
    hasRelatedPages?: boolean;
 }) {
-   const { linkedProblems, deviceGuideUrl, countOfAssociatedProblems } =
-      wikiData;
+   const {
+      linkedProblems,
+      deviceTroubleshootingUrl,
+      countOfAssociatedProblems,
+   } = wikiData;
    const { displayTitle, imageUrl, description } = wikiData.category;
 
    const bufferPx = useBreakpointValue({ base: -40, lg: 0 });
@@ -727,7 +730,7 @@ function RelatedProblems({
             displayTitle={displayTitle}
             description={description}
             countOfAssociatedProblems={countOfAssociatedProblems}
-            deviceGuideUrl={deviceGuideUrl}
+            deviceTroubleshootingUrl={deviceTroubleshootingUrl}
          />
       </Stack>
    );
@@ -743,7 +746,7 @@ function RelatedProblemsV2({
    const {
       linkedProblems,
       relatedProblems,
-      deviceGuideUrl,
+      deviceTroubleshootingUrl,
       countOfAssociatedProblems,
    } = wikiData;
    const { displayTitle, imageUrl, description } = wikiData.category;
@@ -778,7 +781,7 @@ function RelatedProblemsV2({
             displayTitle={displayTitle}
             description={description}
             countOfAssociatedProblems={countOfAssociatedProblems}
-            deviceGuideUrl={deviceGuideUrl}
+            deviceTroubleshootingUrl={deviceTroubleshootingUrl}
          />
       </Stack>
    );
@@ -789,13 +792,13 @@ function DeviceCard({
    displayTitle,
    description,
    countOfAssociatedProblems,
-   deviceGuideUrl,
+   deviceTroubleshootingUrl,
 }: {
    imageUrl: string;
    displayTitle: string;
    description: string;
    countOfAssociatedProblems: number;
-   deviceGuideUrl: string | undefined;
+   deviceTroubleshootingUrl: string | undefined;
 }) {
    return (
       <Stack
@@ -854,7 +857,7 @@ function DeviceCard({
                         ? '1 common problem'
                         : countOfAssociatedProblems + ' common problems'}
                   </Text>
-                  <Link href={deviceGuideUrl} textColor="brand.500">
+                  <Link href={deviceTroubleshootingUrl} textColor="brand.500">
                      {countOfAssociatedProblems === 1
                         ? 'View problem'
                         : 'View all'}


### PR DESCRIPTION
Part 2/2

Change the "View all"/"View problem" link on device cards to use the `deviceTroubleshootingUrl` from the API.

Don't deploy until https://github.com/iFixit/ifixit/pull/50890 is merged.

Connects: https://github.com/iFixit/ifixit/pull/50890
Closes: https://github.com/iFixit/ifixit/issues/50886