### PR TITLE
topic_images api: stop double-encoding params list

### DIFF
--- a/frontend/lib/ifixit-api/devices.ts
+++ b/frontend/lib/ifixit-api/devices.ts
@@ -55,7 +55,7 @@ export async function fetchMultipleDeviceImages(
    });
    try {
       const result = await client.get(
-         `wikis/topic_images?` + encodeURIComponent(params.toString()),
+         `wikis/topic_images?` + params.toString(),
          'device-images'
       );
       return MultipleDeviceApiResponseSchema.parse(result);


### PR DESCRIPTION
We added this in 855251899c2c4f9a7b3c0ebb335cae39eabd1f00 along with several other correct url encoding changes.

Unfortunately, params.toString() already creates a correctly encoded string and encoding it again creates a doubly-encoded garbage url. That means this api hasn't worked at all since Nov-2023; it's been giving 404s.

This was just noticed now because one of our playwright tests loaded a product list page that made this request and resulted in a 404 which failed the test.