### PR TITLE
Handle relative Shopify product redirect urls

### DIFF
--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -39,7 +39,7 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       );
 
       if (product?.__typename === 'ProductRedirect') {
-         const destination = new URL(product.target);
+         const destination = new URL(product.target, ifixitOrigin);
          const requestParams = new URL(urlFromContext(context)).searchParams;
          requestParams.forEach((value, key) => {
             if (!destination.searchParams.has(key)) {


### PR DESCRIPTION
iFixit redirect sku urls are absolute (e.g. https://www.ifixit.com/api/2.0/store/product/arctic-silver-thermal-paste).

Shopify redirect urls are relative (e.g. https://admin.shopify.com/store/ifixit-us/redirects.json?path=/products/apple-watch-series-7-speaker).

This change provides a base url that is used in the case where the redirect url is relative.

## QA

https://www.ifixit.com/products/apple-watch-series-7-speaker should no longer 400 on the production preview for this branch.

The `/products/arctic-silver-thermal-paste` redirect should still work.