### PR TITLE
Drop deprecated cart api coupon fields

### DIFF
--- a/packages/cart-sdk/types.ts
+++ b/packages/cart-sdk/types.ts
@@ -30,8 +30,6 @@ export interface CartLineItem {
 }
 
 export interface APICart {
-   couponName: string;
-   hasCoupon: boolean;
    hasCustomer: boolean;
    totalNumItems: number;
    totals: {


### PR DESCRIPTION
Connects https://github.com/iFixit/ifixit/issues/51463

These fields are going away, so let's drop them from the type.

qa_req 0