### PR TITLE
GitHub Actions: Enable masking option for ECR Login

### DIFF
--- a/.github/workflows/deploy-strapi.yml
+++ b/.github/workflows/deploy-strapi.yml
@@ -31,7 +31,7 @@ jobs:
            id: login-ecr
            uses: aws-actions/amazon-ecr-login@v1
            with:
-               mask-password: true
+              mask-password: true
 
          - name: Build, Tag, and Push Base Image to Amazon ECR Private
            env:

--- a/.github/workflows/deploy-strapi.yml
+++ b/.github/workflows/deploy-strapi.yml
@@ -30,6 +30,8 @@ jobs:
          - name: Login to Amazon ECR
            id: login-ecr
            uses: aws-actions/amazon-ecr-login@v1
+           with:
+               mask-password: true
 
          - name: Build, Tag, and Push Base Image to Amazon ECR Private
            env:


### PR DESCRIPTION
## Description

There is a warning about the 'mask-password' option for the "amazon-ecr-login" action. If ran in debug mode, the password will be outputted. By default this option is not enabled as the expectation is to run the service after the deployment but as a secondary job. As such the password cannot be masked as it is needed to run the service.

https://github.com/aws-actions/amazon-ecr-login#run-an-image-as-a-service

However, this is not the workflow we have set up, therefore we need to enable the option to mask the password.

Reference: https://github.com/iFixit/vigilo/pull/19