### PR TITLE
Product list: Use redirect to type

### DIFF
--- a/frontend/lib/strapi-sdk/generated/sdk.ts
+++ b/frontend/lib/strapi-sdk/generated/sdk.ts
@@ -3663,6 +3663,7 @@ export type FindProductListQuery = {
             brandLogoWidth?: number | null;
             indexVariantsInsteadOfDevice?: boolean | null;
             optionalFilters?: string | null;
+            redirectToType?: Enum_Productlist_Redirecttotype | null;
             heroImage?: {
                __typename?: 'UploadFileEntityResponse';
                data?: {
@@ -4020,6 +4021,7 @@ export type ProductListFieldsFragment = {
    brandLogoWidth?: number | null;
    indexVariantsInsteadOfDevice?: boolean | null;
    optionalFilters?: string | null;
+   redirectToType?: Enum_Productlist_Redirecttotype | null;
    heroImage?: {
       __typename?: 'UploadFileEntityResponse';
       data?: {
@@ -6415,6 +6417,7 @@ export const ProductListFieldsFragmentDoc = `
       }
     }
   }
+  redirectToType
 }
     `;
 export const CallToActionFieldsFragmentDoc = `

--- a/frontend/lib/strapi-sdk/operations/findProductList.graphql
+++ b/frontend/lib/strapi-sdk/operations/findProductList.graphql
@@ -127,6 +127,7 @@ fragment ProductListFields on ProductList {
          }
       }
    }
+   redirectToType
 }
 
 fragment AncestorProductListFields on ProductList {

--- a/frontend/models/product-list/component/product-list-redirect-to-type.server.ts
+++ b/frontend/models/product-list/component/product-list-redirect-to-type.server.ts
@@ -1,16 +1,16 @@
 import { Enum_Productlist_Redirecttotype } from '@lib/strapi-sdk';
-import { ProductListRedirectToType } from './product-list-redirect-to-type';
-import type { TProductListRedirectToType } from './product-list-redirect-to-type';
+import { ProductListRedirectToTypeSchema } from './product-list-redirect-to-type';
+import type { ProductListRedirectToType } from './product-list-redirect-to-type';
 
 export function productListRedirectToTypeFromStrapi(
    type?: Enum_Productlist_Redirecttotype | null
-): TProductListRedirectToType {
+): ProductListRedirectToType {
    switch (type) {
       case Enum_Productlist_Redirecttotype.Permanent:
-         return ProductListRedirectToType.enum.Permanent;
+         return ProductListRedirectToTypeSchema.enum.Permanent;
       case Enum_Productlist_Redirecttotype.Temporary:
-         return ProductListRedirectToType.enum.Temporary;
+         return ProductListRedirectToTypeSchema.enum.Temporary;
       default:
-         return ProductListRedirectToType.enum.Permanent;
+         return ProductListRedirectToTypeSchema.enum.Permanent;
    }
 }

--- a/frontend/models/product-list/component/product-list-redirect-to-type.server.ts
+++ b/frontend/models/product-list/component/product-list-redirect-to-type.server.ts
@@ -1,0 +1,16 @@
+import { Enum_Productlist_Redirecttotype } from '@lib/strapi-sdk';
+import { ProductListRedirectToType } from './product-list-redirect-to-type';
+import type { TProductListRedirectToType } from './product-list-redirect-to-type';
+
+export function productListRedirectToTypeFromStrapi(
+   type?: Enum_Productlist_Redirecttotype | null
+): TProductListRedirectToType {
+   switch (type) {
+      case Enum_Productlist_Redirecttotype.Permanent:
+         return ProductListRedirectToType.enum.Permanent;
+      case Enum_Productlist_Redirecttotype.Temporary:
+         return ProductListRedirectToType.enum.Temporary;
+      default:
+         return ProductListRedirectToType.enum.Permanent;
+   }
+}

--- a/frontend/models/product-list/component/product-list-redirect-to-type.ts
+++ b/frontend/models/product-list/component/product-list-redirect-to-type.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const ProductListRedirectToType = z.enum(['Permanent', 'Temporary']);
+export type TProductListRedirectToType = z.infer<
+   typeof ProductListRedirectToType
+>;

--- a/frontend/models/product-list/component/product-list-redirect-to-type.ts
+++ b/frontend/models/product-list/component/product-list-redirect-to-type.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
-export const ProductListRedirectToType = z.enum(['Permanent', 'Temporary']);
-export type TProductListRedirectToType = z.infer<
-   typeof ProductListRedirectToType
+export const ProductListRedirectToTypeSchema = z.enum([
+   'Permanent',
+   'Temporary',
+]);
+export type ProductListRedirectToType = z.infer<
+   typeof ProductListRedirectToTypeSchema
 >;

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -1,6 +1,6 @@
 export type { ProductListAncestor } from './component/product-list-ancestor';
 export type { ProductListPreview } from './component/product-list-preview';
-export { ProductListRedirectToType } from './component/product-list-redirect-to-type';
+export { ProductListRedirectToTypeSchema } from './component/product-list-redirect-to-type';
 export { ProductListType } from './component/product-list-type';
 export type { ProductListSection } from './sections';
 export type { ProductList, ProductSearchHit, WikiInfoEntry } from './types';

--- a/frontend/models/product-list/index.ts
+++ b/frontend/models/product-list/index.ts
@@ -1,5 +1,6 @@
 export type { ProductListAncestor } from './component/product-list-ancestor';
 export type { ProductListPreview } from './component/product-list-preview';
+export { ProductListRedirectToType } from './component/product-list-redirect-to-type';
 export { ProductListType } from './component/product-list-type';
 export type { ProductListSection } from './sections';
 export type { ProductList, ProductSearchHit, WikiInfoEntry } from './types';

--- a/frontend/models/product-list/server.ts
+++ b/frontend/models/product-list/server.ts
@@ -26,6 +26,7 @@ import algoliasearch from 'algoliasearch';
 import { createProductListAncestorsFromStrapiOrDeviceWiki } from './component/product-list-ancestor';
 import type { ProductListChild } from './component/product-list-child';
 import { ProductListType } from './component/product-list-type';
+import { productListRedirectToTypeFromStrapi } from './component/product-list-redirect-to-type.server';
 import { productListTypeFromStrapi } from './component/product-list-type.server';
 import { productListSections } from './sections';
 import { findProductListReusableSections } from './sections/reusable-sections';
@@ -95,6 +96,9 @@ export async function findProductList(
            ),
         }
       : null;
+   const redirectToType = productListRedirectToTypeFromStrapi(
+      productList?.redirectToType
+   );
 
    const [reusableSections, children] = await Promise.all([
       findProductListReusableSections({
@@ -144,6 +148,7 @@ export async function findProductList(
       isOnStrapi: !!productList,
       itemOverrides: formatItemTypeOverrides(productList?.itemOverrides),
       redirectTo,
+      redirectToType,
    };
 
    return {

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -2,6 +2,7 @@ import { ImageSchema } from '@models/components/image';
 import { z } from 'zod';
 import { ProductListAncestorSchema } from './component/product-list-ancestor';
 import { ProductListChildSchema } from './component/product-list-child';
+import { ProductListRedirectToType } from './component/product-list-redirect-to-type';
 import { ProductListType } from './component/product-list-type';
 import { ProductListSectionSchema } from './sections';
 
@@ -107,6 +108,7 @@ const BaseProductListSchema = z.object({
          type: z.nativeEnum(ProductListType),
       })
       .nullable(),
+   redirectToType: ProductListRedirectToType,
 });
 export type BaseProductList = z.infer<typeof BaseProductListSchema>;
 

--- a/frontend/models/product-list/types.ts
+++ b/frontend/models/product-list/types.ts
@@ -2,7 +2,7 @@ import { ImageSchema } from '@models/components/image';
 import { z } from 'zod';
 import { ProductListAncestorSchema } from './component/product-list-ancestor';
 import { ProductListChildSchema } from './component/product-list-child';
-import { ProductListRedirectToType } from './component/product-list-redirect-to-type';
+import { ProductListRedirectToTypeSchema } from './component/product-list-redirect-to-type';
 import { ProductListType } from './component/product-list-type';
 import { ProductListSectionSchema } from './sections';
 
@@ -108,7 +108,7 @@ const BaseProductListSchema = z.object({
          type: z.nativeEnum(ProductListType),
       })
       .nullable(),
-   redirectToType: ProductListRedirectToType,
+   redirectToType: ProductListRedirectToTypeSchema,
 });
 export type BaseProductList = z.infer<typeof BaseProductListSchema>;
 

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -18,7 +18,11 @@ import { assertNever, invariant, timeAsync } from '@ifixit/helpers';
 import { urlFromContext } from '@ifixit/helpers/nextjs';
 import type { DefaultLayoutProps } from '@layouts/default/server';
 import { getLayoutServerSideProps } from '@layouts/default/server';
-import { ProductList, ProductListType } from '@models/product-list';
+import {
+   ProductList,
+   ProductListRedirectToType,
+   ProductListType,
+} from '@models/product-list';
 import ProductListCache from '@pages/api/nextjs/cache/product-list';
 import compose from 'lodash/flowRight';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
@@ -215,9 +219,12 @@ export const getProductListServerSideProps = ({
             itemType: itemType ?? undefined,
          });
          const params = new URL(urlFromContext(context)).searchParams;
+         const permanent =
+            productList.redirectToType ===
+            ProductListRedirectToType.enum.Permanent;
          return {
             redirect: {
-               permanent: true,
+               permanent,
                destination: `${path}?${params}`,
             },
          };

--- a/frontend/templates/product-list/server.tsx
+++ b/frontend/templates/product-list/server.tsx
@@ -20,7 +20,7 @@ import type { DefaultLayoutProps } from '@layouts/default/server';
 import { getLayoutServerSideProps } from '@layouts/default/server';
 import {
    ProductList,
-   ProductListRedirectToType,
+   ProductListRedirectToTypeSchema,
    ProductListType,
 } from '@models/product-list';
 import ProductListCache from '@pages/api/nextjs/cache/product-list';
@@ -221,7 +221,7 @@ export const getProductListServerSideProps = ({
          const params = new URL(urlFromContext(context)).searchParams;
          const permanent =
             productList.redirectToType ===
-            ProductListRedirectToType.enum.Permanent;
+            ProductListRedirectToTypeSchema.enum.Permanent;
          return {
             redirect: {
                permanent,


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/51356

## QA

- Add a `redirectTo` to a product list in Strapi (https://use-product-list-redirect-to-type.govinor.com/admin)
- Set the `redirectToType`. If unset, the behavior should default to a permanent redirect.
- `redirectToType` should control whether the redirect is permanent (308) or temporary (307)