### PR TITLE
Strapi Deploy: Fix deploy message

### DIFF
--- a/backend/strapi-deploy-actions
+++ b/backend/strapi-deploy-actions
@@ -10,7 +10,8 @@ git fetch --tags --quiet
 
 SUBJECT=$(git rev-list --format="%s" --max-count=1 "$STRAPI_COMMIT" | tail -1)
 COMMIT_LINK="<https://github.com/iFixit/react-commerce/commit/$STRAPI_COMMIT|${SUBJECT}>"
-DEPLOY_LOG_TS=$($SLACK --message="Strapi Deploy: Deploying ${COMMIT_LINK} - 📃 <$BUILD_LOG_URL|build log>")
+BUILD_LOG_LINK="<https://github.com/iFixit/react-commerce/actions/runs/$GITHUB_RUN_ID|Build Log>"
+DEPLOY_LOG_TS=$($SLACK --message="Strapi Deploy: Deploying ${COMMIT_LINK} - 📃 ${BUILD_LOG_LINK}")
 $SLACK --thread_ts="$DEPLOY_LOG_TS" --message="Building Docker image"
 
 strapi_dir="$(git rev-parse --show-toplevel)/backend"

--- a/backend/strapi-deploy-actions
+++ b/backend/strapi-deploy-actions
@@ -9,7 +9,7 @@ SLACK="/home/ifixit/Code/Exec/slackAnnounce.php"
 git fetch --tags --quiet
 
 SUBJECT=$(git rev-list --format="%s" --max-count=1 "$STRAPI_COMMIT" | tail -1)
-COMMIT_LINK="<https://$BUILD_REPO/commit/$STRAPI_COMMIT|${SUBJECT}>"
+COMMIT_LINK="<https://github.com/iFixit/react-commerce/commit/$STRAPI_COMMIT|${SUBJECT}>"
 DEPLOY_LOG_TS=$($SLACK --message="Strapi Deploy: Deploying ${COMMIT_LINK} - 📃 <$BUILD_LOG_URL|build log>")
 $SLACK --thread_ts="$DEPLOY_LOG_TS" --message="Building Docker image"
 


### PR DESCRIPTION
The `BUILD_REPO` variable is not set in the Strapi deploy job, 
so the commit link was broken. This commit hardcodes the link
 to the react-commerce repo.

qa_req 0

Connects: https://github.com/iFixit/react-commerce/issues/2175