### PR TITLE
Tools section backend

### DIFF
--- a/backend/src/api/product/content-types/product/schema.json
+++ b/backend/src/api/product/content-types/product/schema.json
@@ -33,7 +33,8 @@
             "section.banner",
             "section.quote",
             "section.faqs",
-            "product.bit-table"
+            "product.bit-table",
+            "section.tools"
          ],
          "required": true
       }

--- a/backend/src/components/section/tools.json
+++ b/backend/src/components/section/tools.json
@@ -1,0 +1,9 @@
+{
+   "collectionName": "components_section_tools",
+   "info": {
+      "displayName": "Tools",
+      "description": ""
+   },
+   "options": {},
+   "attributes": {}
+}

--- a/backend/types/generated/components.d.ts
+++ b/backend/types/generated/components.d.ts
@@ -488,6 +488,15 @@ export interface SectionStories extends Schema.Component {
    };
 }
 
+export interface SectionTools extends Schema.Component {
+   collectionName: 'components_section_tools';
+   info: {
+      displayName: 'Tools';
+      description: '';
+   };
+   attributes: {};
+}
+
 export interface StoreFooter extends Schema.Component {
    collectionName: 'components_store_footers';
    info: {
@@ -592,6 +601,7 @@ declare module '@strapi/types' {
          'section.service-value-propositions': SectionServiceValuePropositions;
          'section.social-gallery': SectionSocialGallery;
          'section.stories': SectionStories;
+         'section.tools': SectionTools;
          'store.footer': StoreFooter;
          'store.header': StoreHeader;
          'store.shopify-settings': StoreShopifySettings;

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -1110,7 +1110,8 @@ export interface ApiProductProduct extends Schema.CollectionType {
             'section.banner',
             'section.quote',
             'section.faqs',
-            'product.bit-table'
+            'product.bit-table',
+            'section.tools'
          ]
       > &
          Attribute.Required;

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -576,6 +576,11 @@ export type ComponentSectionStories = {
    title?: Maybe<Scalars['String']>;
 };
 
+export type ComponentSectionTools = {
+   __typename?: 'ComponentSectionTools';
+   id: Scalars['ID'];
+};
+
 export type ComponentStoreFooter = {
    __typename?: 'ComponentStoreFooter';
    bottomMenu?: Maybe<MenuEntityResponse>;
@@ -897,6 +902,7 @@ export type GenericMorph =
    | ComponentSectionServiceValuePropositions
    | ComponentSectionSocialGallery
    | ComponentSectionStories
+   | ComponentSectionTools
    | ComponentStoreFooter
    | ComponentStoreHeader
    | ComponentStoreShopifySettings
@@ -1922,6 +1928,7 @@ export type ProductSectionsDynamicZone =
    | ComponentSectionQuote
    | ComponentSectionServiceValuePropositions
    | ComponentSectionStories
+   | ComponentSectionTools
    | Error;
 
 export enum PublicationState {
@@ -3611,6 +3618,7 @@ export type FindProductQuery = {
                     id: string;
                  }
                | { __typename: 'ComponentSectionStories' }
+               | { __typename: 'ComponentSectionTools' }
                | { __typename: 'Error' }
                | null
             >;


### PR DESCRIPTION
Connects https://github.com/iFixit/ifixit/issues/49326

This PR introduces the necessary backend changes to port the old PTT tools section to react-commerce.
Here is the mockup for the new section: https://www.figma.com/file/BolmFORO6ZfHXePOSyEGSS/iFixit---Page-sections?node-id=1839%3A1795&mode=dev

Currently the only scenario in which this section is going to be used is inside the pro tech toolkit product page.

Strapi is currently providing only the section positioning. The section content is static.
This is due to the fact that right now each image requires custom margins and scaling to fit the SVG proportions.
In the future, if we want to make the content of this section dynamic and provide data from Strapi, we will have to consider creating SVGs sized exactly as the tool images. 

1. Visit Vercel [preview](https://react-commerce-git-tools-section-backend-ifixit.vercel.app/products/repair-business-toolkit)
2. Verify that the product page is fully operational - no visible change should be present