### PR TITLE
Obey Strapi product list redirects

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -3970,6 +3970,18 @@ export type FindProductListQuery = {
                   } | null;
                }>;
             } | null;
+            redirectTo?: {
+               __typename?: 'ProductListEntityResponse';
+               data?: {
+                  __typename?: 'ProductListEntity';
+                  attributes?: {
+                     __typename?: 'ProductList';
+                     deviceTitle?: string | null;
+                     handle: string;
+                     type?: Enum_Productlist_Type | null;
+                  } | null;
+               } | null;
+            } | null;
          } | null;
       }>;
    } | null;
@@ -4304,6 +4316,18 @@ export type ProductListFieldsFragment = {
             priority?: number | null;
          } | null;
       }>;
+   } | null;
+   redirectTo?: {
+      __typename?: 'ProductListEntityResponse';
+      data?: {
+         __typename?: 'ProductListEntity';
+         attributes?: {
+            __typename?: 'ProductList';
+            deviceTitle?: string | null;
+            handle: string;
+            type?: Enum_Productlist_Type | null;
+         } | null;
+      } | null;
    } | null;
 };
 
@@ -6361,6 +6385,15 @@ export const ProductListFieldsFragmentDoc = `
     }
   }
   optionalFilters
+  redirectTo {
+    data {
+      attributes {
+        deviceTitle
+        handle
+        type
+      }
+    }
+  }
 }
     `;
 export const CallToActionFieldsFragmentDoc = `

--- a/frontend/lib/strapi-sdk/operations/findProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/findProductList.graphql
@@ -118,6 +118,15 @@ fragment ProductListFields on ProductList {
       }
    }
    optionalFilters
+   redirectTo {
+      data {
+         attributes {
+            deviceTitle
+            handle
+            type
+         }
+      }
+   }
 }
 
 fragment AncestorProductListFields on ProductList {

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -85,6 +85,16 @@ export async function findProductList(
    const isPartsList =
       productListType === ProductListType.AllParts ||
       productListType === ProductListType.DeviceParts;
+   const redirectTo = productList?.redirectTo?.data?.attributes
+      ? {
+           deviceTitle:
+              productList.redirectTo.data.attributes.deviceTitle ?? null,
+           handle: productList.redirectTo.data.attributes.handle,
+           type: productListTypeFromStrapi(
+              productList.redirectTo.data.attributes.type
+           ),
+        }
+      : null;
 
    const [reusableSections, children] = await Promise.all([
       findProductListReusableSections({
@@ -133,6 +143,7 @@ export async function findProductList(
       wikiInfo: deviceWiki?.info || [],
       isOnStrapi: !!productList,
       itemOverrides: formatItemTypeOverrides(productList?.itemOverrides),
+      redirectTo,
    };
 
    return {

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -100,6 +100,13 @@ const BaseProductListSchema = z.object({
    isOnStrapi: z.boolean(),
    itemOverrides: ProductListItemTypeOverrideIndexedSchema,
    indexVariantsInsteadOfDevice: z.boolean().nullable(),
+   redirectTo: z
+      .object({
+         deviceTitle: z.string().nullable(),
+         handle: z.string(),
+         type: z.nativeEnum(ProductListType),
+      })
+      .nullable(),
 });
 export type BaseProductList = z.infer<typeof BaseProductListSchema>;
 

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -209,14 +209,15 @@ export const getProductListServerSideProps = ({
       }
 
       if (productList.redirectTo) {
-         const destination = productListPath({
+         const path = productListPath({
             productList: productList.redirectTo,
             itemType: itemType ?? undefined,
          });
+         const params = new URL(urlFromContext(context)).searchParams;
          return {
             redirect: {
                permanent: true,
-               destination,
+               destination: `${path}?${params}`,
             },
          };
       }

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -7,7 +7,7 @@ import {
    withCache,
 } from '@helpers/cache-control-helpers';
 import { withLogging } from '@helpers/next-helpers';
-import { ifixitOriginFromHost } from '@helpers/path-helpers';
+import { ifixitOriginFromHost, productListPath } from '@helpers/path-helpers';
 import {
    destylizeDeviceItemType,
    destylizeDeviceTitle,
@@ -52,6 +52,7 @@ export const getProductListServerSideProps = ({
       let productList: ProductList | null;
       let shouldRedirectToCanonical = false;
       let canonicalPath: string | null = null;
+      let itemType: string | null = null;
       const ifixitOrigin = ifixitOriginFromHost(context);
       const cacheOptions = { forceMiss };
 
@@ -85,7 +86,7 @@ export const getProductListServerSideProps = ({
                };
             }
 
-            const itemType = itemTypeHandle
+            itemType = itemTypeHandle
                ? destylizeDeviceItemType(itemTypeHandle)
                : null;
 
@@ -203,6 +204,19 @@ export const getProductListServerSideProps = ({
             redirect: {
                permanent: true,
                destination: canonicalPath,
+            },
+         };
+      }
+
+      if (productList.redirectTo) {
+         const destination = productListPath({
+            productList: productList.redirectTo,
+            itemType: itemType ?? undefined,
+         });
+         return {
+            redirect: {
+               permanent: true,
+               destination,
             },
          };
       }


### PR DESCRIPTION
Closes https://github.com/iFixit/react-commerce/issues/2067

## QA

Setting a `redirectTo` on a product list in Strapi (https://product-list-redirects.govinor.com/admin) should cause a redirect. Item types will be passed along in the redirect if applicable, but the device variant will not. Any query parameters in the request should also be added to the redirect url.