### PR TITLE
Strapi: Add redirect type to product list

### DIFF
--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -260,6 +260,11 @@
          "default": false
       },
       "redirectTo": {
+         "pluginOptions": {
+            "i18n": {
+               "localized": false
+            }
+         },
          "type": "relation",
          "relation": "manyToOne",
          "target": "api::product-list.product-list",
@@ -276,6 +281,11 @@
          "default": "permanent"
       },
       "redirectFrom": {
+         "pluginOptions": {
+            "i18n": {
+               "localized": false
+            }
+         },
          "type": "relation",
          "relation": "oneToMany",
          "target": "api::product-list.product-list",

--- a/backend/src/api/product-list/content-types/product-list/schema.json
+++ b/backend/src/api/product-list/content-types/product-list/schema.json
@@ -265,6 +265,16 @@
          "target": "api::product-list.product-list",
          "inversedBy": "redirectFrom"
       },
+      "redirectToType": {
+         "pluginOptions": {
+            "i18n": {
+               "localized": false
+            }
+         },
+         "type": "enumeration",
+         "enum": ["permanent", "temporary"],
+         "default": "permanent"
+      },
       "redirectFrom": {
          "type": "relation",
          "relation": "oneToMany",

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -1342,6 +1342,13 @@ export interface ApiProductListProductList extends Schema.CollectionType {
          'manyToOne',
          'api::product-list.product-list'
       >;
+      redirectToType: Attribute.Enumeration<['permanent', 'temporary']> &
+         Attribute.SetPluginOptions<{
+            i18n: {
+               localized: false;
+            };
+         }> &
+         Attribute.DefaultTo<'permanent'>;
       redirectFrom: Attribute.Relation<
          'api::product-list.product-list',
          'oneToMany',

--- a/backend/types/generated/contentTypes.d.ts
+++ b/backend/types/generated/contentTypes.d.ts
@@ -1341,7 +1341,12 @@ export interface ApiProductListProductList extends Schema.CollectionType {
          'api::product-list.product-list',
          'manyToOne',
          'api::product-list.product-list'
-      >;
+      > &
+         Attribute.SetPluginOptions<{
+            i18n: {
+               localized: false;
+            };
+         }>;
       redirectToType: Attribute.Enumeration<['permanent', 'temporary']> &
          Attribute.SetPluginOptions<{
             i18n: {
@@ -1353,7 +1358,12 @@ export interface ApiProductListProductList extends Schema.CollectionType {
          'api::product-list.product-list',
          'oneToMany',
          'api::product-list.product-list'
-      >;
+      > &
+         Attribute.SetPluginOptions<{
+            i18n: {
+               localized: false;
+            };
+         }>;
       createdAt: Attribute.DateTime;
       updatedAt: Attribute.DateTime;
       publishedAt: Attribute.DateTime;

--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -736,6 +736,11 @@ export enum Enum_Componentsectionfeaturedproducts_Background {
    White = 'white',
 }
 
+export enum Enum_Productlist_Redirecttotype {
+   Permanent = 'permanent',
+   Temporary = 'temporary',
+}
+
 export enum Enum_Productlist_Type {
    AllParts = 'all_parts',
    AllTools = 'all_tools',
@@ -1774,6 +1779,7 @@ export type ProductList = {
    publishedAt?: Maybe<Scalars['DateTime']>;
    redirectFrom?: Maybe<ProductListRelationResponseCollection>;
    redirectTo?: Maybe<ProductListEntityResponse>;
+   redirectToType?: Maybe<Enum_Productlist_Redirecttotype>;
    sections: Array<Maybe<ProductListSectionsDynamicZone>>;
    sortPriority?: Maybe<Scalars['Int']>;
    tagline?: Maybe<Scalars['String']>;
@@ -1856,6 +1862,7 @@ export type ProductListFiltersInput = {
    publishedAt?: InputMaybe<DateTimeFilterInput>;
    redirectFrom?: InputMaybe<ProductListFiltersInput>;
    redirectTo?: InputMaybe<ProductListFiltersInput>;
+   redirectToType?: InputMaybe<StringFilterInput>;
    sortPriority?: InputMaybe<IntFilterInput>;
    tagline?: InputMaybe<StringFilterInput>;
    title?: InputMaybe<StringFilterInput>;
@@ -1891,6 +1898,7 @@ export type ProductListInput = {
    publishedAt?: InputMaybe<Scalars['DateTime']>;
    redirectFrom?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
    redirectTo?: InputMaybe<Scalars['ID']>;
+   redirectToType?: InputMaybe<Enum_Productlist_Redirecttotype>;
    sections?: InputMaybe<Array<Scalars['ProductListSectionsDynamicZoneInput']>>;
    sortPriority?: InputMaybe<Scalars['Int']>;
    tagline?: InputMaybe<Scalars['String']>;

--- a/frontend/lib/strapi-sdk/generated/validation.ts
+++ b/frontend/lib/strapi-sdk/generated/validation.ts
@@ -27,6 +27,7 @@ import {
    Enum_Componentmiscplacement_Showinproductlistpages,
    Enum_Componentpagesplitwithimage_Imageposition,
    Enum_Componentsectionfeaturedproducts_Background,
+   Enum_Productlist_Redirecttotype,
    Enum_Productlist_Type,
    Enum_Reusablesection_Positioninproductlist,
    Enum_Store_Currency,
@@ -554,6 +555,10 @@ export const Enum_Componentpagesplitwithimage_ImagepositionSchema =
 export const Enum_Componentsectionfeaturedproducts_BackgroundSchema =
    z.nativeEnum(Enum_Componentsectionfeaturedproducts_Background);
 
+export const Enum_Productlist_RedirecttotypeSchema = z.nativeEnum(
+   Enum_Productlist_Redirecttotype
+);
+
 export const Enum_Productlist_TypeSchema = z.nativeEnum(Enum_Productlist_Type);
 
 export const Enum_Reusablesection_PositioninproductlistSchema = z.nativeEnum(
@@ -903,6 +908,7 @@ export function ProductListFiltersInputSchema(): z.ZodObject<
       publishedAt: z.lazy(() => DateTimeFilterInputSchema().nullish()),
       redirectFrom: z.lazy(() => ProductListFiltersInputSchema().nullish()),
       redirectTo: z.lazy(() => ProductListFiltersInputSchema().nullish()),
+      redirectToType: z.lazy(() => StringFilterInputSchema().nullish()),
       sortPriority: z.lazy(() => IntFilterInputSchema().nullish()),
       tagline: z.lazy(() => StringFilterInputSchema().nullish()),
       title: z.lazy(() => StringFilterInputSchema().nullish()),
@@ -940,6 +946,7 @@ export function ProductListInputSchema(): z.ZodObject<
       publishedAt: z.unknown().nullish(),
       redirectFrom: z.array(z.string().nullable()).nullish(),
       redirectTo: z.string().nullish(),
+      redirectToType: Enum_Productlist_RedirecttotypeSchema.nullish(),
       sections: z.array(z.lazy(() => z.unknown())).nullish(),
       sortPriority: z.number().nullish(),
       tagline: z.string().nullish(),


### PR DESCRIPTION
Connects https://github.com/iFixit/ifixit/issues/51356

I decided to make `redirectToType` an enum instead of a boolean because I found it more readable as an admin user. If folks disagree I welcome their feedback.

One thing I noticed is that existing product list records do not have a default value populated. It seems like a Strapi bug (or "missing feature") https://github.com/strapi/strapi/issues/18636.

qa_req 0