### PR TITLE
Add metadata to app router product page

### DIFF
--- a/frontend/app/(defaultLayout)/products/app-router/[handle]/json-ld-scripts.tsx
+++ b/frontend/app/(defaultLayout)/products/app-router/[handle]/json-ld-scripts.tsx
@@ -1,0 +1,126 @@
+import { IFIXIT_ORIGIN } from '@config/env';
+import {
+   invariant,
+   parseItemcode,
+   shouldShowProductRating,
+} from '@ifixit/helpers';
+import type { Product } from '@models/product';
+import { imagesFor } from 'app/_helpers/product-helpers';
+import { jsonLdScriptProps } from 'react-schemaorg';
+import type {
+   BreadcrumbList as BreadcrumbListLDSchema,
+   OfferItemCondition,
+   Product as ProductLDSchema,
+} from 'schema-dts';
+
+interface ProductBreadCrumbsJsonLDScriptProps {
+   product: Product;
+}
+
+export function ProductBreadcrumbsJsonLDScript({
+   product,
+}: ProductBreadCrumbsJsonLDScriptProps) {
+   return (
+      <script
+         {...jsonLdScriptProps<BreadcrumbListLDSchema>({
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement:
+               product.breadcrumbs.map((item, index) => ({
+                  '@type': 'ListItem',
+                  position: index + 1,
+                  name: item.label,
+                  item:
+                     item.url && item.url !== '#'
+                        ? `${IFIXIT_ORIGIN}${item.url}`
+                        : undefined,
+               })) || undefined,
+         })}
+      />
+   );
+}
+
+interface ProductJsonLDScriptProps {
+   product: Product;
+   selectedVariantId: string;
+}
+
+export function ProductJsonLDScript({
+   product,
+   selectedVariantId,
+}: ProductJsonLDScriptProps) {
+   const variant = variantFor(selectedVariantId);
+
+   if (variant == null) return null;
+
+   return (
+      <script
+         {...jsonLdScriptProps<ProductLDSchema>({
+            '@context': 'https://schema.org',
+            '@type': 'Product',
+            name: product.metaTitle || undefined,
+            url: variantUrl(),
+            aggregateRating: shouldShowProductRating(product.reviews)
+               ? {
+                    '@type': 'AggregateRating',
+                    ratingValue: product.reviews.rating,
+                    reviewCount: product.reviews.count,
+                 }
+               : undefined,
+            brand: {
+               '@type': 'Brand',
+               name: product.vendor || 'iFixit',
+            },
+            description: product.shortDescription || '',
+            image: imagesFor(product, selectedVariantId).map(
+               (image) => image.url
+            ),
+            mpn: variant.sku || undefined,
+            offers: {
+               '@type': 'Offer',
+               url: variantUrl(),
+               priceCurrency: variant.price.currencyCode,
+               price: variant.price.amount,
+               priceValidUntil: oneYearFromNow(),
+               itemCondition: variantCondition(),
+               availability:
+                  variant.quantityAvailable && variant.quantityAvailable > 0
+                     ? 'https://schema.org/InStock'
+                     : 'https://schema.org/OutOfStock',
+            },
+            sku: parseItemcode(variant.sku || '').productcode,
+         })}
+      />
+   );
+
+   function variantFor(variantId: string) {
+      return product.variants.find((variant) => variant.id === variantId);
+   }
+
+   function variantUrl() {
+      return `${IFIXIT_ORIGIN}/products/${product.handle}?variant=${selectedVariantId}`;
+   }
+
+   function oneYearFromNow() {
+      const result = new Date();
+      result.setFullYear(result.getFullYear() + 1);
+      return result.toISOString();
+   }
+
+   function variantCondition(): OfferItemCondition {
+      invariant(variant);
+
+      const conditionOption = variant.selectedOptions.find(
+         (option) => option.name === 'Condition'
+      );
+
+      switch (conditionOption?.value) {
+         case 'New':
+            return 'https://schema.org/NewCondition';
+         case 'Refurbished':
+            return 'https://schema.org/RefurbishedCondition';
+         default:
+            return 'https://schema.org/UsedCondition';
+      }
+   }
+}

--- a/frontend/app/(defaultLayout)/products/app-router/[handle]/page.tsx
+++ b/frontend/app/(defaultLayout)/products/app-router/[handle]/page.tsx
@@ -1,8 +1,17 @@
 import { DEFAULT_STORE_CODE, IFIXIT_ORIGIN } from '@config/env';
 import { flags } from '@config/flags';
-import Product from '@pages/api/nextjs/cache/product';
+import { invariant } from '@ifixit/helpers';
+import Product, {
+   type Product as ProductType,
+} from '@pages/api/nextjs/cache/product';
 import { devSandboxOrigin, shouldSkipCache } from 'app/_helpers/app-helpers';
