### PR TITLE
Vulcan: Problem: Rename area link to "Troubleshooting"

### DIFF
--- a/frontend/templates/troubleshooting/components/Causes.tsx
+++ b/frontend/templates/troubleshooting/components/Causes.tsx
@@ -40,7 +40,6 @@ export function Causes({
 
    return (
       <>
-         <TOCHeading>Troubleshooting</TOCHeading>
          <Box
             as="nav"
             color="brand.500"

--- a/frontend/templates/troubleshooting/components/NavBar.tsx
+++ b/frontend/templates/troubleshooting/components/NavBar.tsx
@@ -276,7 +276,7 @@ function NavTabs({
             </Box>
          )}
 
-         <Box {...selectedStyleProps}>Answers</Box>
+         <Box {...selectedStyleProps}>Troubleshooting</Box>
       </Flex>
    );
 }


### PR DESCRIPTION
## Problem

We added "Troubleshooting" as a heading in the TOC and section list, but now it looks like "Troubleshooting" only applies up to the Causes and not beyond.

## CR/QA

https://react-commerce-prod-git-vulcan-problem-rename-are-945c10-ifixit.vercel.app/Troubleshooting/Garbage_Disposal/Hums/491105

Spec:

- [ ] Just on the problem page, change the selected area link (currently "Answers") to "Troubleshooting".
- [ ] Drop the "Troubleshooting" header in the TOC; don't replace it with anything
- [ ] Drop the "Troubleshooting" header in the section list; don't replace it with anything

Closes https://github.com/iFixit/ifixit/issues/51467