### PR TITLE
Vulcan: Conditionally render Conclusion TOCHeading

### DIFF
--- a/frontend/templates/troubleshooting/components/Causes.tsx
+++ b/frontend/templates/troubleshooting/components/Causes.tsx
@@ -55,7 +55,7 @@ export function Causes(
             {solutions.map((cause, index) => (
                <Cause key={cause.uniqueId} causeNumber={index + 1} {...cause} />
             ))}
-            <TOCHeading>Conclusion</TOCHeading>
+            {conclusions.length > 0 && <TOCHeading>Conclusion</TOCHeading>}
             {conclusions.map((conclusion) => (
                <Conclusion key={conclusion.uniqueId} {...conclusion} />
             ))}

--- a/frontend/templates/troubleshooting/components/Causes.tsx
+++ b/frontend/templates/troubleshooting/components/Causes.tsx
@@ -55,7 +55,7 @@ export function Causes(
             {solutions.map((cause, index) => (
                <Cause key={cause.uniqueId} causeNumber={index + 1} {...cause} />
             ))}
-            <TOCHeading className="conclusion">Conclusion</TOCHeading>
+            <TOCHeading>Conclusion</TOCHeading>
             {conclusions.map((conclusion) => (
                <Conclusion key={conclusion.uniqueId} {...conclusion} />
             ))}
@@ -240,15 +240,12 @@ const squareStyles = {
 
 function TOCHeading({
    children,
-   className,
 }: {
    children: React.ReactNode & HeadingProps;
-   className?: string;
 }) {
    return (
       <Heading
          as="h3"
-         className={className}
          fontSize={{ base: '20px', mdPlus: 'sm' }}
          fontWeight={{ base: 'semibold', mdPlus: 'medium' }}
          my={3}
@@ -258,7 +255,7 @@ function TOCHeading({
             '&:first-child': {
                mt: 1,
             },
-            '&.conclusion': {
+            '&:not(:first-child)': {
                [`@media (min-width: ${useToken('breakpoints', 'mdPlus')})`]: {
                   display: 'none',
                },

--- a/frontend/templates/troubleshooting/components/Causes.tsx
+++ b/frontend/templates/troubleshooting/components/Causes.tsx
@@ -55,7 +55,7 @@ export function Causes(
             {solutions.map((cause, index) => (
                <Cause key={cause.uniqueId} causeNumber={index + 1} {...cause} />
             ))}
-            {conclusions.length > 0 && <TOCHeading>Conclusion</TOCHeading>}
+            <TOCHeading className="conclusion">Conclusion</TOCHeading>
             {conclusions.map((conclusion) => (
                <Conclusion key={conclusion.uniqueId} {...conclusion} />
             ))}
@@ -241,12 +241,15 @@ const squareStyles = {
 
 function TOCHeading({
    children,
+   className,
 }: {
    children: React.ReactNode & HeadingProps;
+   className?: string;
 }) {
    return (
       <Heading
          as="h3"
+         className={className}
          fontSize={{ base: '20px', mdPlus: 'sm' }}
          fontWeight={{ base: 'semibold', mdPlus: 'medium' }}
          my={3}
@@ -255,6 +258,11 @@ function TOCHeading({
          sx={{
             '&:first-child': {
                mt: 1,
+            },
+            '&.conclusion': {
+               [`@media (min-width: ${useToken('breakpoints', 'mdPlus')})`]: {
+                  display: 'none',
+               },
             },
          }}
       >

--- a/frontend/templates/troubleshooting/components/Causes.tsx
+++ b/frontend/templates/troubleshooting/components/Causes.tsx
@@ -160,7 +160,6 @@ function Problem() {
          href={`#related-problems`}
          {...linkStyles}
          sx={{
-            display: 'flex',
             [`@media (min-width: ${useToken('breakpoints', 'mdPlus')})`]: {
                display: 'none',
             },

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -137,10 +137,8 @@ const Wiki: NextPageWithLayout<{
    const tocWidth = '220px';
    const sidebarWidth = '320px';
 
-   const layoutSwitchBreakpoint = useToken('breakpoints', 'mdPlus');
    const layoutSwitch = {
-      display: 'block',
-      [`@media (min-width: ${layoutSwitchBreakpoint})`]: {
+      [`@media (min-width: ${useToken('breakpoints', 'mdPlus')})`]: {
          display: 'none',
       },
    };


### PR DESCRIPTION
## Issue

Found a bug where we were displaying the Conclusion TOCHeading without content on https://www.ifixit.com/Troubleshooting/Garbage_Disposal/Hums/491105. 

<details>

<img width="1728" alt="Screenshot 2023-12-12 at 4 23 59 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/2d6c9bc5-32d0-43a9-ba8b-cfa3412c0e9b">

</details>

Noted in original pull: https://github.com/iFixit/react-commerce/pull/2143#issuecomment-1853047747

## CR/QA

Confirm were are not displaying an empty TOC Heading for `Conclusion` on various `/Troubleshooting` pages

`/Troubleshooting/Refrigerator/Ice+Maker+Not+Making+Ice/481782`
`/Troubleshooting/Garbage_Disposal/Hums/491105`
`/Troubleshooting/Google_Phone/Google+Pixel+Overheating/479437`
...