### PR TITLE
Vulcan: Sidebar order breakpoint incorrect

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -305,6 +305,7 @@ const troubleshootingStyles: SystemStyleObject = {
 
       '& + ul, & + ol': {
          overflowX: 'auto', // clear sibling lists
+         minWidth: '25%', // prevent unreadable collapsing lists
       },
 
       '&.imageBox_center': {

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -173,19 +173,19 @@ const Wiki: NextPageWithLayout<{
                >
                   <Stack
                      id="main"
-                     display={{ base: 'flex', lg: 'grid' }}
-                     columnGap={{ lg: 12 }}
+                     display={{ base: 'flex', xl: 'grid' }}
+                     columnGap={{ xl: 12 }}
                      spacing={4}
                      height="max-content"
                      sx={{
                         gridTemplateAreas: {
-                           lg: `
+                           xl: `
                               "Content RelatedProblems"
                               "Conclusion RelatedProblems"
                               "AnswersCTA RelatedProblems"
                            `,
                         },
-                        gridTemplateColumns: { lg: `1fr ${sidebarWidth}` },
+                        gridTemplateColumns: { xl: `1fr ${sidebarWidth}` },
                      }}
                   >
                      <Stack spacing={4} gridArea="Content">
@@ -643,25 +643,38 @@ const ConclusionSection = function ConclusionSectionInner({
    const { onClick } = useTOCBufferPxScrollOnClick(conclusion.id);
 
    return (
-      <Box id={conclusion.id} ref={ref}>
-         <HeadingSelfLink id={conclusion.id} onClick={onClick}>
+      <Stack
+         id={conclusion.id}
+         ref={ref}
+         spacing={{ base: 4, sm: 6 }}
+         sx={{
+            '.HeadingSelfLink + .prerendered > ul:first-child': {
+               marginTop: '0',
+            },
+         }}
+      >
+         <HeadingSelfLink
+            id={conclusion.id}
+            onClick={onClick}
+            pt={{ base: 0, sm: 6 }}
+         >
             {conclusion.heading}
          </HeadingSelfLink>
          <PrerenderedHTML html={conclusion.body} template="troubleshooting" />
-      </Box>
+      </Stack>
    );
 };
 
 function Conclusion({ conclusion: conclusions }: { conclusion: Section[] }) {
    return (
-      <Box pt={{ base: 0, sm: 6 }} gridArea="Conclusion">
+      <Stack spacing={{ base: 4, xl: 6 }} gridArea="Conclusion">
          {conclusions.map((conclusion) => (
             <ConclusionSection
                key={conclusion.heading}
                conclusion={conclusion}
             />
          ))}
-      </Box>
+      </Stack>
    );
 }
 
@@ -724,7 +737,6 @@ function RelatedProblems({
          width={{ base: '100%' }}
          alignSelf="start"
          fontSize="14px"
-         pt={{ base: 6, xl: 0 }}
          gridArea="RelatedProblems"
       >
          {hasRelatedPages && <LinkedProblems problems={linkedProblems} />}


### PR DESCRIPTION
## Issue
The device card order displays below the related problems on mobile, but it's currently switching at the wrong breakpoint.

<details>
<summary>Pre-fix Video</summary>

https://github.com/iFixit/react-commerce/assets/1634505/d4a61ff9-3b29-4b97-afdf-1fe8b3a13a06

</details>

## CR/QA
Confirm breakpoints have been corrected after adjusting the breakpoint for `#main` content.

<details>
<summary>Post-fix Video</summary>

https://github.com/iFixit/react-commerce/assets/1634505/ab08671d-2d90-4972-93c1-e7a39fcac957

</details>

https://github.com/iFixit/react-commerce/pull/2141/commits/83c18db24cc673e26c0761fbbf3200c76e0912c5 corrects a bug found while testing

Closes https://github.com/iFixit/ifixit/issues/50953