### PR TITLE
Problem-List: NavBar: Use new `deviceUrls` API values

### DIFF
--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/NavBar.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/NavBar.tsx
@@ -7,17 +7,20 @@ import {
    LinkProps,
 } from '@chakra-ui/react';
 import { BreadCrumbs } from '@ifixit/breadcrumbs';
-import type { BreadcrumbEntry } from '../hooks/useTroubleshootingProblemsProps';
+import type {
+   BreadcrumbEntry,
+   DeviceUrls,
+} from '../hooks/useTroubleshootingProblemsProps';
 
 export function NavBar({
-   deviceGuideUrl,
-   devicePartsUrl,
+   deviceUrls,
    breadcrumbs,
 }: {
    editUrl: string;
    historyUrl: string;
+   deviceUrls: DeviceUrls[];
    breadcrumbs: BreadcrumbEntry[];
-} & NavTabsProps) {
+}) {
    const bc = breadcrumbs.map((breadcrumb) => ({
       label: breadcrumb.title,
       url: breadcrumb.url,
@@ -85,8 +88,7 @@ export function NavBar({
                      overflowX="auto"
                      flexGrow="1"
                      paddingInline={{ base: 0, sm: 2 }}
-                     deviceGuideUrl={deviceGuideUrl}
-                     devicePartsUrl={devicePartsUrl}
+                     deviceUrls={deviceUrls}
                   />
                </Box>
             </Flex>
@@ -95,16 +97,7 @@ export function NavBar({
    );
 }
 
-type NavTabsProps = {
-   deviceGuideUrl?: string;
-   devicePartsUrl?: string;
-};
-
-function NavTabs({
-   devicePartsUrl,
-   deviceGuideUrl,
-   ...props
-}: NavTabsProps & FlexProps) {
+function NavTabs({ deviceUrls, ...props }: FlexProps) {
    // The type here works because all the styles we want to use are available on
    // both Box and Link
    const baseStyleProps: BoxProps & LinkProps = {
@@ -172,6 +165,8 @@ function NavTabs({
          },
       },
    };
+
+   const { devicePartsUrl, deviceGuideUrl } = deviceUrls;
 
    return (
       <Flex {...props} gap={1.5} height="100%">

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/troubleshootingProblems.tsx
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/components/troubleshootingProblems.tsx
@@ -15,8 +15,7 @@ export default function TroubleshootingProblems(
       title,
       editUrl,
       historyUrl,
-      deviceGuideUrl,
-      devicePartsUrl,
+      deviceUrls,
       breadcrumbs,
       answers,
       allAnswersUrl,
@@ -29,8 +28,7 @@ export default function TroubleshootingProblems(
          <NavBar
             editUrl={editUrl}
             historyUrl={historyUrl}
-            deviceGuideUrl={deviceGuideUrl}
-            devicePartsUrl={devicePartsUrl}
+            deviceUrls={deviceUrls}
             breadcrumbs={breadcrumbs}
          />
          <Box

--- a/frontend/app/(defaultLayout)/Troubleshooting/[device]/hooks/useTroubleshootingProblemsProps.ts
+++ b/frontend/app/(defaultLayout)/Troubleshooting/[device]/hooks/useTroubleshootingProblemsProps.ts
@@ -6,8 +6,7 @@ export type TroubleshootingProblemsApiData = {
    editUrl: string;
    historyUrl: string;
    answersUrl: string;
-   deviceGuideUrl?: string;
-   devicePartsUrl?: string;
+   deviceUrls: DeviceUrls[];
    breadcrumbs: BreadcrumbEntry[];
    id: number;
    problems: Problems[];
@@ -30,6 +29,12 @@ export type Answers = {
    imageUrl: string;
    title: string;
    deviceTitle: string;
+};
+
+export type DeviceUrls = {
+   deviceGuideUrl: string;
+   deviceTroubleshootingUrl?: string;
+   devicePartsUrl?: string;
 };
 
 export type TroubleshootingAnswersData = {


### PR DESCRIPTION
## Issue

We are adding API values for `deviceUrls` in https://github.com/iFixit/ifixit/pull/51857. Let's hook them up and enable the NavBar links.

## CR/QA

Confirm the NavBar links are working as expected. Note: not all devices have parts links, but everything should have guide links:

<details>
<summary>Details</summary>

https://github.com/iFixit/react-commerce/assets/1634505/a6b6ca2c-7bdf-4dbf-aa03-e97fe149373a


</details>

Connects https://github.com/iFixit/ifixit/issues/51698