### PR TITLE
Add CTA button on guide cards

### DIFF
--- a/frontend/templates/troubleshooting/Resource.tsx
+++ b/frontend/templates/troubleshooting/Resource.tsx
@@ -37,6 +37,7 @@ export function GuideResource({ guide }: { guide: SectionGuide }) {
          timeRequired={guide.time_required}
          difficulty={guide.difficulty}
          spacing={1.5}
+         showBuyButton={'View Guide'}
       >
          {guide.introduction_rendered && (
             <PrerenderedHTML


### PR DESCRIPTION
This text matches the current [figma](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=588-33&mode=design).

## QA
Make sure a linked guide card on troubleshooting solutions looks good across all screen sizes and matches the [figma](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=588-33&mode=design).

Example page: http://localhost:3000/Troubleshooting/iPhone/Battery+Draining+Fast/480045#Section_Logic_Board

Closes https://github.com/iFixit/ifixit/issues/51458