### PR TITLE
Piwik: Add User Privilege Custom Dimension Tracking

### DIFF
--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -28,6 +28,7 @@ import {
 import {
    trackPiwikPreferredLanguage,
    trackPiwikPreferredStore,
+   trackPiwikUserPrivilege,
 } from '@ifixit/analytics';
 import { useAppContext } from '@ifixit/app';
 import { useAuthenticatedUser } from '@ifixit/auth-sdk';
@@ -95,6 +96,7 @@ const DefaultLayoutComponent = function ({
 
    trackPiwikPreferredStore(PIWIK_ENV);
    trackPiwikPreferredLanguage(PIWIK_ENV, userData?.langid ?? null);
+   trackPiwikUserPrivilege(PIWIK_ENV, userData?.privileges ?? null);
    return (
       <LayoutErrorBoundary>
          <ShopifyStorefrontProvider

--- a/packages/analytics/piwik/index.tsx
+++ b/packages/analytics/piwik/index.tsx
@@ -44,6 +44,21 @@ export function trackPiwikPreferredLanguage(
    }
 }
 
+export function trackPiwikUserPrivilege(
+   piwikEnv: string | undefined,
+   userPrivilege: string[] | null
+): void {
+   const customDimensions = getPiwikCustomDimensionsForEnv(piwikEnv);
+   if (typeof window !== 'undefined' && customDimensions && userPrivilege) {
+      const privilege = userPrivilege.length > 0 ? userPrivilege[0] : 'user';
+      piwikPush([
+         'setCustomDimensionValue',
+         customDimensions['userPrivilege'],
+         privilege,
+      ]);
+   }
+}
+
 export function trackPiwikV2ProductDetailView(items: AnalyticsItem[]) {
    piwikPush(['ecommerceProductDetailView', items.map(formatProduct)]);
 }
@@ -87,6 +102,7 @@ export function trackPiwikCustomAddToCart(
 type PiwikCustomDimensions = {
    preferredStore: number;
    preferredLanguage: number;
+   userPrivilege: number;
 };
 
 function getPiwikCustomDimensionsForEnv(
@@ -97,11 +113,13 @@ function getPiwikCustomDimensionsForEnv(
          return {
             preferredStore: 1,
             preferredLanguage: 2,
+            userPrivilege: 3,
          };
       case 'dev':
          return {
             preferredStore: 1,
             preferredLanguage: 2,
+            userPrivilege: 3,
          };
       default:
          return null;

--- a/packages/analytics/piwik/index.tsx
+++ b/packages/analytics/piwik/index.tsx
@@ -50,7 +50,7 @@ export function trackPiwikUserPrivilege(
 ): void {
    const customDimensions = getPiwikCustomDimensionsForEnv(piwikEnv);
    if (typeof window !== 'undefined' && customDimensions && userPrivilege) {
-      const privilege = userPrivilege.length > 0 ? userPrivilege[0] : 'user';
+      const privilege = userPrivilege.length > 0 ? userPrivilege[0] : 'User';
       piwikPush([
          'setCustomDimensionValue',
          customDimensions['userPrivilege'],

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -1,6 +1,6 @@
 import { IFixitAPIClient, useIFixitApiClient } from '@ifixit/ifixit-api-client';
 import { useLocalPreference } from '@ifixit/ui';
-import { useQuery } from '@tanstack/react-query';
+import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 import * as Sentry from '@sentry/nextjs';
 
@@ -25,9 +25,10 @@ const AuthenticatedUserSchema = z.object({
    links: z.record(z.any()),
    langid: z.string().optional().nullable(),
    unread_notification_count: z.number().optional().nullable(),
+   privileges: z.array(z.string()),
 });
 
-export function useAuthenticatedUser() {
+export function useAuthenticatedUser(): UseQueryResult<User | null> {
    const apiClient = useIFixitApiClient();
    const [cachedUserData, setCachedUserData] = useLocalPreference<User | null>(
       userDataLocalKey,
@@ -110,5 +111,6 @@ async function fetchAuthenticatedUser(
       links: userSchema.data.links,
       langid: userSchema.data.langid ?? null,
       unread_notification_count: userSchema.data.unread_notification_count,
+      privileges: userSchema.data.privileges,
    };
 }


### PR DESCRIPTION
## Overview

We want to track what users are doing what based on user privilege or role (admin, moderator, user, etc). This change will send piwik a userPrivilege dimension if a user is logged in. If the user is not logged in, it will not update or set the dimension.

## QA

Do users have their userPrivilege logged correctly in piwik? If you log out does that userPrivilege change (it shouldn't, we want to track the last privilege you had). 

CC @addison-grant 
Connects: [#51217](https://github.com/iFixit/ifixit/issues/51217)