### PR TITLE
Expand tool category by default

### DIFF
--- a/frontend/templates/product-list/sections/FilterableProductsSection/facets/accordion/index.tsx
+++ b/frontend/templates/product-list/sections/FilterableProductsSection/facets/accordion/index.tsx
@@ -12,7 +12,10 @@ type FacetsAccordianProps = {
    productList: ProductList;
 };
 
-const initialExpandedFacets = ['facet_tags.Item Type'];
+const initialExpandedFacets = [
+   'facet_tags.Item Type',
+   'facet_tags.Tool Category',
+];
 
 export function FacetsAccordion({ productList }: FacetsAccordianProps) {
    const facets = useFilteredFacets(productList);


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/51222

### QA

1. Visit [Vercel preview](https://react-commerce-git-expand-tool-category-facet-acc-749d34-ifixit.vercel.app/Tools/)
2. Verify that the tool category facet accordion is open by default

