### PR TITLE
Actions: Update `aws-actions/amazon-ecr-login` from v1 to v2

### DIFF
--- a/.github/workflows/deploy-strapi.yml
+++ b/.github/workflows/deploy-strapi.yml
@@ -22,7 +22,7 @@ jobs:
            uses: actions/checkout@v3
 
          - name: Configure AWS credentials
-           uses: aws-actions/configure-aws-credentials@v2
+           uses: aws-actions/configure-aws-credentials@v4
            with:
               role-to-assume: 'arn:aws:iam::884681002735:role/github_actions/github-actions-role'
               aws-region: us-east-1

--- a/.github/workflows/deploy-strapi.yml
+++ b/.github/workflows/deploy-strapi.yml
@@ -29,9 +29,7 @@ jobs:
 
          - name: Login to Amazon ECR
            id: login-ecr
-           uses: aws-actions/amazon-ecr-login@v1
-           with:
-              mask-password: true
+           uses: aws-actions/amazon-ecr-login@v2
 
          - name: Build, Tag, and Push Base Image to Amazon ECR Private
            env:


### PR DESCRIPTION
## Summary

Updates `aws-actions/amazon-ecr-login` from v1 to v2.

This will set the `mask-password` option to true by default
so it prevents logging the password in the debug mode, [ref](https://github.com/aws-actions/amazon-ecr-login#new-v2-release).

qa_req 0
connects https://github.com/iFixit/ifixit/issues/51077 