### PR TITLE
Sentry: temp disable production check

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -1,5 +1,5 @@
 import { SENTRY_SAMPLING_ENABLED, VERCEL_ENV } from '@config/env';
-import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
+// import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
 import { SentryErrorIntegration } from '@ifixit/sentry';
 import { BrowserTracing } from '@sentry/browser';
 import * as Sentry from '@sentry/nextjs';

--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -14,8 +14,11 @@ const sampleRate = SENTRY_SAMPLING_ENABLED
 Sentry.init({
    async beforeSend(event) {
       try {
+         /*
+          * Temporarily disable while we move to a new repo
          const current_production = await isCurrentProductionDeployment();
          event.tags = { ...event.tags, current_production };
+         */
       } catch (e) {
          event.tags = { ...event.tags, before_send_error: true };
          event.extra = {

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -13,8 +13,11 @@ const sampleRate = SENTRY_SAMPLING_ENABLED
 Sentry.init({
    async beforeSend(event) {
       try {
+         /*
+          * Temporarily disable while we move to a new repo
          const current_production = await isCurrentProductionDeployment();
          event.tags = { ...event.tags, current_production };
+         */
       } catch (e) {
          event.tags = { ...event.tags, before_send_error: true };
          event.extra = {

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -1,6 +1,6 @@
 import { SentryErrorIntegration } from './../packages/sentry/index';
 import { SENTRY_SAMPLING_ENABLED, VERCEL_ENV } from '@config/env';
-import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
+// import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
 import * as Sentry from '@sentry/nextjs';
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -1,5 +1,5 @@
 import { SENTRY_SAMPLING_ENABLED, VERCEL_ENV } from '@config/env';
-import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
+// import { isCurrentProductionDeployment } from '@helpers/vercel-helpers';
 import { SentryErrorIntegration } from '@ifixit/sentry';
 import * as Sentry from '@sentry/nextjs';
 

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -33,8 +33,11 @@ Sentry.init({
          }
       }
       try {
+         /*
+          * Temporarily disable while we move to a new repo
          const current_production = await isCurrentProductionDeployment();
          event.tags = { ...event.tags, current_production };
+         */
       } catch (e) {
          event.tags = { ...event.tags, before_send_error: true };
          event.extra = {


### PR DESCRIPTION
This won't work the same way once this code is in a private repo.

Let's disable this while we move this code instead of trying to re-solve this problem beforehand.

qa_req 0