### PR TITLE
Product: Add NetSuite admin link

### DIFF
--- a/frontend/helpers/path-helpers.ts
+++ b/frontend/helpers/path-helpers.ts
@@ -80,6 +80,12 @@ export function akeneoUrl() {
    return ifixitOriginWithSubdomain('akeneo');
 }
 
+export function netsuiteProductUrl(sku: string) {
+   return `${IFIXIT_ORIGIN}/api/2.0/cart/netsuite_redirect/${encodeURIComponent(
+      sku
+   )}`;
+}
+
 export interface IFixitAdminProductInvetoryUrlProps {
    product: Pick<Product, 'productcode'>;
 }

--- a/frontend/templates/product/hooks/useProductPageAdminLinks.tsx
+++ b/frontend/templates/product/hooks/useProductPageAdminLinks.tsx
@@ -1,7 +1,8 @@
 import type { PageEditMenuLink } from '@components/admin';
 import {
-   faArrowUpRightFromSquare,
+   faA,
    faImage,
+   faN,
    faShop,
    faWarehouse,
 } from '@fortawesome/pro-solid-svg-icons';
@@ -9,26 +10,34 @@ import {
    akeneoProductUrl,
    iFixitAdminProductImagesUrl,
    iFixitAdminProductInventoryUrl,
+   netsuiteProductUrl,
    shopifyStoreAdminProductUrl,
 } from '@helpers/path-helpers';
-import type { Product } from '@models/product';
+import type { Product, ProductVariant } from '@models/product';
 import { useMemo } from 'react';
 
 interface UseProductPageAdminLinksOptions {
    product: Product;
+   selectedVariant: ProductVariant;
    storeCode: string;
 }
 
 export function useProductPageAdminLinks({
    product,
+   selectedVariant,
    storeCode,
 }: UseProductPageAdminLinksOptions): PageEditMenuLink[] {
    return useMemo(
       () => [
          {
-            icon: faArrowUpRightFromSquare,
+            icon: faA,
             label: 'Akeneo',
             url: akeneoProductUrl({ product }),
+         },
+         {
+            icon: faN,
+            label: 'NetSuite',
+            url: netsuiteProductUrl(selectedVariant.sku ?? ''),
          },
          {
             icon: faShop,
@@ -46,6 +55,6 @@ export function useProductPageAdminLinks({
             url: iFixitAdminProductImagesUrl({ product }),
          },
       ],
-      [product, storeCode]
+      [product, selectedVariant, storeCode]
    );
 }

--- a/frontend/templates/product/index.tsx
+++ b/frontend/templates/product/index.tsx
@@ -79,6 +79,7 @@ const ProductTemplate: NextPageWithLayout<ProductTemplateProps> = () => {
 
    const adminLinks = useProductPageAdminLinks({
       product,
+      selectedVariant,
       storeCode: DEFAULT_STORE_CODE,
    });
 


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/51121

## QA

Visit the Vercel preview logged in with your iFixit account. Visit a product page, and confirm that the admin edit link for netsuite takes you to NetSuite in a new tab.

![image](https://github.com/iFixit/react-commerce/assets/52104630/19620910-463f-4abb-adc6-af9043174ff3)
