### PR TITLE
Product: Follow Shopify redirects

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -8052,6 +8052,7 @@ export type ProductVariantFieldsFragment = {
 
 export type FindProductQueryVariables = Exact<{
    handle?: InputMaybe<Scalars['String']>;
+   pathQuery?: InputMaybe<Scalars['String']>;
 }>;
 
 export type FindProductQuery = {
@@ -8296,6 +8297,13 @@ export type FindProductQuery = {
          }>;
       };
    } | null;
+   urlRedirects: {
+      __typename?: 'UrlRedirectConnection';
+      edges: Array<{
+         __typename?: 'UrlRedirectEdge';
+         node: { __typename?: 'UrlRedirect'; target: string };
+      }>;
+   };
 };
 
 export type ProductOptionFieldsFragment = {
@@ -8478,7 +8486,7 @@ export const ProductOptionFieldsFragmentDoc = `
 }
     `;
 export const FindProductDocument = `
-    query findProduct($handle: String) {
+    query findProduct($handle: String, $pathQuery: String) {
   product(handle: $handle) {
     id
     title
@@ -8562,6 +8570,13 @@ export const FindProductDocument = `
       }
     }
     vendor
+  }
+  urlRedirects(first: 1, query: $pathQuery) {
+    edges {
+      node {
+        target
+      }
+    }
   }
 }
     ${ProductPreviewFieldsFragmentDoc}

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -1,4 +1,4 @@
-query findProduct($handle: String) {
+query findProduct($handle: String, $pathQuery: String) {
    product(handle: $handle) {
       id
       title
@@ -100,6 +100,13 @@ query findProduct($handle: String) {
          }
       }
       vendor
+   }
+   urlRedirects(first: 1, query: $pathQuery) {
+      edges {
+         node {
+            target
+         }
+      }
    }
 }
 

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -56,6 +56,7 @@ export type {
 export type Product = z.infer<typeof ProductSchema>;
 
 export const ProductSchema = z.object({
+   __typename: z.literal('Product'),
    id: z.string(),
    handle: z.string(),
    title: z.string(),
@@ -131,6 +132,7 @@ export async function getProduct({
    const noindex = shopifyProduct.noindex?.value === '1';
 
    return {
+      __typename: 'Product',
       id: shopifyProduct.id,
       handle: shopifyProduct.handle,
       noindex,

--- a/frontend/models/product/server.ts
+++ b/frontend/models/product/server.ts
@@ -15,6 +15,7 @@ export type FindProductArgs = {
 
 type ShopifyProductRedirect = z.infer<typeof ShopifyProductRedirectSchema>;
 export const ShopifyProductRedirectSchema = z.object({
+   __typename: z.literal('ShopifyProductRedirect'),
    target: z.string(),
 });
 
@@ -59,7 +60,9 @@ export async function findProduct({
       iFixitProduct: iFixitQueryResponse,
    });
    if (product == null) {
-      return urlRedirect ? { target: urlRedirect } : null;
+      return urlRedirect
+         ? { __typename: 'ShopifyProductRedirect', target: urlRedirect }
+         : null;
    }
 
    return product;

--- a/frontend/pages/api/nextjs/cache/product.ts
+++ b/frontend/pages/api/nextjs/cache/product.ts
@@ -1,7 +1,10 @@
 import { Duration } from '@lib/duration';
 import { withCache } from '@lib/swr-cache';
 import { ProductSchema } from '@models/product';
-import { findProduct } from '@models/product/server';
+import {
+   ShopifyProductRedirectSchema,
+   findProduct,
+} from '@models/product/server';
 import { z } from 'zod';
 
 export type {
@@ -18,7 +21,9 @@ export default withCache({
       storeCode: z.string(),
       ifixitOrigin: z.string(),
    }),
-   valueSchema: ProductSchema.nullable(),
+   valueSchema: z
+      .union([ProductSchema, ShopifyProductRedirectSchema])
+      .nullable(),
    async getFreshValue({ handle, storeCode, ifixitOrigin }) {
       return findProduct({
          handle,

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
          { forceMiss }
       );
 
-      if (product && 'target' in product) {
+      if (product?.__typename === 'ShopifyProductRedirect') {
          return {
             redirect: {
                destination: product.target,

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -38,6 +38,15 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
          { forceMiss }
       );
 
+      if (product && 'target' in product) {
+         return {
+            redirect: {
+               destination: product.target,
+               permanent: true,
+            },
+         };
+      }
+
       if (product == null) {
          return {
             notFound: true,

--- a/frontend/tests/jest/__mocks__/products/battery.ts
+++ b/frontend/tests/jest/__mocks__/products/battery.ts
@@ -90,6 +90,7 @@ const batteryProductVariants: ProductVariant[] = [
 ];
 
 export const mockedBatteryProduct: Product = {
+   __typename: 'Product',
    id: 'gid://shopify/Product/6556284026970',
    title: 'Moto G7 Play Battery',
    handle: 'moto-g7-play-replacement-battery',

--- a/frontend/tests/jest/__mocks__/products/generic.ts
+++ b/frontend/tests/jest/__mocks__/products/generic.ts
@@ -181,6 +181,7 @@ const productVariants: ProductVariant[] = [
 ];
 
 export const mockedProduct: Product = {
+   __typename: 'Product',
    id: 'gid://shopify/Product/1231231231231',
    title: 'Mocked Product Title',
    handle: 'iphone-6s-plus-replacement-battery',

--- a/frontend/tests/jest/__mocks__/products/part.ts
+++ b/frontend/tests/jest/__mocks__/products/part.ts
@@ -94,6 +94,7 @@ const partProductVariants: ProductVariant[] = [
 ];
 
 export const mockedPartProduct: Product = {
+   __typename: 'Product',
    id: 'gid://shopify/Product/6581511684186',
    title: 'Galaxy A51 Screen',
    handle: 'galaxy-a51-screen',

--- a/frontend/tests/jest/__mocks__/products/tool.ts
+++ b/frontend/tests/jest/__mocks__/products/tool.ts
@@ -80,6 +80,7 @@ const toolProductVariants: ProductVariant[] = [
 ];
 
 export const mockedToolProduct: Product = {
+   __typename: 'Product',
    id: 'gid://shopify/Product/6556235071578',
    title: 'Hakko 5B SA Curved Tweezers',
    handle: 'hakko-5b-sa-curved-tweezers',

--- a/frontend/tests/playwright/fixtures/shopify-mocked-queries.ts
+++ b/frontend/tests/playwright/fixtures/shopify-mocked-queries.ts
@@ -983,4 +983,5 @@ export const findProductQueryMock: FindProductQuery = {
       },
       vendor: '',
    },
+   urlRedirects: { edges: [] },
 };


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/50841

Our PHP [backend](https://github.com/iFixit/ifixit/blob/master/iFixit/Shopify/ShopifyUrlHandleRedirectJob.php) adds product redirects to Shopify whenever a product handle is changed.

## QA

Shopify redirects should be followed, unless the given handle corresponds to an enabled product that exists.

For example, `/products/t5-torx-screwdriver-1` should redirect to `/products/t5-torx-screwdriver`.
![image](https://github.com/iFixit/react-commerce/assets/52104630/3c569346-b2ae-4286-b14e-41a8d15bd7b0)

For a specific path or target, you can use
https://admin.shopify.com/store/ifixit-us/redirects.json?path=/products/macbook-pro-13-a2159-2019-trackpad


Existing product redirects are viewable at https://admin.shopify.com/store/ifixit-test/redirects.json