### PR TITLE
VSCode: Update eslint Setting Value

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
    "editor.formatOnSave": false,
    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "always"
    },
    "[javascript][javascriptreact][typescript][typescriptreact]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode",


### PR DESCRIPTION
## Issue
I noticed an odd automatic update to our `source.fixAll.eslint` setting, dig a little digging, and found that the values have changed from boolean: https://code.visualstudio.com/updates/v1_83#_code-actions-on-save-and-auto-save 

This updates our setting, so autosave still functions as it currently does.

## CR
Confirm formatting on VSCode still functions as expected with the new `always` value.

qa_req 0

