### PR TITLE
Product Pages: Support encoded slashes

### DIFF
--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -285,11 +285,23 @@ async function getSafeServerState({
 function getDevicePathSegments(
    context: GetServerSidePropsContext<ParsedUrlQuery>
 ) {
-   const { deviceHandleItemType } = context.params || {};
-   if (Array.isArray(deviceHandleItemType)) {
-      return deviceHandleItemType;
-   }
-   return [];
+   /**
+    * We should be able to use `context.params` here,
+    * but see: https://github.com/vercel/next.js/issues/49646
+    *
+    * Basically something like device:variant%2FWithASlash
+    * Will be parsed into:
+    *   ['device', 'variant', 'WithASlash']
+    * Instead of:
+    *  ['device', 'variant/WithASlash']
+    */
+   const path = context.resolvedUrl.split('?')[0];
+   // turn into an array of path segments
+   const segments = path.split('/').filter(Boolean);
+   // remove the first segment, which is always 'Parts'
+   segments.shift();
+   const decodedSegments = segments.map(decodeURIComponent);
+   return decodedSegments;
 }
 
 function getDeviceCanonicalPath(


### PR DESCRIPTION
See: https://github.com/vercel/next.js/issues/49646

We have slashes in some variants.

You can see the bug by visiting:

 * https://www.ifixit.com/Parts/iPhone_XR:A1984_US%2FCanada
 * Click Any item type and the page loads fine
 * Refresh and the page 404s

This works around the issue by manually handling the url parsing for this page. We only needed the path segments.

