### PR TITLE
Footer: Fix HTML Semantics Warning

### DIFF
--- a/packages/footer/components/Shared.tsx
+++ b/packages/footer/components/Shared.tsx
@@ -72,9 +72,9 @@ export const FooterLink = forwardRef<FooterLinkProps, 'a'>(
             onClick={trackedOnClick}
             {...otherProps}
          >
-            <Text fontSize={fontSize} lineHeight="1em" color={customColor}>
+            <Box fontSize={fontSize} lineHeight="1em" color={customColor}>
                {children}
-            </Text>
+            </Box>
             {icon && <Icon as={icon} boxSize="6" />}
          </HStack>
       );


### PR DESCRIPTION
## Issue

Quick fix. I'm seeing this warning on dev:

`Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.`

<details>

<img width="1909" alt="Screenshot 2024-01-08 at 11 42 02 AM" src="https://github.com/iFixit/react-commerce/assets/1634505/48dd67b7-ba47-49fe-ba7a-f35fc4b382bb">

</details>

We're passing in children, which looks to have another Text component or paragraph element, so let's convert the parent to a Box instead.

## CR/QA

Confirm footer is still functioning as expected.