### PR TITLE
Header: Update Design

### DIFF
--- a/frontend/components/community/navigation.tsx
+++ b/frontend/components/community/navigation.tsx
@@ -167,7 +167,7 @@ export default function NavigationDisplay({
                      fontSize={`${fontSize.md}`}
                      fontWeight={`${fontWeight.normal}`}
                   >
-                     {'Join the Community'}
+                     {'Community'}
                   </Button>
                )}
             </ButtonGroup>

--- a/packages/ui/header/Search.tsx
+++ b/packages/ui/header/Search.tsx
@@ -64,7 +64,7 @@ export const SearchInput = forwardRef<InputGroupProps, 'input'>(
                   h="4"
                   mr="-2"
                   mb="-1px"
-                  color="gray.400"
+                  color="gray.600"
                />
             </InputLeftElement>
             <Input
@@ -72,18 +72,16 @@ export const SearchInput = forwardRef<InputGroupProps, 'input'>(
                name="query"
                placeholder="Search"
                _placeholder={{
-                  color: 'gray.400',
+                  color: 'gray.500',
                }}
                tabIndex={0}
                variant="filled"
-               bg="gray.800"
+               bg="gray.200"
+               color="gray.700"
                fontSize="sm"
                borderRadius="full"
-               _hover={{
-                  bg: 'gray.700',
-               }}
                _focus={{
-                  bg: 'gray.700',
+                  bg: 'gray.100',
                }}
             />
          </InputGroup>


### PR DESCRIPTION
# WIP

## Issue

Let's implement Mattia's new header design. It's a nicer UX, and increases usable space by changing `Join the Community` to just `Community`.

<img width="1560" alt="Screenshot 2023-12-12 at 4 53 02 PM" src="https://github.com/iFixit/ifixit/assets/1634505/8f0049d4-f648-4905-bd55-84ffdbb3fff1">

[Mockup](https://www.figma.com/file/sfj6r7Bn6eREMvuqo0f7Du/iFixit---Components?type=design&node-id=1134-33091&mode=design&t=wvmoQiNw95L7AeLq-4)

## CR/QA

Header changes are isolated to the search box and it's contents, and the `Community` text.

Linked to https://github.com/iFixit/ifixit/issues/51106