### PR TITLE
Defensively parse fetch request body

### DIFF
--- a/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
+++ b/frontend/lib/shopify-storefront-sdk/generated/sdk.ts
@@ -2654,7 +2654,7 @@ export enum CountryCode {
    Tn = 'TN',
    /** Tonga. */
    To = 'TO',
-   /** Turkey. */
+   /** Türkiye. */
    Tr = 'TR',
    /** Trinidad & Tobago. */
    Tt = 'TT',

--- a/packages/sentry/index.tsx
+++ b/packages/sentry/index.tsx
@@ -40,13 +40,20 @@ const withSentry: FetchMiddleware = (fetcher) => async (input, init) => {
       });
    }
 
+   let body;
+   try {
+      body = init?.body ? JSON.parse(String(init?.body)) : undefined;
+   } catch (e) {
+      body = init?.body ?? undefined;
+   }
+
    const context = {
       // Underscore sorts the resource first in Sentry's UI
       _resource: input,
       headers: init?.headers,
       method: init?.method,
       // Parse to pretty print GraphQL queries
-      body: init?.body ? JSON.parse(String(init?.body)) : undefined,
+      body,
    };
    try {
       const response = await fetcher(input, init);


### PR DESCRIPTION
The [errors spike](https://ifixit.sentry.io/alerts/rules/details/180935/?end=2024-01-09T18%3A25%3A00&start=2024-01-09T16%3A40%3A29) that appeared today seems to be related to the way in which the sentry fetch config parses the input body.
This PR handles the process more defensively, not giving for granted that the body is JSON encoded.

qa_req 0 