### PR TITLE
Show Errors in Cart Drawer

### DIFF
--- a/packages/cart-sdk/hooks/use-add-to-cart.ts
+++ b/packages/cart-sdk/hooks/use-add-to-cart.ts
@@ -33,7 +33,7 @@ type AddBundleToCartInput = {
 export function useAddToCart(analyticsMessage?: string) {
    const client = useQueryClient();
    const iFixitApiClient = useIFixitApiClient();
-   const { addErrorMessage } = useCartDrawer();
+   const { addError } = useCartDrawer();
    const mutation = useMutation(
       async (input) => {
          switch (input.type) {
@@ -108,7 +108,7 @@ export function useAddToCart(analyticsMessage?: string) {
                cartKeys.cart,
                context?.previousCart
             );
-            addErrorMessage(error);
+            addError(error);
          },
          onSuccess: (data, variables) => {
             trackPiwikCustomAddToCart(variables, analyticsMessage);

--- a/packages/cart-sdk/hooks/use-add-to-cart.ts
+++ b/packages/cart-sdk/hooks/use-add-to-cart.ts
@@ -10,6 +10,7 @@ import { useIFixitApiClient } from '@ifixit/ifixit-api-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Cart, CartLineItem } from '../types';
 import { cartKeys } from '../utils';
+import { useCartDrawer } from '@ifixit/ui';
 
 export type AddToCartInput = AddProductToCartInput | AddBundleToCartInput;
 
@@ -32,6 +33,7 @@ type AddBundleToCartInput = {
 export function useAddToCart(analyticsMessage?: string) {
    const client = useQueryClient();
    const iFixitApiClient = useIFixitApiClient();
+   const { addErrorMessage } = useCartDrawer();
    const mutation = useMutation(
       async (input) => {
          switch (input.type) {
@@ -105,6 +107,9 @@ export function useAddToCart(analyticsMessage?: string) {
             client.setQueryData<Cart | undefined>(
                cartKeys.cart,
                context?.previousCart
+            );
+            addErrorMessage(
+               (error as string) || 'An error occurred updating the cart.'
             );
          },
          onSuccess: (data, variables) => {

--- a/packages/cart-sdk/hooks/use-add-to-cart.ts
+++ b/packages/cart-sdk/hooks/use-add-to-cart.ts
@@ -108,9 +108,7 @@ export function useAddToCart(analyticsMessage?: string) {
                cartKeys.cart,
                context?.previousCart
             );
-            addErrorMessage(
-               (error as string) || 'An error occurred updating the cart.'
-            );
+            addErrorMessage(error);
          },
          onSuccess: (data, variables) => {
             trackPiwikCustomAddToCart(variables, analyticsMessage);

--- a/packages/cart-sdk/hooks/use-remove-line-item.ts
+++ b/packages/cart-sdk/hooks/use-remove-line-item.ts
@@ -7,6 +7,7 @@ import { useIFixitApiClient } from '@ifixit/ifixit-api-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Cart, CartLineItem } from '../types';
 import { cartKeys } from '../utils';
+import { useCartDrawer } from '@ifixit/ui';
 
 interface DeleteLineItemInput {
    item: CartLineItem;
@@ -18,6 +19,7 @@ interface DeleteLineItemInput {
 export function useRemoveLineItem() {
    const client = useQueryClient();
    const iFixitApiClient = useIFixitApiClient();
+   const { addErrorMessage } = useCartDrawer();
    const mutation = useMutation(
       async (input) => {
          await iFixitApiClient.delete(
@@ -74,6 +76,9 @@ export function useRemoveLineItem() {
             client.setQueryData<Cart | undefined>(
                cartKeys.cart,
                context?.previousCart
+            );
+            addErrorMessage(
+               (error as string) || 'An error occurred updating the cart.'
             );
          },
          onSuccess: (data, variables) => {

--- a/packages/cart-sdk/hooks/use-remove-line-item.ts
+++ b/packages/cart-sdk/hooks/use-remove-line-item.ts
@@ -77,9 +77,7 @@ export function useRemoveLineItem() {
                cartKeys.cart,
                context?.previousCart
             );
-            addErrorMessage(
-               (error as string) || 'An error occurred updating the cart.'
-            );
+            addErrorMessage(error);
          },
          onSuccess: (data, variables) => {
             const cart = client.getQueryData<Cart>(cartKeys.cart);

--- a/packages/cart-sdk/hooks/use-remove-line-item.ts
+++ b/packages/cart-sdk/hooks/use-remove-line-item.ts
@@ -19,7 +19,7 @@ interface DeleteLineItemInput {
 export function useRemoveLineItem() {
    const client = useQueryClient();
    const iFixitApiClient = useIFixitApiClient();
-   const { addErrorMessage } = useCartDrawer();
+   const { addError } = useCartDrawer();
    const mutation = useMutation(
       async (input) => {
          await iFixitApiClient.delete(
@@ -77,7 +77,7 @@ export function useRemoveLineItem() {
                cartKeys.cart,
                context?.previousCart
             );
-            addErrorMessage(error);
+            addError(error);
          },
          onSuccess: (data, variables) => {
             const cart = client.getQueryData<Cart>(cartKeys.cart);

--- a/packages/cart-sdk/hooks/use-update-line-item-quantity.ts
+++ b/packages/cart-sdk/hooks/use-update-line-item-quantity.ts
@@ -21,7 +21,7 @@ interface UpdateLineItemQuantityInput {
 export function useUpdateLineItemQuantity() {
    const client = useQueryClient();
    const iFixitApiClient = useIFixitApiClient();
-   const { addErrorMessage } = useCartDrawer();
+   const { addError } = useCartDrawer();
    const mutation = useMutation(
       async (input) => {
          return iFixitApiClient.post(
@@ -93,7 +93,7 @@ export function useUpdateLineItemQuantity() {
                cartKeys.cart,
                context?.previousCart
             );
-            addErrorMessage(error);
+            addError(error);
          },
          onSuccess: (data, variables) => {
             const analyticsItems = convertCartLineItemsToAnalyticsItem([

--- a/packages/cart-sdk/hooks/use-update-line-item-quantity.ts
+++ b/packages/cart-sdk/hooks/use-update-line-item-quantity.ts
@@ -93,9 +93,7 @@ export function useUpdateLineItemQuantity() {
                cartKeys.cart,
                context?.previousCart
             );
-            addErrorMessage(
-               (error as string) || 'An error occurred updating the cart.'
-            );
+            addErrorMessage(error);
          },
          onSuccess: (data, variables) => {
             const analyticsItems = convertCartLineItemsToAnalyticsItem([

--- a/packages/cart-sdk/hooks/use-update-line-item-quantity.ts
+++ b/packages/cart-sdk/hooks/use-update-line-item-quantity.ts
@@ -8,6 +8,7 @@ import { useIFixitApiClient } from '@ifixit/ifixit-api-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Cart, CartLineItem } from '../types';
 import { cartKeys } from '../utils';
+import { useCartDrawer } from '@ifixit/ui';
 
 interface UpdateLineItemQuantityInput {
    item: CartLineItem;
@@ -20,6 +21,7 @@ interface UpdateLineItemQuantityInput {
 export function useUpdateLineItemQuantity() {
    const client = useQueryClient();
    const iFixitApiClient = useIFixitApiClient();
+   const { addErrorMessage } = useCartDrawer();
    const mutation = useMutation(
       async (input) => {
          return iFixitApiClient.post(
@@ -90,6 +92,9 @@ export function useUpdateLineItemQuantity() {
             client.setQueryData<Cart | undefined>(
                cartKeys.cart,
                context?.previousCart
+            );
+            addErrorMessage(
+               (error as string) || 'An error occurred updating the cart.'
             );
          },
          onSuccess: (data, variables) => {

--- a/packages/cart-sdk/package.json
+++ b/packages/cart-sdk/package.json
@@ -11,7 +11,8 @@
       "@ifixit/helpers": "workspace:*",
       "@ifixit/ifixit-api-client": "workspace:*",
       "@ifixit/local-storage": "workspace:*",
-      "@ifixit/shopify-storefront-client": "workspace:*"
+      "@ifixit/shopify-storefront-client": "workspace:*",
+      "@ifixit/ui": "workspace:*"
    },
    "peerDependencies": {
       "@tanstack/react-query": "4.x"

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -45,7 +45,6 @@ export function CartDrawer() {
    const cart = useCart();
    const checkout = useCheckout();
    const isCartEmpty = cart.isFetched && !cart.data?.hasItemsInCart;
-   const clearAddToCartErrors = () => clearErrors();
    const hasErrors = errors.length > 0;
    return (
       <>
@@ -136,7 +135,7 @@ export function CartDrawer() {
                      {hasErrors && (
                         <CartUpdateError
                            errors={errors}
-                           onDismiss={clearAddToCartErrors}
+                           onDismiss={clearErrors}
                         />
                      )}
                      {cart.data?.hasItemsInCart && (

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -254,15 +254,41 @@ function CheckoutError({ error, onDismiss }: CheckoutErrorProps) {
          );
    }
 
+   return <DrawerError errorMsg={checkoutError} onDismiss={onDismiss} />;
+}
+
+interface CartUpdateErrorProps {
+   errors: any;
+   onDismiss: () => void;
+}
+
+function CartUpdateError({ errors, onDismiss }: CartUpdateErrorProps) {
+   let cartError = (
+      <>
+         Oops! Something went wrong when updating your cart. If the problem
+         persists please contact{' '}
+         <a href="mailto:support@ifixit.com">support@ifixit.com</a>
+      </>
+   );
+
+   return <DrawerError errorMsg={cartError} onDismiss={onDismiss} />;
+}
+
+interface DrawerErrorProps {
+   errorMsg: React.ReactElement | null;
+   onDismiss: () => void;
+}
+
+function DrawerError({ errorMsg, onDismiss }: DrawerErrorProps) {
    React.useEffect(() => {
-      if (checkoutError) {
+      if (errorMsg) {
          const id = setTimeout(onDismiss, 5000);
          return () => clearTimeout(id);
       }
-   }, [checkoutError, onDismiss]);
+   }, [errorMsg, onDismiss]);
 
    return (
-      <Collapse show={checkoutError != null}>
+      <Collapse show={errorMsg != null}>
          <Box p="3">
             <Alert status="error">
                <FaIcon
@@ -273,7 +299,7 @@ function CheckoutError({ error, onDismiss }: CheckoutErrorProps) {
                   color="red.500"
                />
                <Box flexGrow={1}>
-                  <AlertDescription>{checkoutError}</AlertDescription>
+                  <AlertDescription>{errorMsg}</AlertDescription>
                </Box>
                <CloseButton
                   alignSelf="flex-start"

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -39,23 +39,14 @@ import { useCartDrawer } from './hooks/useCartDrawer';
 
 export function CartDrawer() {
    const appContext = useAppContext();
-   const {
-      isOpen,
-      onOpen,
-      onClose,
-      onViewCart,
-      errorMessages,
-      clearErrorMessages,
-   } = useCartDrawer();
+   const { isOpen, onOpen, onClose, onViewCart, errors, clearErrors } =
+      useCartDrawer();
    const isMounted = useIsMountedState();
    const cart = useCart();
    const checkout = useCheckout();
    const isCartEmpty = cart.isFetched && !cart.data?.hasItemsInCart;
-   const clearAddToCartErrors = () => clearErrorMessages();
-   const [hasErrors, setHasErrors] = React.useState(errorMessages.length > 0);
-   React.useEffect(() => {
-      setHasErrors(errorMessages.length > 0);
-   }, [errorMessages]);
+   const clearAddToCartErrors = () => clearErrors();
+   const hasErrors = errors.length > 0;
    return (
       <>
          <CartDrawerTrigger
@@ -144,7 +135,7 @@ export function CartDrawer() {
                      )}
                      {hasErrors && (
                         <CartUpdateError
-                           errors={errorMessages}
+                           errors={errors}
                            onDismiss={clearAddToCartErrors}
                         />
                      )}

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -292,7 +292,7 @@ interface DrawerErrorProps {
 function DrawerError({ errorMsg, onDismiss }: DrawerErrorProps) {
    React.useEffect(() => {
       if (errorMsg) {
-         const id = setTimeout(onDismiss, 5000);
+         const id = setTimeout(onDismiss, 10000);
          return () => clearTimeout(id);
       }
    }, [errorMsg, onDismiss]);

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -39,12 +39,23 @@ import { useCartDrawer } from './hooks/useCartDrawer';
 
 export function CartDrawer() {
    const appContext = useAppContext();
-   const { isOpen, onOpen, onClose, onViewCart } = useCartDrawer();
+   const {
+      isOpen,
+      onOpen,
+      onClose,
+      onViewCart,
+      errorMessages,
+      clearErrorMessages,
+   } = useCartDrawer();
    const isMounted = useIsMountedState();
    const cart = useCart();
    const checkout = useCheckout();
    const isCartEmpty = cart.isFetched && !cart.data?.hasItemsInCart;
-
+   const clearAddToCartErrors = () => clearErrorMessages();
+   const [hasErrors, setHasErrors] = React.useState(errorMessages.length > 0);
+   React.useEffect(() => {
+      setHasErrors(errorMessages.length > 0);
+   }, [errorMessages]);
    return (
       <>
          <CartDrawerTrigger
@@ -130,6 +141,12 @@ export function CartDrawer() {
                               persists, please contact us.
                            </AlertDescription>
                         </Alert>
+                     )}
+                     {hasErrors && (
+                        <CartUpdateError
+                           errors={errorMessages}
+                           onDismiss={clearAddToCartErrors}
+                        />
                      )}
                      {cart.data?.hasItemsInCart && (
                         <>

--- a/packages/ui/cart/drawer/CartDrawer.tsx
+++ b/packages/ui/cart/drawer/CartDrawer.tsx
@@ -169,14 +169,7 @@ export function CartDrawer() {
                            <CrossSell />
                         </>
                      )}
-                     <Fade
-                        show={isCartEmpty}
-                        disableExitAnimation
-                        position="absolute"
-                        w="full"
-                        top="0"
-                        left="0"
-                     >
+                     <Fade show={isCartEmpty} disableExitAnimation w="full">
                         <CartEmptyState onClose={onClose} />
                      </Fade>
                   </DrawerBody>

--- a/packages/ui/cart/drawer/hooks/useCartDrawer.tsx
+++ b/packages/ui/cart/drawer/hooks/useCartDrawer.tsx
@@ -6,17 +6,36 @@ import { useCart } from '@ifixit/cart-sdk';
 import * as React from 'react';
 import { trackInPiwik } from '@ifixit/analytics/piwik/track-event';
 
-export type CartDrawerContext = ReturnType<typeof useDisclosure> & {};
-
+export type CartDrawerContext = ReturnType<typeof useDisclosure> & {
+   errorMessages: string[];
+   addErrorMessage: (message: string) => void;
+   clearErrorMessages: () => void;
+};
 const CartDrawerContext = React.createContext<CartDrawerContext | null>(null);
 
 type CartDrawerProviderProps = React.PropsWithChildren<{}>;
 
 export function CartDrawerProvider({ children }: CartDrawerProviderProps) {
    const disclosure = useDisclosure();
-   const value = React.useMemo((): CartDrawerContext => {
-      return disclosure;
-   }, [disclosure]);
+   const [errorMessages, setErrorMessages] = React.useState<string[]>([]);
+
+   const addErrorMessage = (errorMessage: string) => {
+      setErrorMessages((prevMessages) => [...prevMessages, errorMessage]);
+   };
+
+   const clearErrorMessages = () => {
+      setErrorMessages([]);
+   };
+
+   const value = React.useMemo(
+      (): CartDrawerContext => ({
+         ...disclosure,
+         errorMessages,
+         addErrorMessage,
+         clearErrorMessages,
+      }),
+      [disclosure, errorMessages]
+   );
 
    return (
       <CartDrawerContext.Provider value={value}>

--- a/packages/ui/cart/drawer/hooks/useCartDrawer.tsx
+++ b/packages/ui/cart/drawer/hooks/useCartDrawer.tsx
@@ -7,9 +7,9 @@ import * as React from 'react';
 import { trackInPiwik } from '@ifixit/analytics/piwik/track-event';
 
 export type CartDrawerContext = ReturnType<typeof useDisclosure> & {
-   errorMessages: Error[];
-   addErrorMessage: (newError: unknown) => void;
-   clearErrorMessages: () => void;
+   errors: Error[];
+   addError: (newError: unknown) => void;
+   clearErrors: () => void;
 };
 const CartDrawerContext = React.createContext<CartDrawerContext | null>(null);
 
@@ -17,7 +17,7 @@ type CartDrawerProviderProps = React.PropsWithChildren<{}>;
 
 export function CartDrawerProvider({ children }: CartDrawerProviderProps) {
    const disclosure = useDisclosure();
-   const [errorMessages, setErrorMessages] = React.useState<Error[]>([]);
+   const [errors, setErrors] = React.useState<Error[]>([]);
 
    const addError = (newError: unknown) => {
       let error: Error;
@@ -28,21 +28,21 @@ export function CartDrawerProvider({ children }: CartDrawerProviderProps) {
       } else {
          error = new Error('Unknown error');
       }
-      setErrorMessages((prevErrors) => [...prevErrors, error]);
+      setErrors((prevErrors) => [...prevErrors, error]);
    };
 
    const clearErrors = () => {
-      setErrorMessages([]);
+      setErrors([]);
    };
 
    const value = React.useMemo(
       (): CartDrawerContext => ({
          ...disclosure,
-         errorMessages,
-         addErrorMessage: addError,
-         clearErrorMessages: clearErrors,
+         errors,
+         addError,
+         clearErrors,
       }),
-      [disclosure, errorMessages]
+      [disclosure, errors]
    );
 
    return (

--- a/packages/ui/cart/drawer/hooks/useCartDrawer.tsx
+++ b/packages/ui/cart/drawer/hooks/useCartDrawer.tsx
@@ -7,8 +7,8 @@ import * as React from 'react';
 import { trackInPiwik } from '@ifixit/analytics/piwik/track-event';
 
 export type CartDrawerContext = ReturnType<typeof useDisclosure> & {
-   errorMessages: string[];
-   addErrorMessage: (message: string) => void;
+   errorMessages: Error[];
+   addErrorMessage: (newError: unknown) => void;
    clearErrorMessages: () => void;
 };
 const CartDrawerContext = React.createContext<CartDrawerContext | null>(null);
@@ -17,13 +17,21 @@ type CartDrawerProviderProps = React.PropsWithChildren<{}>;
 
 export function CartDrawerProvider({ children }: CartDrawerProviderProps) {
    const disclosure = useDisclosure();
-   const [errorMessages, setErrorMessages] = React.useState<string[]>([]);
+   const [errorMessages, setErrorMessages] = React.useState<Error[]>([]);
 
-   const addErrorMessage = (errorMessage: string) => {
-      setErrorMessages((prevMessages) => [...prevMessages, errorMessage]);
+   const addError = (newError: unknown) => {
+      let error: Error;
+      if (newError instanceof Error) {
+         error = newError;
+      } else if (typeof newError === 'string') {
+         error = new Error(newError);
+      } else {
+         error = new Error('Unknown error');
+      }
+      setErrorMessages((prevErrors) => [...prevErrors, error]);
    };
 
-   const clearErrorMessages = () => {
+   const clearErrors = () => {
       setErrorMessages([]);
    };
 
@@ -31,8 +39,8 @@ export function CartDrawerProvider({ children }: CartDrawerProviderProps) {
       (): CartDrawerContext => ({
          ...disclosure,
          errorMessages,
-         addErrorMessage,
-         clearErrorMessages,
+         addErrorMessage: addError,
+         clearErrorMessages: clearErrors,
       }),
       [disclosure, errorMessages]
    );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,9 @@ importers:
       '@ifixit/shopify-storefront-client':
         specifier: workspace:*
         version: link:../shopify-storefront-client
+      '@ifixit/ui':
+        specifier: workspace:*
+        version: link:../ui
       '@tanstack/react-query':
         specifier: 4.x
         version: 4.14.5(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
## Overview

We sometimes can have things error out when trying to update the cart. We would roll back the cart but not change anything, and not tell our user that anything wrong happened. Now we give some visual feedback that there was an error updating the cart in the cart drawer.

## QA

When we have an error updating the cart (adding a bad product, product is out of inventory, removing an item and it fails) we now display an error message in the cart drawer. The error message is closable, and also disappears after an alloted time.

Also, the checkout errors also still display as expected.

CC @dhmacs 
Closes: https://github.com/iFixit/ifixit/issues/51213