### PR TITLE
Problems List: Finalize UI styles

### DIFF
--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/AnswerCard.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/AnswerCard.tsx
@@ -57,10 +57,10 @@ export function AnswerCard({
             </GridItem>
             <GridItem area="text" display="flex">
                <Stack spacing={1.5} justifyContent="center" lineHeight="normal">
-                  <Text>{deviceTitle}</Text>
                   <LinkOverlay href={url} color="brand.500">
                      <Text noOfLines={5}>{title}</Text>
                   </LinkOverlay>
+                  <Text>{deviceTitle}</Text>
                </Stack>
             </GridItem>
          </Grid>

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/AnswerCard.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/AnswerCard.tsx
@@ -4,6 +4,7 @@ import {
    Image,
    LinkBox,
    LinkOverlay,
+   Stack,
    Text,
 } from '@chakra-ui/react';
 import {
@@ -20,7 +21,6 @@ export function AnswerCard({
 
    return (
       <LinkBox
-         flex="1"
          overflow="hidden"
          borderColor="gray.300"
          borderWidth="1px"
@@ -28,25 +28,21 @@ export function AnswerCard({
          backgroundColor="white"
          transition={`border-color var(--chakra-transition-duration-normal)`}
          _hover={{ borderColor: 'brand.500' }}
-         padding={3}
+         padding={{ base: 2, sm: 3 }}
          fontWeight="semibold"
       >
          <Grid
             templateAreas={`
-                  "image link"
-                  "image title"
+                  "image text"
                `}
-            gridTemplateColumns="auto 1fr"
-            gridTemplateRows="auto 1fr"
-            gap={1.5}
+            gridTemplateColumns="75px 1fr"
+            gap={2}
          >
             <GridItem
                area="image"
                outline="1px solid"
                outlineColor="gray.300"
                borderRadius="md"
-               width={{ lg: '64px' }}
-               mr={2}
                aspectRatio="4 / 3"
                overflow="hidden"
             >
@@ -59,13 +55,13 @@ export function AnswerCard({
                   alt={deviceTitle}
                />
             </GridItem>
-            <GridItem area="title" display={{ base: 'initial', lg: 'flex' }}>
-               <Text>{deviceTitle}</Text>
-            </GridItem>
-            <GridItem area="link" lineHeight="initial">
-               <LinkOverlay href={url} color="brand.500">
-                  {title}
-               </LinkOverlay>
+            <GridItem area="text" display="flex">
+               <Stack spacing={1.5} justifyContent="center" lineHeight="normal">
+                  <Text>{deviceTitle}</Text>
+                  <LinkOverlay href={url} color="brand.500">
+                     <Text noOfLines={5}>{title}</Text>
+                  </LinkOverlay>
+               </Stack>
             </GridItem>
          </Grid>
       </LinkBox>

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/AnswerCard.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/AnswerCard.tsx
@@ -55,7 +55,7 @@ export function AnswerCard({
                   alt={deviceTitle}
                />
             </GridItem>
-            <GridItem area="text" display="flex">
+            <GridItem area="text" display="flex" fontSize="sm">
                <Stack spacing={1.5} justifyContent="center" lineHeight="normal">
                   <LinkOverlay href={url} color="brand.500">
                      <Text noOfLines={5}>{title}</Text>

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/Answers.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/Answers.tsx
@@ -19,17 +19,16 @@ export function Answers({
                   fontWeight="medium"
                   lineHeight="normal"
                >
-                  Didn&apos;t find your problem?
+                  Didn&apos;t see your problem? Try one of these answers.
                </Heading>
                <Text>
-                  Browse the most common questions asked by users and try to see
-                  if someone has already answered your problem. If you
-                  can&apos;t find a resolution to your problem, you can always
-                  ask.
+                  Browse the most common questions asked by users to see if
+                  someone already has an answer. If you can&apos;t find a
+                  solution to your problem, you can always ask.
                </Text>
             </Stack>
             <SimpleGrid
-               className="list"
+               className="answers-list"
                columns={{ base: 1, md: 2 }}
                spacing={3}
             >
@@ -37,19 +36,19 @@ export function Answers({
                   <AnswerCard answer={answer} key={answer.title} />
                ))}
             </SimpleGrid>
+            <Link
+               href={allAnswersUrl}
+               color="brand.500"
+               fontSize="sm"
+               width="fit-content"
+            >
+               See all{' '}
+               <Box as="span" fontWeight="semibold">
+                  {allAnswersCount}
+               </Box>{' '}
+               questions
+            </Link>
          </Stack>
-         <Link
-            href={allAnswersUrl}
-            color="brand.500"
-            fontSize="sm"
-            width="fit-content"
-         >
-            See all{' '}
-            <Box as="span" fontWeight="semibold">
-               {allAnswersCount}
-            </Box>{' '}
-            questions
-         </Link>
       </>
    );
 }

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/Answers.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/Answers.tsx
@@ -31,6 +31,7 @@ export function Answers({
                className="answers-list"
                columns={{ base: 1, md: 2 }}
                spacing={3}
+               autoRows="min-content"
             >
                {answersData.map((answer: any) => (
                   <AnswerCard answer={answer} key={answer.title} />

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/NavBar.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/NavBar.tsx
@@ -38,7 +38,7 @@ export function NavBar({
             className="NavBar"
             maxWidth="1280px"
             mx="auto"
-            px={{ md: 8 }}
+            px={{ sm: 4, md: 8 }}
             width="100%"
             flexDirection={{ base: 'column-reverse', sm: 'row' }}
             justify="stretch"

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/ProblemCard.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/ProblemCard.tsx
@@ -40,9 +40,9 @@ export function ProblemCard({
       >
          <Stack
             direction="row"
-            spacing={4}
+            spacing={{ base: 3, sm: 4 }}
             alignSelf="stretch"
-            p={5}
+            p={{ base: 4, sm: 5 }}
             flex="1"
             color="gray.900"
          >
@@ -80,7 +80,7 @@ export function ProblemCard({
             borderTop="1px solid"
             borderColor="gray.200"
             py={2}
-            px={5}
+            px={{ base: 4, sm: 5 }}
          >
             <Image
                src={imageSrcThumbnail}

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/troubleshootingProblems.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/troubleshootingProblems.tsx
@@ -38,7 +38,8 @@ export default function TroubleshootingProblems(
             maxWidth="1280px"
             mx="auto"
             px={{ base: 4, md: 8 }}
-            py={{ md: 8 }}
+            pt={{ md: 8 }}
+            pb={8}
          >
             <Stack as="main" spacing={6}>
                <Box className="header">
@@ -58,8 +59,8 @@ export default function TroubleshootingProblems(
                   </Text>
                </Box>
                <SimpleGrid
-                  className="list"
-                  columns={{ base: 1, sm: 2 }}
+                  className="problem-list"
+                  columns={{ base: 1, md: 2 }}
                   spacing={{ base: 4, md: 6 }}
                >
                   {ProblemsData.map((problem: any, index: number) => (


### PR DESCRIPTION
## Issue

We found a few UI issues when reviewing the Problems List page yesterday during a Vulcan meeting. This is a second pass at the styles to shore it up.

## CR/QA

[Figma link](https://www.figma.com/file/QVLUEpDVoyiMM4MXEGq1L9/iFixit---Problems?type=design&node-id=1-122&mode=design&t=ayzLTnsYXY4NW2PN-0)

https://react-commerce-prod-git-problems-list-finalize-ui-styles-ifixit.vercel.app/Troubleshooting/Google_Phone

**Fixed:**

- On mobile: Device images in question cards are variable size. [(ref link)](https://ifixit.slack.com/archives/CDFNZ4N4A/p1706051332728989)
- On mobile: Missing margin on the bottom of the question count. [(ref link)](https://ifixit.slack.com/archives/CDFNZ4N4A/p1706051332728989)
- Double-check desktop/mobile spacing variances
- Refactor the AnswerCard layout to vertically center the text
- Adjust Answers heading text (I reached out to Max about this earlier today. He's going to get back to me with any tweaks)

Connects https://github.com/iFixit/ifixit/issues/51698