### PR TITLE
Create valid redirect urls when params exist

### DIFF
--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -54,10 +54,16 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       }
 
       if (product.redirectUrl) {
-         const query = new URL(urlFromContext(context)).search;
+         const destination = new URL(product.redirectUrl);
+         const requestParams = new URL(urlFromContext(context)).searchParams;
+         requestParams.forEach((value, key) => {
+            if (!destination.searchParams.has(key)) {
+               destination.searchParams.append(key, value);
+            }
+         });
          return {
             redirect: {
-               destination: `${product.redirectUrl}${query}`,
+               destination: destination.href,
                permanent: true,
             },
          };


### PR DESCRIPTION
Connects https://github.com/iFixit/ifixit/issues/45225

Creates a valid url when both the redirect url and the request url have search params. If the urls have overlapping params, the parameters from the redirect url are used.

## QA

- Give a product a redirect url in shopify admin that has a query param (the redirect url must point to a different product).
  - For example, I gave [arctic silver thermal paste](https://admin.shopify.com/store/ifixit-test/products/6579687948378) a redirect to https://www.ifixit.com/products/ifixit-thermal-paste?variant=40263220166759
- Then try to visit `/products/arctic-silver-thermal-paste` on the react-commerce deployment with some existing query params.
  - Maybe `?a=b` or `?a=b&b=c` or `?variant=39333662982234` which is the other [detailing brush variant](https://admin.shopify.com/store/ifixit-test/products/6556177203290/variants/39333662982234)
- Confirm that the request url params are appended to the redirect url params. The redirect url params (particularly `variant`) should take precedence over the request url params.