### PR TITLE
Product: Make tooltips visible to screen readers

### DIFF
--- a/frontend/templates/product/sections/ProductOverviewSection/AddToCart/ShippingRestrictions.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/AddToCart/ShippingRestrictions.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, StackProps, VStack } from '@chakra-ui/react';
+import { Box, Flex, IconButton, StackProps, VStack } from '@chakra-ui/react';
 import { Tooltip } from '@components/ui/Tooltip';
 import { faCircleInfo } from '@fortawesome/pro-solid-svg-icons';
 import { FaIcon } from '@ifixit/icons';
@@ -73,12 +73,18 @@ export function ShippingRestrictions({
                      {shippingRestriction.notice}
                      <Tooltip
                         trigger={
-                           <FaIcon
-                              icon={faCircleInfo}
-                              h="4"
-                              mt="1px"
-                              ml="1.5"
-                              color="gray.400"
+                           <IconButton
+                              aria-label="Learn more about this shipping restriction"
+                              ml="1"
+                              size="sm"
+                              variant="ghost"
+                              icon={
+                                 <FaIcon
+                                    icon={faCircleInfo}
+                                    h="4"
+                                    color="gray.400"
+                                 />
+                              }
                            />
                         }
                         content={

--- a/frontend/templates/product/sections/ProductOverviewSection/ValuePropositionList.tsx
+++ b/frontend/templates/product/sections/ProductOverviewSection/ValuePropositionList.tsx
@@ -1,4 +1,4 @@
-import { Box, List, ListIcon, ListItem } from '@chakra-ui/react';
+import { Box, IconButton, List, ListIcon, ListItem } from '@chakra-ui/react';
 import { Tooltip } from '@components/ui/Tooltip';
 import {
    faBadgeDollar,
@@ -62,12 +62,14 @@ export function ValuePropositionList() {
                <div>30-day returns</div>
                <Tooltip
                   trigger={
-                     <FaIcon
-                        icon={faCircleInfo}
-                        h="4"
-                        mt="1px"
-                        ml="1.5"
-                        color="gray.400"
+                     <IconButton
+                        aria-label="Learn more about our return policy"
+                        ml="1"
+                        size="sm"
+                        variant="ghost"
+                        icon={
+                           <FaIcon icon={faCircleInfo} h="4" color="gray.400" />
+                        }
                      />
                   }
                   content={


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/51384

Makes the shipping restriction and returns notice visible to screen readers. Also adds aria label text to each.

This is similar to what we do for the prop 65 warning.

Chakra's docs recommend that the popover trigger be focusable, hence the use of IconButton. https://chakra-ui.com/docs/components/popover/usage#basic-usage

## QA

Visit the Vercel preview and make sure that the shipping restrictions and returns info buttons are not skipped by screen readers.