+import { defaultVariantId, imagesFor } from 'app/_helpers/product-helpers';
+import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
+import {
+   ProductBreadcrumbsJsonLDScript,
+   ProductJsonLDScript,
+} from './json-ld-scripts';
 
 export interface ProductPageProps {
    params: {
@@ -33,5 +42,89 @@ export default async function ProductPage({
 
    if (data.__typename === 'ProductRedirect') redirect(data.target);
 
-   return <div>Product: {data.title}</div>;
+   return (
+      <>
+         <ProductBreadcrumbsJsonLDScript product={data} />
+         <ProductJsonLDScript
+            product={data}
+            selectedVariantId={selectedVariantId(data, searchParams)}
+         />
+         <div>Product: {data.title}</div>
+      </>
+   );
+}
+
+export async function generateMetadata({
+   params,
+   searchParams,
+}: ProductPageProps): Promise<Metadata> {
+   const product = await Product.get(
+      {
+         handle: params.handle,
+         storeCode: DEFAULT_STORE_CODE,
+         ifixitOrigin: devSandboxOrigin() ?? IFIXIT_ORIGIN,
+      },
+      { forceMiss: shouldSkipCache(searchParams) }
+   );
+
+   if (product == null || product.__typename !== 'Product') return {};
+
+   return {
+      title: product.metaTitle,
+      description: product.shortDescription,
+      openGraph: {
+         title: product.metaTitle ?? undefined,
+         description: product.shortDescription ?? undefined,
+         type: 'website',
+         url: productCanonicalUrl(),
+         images: productImages().map((image) => ({ url: image.url })),
+      },
+      robots: shouldBlockCrawlers()
+         ? { follow: false, index: false }
+         : undefined,
+      alternates: {
+         canonical: shouldBlockCrawlers() ? undefined : productCanonicalUrl(),
+         languages: alternateLanguages(),
+      },
+   };
+
+   function alternateLanguages(): Record<string, string> {
+      invariant(product?.__typename === 'Product');
+      const result: Record<string, string> = {};
+      if (product.enabledDomains) {
+         for (const store of product.enabledDomains) {
+            for (const locale of store.locales) {
+               result[locale] = `${store.domain}/products/${product.handle}`;
+            }
+         }
+      }
+      return result;
+   }
+
+   function productCanonicalUrl(): string {
+      invariant(product?.__typename === 'Product');
+      return `${IFIXIT_ORIGIN}/products/${product.handle}`;
+   }
+
+   function shouldBlockCrawlers() {
+      invariant(product?.__typename === 'Product');
+      return isOnlyForPros() || !product.isEnabled || product.noindex;
+   }
+
+   function isOnlyForPros() {
+      invariant(product?.__typename === 'Product');
+      return product.tags.find((tag: string) => tag === 'Pro Only') != null;
+   }
+
+   function productImages() {
+      invariant(product?.__typename === 'Product');
+      return imagesFor(product, selectedVariantId(product, searchParams));
+   }
+}
+
+function selectedVariantId(
+   product: ProductType,
+   searchParams: ProductPageProps['searchParams']
+) {
+   return searchParams.variant ?? defaultVariantId(product);
 }

--- a/frontend/app/_helpers/product-helpers.ts
+++ b/frontend/app/_helpers/product-helpers.ts
@@ -1,0 +1,27 @@
+import type { Image } from '@models/components/image';
+import type { Product } from '@models/product';
+
+export function imagesFor(
+   product: Product,
+   selectedVariantId: string
+): Image[] {
+   const genericImages = product.images.filter((image) => {
+      return image.variantId === null;
+   });
+
+   const selectedVariantImages = product.images.filter(
+      (image) => image.variantId === selectedVariantId
+   );
+
+   const relevantImages = genericImages.concat(selectedVariantImages);
+
+   return relevantImages.length > 0 ? relevantImages : product.fallbackImages;
+}
+
+export function defaultVariantId(product: Product): string {
+   const variant =
+      product.variants.find(
+         (variant) => variant.quantityAvailable && variant.quantityAvailable > 0
+      ) ?? product.variants[0];
+   return variant.id;
+}

--- a/frontend/app/global-error.tsx
+++ b/frontend/app/global-error.tsx
@@ -18,7 +18,7 @@ export default function GlobalError({ error }: GlobalErrorProps) {
       });
    }, [error]);
    return (
-      <html>
+      <html lang="en">
          <body>
             <Center p="4">
                <Alert


### PR DESCRIPTION
Part of https://github.com/iFixit/ifixit/issues/51165

Under the app router metadata for a page has to be declared using the [`generateMetadata`](https://nextjs.org/docs/app/building-your-application/optimizing/metadata) function, which exports a typed object. This PR converts the `frontend/templates/product/MetaTags.tsx` component into this new format.

## QA

Compare an [`app router` product page preview](https://react-commerce-git-add-app-router-product-page-metadata-ifixit.vercel.app/products/app-router/iphone-11-screen) with its matching [`pages` product page preview](https://react-commerce-git-add-app-router-product-page-metadata-ifixit.vercel.app/products/iphone-11-screen) to verify that:

- They have the same meta title
- They have the same meta description
- They have the same open graph meta tags
- They have the same canonical url
- They have the same alternate languages
- They have `noindex,nofollow` robots meta tags if:
  - The Shopify product has a `Pro Only` tag (`pages` product page would have `X-Robots-Tag` response header instead of robots meta tag, but it's essentially the same thing)
  - Does not have active variants (a variant is considered "active" if it has `Enabled 2` metafield set to true and either has stock or has `Disabled When OOS` metafield set to false. 
  - They're marked as SEO hidden in Shopify (`seo.hidden` metafield)
- They have the same json-ld scripts (i.e.`Product` and `BreadcrumbList`)

