### PR TITLE
Vulcan: Wrap pre elements

### DIFF
--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -70,7 +70,7 @@ const sharedStyles: SystemStyleObject = {
       paddingInline: 1,
       maxWidth: '100%',
       overflow: 'auto',
-      textWrap: 'wrap',
+      whiteSpace: 'break-spaces',
    },
 
    th: {

--- a/frontend/components/common/PrerenderedHTML.tsx
+++ b/frontend/components/common/PrerenderedHTML.tsx
@@ -70,6 +70,7 @@ const sharedStyles: SystemStyleObject = {
       paddingInline: 1,
       maxWidth: '100%',
       overflow: 'auto',
+      textWrap: 'wrap',
    },
 
    th: {


### PR DESCRIPTION
## Issue

I saw an error div rendered on a Vulcan page that I hadn’t seen before: [ifixit.com/Troubleshooting/Nintendo_Switch/Will+Not+Turn+On/481634](https://www.ifixit.com/Troubleshooting/Nintendo_Switch/Will+Not+Turn+On/481634)

It's breaking the page layout because the pre elements don't wrap.

<details>
<summary>Pre-fix Details</summary>

<img width="1982" alt="Screenshot 2024-01-16 at 3 53 47 PM" src="https://github.com/iFixit/ifixit/assets/1634505/cb1d2cc0-cc84-4b83-9790-2495d465fd40">

</details>

## CR/QA

This issue was only present on the live site, but Shawn has since fixed the content issue ([Slack ref](https://ifixit.slack.com/archives/C01GVQAAGDU/p1705450363393529?thread_ts=1705449298.795689&cid=C01GVQAAGDU)). I have a video of the proposed fix being toggled, which should suffice:

<details>
<summary>Post-fix Details</summary>

https://github.com/iFixit/react-commerce/assets/1634505/0ea5235a-a272-4fdb-a525-b57bb79af44c

</details>

Closes https://github.com/iFixit/ifixit/issues/51605