### PR TITLE
Vulcan: Fix related problem image corners

### DIFF
--- a/frontend/templates/troubleshooting/Problem.tsx
+++ b/frontend/templates/troubleshooting/Problem.tsx
@@ -47,6 +47,7 @@ export default function ProblemCard({ problem }: { problem: Problem }) {
                height={{ base: '56px', lg: '32px' }}
                mr={2}
                aspectRatio="4 / 3"
+               overflow="hidden"
             >
                <Image
                   height="100%"


### PR DESCRIPTION
## Issue

Image corners are overflowing past the parent bounds when `borderRadius` is applied. Just needs `overflow: hidden` applied.

![image](https://github.com/iFixit/ifixit/assets/72166715/6e365859-5489-482a-b54c-668f1773191a)

## CR/QA

`/Troubleshooting/Google_Phone/Google+Pixel+Overheating/479437#Section_See_Also`

Confirm image corners are now hidden.

<details>
<summary>Post-fix</summary>

<img width="1728" alt="Screenshot 2023-12-14 at 1 25 59 PM" src="https://github.com/iFixit/react-commerce/assets/1634505/5145cb33-7375-4244-878f-3c1bde67501a">

</details>

Closes https://github.com/iFixit/ifixit/issues/50699