### PR TITLE
Seeding - check 404 before failing

### DIFF
--- a/backend/src/plugins/addons/server/services/seed/custom/content-fetcher.ts
+++ b/backend/src/plugins/addons/server/services/seed/custom/content-fetcher.ts
@@ -90,11 +90,11 @@ export class ContentFetcher<Content = any> {
       const query = this.computeQuery(params);
       const endpoint = `${this.endpoint}?${query}`;
       const response = await fetch(endpoint);
-      if (!response.ok) {
-         throw new Error(`Failed to fetch from ${endpoint}`);
-      }
       if (response.status === 404) {
          throw new ContentTypeNotFoundError(this.apiId);
+      }
+      if (!response.ok) {
+         throw new Error(`Failed to fetch from ${endpoint}`);
       }
       return response.json();
    }


### PR DESCRIPTION
This PR switches two checks that were performed during Strapi seeding.
In detail we should check for 404 before checking the generic `response.ok`, otherwise new models introduced locally will make the seeding process fail.

qa_req 0