### PR TITLE
Troubleshooting: 4:3 link card images

### DIFF
--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -64,6 +64,7 @@ export function ProductResource({ product }: { product: SectionProduct }) {
          spacing={1}
          showBuyButton={true}
          openInNewTab={true}
+         imageRatio={1}
       >
          <ResourceProductRating product={product} />
          <ResourceProductPrice price={price} />
@@ -199,6 +200,7 @@ function Resource({
    showBuyButton,
    openInNewTab,
    children,
+   imageRatio = 4 / 3,
 }: React.PropsWithChildren<{
    title: string;
    showStackedImages?: boolean;
@@ -210,6 +212,7 @@ function Resource({
    href: string;
    showBuyButton?: string | boolean;
    openInNewTab?: boolean;
+   imageRatio?: number;
 }>) {
    const difficultyTheme =
       difficulty && hasKey(DifficultyThemeLookup, difficulty)
@@ -230,7 +233,7 @@ function Resource({
                   borderRadius="md"
                   outline="1px solid"
                   outlineColor="gray.300"
-                  aspectRatio={4 / 3}
+                  aspectRatio={imageRatio}
                >
                   {showStackedImages && (
                      // Renders an empty box to fake the stacked image effect

--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -170,7 +170,7 @@ function ResourceBox({
          borderColor="gray.400"
          borderWidth="1px"
          borderRadius="md"
-         minHeight="88px"
+         minHeight="72px"
          padding={3}
          display="flex"
          width="100%"
@@ -224,41 +224,42 @@ function Resource({
    return (
       <ResourceBox>
          {imageUrl && (
-            <Box
-               position="relative"
-               mr={2}
-               boxSize="64px"
-               minWidth="64px"
-               borderRadius="md"
-               outline="1px solid"
-               outlineColor="gray.300"
-            >
-               {showStackedImages && (
-                  // Renders an empty box to fake the stacked image effect
-                  <Box
-                     width="100%"
-                     height="100%"
-                     borderRadius="inherit"
+            <Box width="64px" position="relative" mr={2}>
+               <Box
+                  width="100%"
+                  borderRadius="md"
+                  outline="1px solid"
+                  outlineColor="gray.300"
+                  aspectRatio={4 / 3}
+               >
+                  {showStackedImages && (
+                     // Renders an empty box to fake the stacked image effect
+                     <Box
+                        aspectRatio="inherit"
+                        width="inherit"
+                        height="inherit"
+                        borderRadius="inherit"
+                        outline="inherit"
+                        outlineColor="inherit"
+                        position="absolute"
+                        top="0"
+                        transform="rotate(6deg)"
+                     />
+                  )}
+                  <Image
                      outline="inherit"
                      outlineColor="inherit"
-                     position="absolute"
-                     top="0"
-                     transform="rotate(6deg)"
+                     borderRadius="inherit"
+                     objectFit="contain"
+                     width="100%"
+                     height="100%"
+                     alt={title}
+                     src={imageUrl}
+                     position="relative"
+                     zIndex="1"
+                     bgColor="white"
                   />
-               )}
-               <Image
-                  outline="inherit"
-                  outlineColor="inherit"
-                  borderRadius="inherit"
-                  objectFit="contain"
-                  width="100%"
-                  height="100%"
-                  alt={title}
-                  src={imageUrl}
-                  position="relative"
-                  zIndex="1"
-                  bgColor="white"
-               />
+               </Box>
             </Box>
          )}
          <Flex flex="1" flexDirection={{ base: 'column', sm: 'row' }}>


### PR DESCRIPTION
## Overview
Makes the link card images on troubleshooting pages 4:3 ratio to match [the figma](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=588-33&mode=design&t=oZ88nbX5qcuK3xcO-0).

This also keeps product link card images in 1:1 ratio because those images will always be 1:1.

## QA
- Check that [part collection link cards](http://localhost:3000/Troubleshooting/iPhone/Won't+Turn+On/405189?revisionid=HEAD) and [guide link cards](/Troubleshooting/Refrigerator/Compressor+Not+Running/505022) now have a 4:3 aspect ratio and matches [the figma](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=588-33&mode=design&t=oZ88nbX5qcuK3xcO-0).
- Check that [product link cards](http://localhost:3000/Troubleshooting/Refrigerator/Compressor+Not+Running/505022#Section_Thermistor_Failure_Faulty_Defrost_Temperature_Sensor) still have 1:1 aspect ratio.

Connects https://github.com/iFixit/ifixit/issues/50990