### PR TITLE
Troubleshooting: Add causes header

### DIFF
--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -551,14 +551,15 @@ function IntroductionSection({
 
 function CausesListHeader() {
    return (
-      <HeadingSelfLink
-         fontWeight="semibold"
+      <Heading
+         as="h2"
          aria-label="Causes"
-         id={'causes'}
-         selfLinked
+         fontSize={{ base: '20px', mdPlus: '24px' }}
+         fontWeight="semibold"
+         lineHeight="normal"
       >
          Causes
-      </HeadingSelfLink>
+      </Heading>
    );
 }
 

--- a/frontend/templates/troubleshooting/index.tsx
+++ b/frontend/templates/troubleshooting/index.tsx
@@ -247,6 +247,7 @@ const Wiki: NextPageWithLayout<{
                         </Stack>
                         {wikiData.solutions.length > 0 && (
                            <Stack spacing={6}>
+                              <CausesListHeader />
                               {wikiData.solutions.map((solution, index) => (
                                  <SolutionCard
                                     key={solution.heading}
@@ -545,6 +546,19 @@ function IntroductionSection({
          )}
          <PrerenderedHTML html={intro.body} template="troubleshooting" />
       </Stack>
+   );
+}
+
+function CausesListHeader() {
+   return (
+      <HeadingSelfLink
+         fontWeight="semibold"
+         aria-label="Causes"
+         id={'causes'}
+         selfLinked
+      >
+         Causes
+      </HeadingSelfLink>
    );
 }
 


### PR DESCRIPTION
## Overview
We display a 'Causes' header in the TOC, but don't actually show one in the troubleshooting page content. This adds one in the same style as the other headers.

We don't want to be able to permalink to this, so it should just be an h2 without special link properties.

If there are no causes to display, we don't render the header.

Closes https://github.com/iFixit/ifixit/issues/51468