### PR TITLE
Use redirect sku from iFixit product API

### DIFF
--- a/frontend/lib/ifixit-api/productData.ts
+++ b/frontend/lib/ifixit-api/productData.ts
@@ -1,25 +1,35 @@
 import { IFixitAPIClient } from '@ifixit/ifixit-api-client';
-import { invariant } from '@ifixit/helpers';
+import { captureException } from '@ifixit/sentry';
+import { z } from 'zod';
 
-export type ProductDataApiResponse = {
-   variantOptions: {
-      [o_code: string]: string[];
-   };
-   compatibilityNotes: string[];
-};
+const iFixitFindProductQuerySchema = z.object({
+   variantOptions: z.record(z.array(z.string())),
+   compatibilityNotes: z.array(z.string()),
+});
+export type iFixitFindProductQuery = z.infer<
+   typeof iFixitFindProductQuerySchema
+>;
 
 export async function fetchProductData(
    client: IFixitAPIClient,
    handle: string
-): Promise<ProductDataApiResponse | null> {
+): Promise<iFixitFindProductQuery | null> {
    const productHandle = encodeURIComponent(handle);
-   try {
-      invariant(
-         productHandle.length > 0,
-         'productHandle cannot be a blank string'
-      );
-      return await client.get(`store/product/${productHandle}`, 'product-data');
-   } catch (error: any) {
+   if (!productHandle) return null;
+   const response = await client.get(
+      `store/product/${productHandle}`,
+      'product-data'
+   );
+   const parsed = iFixitFindProductQuerySchema.safeParse(response);
+   if (!parsed.success) {
+      console.error('Invalid product data response', response, parsed.error);
+      captureException('Invalid product data response', {
+         extra: {
+            response,
+            parsing_error: parsed.error,
+         },
+      });
       return null;
    }
+   return parsed.data;
 }

--- a/frontend/lib/ifixit-api/productData.ts
+++ b/frontend/lib/ifixit-api/productData.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 const iFixitFindProductQuerySchema = z.object({
    variantOptions: z.record(z.array(z.string())),
    compatibilityNotes: z.array(z.string()),
+   redirectSkuUrl: z.string().nullable(),
 });
 export type iFixitFindProductQuery = z.infer<
    typeof iFixitFindProductQuerySchema
@@ -22,8 +23,12 @@ export async function fetchProductData(
    );
    const parsed = iFixitFindProductQuerySchema.safeParse(response);
    if (!parsed.success) {
-      console.error('Invalid product data response', response, parsed.error);
-      captureException('Invalid product data response', {
+      console.error(
+         'Invalid product data from iFixit API',
+         response,
+         parsed.error
+      );
+      captureException('Invalid product data from iFixit API', {
          extra: {
             response,
             parsing_error: parsed.error,

--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -8074,7 +8074,6 @@ export type FindProductQuery = {
       prop65Chemicals?: { __typename?: 'Metafield'; value: string } | null;
       productVideos?: { __typename?: 'Metafield'; value: string } | null;
       productVideosJson?: { __typename?: 'Metafield'; value: string } | null;
-      redirectUrl?: { __typename?: 'Metafield'; value: string } | null;
       replacementGuides?: { __typename?: 'Metafield'; value: string } | null;
       featuredProductVariants?: {
          __typename?: 'Metafield';
@@ -8518,9 +8517,6 @@ export const FindProductDocument = `
       value
     }
     productVideosJson: metafield(namespace: "ifixit", key: "product_videos_json") {
-      value
-    }
-    redirectUrl: metafield(namespace: "ifixit", key: "redirect_url") {
       value
     }
     replacementGuides: metafield(namespace: "ifixit", key: "replacement_guides") {

--- a/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
+++ b/frontend/lib/shopify-storefront-sdk/operations/findProduct.graphql
@@ -41,9 +41,6 @@ query findProduct($handle: String, $pathQuery: String) {
       ) {
          value
       }
-      redirectUrl: metafield(namespace: "ifixit", key: "redirect_url") {
-         value
-      }
       replacementGuides: metafield(
          namespace: "ifixit"
          key: "replacement_guides"

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -45,7 +45,7 @@ import {
    ProductVideosSchema,
 } from './components/product-video';
 import { getProductSections, ProductSectionSchema } from './sections';
-import { ProductDataApiResponse } from '@lib/ifixit-api/productData';
+import type { iFixitFindProductQuery } from '@lib/ifixit-api/productData';
 import { ImageAltFallback } from '@models/components/image';
 
 export type {
@@ -90,7 +90,7 @@ export const ProductSchema = z.object({
 
 type ShopifyProduct = NonNullable<ShopifyFindProductQuery['product']>;
 type StrapiProduct = NonNullable<StrapiFindProductQuery['products']>['data'][0];
-type iFixitProduct = NonNullable<ProductDataApiResponse>;
+type iFixitProduct = NonNullable<iFixitFindProductQuery>;
 
 interface GetProductArgs {
    shopifyProduct: ShopifyProduct | null | undefined;

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -82,7 +82,6 @@ export const ProductSchema = z.object({
    reviews: ProductReviewsSchema.nullable(),
    oemPartnership: ProductOemPartnershipSchema.nullable(),
    enabledDomains: z.array(ProductEnabledDomainSchema).nullable(),
-   redirectUrl: z.string().nullable(),
    vendor: z.string().nullable(),
    crossSellVariants: z.array(ProductPreviewSchema),
    sections: z.array(ProductSectionSchema),
@@ -177,7 +176,6 @@ export async function getProduct({
       enabledDomains: productEnabledDomainsFromMetafield(
          shopifyProduct.enabledDomains?.value
       ),
-      redirectUrl: shopifyProduct.redirectUrl?.value ?? null,
       vendor: shopifyProduct.vendor ?? null,
       crossSellVariants: getAllCrossSellProductVariant(shopifyProduct),
       sections,

--- a/frontend/models/product/server.ts
+++ b/frontend/models/product/server.ts
@@ -15,7 +15,7 @@ export type FindProductArgs = {
 
 type ShopifyProductRedirect = z.infer<typeof ShopifyProductRedirectSchema>;
 export const ShopifyProductRedirectSchema = z.object({
-   __typename: z.literal('ShopifyProductRedirect'),
+   __typename: z.literal('ProductRedirect'),
    target: z.string(),
 });
 
@@ -61,7 +61,7 @@ export async function findProduct({
    });
    if (product == null) {
       return urlRedirect
-         ? { __typename: 'ShopifyProductRedirect', target: urlRedirect }
+         ? { __typename: 'ProductRedirect', target: urlRedirect }
          : null;
    }
 

--- a/frontend/models/product/server.ts
+++ b/frontend/models/product/server.ts
@@ -53,6 +53,13 @@ export async function findProduct({
          ),
       ]);
 
+   if (iFixitQueryResponse?.redirectSkuUrl) {
+      return {
+         __typename: 'ProductRedirect',
+         target: iFixitQueryResponse.redirectSkuUrl,
+      };
+   }
+
    const urlRedirect = shopifyQueryResponse.urlRedirects.edges[0]?.node?.target;
    const product = await getProduct({
       shopifyProduct: shopifyQueryResponse.product,

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
          { forceMiss }
       );
 
-      if (product?.__typename === 'ShopifyProductRedirect') {
+      if (product?.__typename === 'ProductRedirect') {
          return {
             redirect: {
                destination: product.target,

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -39,6 +39,13 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       );
 
       if (product?.__typename === 'ProductRedirect') {
+         const destination = new URL(product.target);
+         const requestParams = new URL(urlFromContext(context)).searchParams;
+         requestParams.forEach((value, key) => {
+            if (!destination.searchParams.has(key)) {
+               destination.searchParams.append(key, value);
+            }
+         });
          return {
             redirect: {
                destination: product.target,
@@ -50,22 +57,6 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       if (product == null) {
          return {
             notFound: true,
-         };
-      }
-
-      if (product.redirectUrl) {
-         const destination = new URL(product.redirectUrl);
-         const requestParams = new URL(urlFromContext(context)).searchParams;
-         requestParams.forEach((value, key) => {
-            if (!destination.searchParams.has(key)) {
-               destination.searchParams.append(key, value);
-            }
-         });
-         return {
-            redirect: {
-               destination: destination.href,
-               permanent: true,
-            },
          };
       }
 

--- a/frontend/tests/jest/__mocks__/products/battery.ts
+++ b/frontend/tests/jest/__mocks__/products/battery.ts
@@ -192,7 +192,6 @@ export const mockedBatteryProduct: Product = {
    isEnabled: true,
    iFixitProductId: 'IF390-042',
    productcode: '390042',
-   redirectUrl: null,
    vendor: '',
    crossSellVariants: [],
    sections: [

--- a/frontend/tests/jest/__mocks__/products/generic.ts
+++ b/frontend/tests/jest/__mocks__/products/generic.ts
@@ -285,7 +285,6 @@ export const mockedProduct: Product = {
    productcode: '315007',
    productVideosJson: null,
    enabledDomains: null,
-   redirectUrl: null,
    vendor: '',
    crossSellVariants: [
       {

--- a/frontend/tests/jest/__mocks__/products/part.ts
+++ b/frontend/tests/jest/__mocks__/products/part.ts
@@ -202,7 +202,6 @@ export const mockedPartProduct: Product = {
    isEnabled: true,
    iFixitProductId: 'IF457-000',
    productcode: '457000',
-   redirectUrl: null,
    vendor: '',
    crossSellVariants: [],
    sections: [

--- a/frontend/tests/jest/__mocks__/products/tool.ts
+++ b/frontend/tests/jest/__mocks__/products/tool.ts
@@ -135,7 +135,6 @@ export const mockedToolProduct: Product = {
    isEnabled: true,
    iFixitProductId: 'IF317-048',
    productcode: '317048',
-   redirectUrl: null,
    vendor: '',
    crossSellVariants: [
       {


### PR DESCRIPTION
Connects https://github.com/iFixit/ifixit/issues/45225

## QA

The product redirect sku metafield is no longer used. Instead, we issue the same kind of redirect if the iFixit API returns a `redirectSkuUrl` for a product. You might need to use `?disableCacheGets`.

The api is https://www.cominor.com/api/2.0/store/product/some-product-handle

Blocked by https://github.com/iFixit/ifixit/pull/51270