### PR TITLE
Refactor product redirect

### DIFF
--- a/frontend/app/_helpers/app-helpers.ts
+++ b/frontend/app/_helpers/app-helpers.ts
@@ -1,0 +1,18 @@
+import { CACHE_DISABLED } from '@config/env';
+import { headers } from 'next/headers';
+
+export function shouldSkipCache(
+   searchParams: Record<string, string | string[] | undefined>
+) {
+   return searchParams.disableCacheGets != null || CACHE_DISABLED;
+}
+
+export function devSandboxOrigin(): string | null {
+   const host =
+      headers().get('x-ifixit-forwarded-host') ||
+      headers().get('x-forwarded-host');
+   const isDevProxy = !!host?.match(
+      /^(?!react-commerce).*(\.cominor\.com|\.ubreakit\.com)$/
+   );
+   return isDevProxy ? `https://${host}` : null;
+}

--- a/frontend/lib/ifixit-api/productData.ts
+++ b/frontend/lib/ifixit-api/productData.ts
@@ -2,19 +2,19 @@ import { FetchError, IFixitAPIClient } from '@ifixit/ifixit-api-client';
 import { captureException } from '@ifixit/sentry';
 import { z } from 'zod';
 
-const iFixitFindProductQuerySchema = z.object({
+const IFixitFindProductQuerySchema = z.object({
    variantOptions: z.record(z.array(z.string())),
    compatibilityNotes: z.array(z.string()),
    redirectSkuUrl: z.string().nullable(),
 });
-export type iFixitFindProductQuery = z.infer<
-   typeof iFixitFindProductQuerySchema
+export type IFixitFindProductQuery = z.infer<
+   typeof IFixitFindProductQuerySchema
 >;
 
 export async function fetchProductData(
    client: IFixitAPIClient,
    handle: string
-): Promise<iFixitFindProductQuery | null> {
+): Promise<IFixitFindProductQuery | null> {
    const productHandle = encodeURIComponent(handle);
    if (!productHandle) return null;
    let response;
@@ -27,7 +27,7 @@ export async function fetchProductData(
       if (!(e instanceof FetchError) || e.response.status !== 404) throw e;
       return null;
    }
-   const parsed = iFixitFindProductQuerySchema.safeParse(response);
+   const parsed = IFixitFindProductQuerySchema.safeParse(response);
    if (!parsed.success) {
       console.error(
          'Invalid product data from iFixit API',

--- a/frontend/models/product/index.ts
+++ b/frontend/models/product/index.ts
@@ -45,7 +45,7 @@ import {
    ProductVideosSchema,
 } from './components/product-video';
 import { getProductSections, ProductSectionSchema } from './sections';
-import type { iFixitFindProductQuery } from '@lib/ifixit-api/productData';
+import type { IFixitFindProductQuery } from '@lib/ifixit-api/productData';
 import { ImageAltFallback } from '@models/components/image';
 
 export type {
@@ -87,9 +87,16 @@ export const ProductSchema = z.object({
    sections: z.array(ProductSectionSchema),
 });
 
+export type ProductRedirect = z.infer<typeof ProductRedirectSchema>;
+
+export const ProductRedirectSchema = z.object({
+   __typename: z.literal('ProductRedirect'),
+   target: z.string(),
+});
+
 type ShopifyProduct = NonNullable<ShopifyFindProductQuery['product']>;
 type StrapiProduct = NonNullable<StrapiFindProductQuery['products']>['data'][0];
-type iFixitProduct = NonNullable<iFixitFindProductQuery>;
+type iFixitProduct = NonNullable<IFixitFindProductQuery>;
 
 interface GetProductArgs {
    shopifyProduct: ShopifyProduct | null | undefined;

--- a/frontend/models/product/server.ts
+++ b/frontend/models/product/server.ts
@@ -48,11 +48,11 @@ export async function findProduct({
 
    return (
       getIFixitRedirect() ??
-      getProduct({
+      (await getProduct({
          shopifyProduct: shopifyQueryResponse.product,
          strapiProduct: strapiQueryResponse.products?.data[0],
          iFixitProduct: iFixitQueryResponse,
-      }) ??
+      })) ??
       getShopifyRedirect()
    );
 

--- a/frontend/pages/api/nextjs/cache/product.ts
+++ b/frontend/pages/api/nextjs/cache/product.ts
@@ -1,10 +1,7 @@
 import { Duration } from '@lib/duration';
 import { withCache } from '@lib/swr-cache';
-import { ProductSchema } from '@models/product';
-import {
-   ShopifyProductRedirectSchema,
-   findProduct,
-} from '@models/product/server';
+import { ProductRedirectSchema, ProductSchema } from '@models/product';
+import { findProduct } from '@models/product/server';
 import { z } from 'zod';
 
 export type {
@@ -21,9 +18,7 @@ export default withCache({
       storeCode: z.string(),
       ifixitOrigin: z.string(),
    }),
-   valueSchema: z
-      .union([ProductSchema, ShopifyProductRedirectSchema])
-      .nullable(),
+   valueSchema: z.union([ProductSchema, ProductRedirectSchema]).nullable(),
    async getFreshValue({ handle, storeCode, ifixitOrigin }) {
       return findProduct({
          handle,

--- a/frontend/templates/product/server.tsx
+++ b/frontend/templates/product/server.tsx
@@ -7,7 +7,6 @@ import {
 import { withLogging } from '@helpers/next-helpers';
 import { ifixitOriginFromHost } from '@helpers/path-helpers';
 import { invariant } from '@ifixit/helpers';
-import { urlFromContext } from '@ifixit/helpers/nextjs';
 import { getLayoutServerSideProps } from '@layouts/default/server';
 import Product from '@pages/api/nextjs/cache/product';
 import compose from 'lodash/flowRight';
@@ -39,13 +38,6 @@ export const getServerSideProps: GetServerSideProps<ProductTemplateProps> =
       );
 
       if (product?.__typename === 'ProductRedirect') {
-         const destination = new URL(product.target, ifixitOrigin);
-         const requestParams = new URL(urlFromContext(context)).searchParams;
-         requestParams.forEach((value, key) => {
-            if (!destination.searchParams.has(key)) {
-               destination.searchParams.append(key, value);
-            }
-         });
          return {
             redirect: {
                destination: product.target,


### PR DESCRIPTION
This PR contains a minor refactor of the product redirect logic and adds product fetching to the app router page.

## QA

Redirects should be followed (both from Shopify or iFixit), unless the given handle corresponds to an enabled product that exists.

For example, [`/products/ipad-air-4-battery`](https://react-commerce-git-refactor-product-redirect-ifixit.vercel.app/products/ipad-air-4-battery) should redirect to `/products/ipad-air-4-5-battery`.
