### PR TITLE
A11y: Add visually hidden price qualifiers

### DIFF
--- a/frontend/tests/jest/tests/ProductSection.test.tsx
+++ b/frontend/tests/jest/tests/ProductSection.test.tsx
@@ -203,7 +203,7 @@ describe('ProductSection Tests', () => {
          const price = within(productPrice).getByTestId('price');
 
          expect(price).toBeInTheDocument();
-         expect(price.textContent).toBe('$29.99');
+         expect(price.textContent).toContain('$29.99');
       });
 
       test('Discounted Price Renders', async () => {
@@ -229,29 +229,15 @@ describe('ProductSection Tests', () => {
             'product-price-section'
          );
          const price = within(productPrice).getByTestId('price');
-
          expect(price).toBeInTheDocument();
-         expect(price.textContent).toBe('$' + discountPrice);
+         expect(price.textContent).toContain('$' + discountPrice);
 
-         // Get the parent element of the element
-         const parentElement = price.parentElement;
-
-         // Get all of the children of the parent element
-         const children = parentElement?.children;
-
-         // Filter out the element itself to get only its siblings
-         const siblings = Array.prototype.filter.call(
-            children,
-            (child: HTMLElement) => {
-               return child !== price;
-            }
+         const discountBadge =
+            within(productPrice).getByTestId('product-discount');
+         expect(discountBadge).toBeInTheDocument();
+         expect(discountBadge.textContent).toContain(
+            discountPercentage + '% OFF'
          );
-
-         const priceTexts = [discountPercentage + '% OFF', '$' + originalPrice];
-
-         siblings.forEach((sibling: HTMLElement) => {
-            expect(priceTexts).toContain(sibling.textContent);
-         });
       });
    });
 

--- a/frontend/tests/jest/tests/__snapshots__/ProductListItem.test.tsx.snap
+++ b/frontend/tests/jest/tests/__snapshots__/ProductListItem.test.tsx.snap
@@ -181,6 +181,11 @@ exports[`ProductListItem renders and matches the snapshot 1`] = `
               class="chakra-text css-mafz32"
               data-testid="price"
             >
+              <span
+                class="css-idkz9h"
+              >
+                Sale price 
+              </span>
               $5.00
             </p>
           </div>

--- a/frontend/tests/playwright/fixtures/product-page.ts
+++ b/frontend/tests/playwright/fixtures/product-page.ts
@@ -49,27 +49,14 @@ export class ProductPage {
     * with the format $###.## or $###
     */
    async getCurrentPrice(): Promise<number> {
+      const priceRe = /\$[0-9]+(\.[0-9]{1,2})?$/;
       const price = await this.page
          .getByTestId('product-price-section')
          .getByTestId('price')
          .textContent();
       expect(price).not.toEqual('');
-      expect(price).toMatch(/\$[0-9]+(\.[0-9]{1,2})?$/);
-      return parseFloat(price!.slice(1));
-   }
-
-   /**
-    * @description Locates and returns the original product price as a string
-    * with the format $###.## or $###
-    */
-   async getDiscountedPrice(): Promise<number> {
-      const price = await this.page
-         .getByTestId('product-price-section')
-         .getByTestId('compare-at-price')
-         .textContent();
-      expect(price).not.toEqual('');
-      expect(price).toMatch(/\$[0-9]+(\.[0-9]{1,2})?$/);
-      return parseFloat(price!.slice(1));
+      expect(price).toMatch(priceRe);
+      return parseFloat(price!.match(priceRe)![0].slice(1));
    }
 
    /**

--- a/packages/ui/commerce/ProductPrice.tsx
+++ b/packages/ui/commerce/ProductPrice.tsx
@@ -15,6 +15,7 @@ import {
    Text,
    ThemeTypings,
    useMultiStyleConfig,
+   VisuallyHidden,
 } from '@chakra-ui/react';
 import { faRectanglePro } from '@fortawesome/pro-solid-svg-icons';
 import { computeDiscountPercentage, formatMoney, Money } from '@ifixit/helpers';
@@ -155,6 +156,7 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
                      color={`${colorScheme}.500`}
                   />
                )}
+               <VisuallyHidden>Sale price </VisuallyHidden>
                {formattedPrice}
             </Text>
             {isDiscounted && (
@@ -165,6 +167,7 @@ const ProductPrice = forwardRef<BoxProps & ProductPriceProps, 'div'>(
                      mr={direction === 'row-reverse' ? 1 : 0}
                      data-testid="compare-at-price"
                   >
+                     <VisuallyHidden>Regular price </VisuallyHidden>
                      {formattedCompareAtPrice}
                   </Text>
                   {isDiscounted && showDiscountLabel && isHorizontal && (


### PR DESCRIPTION
Closes https://github.com/iFixit/ifixit/issues/51386

## QA

Visit the vercel preview and make sure product page and product list page prices are more clear for screen readers.