### PR TITLE
Piwik: Use greatest_privilege in User API Response

### DIFF
--- a/frontend/layouts/default/index.tsx
+++ b/frontend/layouts/default/index.tsx
@@ -96,7 +96,7 @@ const DefaultLayoutComponent = function ({
 
    trackPiwikPreferredStore(PIWIK_ENV);
    trackPiwikPreferredLanguage(PIWIK_ENV, userData?.langid ?? null);
-   trackPiwikUserPrivilege(PIWIK_ENV, userData?.privileges ?? null);
+   trackPiwikUserPrivilege(PIWIK_ENV, userData?.greatest_privilege ?? null);
    return (
       <LayoutErrorBoundary>
          <ShopifyStorefrontProvider

--- a/packages/analytics/piwik/index.tsx
+++ b/packages/analytics/piwik/index.tsx
@@ -46,15 +46,14 @@ export function trackPiwikPreferredLanguage(
 
 export function trackPiwikUserPrivilege(
    piwikEnv: string | undefined,
-   userPrivilege: string[] | null
+   userPrivilege: string | null
 ): void {
    const customDimensions = getPiwikCustomDimensionsForEnv(piwikEnv);
    if (typeof window !== 'undefined' && customDimensions && userPrivilege) {
-      const privilege = userPrivilege.length > 0 ? userPrivilege[0] : 'User';
       piwikPush([
          'setCustomDimensionValue',
          customDimensions['userPrivilege'],
-         privilege,
+         userPrivilege,
       ]);
    }
 }

--- a/packages/auth-sdk/user.tsx
+++ b/packages/auth-sdk/user.tsx
@@ -26,6 +26,7 @@ const AuthenticatedUserSchema = z.object({
    langid: z.string().optional().nullable(),
    unread_notification_count: z.number().optional().nullable(),
    privileges: z.array(z.string()),
+   greatest_privilege: z.string().optional(),
 });
 
 export function useAuthenticatedUser(): UseQueryResult<User | null> {


### PR DESCRIPTION
## Overview

We were running into issues where piwik was getting translated privilege names in its data. This isn't desired. Lets make sure that doesn't happen with these changes.

## QA

Is this only sending the correct user privileges (not translated) to piwik now? 

Connects: https://github.com/iFixit/ifixit/issues/51313